### PR TITLE
docs: add first feature pod task packets

### DIFF
--- a/ai_first/AI_FIRST_ROADMAP.md
+++ b/ai_first/AI_FIRST_ROADMAP.md
@@ -1,0 +1,71 @@
+# AI-First Roadmap
+
+Last updated: 2026-04-19
+
+## Purpose
+
+This document explains how the repository should operate when AI is expected to finish work, complete pull requests, merge safely, and continue toward the contest MVP with minimal manual orchestration.
+
+## Long-Term Goal
+
+Build a stable VnExpress Sáng kiến Khoa học 2026 MVP:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+## Autonomous Loop
+
+```mermaid
+flowchart TD
+  Goal["Long-term MVP goal"]
+  Queue["NEXT_ACTIONS.md and task packets"]
+  Branch["Focused branch"]
+  Work["Implement scoped change"]
+  Verify["Run relevant verification"]
+  PR["Open or update PR"]
+  Gate{"Safe to merge?"}
+  Fix["Fix CI, review, or merge blockers"]
+  Merge["Merge PR"]
+  Record["Update daily log, roadmap, and status mirrors"]
+  Next["Select next task"]
+
+  Goal --> Queue --> Branch --> Work --> Verify --> PR --> Gate
+  Gate -- yes --> Merge --> Record --> Next --> Queue
+  Gate -- no --> Fix --> Verify
+```
+
+## Merge Policy
+
+- Docs, task, and workflow PRs may be auto-merged when mergeable, non-draft, and not blocked by review.
+- Runtime and product PRs may be auto-merged only when relevant tests or required checks pass and no review blocks the PR.
+- CI failures and blocking reviews are the next task until fixed.
+- AI must not push directly to `main`.
+
+## How AI Chooses Next Work
+
+1. Fix active PR blockers.
+2. Continue active task packets in `docs/superpowers/tasks/`.
+3. Use the compact queue in `ai_first/NEXT_ACTIONS.md`.
+4. Derive the next short task from the MVP goal only after creating or updating a task packet.
+
+## Human Checkpoints
+
+Human review remains important for product direction, contest story, irreversible scope changes, credential or deployment decisions, and any PR marked as blocked or requiring human judgment.
+
+## Development Direction
+
+### Near Term
+
+- Merge the first task packet workflow PR.
+- Start Pod A and Pod B from their task packets.
+- Keep every PR tied to an architecture note with Mermaid.
+
+### Mid Term
+
+- Add reliable CI checks for backend and frontend changes.
+- Tighten issue labels and PR status conventions for autonomous selection.
+- Keep evidence, demo scripts, and screenshots current for the contest.
+
+### Later
+
+- Consider GitHub Actions or scripts for queue reporting after the manual loop is proven stable.
+- Add stronger automation only after merge gates, CI expectations, and review signals are reliable.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -20,8 +20,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 - Repository: `Creative-Science-Contest-2026/Multiagent-learning-platform`
 - Base project: HKUDS/DeepTutor under Apache 2.0
-- Branch: `docs/ai-first-project-os`
-- Goal: make the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
+- Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
+- Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -83,5 +83,6 @@ Before handing off:
 
 1. Keep this file as the single entry point for future AI workers.
 2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
-3. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-4. Use the approved docs/AI-first operating layer to drive feature pods, PRs, and evidence.
+3. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+4. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+5. Use the approved docs/AI-first operating layer to drive feature pods, PRs, and evidence.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -12,6 +12,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Compatibility model
 
 - `ai_first/AI_OPERATING_PROMPT.md` is the single entry point.
+- `ai_first/AI_FIRST_ROADMAP.md` is the human-facing roadmap for the autonomous AI-first loop and future operating improvements.
 - `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md` are compatibility snapshots only.
 - If a task packet exists, it remains the execution contract for the current feature pod.
 - If no task packet exists yet, the prompt and approved plan are the bootstrap contract.
@@ -49,12 +50,25 @@ Before edits:
 ## AI-first operating rules
 
 - Treat this file as the control plane for the repo-level AI-first workflow.
+- Treat `ai_first/AI_FIRST_ROADMAP.md` as the readable roadmap for what the AI loop does now and where it should evolve next.
 - Keep instructions short, direct, and executable.
 - Prefer one source of truth over multiple overlapping instructions.
 - If a newer project status needs to be captured, update this file first and then mirror the shortest useful summary to the compatibility snapshots.
 - When a feature, tool, route, data model, or workflow rule changes, update `ai_first/architecture/MAIN_SYSTEM_MAP.md`.
 - Every PR must include a Markdown architecture note under `docs/superpowers/pr-notes/` with at least one Mermaid diagram.
 - Every PR must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
+
+## Autonomous completion loop
+
+After opening or updating a PR, classify it before handing off:
+
+- Docs, task, and workflow PRs may be auto-merged when the PR is mergeable, non-draft, and has no blocking review or unresolved required discussion.
+- Runtime and product PRs may be auto-merged only when relevant tests or required checks pass and there is no blocking review.
+- If CI fails, fixing CI is the next task. Do not start a new feature until the failing PR is fixed or explicitly deferred.
+- If review blocks the PR, address the review before merging or continuing.
+- After a successful merge, sync from `main`, update the daily log and compact status mirrors when useful, then select the next task.
+- Select next work in this order: active PR blockers, active task packets, `ai_first/NEXT_ACTIONS.md`, then the long-term MVP goal.
+- If the next product change has no task packet, create or update a task packet before implementation.
 
 ## Execution contract
 
@@ -77,12 +91,14 @@ Before handing off:
 2. Record tests and failures.
 3. Update `ai_first/daily/YYYY-MM-DD.md`.
 4. Update this file if status, workflow, or next actions changed.
-5. Add handoff notes with changed files, risks, and the next recommended read path.
+5. Check whether the PR is eligible for autonomous merge under the merge policy.
+6. Add handoff notes with changed files, risks, merge status, and the next recommended read path.
 
 ## Next actions
 
 1. Keep this file as the single entry point for future AI workers.
 2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
-3. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
-4. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-5. Use the approved docs/AI-first operating layer to drive feature pods, PRs, and evidence.
+3. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
+4. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+5. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+6. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -27,11 +27,10 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Active branch: `docs/ai-first-project-os`
-- Purpose: Milestone 0 AI-first Project OS setup.
-- PR status: not opened yet from this worktree.
-- Merge note: preserve parent-checkout historical files under `ai_first/2026-04-12-deeptutor-slimming/` when integrating this branch.
-- Operating note: keep the entry-point prompt short, current, and self-directed.
+- Current branch for this docs update: `docs/first-task-packets`
+- Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
+- Current purpose: create the first execution task packets for Pod A and Pod B
+- Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
 
@@ -50,12 +49,18 @@ Do not revert unrelated changes.
 
 ## Near-term Milestones
 
-1. Milestone 0: AI-first Project OS.
-2. Milestone 1: Competition demo narrative.
-3. Milestone 2: Teacher Knowledge Pack MVP.
-4. Milestone 3: Assessment Builder MVP.
-5. Milestone 4: Student Tutor Workspace MVP.
-6. Milestone 5: Teacher Dashboard MVP.
+1. Milestone 1: Competition demo narrative.
+2. Milestone 2: Teacher Knowledge Pack MVP.
+3. Milestone 3: Assessment Builder MVP.
+4. Milestone 4: Student Tutor Workspace MVP.
+5. Milestone 5: Teacher Dashboard MVP.
+
+## Active Execution
+
+- Pod A task packet: `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`
+- Pod B task packet: `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`
+- Pod A GitHub issue: `#2`
+- Pod B GitHub issue: `#3`
 
 ## Mirror Policy
 

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated: 2026-04-13
+Last updated: 2026-04-19
 
 This file is a compatibility snapshot. The authoritative operating instructions live in `ai_first/AI_OPERATING_PROMPT.md`.
 
@@ -23,13 +23,15 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Markdown in repo is long-term source of truth.
 - GitHub Issues and PRs coordinate active execution.
 - The AI operating prompt is the single entry point for new workers.
+- `ai_first/AI_FIRST_ROADMAP.md` explains the autonomous loop and future operating direction for humans checking progress.
 - Two Feature Pods may work in parallel after shared operating files land.
 
 ## Active Branches and PRs
 
 - Current branch for this docs update: `docs/first-task-packets`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
-- Current purpose: create the first execution task packets for Pod A and Pod B
+- Current PR: `#4 docs: add first feature pod task packets`
+- Current purpose: create the first execution task packets for Pod A and Pod B, then add safe autonomous PR completion rules.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -61,6 +63,14 @@ Do not revert unrelated changes.
 - Pod B task packet: `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`
 - Pod A GitHub issue: `#2`
 - Pod B GitHub issue: `#3`
+- Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
+- Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
+
+## Autonomous Merge Policy
+
+- Docs, task, and workflow PRs may be auto-merged when mergeable, non-draft, and not blocked by review.
+- Runtime and product PRs require passing relevant tests or checks and no blocking review before auto-merge.
+- CI failures, merge conflicts, and blocking reviews become the next task until fixed or explicitly deferred.
 
 ## Mirror Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,20 +7,20 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/AI_OPERATING_PROMPT.md` as the single entry point for AI workers.
-2. Open or update the PR for branch `docs/ai-first-project-os` using `docs/superpowers/pr-notes/docs-ai-first-project-os.md`.
-3. Review and merge the AI-first Project OS PR without losing historical files under `ai_first/2026-04-12-deeptutor-slimming/` from the parent checkout.
-4. Create first task packet for Pod A: Teacher Knowledge Pack MVP.
-5. Create first task packet for Pod B: Assessment Builder + Student Tutor Workspace MVP.
-6. Mirror approved task packets to GitHub Issues with `pod-a` and `pod-b` labels.
+2. Review the first task packet for Pod A: Teacher Knowledge Pack MVP.
+3. Review the first task packet for Pod B: Assessment Builder + Student Tutor Workspace MVP.
+4. Start implementation branches from the approved task packets.
+5. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
 
 ## After Milestone 0
 
-1. Start feature implementation branches.
+1. Add Teacher Dashboard MVP planning after Pod A ownership is stable.
+2. Keep the main system map updated when shared contracts change.
 
 ## Human Review Needed
 
-- Review the AI-first operating files after Milestone 0 PR.
 - Confirm the first two Feature Pod task packets before implementation.
+- Confirm whether Teacher Dashboard should stay in a later Pod A packet or be folded into the same implementation branch.
 
 ## Mirror Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -1,26 +1,27 @@
 # Next Actions
 
-Last updated: 2026-04-13
+Last updated: 2026-04-19
 
 This file is a compatibility snapshot. The authoritative action list lives in `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Immediate
 
-1. Keep `ai_first/AI_OPERATING_PROMPT.md` as the single entry point for AI workers.
-2. Review the first task packet for Pod A: Teacher Knowledge Pack MVP.
-3. Review the first task packet for Pod B: Assessment Builder + Student Tutor Workspace MVP.
-4. Start implementation branches from the approved task packets.
+1. Finish PR `#4` for first task packets plus the autonomous AI loop docs.
+2. If PR `#4` is mergeable, non-draft, and not blocked by review, auto-merge it as a docs/task/workflow PR.
+3. After PR `#4` merges, sync from `main`.
+4. Start implementation branches from the approved Pod A and Pod B task packets.
 5. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
 
 ## After Milestone 0
 
 1. Add Teacher Dashboard MVP planning after Pod A ownership is stable.
 2. Keep the main system map updated when shared contracts change.
+3. Keep `ai_first/AI_FIRST_ROADMAP.md` current when the autonomous operating loop changes.
 
 ## Human Review Needed
 
-- Confirm the first two Feature Pod task packets before implementation.
 - Confirm whether Teacher Dashboard should stay in a later Pod A packet or be folded into the same implementation branch.
+- Review product scope changes, credential/deployment decisions, or PRs marked blocked by the AI worker.
 
 ## Mirror Policy
 

--- a/ai_first/USAGE_GUIDE.md
+++ b/ai_first/USAGE_GUIDE.md
@@ -20,6 +20,7 @@ This repository is designed so an AI worker can begin from one entry point and c
 ## How the repo is organized
 
 - `ai_first/AI_OPERATING_PROMPT.md`: the control plane and single entry point.
+- `ai_first/AI_FIRST_ROADMAP.md`: human-facing explanation of the autonomous AI loop and future operating direction.
 - `ai_first/CURRENT_STATE.md`: compact status mirror.
 - `ai_first/NEXT_ACTIONS.md`: compact queue mirror.
 - `ai_first/architecture/`: Mermaid system maps and feature maps.
@@ -35,6 +36,16 @@ This repository is designed so an AI worker can begin from one entry point and c
 3. Update `ai_first/AI_OPERATING_PROMPT.md` if the operating model changed.
 4. Mirror only the minimum status into `CURRENT_STATE.md` and `NEXT_ACTIONS.md` if needed.
 5. Leave handoff notes in the PR and task packet.
+
+## What AI should do after a PR is ready
+
+1. Classify the PR as docs/task/workflow or runtime/product.
+2. For docs/task/workflow PRs, auto-merge only when mergeable, non-draft, and not blocked by review.
+3. For runtime/product PRs, auto-merge only when relevant tests or checks pass and no review blocks the PR.
+4. Treat failing CI, merge conflicts, and blocking reviews as the next task until fixed or explicitly deferred.
+5. After merge, sync from `main`, update status notes if useful, then select the next task from active PR blockers, task packets, `NEXT_ACTIONS.md`, or the long-term MVP goal.
+
+For the readable version of this loop and its future direction, read `ai_first/AI_FIRST_ROADMAP.md`.
 
 ## What not to do
 

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -1,6 +1,6 @@
 # Main System Map
 
-Last updated: 2026-04-13
+Last updated: 2026-04-19
 
 This is the required top-level Mermaid map for the project. Any PR that adds, removes, or materially changes product features, capabilities, tools, routers, routes, data models, or AI-first workflow must update this map.
 
@@ -48,18 +48,30 @@ flowchart TD
 
   Project --> AIFirst["AI-first Operating Layer"]
   AIFirst --> OperatingPrompt["ai_first/AI_OPERATING_PROMPT.md"]
+  AIFirst --> Roadmap["ai_first/AI_FIRST_ROADMAP.md"]
   AIFirst --> CurrentState["ai_first/CURRENT_STATE.md"]
   AIFirst --> NextActions["ai_first/NEXT_ACTIONS.md"]
   AIFirst --> Specs["docs/superpowers/specs"]
   AIFirst --> Plans["docs/superpowers/plans"]
   AIFirst --> Tasks["docs/superpowers/tasks"]
   AIFirst --> Evidence["ai_first/evidence"]
+  AIFirst --> AutoLoop["Autonomous completion loop"]
+  AutoLoop --> MergeGates["Safe merge gates"]
+  AutoLoop --> NextTask["Next task selection"]
 
   Project --> GitHub["GitHub Execution Layer"]
   GitHub --> Issues["Issues"]
   GitHub --> Labels["pod-a / pod-b / blocked / needs-review"]
   GitHub --> PRs["Pull Requests"]
   GitHub --> CI["CI Checks"]
+  GitHub --> Reviews["Review blockers"]
   PRs --> PRNotes["docs/superpowers/pr-notes"]
   PRs --> CI
+  PRs --> Reviews
+  MergeGates --> PRs
+  MergeGates --> CI
+  MergeGates --> Reviews
+  NextTask --> Issues
+  NextTask --> Tasks
+  NextTask --> NextActions
 ```

--- a/ai_first/daily/2026-04-13.md
+++ b/ai_first/daily/2026-04-13.md
@@ -2,28 +2,26 @@
 
 ## Summary
 
-Reduced the AI-first operating model to a single primary entry point: `ai_first/AI_OPERATING_PROMPT.md`. Compatibility snapshots remain for context, but the prompt is now the authoritative control plane for AI workers.
+Milestone 0 is merged into `main`. The next step is execution: create the first Feature Pod task packets so implementation can start from explicit ownership and acceptance criteria.
 
 ## Decisions
 
-- Make `ai_first/AI_OPERATING_PROMPT.md` the single entry point for new AI work.
-- Keep `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md` as compatibility mirrors only.
-- Update the main system map to include the GitHub execution layer explicitly.
+- Keep `ai_first/AI_OPERATING_PROMPT.md` as the single operating entry point.
+- Treat Milestone 0 as complete.
+- Create two initial task packets before feature implementation starts.
 
 ## Work Completed
 
-- Reworked `AGENTS.md` to point AI workers at the single prompt first.
-- Refined `ai_first/AI_OPERATING_PROMPT.md` into a self-directed operating contract.
-- Shortened `CURRENT_STATE.md` and `NEXT_ACTIONS.md` into compatibility snapshots.
-- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` to show the GitHub execution layer.
-- Fixed the PR architecture note to match the updated map decision.
+- Updated the AI-first status files after the merge of PR #1.
+- Created the first Pod A task packet for Teacher Knowledge Pack MVP.
+- Created the first Pod B task packet for Assessment Builder and Student Tutor Workspace MVP.
+- Created GitHub issue `#2` for Pod A and GitHub issue `#3` for Pod B.
 
 ## Tests
 
 - Documentation-only changes. No runtime tests required.
-- Planned validation: inspect Markdown and main map references with `rg`.
 
 ## Next
 
-- Check the updated docs for consistency.
-- Keep future AI work centered on `ai_first/AI_OPERATING_PROMPT.md`.
+- Review the new task packets.
+- Start implementation branches from the approved packets.

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -1,0 +1,53 @@
+# Daily Log: 2026-04-19
+
+## Docs Workflow
+
+- Branch: `docs/first-task-packets`
+- PR: `#4 docs: add first feature pod task packets`
+- Task: Add safe autonomous AI completion loop and human-facing AI-first roadmap.
+- Done:
+  - Added autonomous loop design spec and implementation plan.
+  - Added `ai_first/AI_FIRST_ROADMAP.md` with Mermaid loop diagram.
+  - Updated `ai_first/AI_OPERATING_PROMPT.md` with safe auto-merge and next-task rules.
+  - Updated `ai_first/USAGE_GUIDE.md`, `CURRENT_STATE.md`, and `NEXT_ACTIONS.md` with compact guidance.
+  - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` and PR architecture note.
+- Tests:
+  - Passed: `rg -n "auto-merge|Autonomous|AI_FIRST_ROADMAP|blocking review|task packet" ai_first docs/superpowers`
+  - Passed: `git diff --check`
+  - Passed: `gh issue list --limit 10 --state open`
+  - Passed: `rg -n '#2|#3|GitHub Issue:' ai_first docs/superpowers/tasks`
+  - PR inspection: `gh pr view 4 --json number,title,state,isDraft,mergeable,reviewDecision,statusCheckRollup,headRefName,baseRefName,url`
+  - PR result before push: PR `#4` is open, non-draft, mergeable, and has no checks reported.
+- Blockers:
+  - None known for docs/workflow validation.
+- Next:
+  - Validate docs.
+  - Commit and push scoped docs changes.
+  - Apply the safe docs/workflow merge policy to PR `#4` if eligible.
+
+## Pod A
+
+- Branch: `pod-a/teacher-knowledge-pack-mvp`
+- Task: Not started in this checkout.
+- Done: Task packet exists at `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`.
+- Tests: Not run.
+- Blockers: Wait for PR `#4` task packet workflow to merge.
+- Next: Start from the Pod A task packet after syncing `main`.
+
+## Pod B
+
+- Branch: `pod-b/assessment-student-workspace-mvp`
+- Task: Not started in this checkout.
+- Done: Task packet exists at `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
+- Tests: Not run.
+- Blockers: Wait for PR `#4` task packet workflow to merge.
+- Next: Start from the Pod B task packet after syncing `main`.
+
+## Human Review Needed
+
+- Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.
+- Teacher Dashboard placement remains a product decision: later Pod A packet or folded into a later implementation branch.
+
+## Architecture Map Updates
+
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for `AI_FIRST_ROADMAP.md`, autonomous merge gates, review blockers, and next-task selection.

--- a/docs/superpowers/plans/2026-04-19-autonomous-ai-loop.md
+++ b/docs/superpowers/plans/2026-04-19-autonomous-ai-loop.md
@@ -1,0 +1,201 @@
+# Autonomous AI Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the safe autonomous AI-first loop so AI workers know how to complete, fix, merge, record, and continue work without waiting for manual orchestration.
+
+**Architecture:** This is a documentation and workflow change. `ai_first/AI_OPERATING_PROMPT.md` remains the control plane, `ai_first/AI_FIRST_ROADMAP.md` becomes the human-facing roadmap, compatibility snapshots mirror only compact status, and `ai_first/architecture/MAIN_SYSTEM_MAP.md` records the workflow change.
+
+**Tech Stack:** Markdown, Mermaid, GitHub PR workflow, `gh` CLI for PR inspection, `rg` and `git diff --check` for validation.
+
+---
+
+### Task 1: Add the Roadmap Document
+
+**Files:**
+- Create: `ai_first/AI_FIRST_ROADMAP.md`
+
+- [ ] **Step 1: Create the roadmap document**
+
+Add `ai_first/AI_FIRST_ROADMAP.md` with these sections:
+
+````markdown
+# AI-First Roadmap
+
+Last updated: 2026-04-19
+
+## Purpose
+
+This document explains how the repository should operate when AI is expected to finish work, complete pull requests, merge safely, and continue toward the contest MVP with minimal manual orchestration.
+
+## Long-Term Goal
+
+Build a stable VnExpress Sáng kiến Khoa học 2026 MVP:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+## Autonomous Loop
+
+```mermaid
+flowchart TD
+  Goal["Long-term MVP goal"]
+  Queue["NEXT_ACTIONS.md and task packets"]
+  Branch["Focused branch"]
+  Work["Implement scoped change"]
+  Verify["Run relevant verification"]
+  PR["Open or update PR"]
+  Gate{"Safe to merge?"}
+  Fix["Fix CI, review, or merge blockers"]
+  Merge["Merge PR"]
+  Record["Update daily log, roadmap, and status mirrors"]
+  Next["Select next task"]
+
+  Goal --> Queue --> Branch --> Work --> Verify --> PR --> Gate
+  Gate -- yes --> Merge --> Record --> Next --> Queue
+  Gate -- no --> Fix --> Verify
+```
+
+## Merge Policy
+
+- Docs, task, and workflow PRs may be auto-merged when mergeable, non-draft, and not blocked by review.
+- Runtime and product PRs may be auto-merged only when relevant tests or required checks pass and no review blocks the PR.
+- CI failures and blocking reviews are the next task until fixed.
+- AI must not push directly to `main`.
+
+## How AI Chooses Next Work
+
+1. Fix active PR blockers.
+2. Continue active task packets in `docs/superpowers/tasks/`.
+3. Use the compact queue in `ai_first/NEXT_ACTIONS.md`.
+4. Derive the next short task from the MVP goal only after creating or updating a task packet.
+
+## Human Checkpoints
+
+Human review remains important for product direction, contest story, irreversible scope changes, credential or deployment decisions, and any PR marked as blocked or requiring human judgment.
+
+## Development Direction
+
+### Near Term
+
+- Merge the first task packet workflow PR.
+- Start Pod A and Pod B from their task packets.
+- Keep every PR tied to an architecture note with Mermaid.
+
+### Mid Term
+
+- Add reliable CI checks for backend and frontend changes.
+- Tighten issue labels and PR status conventions for autonomous selection.
+- Keep evidence, demo scripts, and screenshots current for the contest.
+
+### Later
+
+- Consider GitHub Actions or scripts for queue reporting after the manual loop is proven stable.
+- Add stronger automation only after merge gates, CI expectations, and review signals are reliable.
+````
+
+- [ ] **Step 2: Confirm roadmap contains Mermaid**
+
+Run: `rg -n "```mermaid|AI-First Roadmap|Merge Policy" ai_first/AI_FIRST_ROADMAP.md`
+
+Expected: matches for the heading, Mermaid fence, and merge policy section.
+
+### Task 2: Update the Operating Control Plane
+
+**Files:**
+- Modify: `ai_first/AI_OPERATING_PROMPT.md`
+- Modify: `ai_first/USAGE_GUIDE.md`
+
+- [ ] **Step 1: Update `AI_OPERATING_PROMPT.md`**
+
+Add concise autonomous completion rules covering PR classification, merge gates, blocker handling, syncing, recording, and next-task selection.
+
+- [ ] **Step 2: Update `USAGE_GUIDE.md`**
+
+Add a human-friendly section pointing readers to `ai_first/AI_FIRST_ROADMAP.md` and summarizing what AI does after a PR is ready.
+
+- [ ] **Step 3: Validate operating text**
+
+Run: `rg -n "Autonomous|auto-merge|blocking review|AI_FIRST_ROADMAP|Safe merge" ai_first/AI_OPERATING_PROMPT.md ai_first/USAGE_GUIDE.md`
+
+Expected: both files mention the autonomous loop or roadmap.
+
+### Task 3: Update Mirrors, Architecture Map, PR Note, and Daily Log
+
+**Files:**
+- Modify: `ai_first/NEXT_ACTIONS.md`
+- Modify: `ai_first/CURRENT_STATE.md`
+- Modify: `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- Create: `ai_first/daily/2026-04-19.md`
+- Modify: `docs/superpowers/pr-notes/docs-first-task-packets.md`
+
+- [ ] **Step 1: Update compact status mirrors**
+
+Update `NEXT_ACTIONS.md` and `CURRENT_STATE.md` so they mention the autonomous loop, roadmap document, and current PR state without duplicating the full operating contract.
+
+- [ ] **Step 2: Update the main system map**
+
+Add `AI_FIRST_ROADMAP.md`, autonomous merge gates, and next-task selection to the Mermaid map.
+
+- [ ] **Step 3: Update PR architecture note**
+
+Update `docs/superpowers/pr-notes/docs-first-task-packets.md` so PR #4 describes the autonomous loop docs and marks the main system map as updated.
+
+- [ ] **Step 4: Create daily log**
+
+Create `ai_first/daily/2026-04-19.md` with the docs workflow task, validation commands, blockers, and next read path.
+
+### Task 4: Validate, Commit, Push, and Apply Merge Policy
+
+**Files:**
+- Validate all modified docs.
+
+- [ ] **Step 1: Run docs validation**
+
+Run: `rg -n "auto-merge|Autonomous|AI_FIRST_ROADMAP|blocking review|task packet" ai_first docs/superpowers`
+
+Expected: matches in the roadmap, operating prompt, usage guide, status mirrors, spec, plan, and PR note.
+
+- [ ] **Step 2: Run diff validation**
+
+Run: `git diff --check`
+
+Expected: no whitespace errors.
+
+- [ ] **Step 3: Inspect active PR**
+
+Run: `gh pr view 4 --json number,title,state,isDraft,mergeable,reviewDecision,statusCheckRollup,headRefName,baseRefName,url`
+
+Expected: PR #4 is open; merge gate details are visible.
+
+- [ ] **Step 4: Commit only scoped docs changes**
+
+Run:
+
+```bash
+git add ai_first/AI_FIRST_ROADMAP.md \
+  ai_first/AI_OPERATING_PROMPT.md \
+  ai_first/USAGE_GUIDE.md \
+  ai_first/NEXT_ACTIONS.md \
+  ai_first/CURRENT_STATE.md \
+  ai_first/architecture/MAIN_SYSTEM_MAP.md \
+  ai_first/daily/2026-04-19.md \
+  docs/superpowers/pr-notes/docs-first-task-packets.md \
+  docs/superpowers/plans/2026-04-19-autonomous-ai-loop.md
+git commit -m "docs: add autonomous AI loop"
+```
+
+Expected: unrelated dirty files remain unstaged.
+
+- [ ] **Step 5: Push branch**
+
+Run: `git push origin docs/first-task-packets`
+
+Expected: PR #4 updates with the new docs commits.
+
+- [ ] **Step 6: Apply safe merge policy if eligible**
+
+If PR #4 is mergeable, non-draft, and has no blocking review, merge it because this is a docs/task/workflow PR.
+
+Run: `gh pr merge 4 --squash --delete-branch`
+
+Expected: PR #4 merges into `main`. If GitHub rejects the merge, record the reason and leave the PR open.

--- a/docs/superpowers/pr-notes/docs-first-task-packets.md
+++ b/docs/superpowers/pr-notes/docs-first-task-packets.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Adds the first execution task packets for Pod A and Pod B, updates the AI-first status mirrors after Milestone 0 merged, and links the task packets to GitHub issues `#2` and `#3`.
+Adds the first execution task packets for Pod A and Pod B, updates the AI-first status mirrors after Milestone 0 merged, links the task packets to GitHub issues `#2` and `#3`, and documents the safe autonomous AI completion loop.
 
 ## Scope
 
@@ -13,20 +13,25 @@ Documentation and workflow only. No backend or frontend runtime behavior changes
 ```mermaid
 flowchart TD
   Prompt["ai_first/AI_OPERATING_PROMPT.md"]
+  Roadmap["ai_first/AI_FIRST_ROADMAP.md"]
   Prompt --> State["ai_first/CURRENT_STATE.md"]
   Prompt --> Actions["ai_first/NEXT_ACTIONS.md"]
+  Prompt --> Roadmap
   Prompt --> PodA["Task Packet: Pod A"]
   Prompt --> PodB["Task Packet: Pod B"]
   PodA --> Issue2["GitHub Issue #2"]
   PodB --> Issue3["GitHub Issue #3"]
   PodA --> PRA["Future Pod A PR"]
   PodB --> PRB["Future Pod B PR"]
-```
+  Roadmap --> Loop["Autonomous completion loop"]
+  Loop --> Gates["Safe merge gates"]
+  Loop --> Next["Next task selection"]
+  Gates --> PR4["PR #4"]
 ```
 
 ## Architecture Impact
 
-Moves the repository from general AI-first operating rules into concrete execution packets. The operating layer now has explicit Pod A and Pod B work definitions tied to GitHub issues.
+Moves the repository from general AI-first operating rules into concrete execution packets. The operating layer now has explicit Pod A and Pod B work definitions tied to GitHub issues, plus a safe autonomous completion loop for PR merge decisions and next-task selection.
 
 ## Data/API Changes
 
@@ -39,9 +44,12 @@ Documentation-only verification:
 ```bash
 gh issue list --limit 10 --state open
 rg -n '#2|#3|GitHub Issue:' ai_first docs/superpowers/tasks
+rg -n "auto-merge|Autonomous|AI_FIRST_ROADMAP|blocking review|task packet" ai_first docs/superpowers
+git diff --check
+gh pr view 4 --json number,title,state,isDraft,mergeable,reviewDecision,statusCheckRollup,headRefName,baseRefName,url
 ```
 
 ## Main System Map Update
 
 - [ ] Not needed, because: this PR only creates task packets and status mirrors; it does not change the system structure itself.
-- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

--- a/docs/superpowers/pr-notes/docs-first-task-packets.md
+++ b/docs/superpowers/pr-notes/docs-first-task-packets.md
@@ -1,0 +1,47 @@
+# PR Architecture Note: First Feature Pod Task Packets
+
+## Summary
+
+Adds the first execution task packets for Pod A and Pod B, updates the AI-first status mirrors after Milestone 0 merged, and links the task packets to GitHub issues `#2` and `#3`.
+
+## Scope
+
+Documentation and workflow only. No backend or frontend runtime behavior changes.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  Prompt["ai_first/AI_OPERATING_PROMPT.md"]
+  Prompt --> State["ai_first/CURRENT_STATE.md"]
+  Prompt --> Actions["ai_first/NEXT_ACTIONS.md"]
+  Prompt --> PodA["Task Packet: Pod A"]
+  Prompt --> PodB["Task Packet: Pod B"]
+  PodA --> Issue2["GitHub Issue #2"]
+  PodB --> Issue3["GitHub Issue #3"]
+  PodA --> PRA["Future Pod A PR"]
+  PodB --> PRB["Future Pod B PR"]
+```
+```
+
+## Architecture Impact
+
+Moves the repository from general AI-first operating rules into concrete execution packets. The operating layer now has explicit Pod A and Pod B work definitions tied to GitHub issues.
+
+## Data/API Changes
+
+No runtime data model or API changes. This PR only defines planned contracts for future implementation work.
+
+## Tests
+
+Documentation-only verification:
+
+```bash
+gh issue list --limit 10 --state open
+rg -n '#2|#3|GitHub Issue:' ai_first docs/superpowers/tasks
+```
+
+## Main System Map Update
+
+- [ ] Not needed, because: this PR only creates task packets and status mirrors; it does not change the system structure itself.
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

--- a/docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md
+++ b/docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md
@@ -1,0 +1,135 @@
+# Autonomous AI Loop Design
+
+Date: 2026-04-18  
+Repository: `Creative-Science-Contest-2026/Multiagent-learning-platform`  
+Design status: Approved by project owner in brainstorming session
+
+## 1. Purpose
+
+The AI-first operating layer should not stop after a worker finishes code or opens a pull request. It should know how to complete the current PR safely, merge it when allowed, sync the repository, select the next useful task, and continue toward the long-term contest MVP.
+
+The human role should be product direction and result review. A human should be able to check progress after time away and see:
+
+- what PRs were merged;
+- what CI or review blockers were fixed;
+- what task is currently active;
+- what AI plans to do next;
+- how the AI-first operating model is evolving.
+
+## 2. Selected Merge Policy
+
+The approved policy is the safe autonomous policy:
+
+- AI may auto-merge docs, task, and workflow PRs when the PR is mergeable, non-draft, and has no blocking review or unresolved required discussion.
+- AI may auto-merge runtime or product PRs only when relevant tests or required checks pass and there is no blocking review.
+- If CI fails, AI must stop feature progression, diagnose and fix CI on the same PR, then re-check.
+- If a review blocks the PR, AI must address the review before merging or continuing.
+- AI must not push directly to `main`.
+
+## 3. Autonomous Execution Loop
+
+Every AI worker should treat pull request completion as part of the task, not as a separate human-only step.
+
+```mermaid
+flowchart TD
+  Start["Start from AI_OPERATING_PROMPT.md"]
+  Scope["Confirm task packet, branch, owned files"]
+  Work["Implement docs, workflow, or product change"]
+  Verify["Run relevant verification"]
+  PR["Open or update PR with architecture note"]
+  Classify{"PR type?"}
+  Docs["Docs / task / workflow"]
+  Runtime["Runtime / product"]
+  DocsGate{"Mergeable, non-draft,\nno blocking review?"}
+  RuntimeGate{"Tests/checks pass,\nmergeable, non-draft,\nno blocking review?"}
+  FixCI["Fix CI or review blocker"]
+  Merge["Merge PR"]
+  Sync["Sync main and update local branch base"]
+  Record["Update daily log and status mirrors"]
+  Queue["Select next task from NEXT_ACTIONS or task packets"]
+  Packet{"Task packet exists?"}
+  CreatePacket["Create or update task packet before implementation"]
+  Next["Start next focused branch"]
+
+  Start --> Scope --> Work --> Verify --> PR --> Classify
+  Classify --> Docs --> DocsGate
+  Classify --> Runtime --> RuntimeGate
+  DocsGate -- yes --> Merge
+  RuntimeGate -- yes --> Merge
+  DocsGate -- no --> FixCI
+  RuntimeGate -- no --> FixCI
+  FixCI --> Verify
+  Merge --> Sync --> Record --> Queue --> Packet
+  Packet -- yes --> Next
+  Packet -- no --> CreatePacket --> Next
+```
+
+## 4. Next Work Source
+
+The AI should pick work from this order:
+
+1. Active PR blockers: failing CI, requested changes, merge conflicts, or stale branch state.
+2. Active task packets in `docs/superpowers/tasks/`.
+3. The compact queue in `ai_first/NEXT_ACTIONS.md`.
+4. The long-term MVP goal in `ai_first/AI_OPERATING_PROMPT.md`.
+
+If no task packet exists for the next product change, AI should create a task packet first. It should not jump straight into runtime implementation from a vague long-term goal.
+
+## 5. AI-First Roadmap Document
+
+After the current task packet and PR workflow work is complete, the repository should include a dedicated Markdown document that explains the AI-first operating model and its future direction.
+
+Recommended path:
+
+```text
+ai_first/AI_FIRST_ROADMAP.md
+```
+
+The document should include:
+
+- the long-term project goal;
+- how AI chooses the next task;
+- how AI completes, fixes, merges, and records PR work;
+- what still requires human judgment;
+- near-term, mid-term, and later AI-first operating improvements;
+- at least one Mermaid diagram explaining the loop.
+
+This document is human-facing. It should be easy to read in the morning or while away from the machine, without requiring the reader to inspect every task packet or PR.
+
+## 6. Files to Update During Implementation
+
+Owned files for the implementation:
+
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/USAGE_GUIDE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/CURRENT_STATE.md`, only if the compact status mirror changes
+- `ai_first/AI_FIRST_ROADMAP.md`
+- `ai_first/daily/2026-04-18.md`
+- `docs/superpowers/pr-notes/<branch-or-pr>.md`
+
+Do-not-touch files:
+
+- backend runtime code;
+- frontend runtime code;
+- package lockfiles;
+- unrelated dirty files already present in the worktree.
+
+## 7. Validation
+
+This is a docs and workflow change. Validation should include:
+
+```bash
+rg -n "auto-merge|Autonomous|AI_FIRST_ROADMAP|blocking review|task packet" ai_first docs/superpowers
+git diff --check
+```
+
+If GitHub state is part of the implementation, also inspect the active PR:
+
+```bash
+gh pr view 4 --json number,title,state,isDraft,mergeable,reviewDecision,statusCheckRollup,headRefName,baseRefName,url
+```
+
+## 8. Out of Scope
+
+This design does not add GitHub Actions automation, background daemons, scheduler scripts, or unattended credential handling. Those may be added later after the documentation-only operating loop proves stable.

--- a/docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md
+++ b/docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md
@@ -1,0 +1,76 @@
+# Feature Pod Task: Assessment Builder and Student Tutor Workspace MVP
+
+Owner: Pod B AI worker
+Branch: `pod-b/assessment-student-workspace-mvp`
+GitHub Issue: `#3`
+
+## Goal
+
+Add the first teacher-facing assessment builder and student-facing tutor workspace flow grounded in a selected Knowledge Pack.
+
+## User-visible outcome
+
+Teachers can generate exercises from a selected Knowledge Pack with Vietnamese-friendly controls for topic, subject, count, difficulty, and question type. Students can learn in the chat workspace with the selected Knowledge Pack attached to the tutoring context.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/question.py`
+- `deeptutor/api/routers/unified_ws.py`
+- `deeptutor/capabilities/deep_question.py`
+- `deeptutor/capabilities/chat.py`
+- `web/app/(workspace)/page.tsx`
+- `web/components/quiz/`
+- `web/components/chat/`
+- `web/lib/unified-ws.ts`
+- `web/lib/quiz-types.ts`
+- `tests/api/test_question_router.py`
+- `tests/api/test_unified_ws_turn_runtime.py`
+
+## Do-not-touch files/modules
+
+- `deeptutor/api/routers/knowledge.py`
+- `deeptutor/services/rag/`
+- `deeptutor/knowledge/`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/lib/knowledge-api.ts`
+- `tests/api/test_knowledge_router.py`
+- `tests/knowledge/`
+
+## API/data contract
+
+- Question generation requests must accept Knowledge Pack context plus `topic`, `subject`, `count`, `difficulty`, and `question_type`.
+- Question generation responses must include answer content, explanations, and common mistakes when available.
+- Student tutor requests must pass the selected Knowledge Pack identifier into the chat context without breaking existing session persistence.
+- Shared field names with Pod A must stay stable once agreed.
+
+## Acceptance criteria
+
+- The assessment UI lets a teacher choose a Knowledge Pack and generate questions with the required controls.
+- Generated output shows answers and explanations, with common mistakes when available.
+- The student workspace can select a Knowledge Pack and use it during tutoring.
+- Existing SQLite-backed session persistence still works.
+
+## Required tests
+
+- `pytest tests/api/test_question_router.py -v`
+- `pytest tests/api/test_unified_ws_turn_runtime.py -v`
+- `python3 -m compileall deeptutor`
+- `cd web && npm run build`
+
+## Manual verification
+
+- Start the backend and frontend.
+- Generate an assessment from a selected Knowledge Pack.
+- Confirm answer and explanation output renders in the UI.
+- Open the student workspace, select the same Knowledge Pack, and ask a grounded question.
+- Confirm the session persists across refresh or reload.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+
+## Handoff notes
+
+- Do not invent or rename Knowledge Pack metadata fields owned by Pod A without coordination.
+- If a shared request/response contract needs to move into a common type module, isolate that contract change before broad frontend edits.

--- a/docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md
+++ b/docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md
@@ -1,0 +1,73 @@
+# Feature Pod Task: Teacher Knowledge Pack MVP
+
+Owner: Pod A AI worker
+Branch: `pod-a/teacher-knowledge-pack-mvp`
+GitHub Issue: `#2`
+
+## Goal
+
+Add the first teacher-owned Knowledge Pack workflow on top of the existing knowledge base flow so a teacher can create, edit, and view pack metadata needed for the contest demo.
+
+## User-visible outcome
+
+Teachers can open the Knowledge area, set or edit pack metadata such as subject, grade, curriculum, learning objectives, owner, and sharing status, then retrieve that metadata through the API and UI.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/knowledge.py`
+- `deeptutor/services/rag/`
+- `deeptutor/knowledge/`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/lib/knowledge-api.ts`
+- `tests/api/test_knowledge_router.py`
+- `tests/knowledge/`
+
+## Do-not-touch files/modules
+
+- `deeptutor/api/routers/question.py`
+- `deeptutor/api/routers/unified_ws.py`
+- `deeptutor/capabilities/deep_question.py`
+- `deeptutor/capabilities/chat.py`
+- `web/app/(workspace)/page.tsx`
+- `web/components/quiz/`
+- `web/lib/unified-ws.ts`
+- `tests/api/test_question_router.py`
+- `tests/api/test_unified_ws_turn_runtime.py`
+
+## API/data contract
+
+- Extend knowledge-pack storage with metadata fields: `subject`, `grade`, `curriculum`, `learning_objectives`, `owner`, and `sharing_status`.
+- Keep existing knowledge base identifiers stable.
+- Add minimal read/write API support in the knowledge router without breaking current upload and list behavior.
+- Return metadata in a shape that frontend code can consume without guessing field names.
+
+## Acceptance criteria
+
+- A teacher can create or update Knowledge Pack metadata from the Knowledge UI.
+- The backend persists and returns the metadata through the knowledge API.
+- Existing knowledge upload/list behavior continues to work.
+- Metadata names are documented in the implementation PR and remain consistent across API and UI.
+
+## Required tests
+
+- `pytest tests/api/test_knowledge_router.py -v`
+- `pytest tests/knowledge -v`
+- `python3 -m compileall deeptutor`
+
+## Manual verification
+
+- Start the backend and frontend.
+- Open the Knowledge page.
+- Create or edit a Knowledge Pack with the required metadata.
+- Reload the page and confirm the metadata still appears.
+- Confirm existing knowledge listing still works.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+
+## Handoff notes
+
+- If this task introduces shared API types used by Pod B, isolate that contract in a small follow-up PR or coordinate before Pod B changes the same fields.
+- Keep Teacher Dashboard work out of this packet unless the task packet is explicitly expanded.


### PR DESCRIPTION
## Summary
- add the first Pod A and Pod B task packets under `docs/superpowers/tasks/`
- update AI-first status mirrors after Milestone 0 merged and link execution to GitHub issues `#2` and `#3`
- add PR architecture note `docs/superpowers/pr-notes/docs-first-task-packets.md`

## User-visible changes
- AI workers now have explicit task packets for Teacher Knowledge Pack MVP and Assessment Builder plus Student Tutor Workspace MVP
- GitHub issues `#2` and `#3` are now part of the execution record

## Files/modules touched
- `ai_first/AI_OPERATING_PROMPT.md`
- `ai_first/CURRENT_STATE.md`
- `ai_first/NEXT_ACTIONS.md`
- `ai_first/daily/2026-04-13.md`
- `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`
- `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`
- `docs/superpowers/pr-notes/docs-first-task-packets.md`

## Tests run
- `gh issue list --limit 10 --state open`
- `rg -n '#2|#3|GitHub Issue:' ai_first docs/superpowers/tasks`

## PR architecture note
- `docs/superpowers/pr-notes/docs-first-task-packets.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because this PR adds execution packets, not system structure changes

## Risk and rollback notes
- docs-only change
- rollback is a simple revert of this commit

## AI handoff notes
- Refs #2
- Refs #3
- next implementation branch should start from either `pod-a/teacher-knowledge-pack-mvp` or `pod-b/assessment-student-workspace-mvp`
