### PR TITLE
docs: update queue after pr4 merge

### DIFF
--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,10 +28,10 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/first-task-packets`
+- Current branch for this docs update: `docs/post-pr4-next-actions`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
-- Current PR: `#4 docs: add first feature pod task packets`
-- Current purpose: create the first execution task packets for Pod A and Pod B, then add safe autonomous PR completion rules.
+- PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
+- Current purpose: update the queue after PR `#4`, then continue with Pod A before Pod B.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -65,6 +65,10 @@ Do not revert unrelated changes.
 - Pod B GitHub issue: `#3`
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
+
+## Current Next Task
+
+Audit the existing `pod-a/teacher-knowledge-pack-mvp` worktree before continuing implementation. It contains uncommitted changes in both Pod A-owned files and Pod B-owned/do-not-touch files, so the next AI worker must separate scope before committing or editing.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,17 +6,19 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Finish PR `#4` for first task packets plus the autonomous AI loop docs.
-2. If PR `#4` is mergeable, non-draft, and not blocked by review, auto-merge it as a docs/task/workflow PR.
-3. After PR `#4` merges, sync from `main`.
-4. Start implementation branches from the approved Pod A and Pod B task packets.
-5. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
+1. Audit the existing `pod-a/teacher-knowledge-pack-mvp` worktree before continuing implementation because it contains uncommitted cross-scope changes.
+2. Complete Pod A: Teacher Knowledge Pack MVP from `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`.
+3. Open a Pod A PR linked to GitHub issue `#2` with a PR architecture note and Mermaid diagram.
+4. Fix any Pod A CI, test, or review blockers before starting the next feature.
+5. After Pod A merges, start Pod B: Assessment Builder and Student Tutor Workspace MVP from `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
+6. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
 
 ## After Milestone 0
 
 1. Add Teacher Dashboard MVP planning after Pod A ownership is stable.
 2. Keep the main system map updated when shared contracts change.
 3. Keep `ai_first/AI_FIRST_ROADMAP.md` current when the autonomous operating loop changes.
+4. Add reliable backend and frontend CI checks before allowing broader runtime auto-merge.
 
 ## Human Review Needed
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -21,9 +21,9 @@
 - Blockers:
   - None known for docs/workflow validation.
 - Next:
-  - Validate docs.
-  - Commit and push scoped docs changes.
-  - Apply the safe docs/workflow merge policy to PR `#4` if eligible.
+  - PR `#4` merged into `main`.
+  - Update queue after PR `#4`.
+  - Audit the existing Pod A worktree before continuing implementation.
 
 ## Pod A
 
@@ -31,8 +31,8 @@
 - Task: Not started in this checkout.
 - Done: Task packet exists at `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`.
 - Tests: Not run.
-- Blockers: Wait for PR `#4` task packet workflow to merge.
-- Next: Start from the Pod A task packet after syncing `main`.
+- Blockers: Existing Pod A worktree contains uncommitted cross-scope changes and must be audited before implementation continues.
+- Next: Separate Pod A-owned changes from Pod B-owned/do-not-touch changes, then finish Knowledge Pack MVP.
 
 ## Pod B
 
@@ -40,8 +40,8 @@
 - Task: Not started in this checkout.
 - Done: Task packet exists at `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
 - Tests: Not run.
-- Blockers: Wait for PR `#4` task packet workflow to merge.
-- Next: Start from the Pod B task packet after syncing `main`.
+- Blockers: Wait for Pod A Knowledge Pack metadata contract to stabilize.
+- Next: Start from the Pod B task packet after Pod A merges.
 
 ## Human Review Needed
 


### PR DESCRIPTION
## Summary
- mark PR #4 as merged in the AI-first state mirrors
- set the next autonomous task to audit the existing Pod A worktree
- clarify that Pod A should finish before Pod B starts

## Scope
Docs/workflow only. No runtime or frontend behavior changes.

## Validation
- `rg -n "PR #4|pod-a/teacher-knowledge-pack-mvp|Pod A|Pod B|cross-scope|auto-merge" ai_first/NEXT_ACTIONS.md ai_first/CURRENT_STATE.md ai_first/daily/2026-04-19.md`
- `git diff --check`

## Handoff
Next AI task is to audit `.worktrees/pod-a-teacher-knowledge-pack-mvp` for cross-scope changes before continuing Pod A implementation.
