### PR TITLE
feat: add teacher knowledge pack metadata

### DIFF
--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -68,7 +68,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Audit the existing `pod-a/teacher-knowledge-pack-mvp` worktree before continuing implementation. It contains uncommitted changes in both Pod A-owned files and Pod B-owned/do-not-touch files, so the next AI worker must separate scope before committing or editing.
+Pod A Teacher Knowledge Pack MVP is in progress on `pod-a/teacher-knowledge-pack-mvp-clean`. The clean branch contains only Pod A-owned changes copied from the dirty worktree plus the required architecture note and main system map update. The original dirty worktree still exists and should be preserved because it contains uncommitted Pod B and unrelated changes.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,12 +6,11 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Audit the existing `pod-a/teacher-knowledge-pack-mvp` worktree before continuing implementation because it contains uncommitted cross-scope changes.
-2. Complete Pod A: Teacher Knowledge Pack MVP from `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`.
-3. Open a Pod A PR linked to GitHub issue `#2` with a PR architecture note and Mermaid diagram.
-4. Fix any Pod A CI, test, or review blockers before starting the next feature.
-5. After Pod A merges, start Pod B: Assessment Builder and Student Tutor Workspace MVP from `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
-6. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
+1. Finish and publish Pod A: Teacher Knowledge Pack MVP from `pod-a/teacher-knowledge-pack-mvp-clean`.
+2. Fix any Pod A CI, test, or review blockers before starting the next feature.
+3. After Pod A merges, start Pod B: Assessment Builder and Student Tutor Workspace MVP from `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
+4. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
+5. Preserve the original dirty `pod-a/teacher-knowledge-pack-mvp` worktree until its Pod B/unrelated changes are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -35,6 +35,7 @@ flowchart TD
   Project --> Product["Contest MVP Product Layer"]
   Product --> TeacherWorkspace["Teacher Workspace"]
   Product --> KnowledgePack["Knowledge Pack"]
+  KnowledgePack --> KPMetaFlow["Metadata Create/Edit/Update Flow"]
   Product --> AssessmentBuilder["Assessment Builder"]
   Product --> StudentTutor["Student Tutor Workspace"]
   Product --> TeacherDashboard["Teacher Dashboard"]

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -27,12 +27,23 @@
 
 ## Pod A
 
-- Branch: `pod-a/teacher-knowledge-pack-mvp`
-- Task: Not started in this checkout.
-- Done: Task packet exists at `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`.
-- Tests: Not run.
-- Blockers: Existing Pod A worktree contains uncommitted cross-scope changes and must be audited before implementation continues.
-- Next: Separate Pod A-owned changes from Pod B-owned/do-not-touch changes, then finish Knowledge Pack MVP.
+- Branch: `pod-a/teacher-knowledge-pack-mvp-clean`
+- Task: Teacher Knowledge Pack MVP.
+- Done:
+  - Audited existing dirty `pod-a/teacher-knowledge-pack-mvp` worktree.
+  - Copied only Pod A-owned Knowledge Pack metadata changes onto a clean branch from current `main`.
+  - Added Knowledge Pack metadata create/edit/update flow to the Knowledge page.
+  - Added backend metadata normalization, validation, and response exposure.
+  - Added Pod A PR architecture note with Mermaid.
+  - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`.
+- Tests:
+  - Passed: `pytest tests/api/test_knowledge_router.py -v` (11 passed)
+  - Passed: `pytest tests/knowledge -v` (3 passed)
+  - Passed: `python3 -m compileall deeptutor`
+  - Passed: `cd web && npm run build`
+- Blockers:
+  - Original dirty `pod-a/teacher-knowledge-pack-mvp` worktree still contains Pod B/unrelated changes and should be preserved until handled intentionally.
+- Next: Commit, push, open PR for Pod A, then fix CI/review if needed.
 
 ## Pod B
 

--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -50,6 +50,7 @@ router = APIRouter()
 # Constants for byte conversions
 BYTES_PER_GB = 1024**3
 BYTES_PER_MB = 1024**2
+ALLOWED_SHARING_STATUSES = {"private", "team", "public"}
 
 
 def format_bytes_human_readable(size_bytes: int) -> str:
@@ -82,6 +83,7 @@ class KnowledgeBaseInfo(BaseModel):
     statistics: dict
     status: str | None = None
     progress: dict | None = None
+    metadata: dict | None = None
 
 
 class LinkFolderRequest(BaseModel):
@@ -188,6 +190,66 @@ def _validate_registered_provider(raw_provider: str | None) -> str:
         )
 
     return normalize_provider_name(candidate)
+
+
+def _normalize_teacher_pack_config(config: dict) -> dict:
+    normalized = dict(config)
+
+    text_fields = ("subject", "grade", "curriculum", "owner")
+    for field in text_fields:
+        if field not in normalized:
+            continue
+        value = normalized[field]
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise HTTPException(status_code=400, detail=f"'{field}' must be a string")
+        value = value.strip()
+        normalized[field] = value or None
+
+    if "learning_objectives" in normalized:
+        objectives = normalized["learning_objectives"]
+        if objectives is None:
+            pass
+        elif isinstance(objectives, str):
+            cleaned = [item.strip() for item in objectives.splitlines() if item.strip()]
+            normalized["learning_objectives"] = cleaned or None
+        elif isinstance(objectives, list):
+            if not all(isinstance(item, str) for item in objectives):
+                raise HTTPException(
+                    status_code=400,
+                    detail="'learning_objectives' must be a list of strings",
+                )
+            cleaned = [item.strip() for item in objectives if item.strip()]
+            normalized["learning_objectives"] = cleaned or None
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail="'learning_objectives' must be a string or list of strings",
+            )
+
+    if "sharing_status" in normalized:
+        raw_status = normalized["sharing_status"]
+        if raw_status is None:
+            pass
+        elif not isinstance(raw_status, str):
+            raise HTTPException(status_code=400, detail="'sharing_status' must be a string")
+        else:
+            sharing_status = raw_status.strip().lower()
+            if not sharing_status:
+                normalized["sharing_status"] = None
+            elif sharing_status not in ALLOWED_SHARING_STATUSES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "'sharing_status' must be one of "
+                        f"{sorted(ALLOWED_SHARING_STATUSES)}"
+                    ),
+                )
+            else:
+                normalized["sharing_status"] = sharing_status
+
+    return normalized
 
 
 def _load_kb_entry_or_404(manager: KnowledgeBaseManager, kb_name: str) -> dict:
@@ -455,11 +517,15 @@ async def update_kb_config(kb_name: str, config: dict):
     try:
         from deeptutor.services.config import get_kb_config_service
 
-        if "rag_provider" in config:
-            config["rag_provider"] = _validate_registered_provider(config.get("rag_provider"))
+        normalized_config = _normalize_teacher_pack_config(config)
+
+        if "rag_provider" in normalized_config:
+            normalized_config["rag_provider"] = _validate_registered_provider(
+                normalized_config.get("rag_provider")
+            )
 
         service = get_kb_config_service()
-        service.set_kb_config(kb_name, config)
+        service.set_kb_config(kb_name, normalized_config)
         return {"status": "success", "kb_name": kb_name, "config": service.get_kb_config(kb_name)}
     except HTTPException:
         raise
@@ -540,6 +606,7 @@ async def list_knowledge_bases():
                         statistics=info.get("statistics", {}),
                         status=info.get("status"),
                         progress=info.get("progress"),
+                        metadata=info.get("metadata"),
                     )
                 )
             except Exception as e:
@@ -562,6 +629,7 @@ async def list_knowledge_bases():
                                 },
                                 status="unknown",
                                 progress=None,
+                                metadata=None,
                             )
                         )
                 except Exception as fallback_err:

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -21,6 +21,32 @@ from deeptutor.services.rag.factory import DEFAULT_PROVIDER, LEGACY_PROVIDER_ALI
 
 logger = get_logger("KnowledgeBaseManager")
 
+PACK_METADATA_FIELDS = (
+    "subject",
+    "grade",
+    "curriculum",
+    "learning_objectives",
+    "owner",
+    "sharing_status",
+)
+
+
+def _normalize_teacher_pack_field(field: str, value):
+    if value is None:
+        return None
+
+    if field == "learning_objectives":
+        if isinstance(value, list):
+            cleaned = [item.strip() for item in value if isinstance(item, str) and item.strip()]
+            return cleaned or None
+        return None
+
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized or None
+
+    return None
+
 
 # Cross-platform file locking
 @contextmanager
@@ -441,6 +467,11 @@ class KnowledgeBaseManager:
                 "created_at": kb_config.get("created_at"),
                 "last_updated": kb_config.get("updated_at"),
             }
+            for field in PACK_METADATA_FIELDS:
+                if field in kb_config:
+                    normalized = _normalize_teacher_pack_field(field, kb_config[field])
+                    if normalized is not None:
+                        metadata[field] = normalized
             # Remove None values
             metadata = {k: v for k, v in metadata.items() if v is not None}
             return metadata
@@ -502,6 +533,11 @@ class KnowledgeBaseManager:
             "rag_provider": rag_provider,
             "needs_reindex": needs_reindex,
         }
+        for field in PACK_METADATA_FIELDS:
+            if field in kb_config:
+                normalized = _normalize_teacher_pack_field(field, kb_config[field])
+                if normalized is not None:
+                    metadata[field] = normalized
         if created_at:
             metadata["created_at"] = created_at
         if updated_at:

--- a/docs/superpowers/pr-notes/pod-a-teacher-knowledge-pack-mvp.md
+++ b/docs/superpowers/pr-notes/pod-a-teacher-knowledge-pack-mvp.md
@@ -1,0 +1,69 @@
+# PR Architecture Note: Pod A Teacher Knowledge Pack MVP
+
+## Summary
+
+Adds the first teacher-owned Knowledge Pack metadata workflow. Teachers can create, edit, view, and persist pack metadata for subject, grade, curriculum, learning objectives, owner, and sharing status.
+
+## Scope
+
+Pod A-owned backend, frontend, and tests only:
+
+- Knowledge API metadata validation and response exposure.
+- Knowledge manager metadata normalization.
+- Knowledge page create/edit metadata UI.
+- Knowledge API client metadata types and update helper.
+- Pod A tests for metadata persistence, validation, listing, and normalization.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Teacher["Teacher"]
+  KnowledgeUI["Knowledge Page"]
+  KnowledgeAPI["web/lib/knowledge-api.ts"]
+  Router["Knowledge Router"]
+  Normalize["Normalize + Validate Metadata"]
+  Config["KB Config Service"]
+  Manager["KnowledgeBaseManager"]
+  Responses["KB Detail/List Responses"]
+
+  Teacher --> KnowledgeUI
+  KnowledgeUI --> KnowledgeAPI
+  KnowledgeAPI -->|PUT /api/v1/knowledge/{kb}/config| Router
+  Router --> Normalize
+  Normalize --> Config
+  Config --> Manager
+  Manager --> Responses
+  Responses --> KnowledgeUI
+```
+
+## Architecture Impact
+
+The Knowledge Pack product layer now has a concrete metadata create/edit/update flow. This changes the AI-first main system map by adding the Knowledge Pack metadata flow node.
+
+## Data/API Changes
+
+Knowledge Pack metadata fields are:
+
+- `subject`
+- `grade`
+- `curriculum`
+- `learning_objectives`
+- `owner`
+- `sharing_status`
+
+The knowledge config endpoint accepts those fields, trims string values, normalizes learning objectives, validates sharing status as `private`, `team`, or `public`, and exposes metadata in KB detail/list responses.
+
+## Tests
+
+```bash
+pytest tests/api/test_knowledge_router.py -v
+pytest tests/knowledge -v
+python3 -m compileall deeptutor
+cd web && npm run build
+```
+
+## Main System Map Update
+
+- [ ] Not needed, because:
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -14,19 +15,35 @@ except Exception:  # pragma: no cover - optional dependency in lightweight envs
 
 pytestmark = pytest.mark.skipif(FastAPI is None or TestClient is None, reason="fastapi not installed")
 
-if FastAPI is not None and TestClient is not None:
-    knowledge_router_module = importlib.import_module("deeptutor.api.routers.knowledge")
-    router = knowledge_router_module.router
-else:  # pragma: no cover - optional dependency in lightweight envs
-    knowledge_router_module = None
-    router = None
+knowledge_router_module = None
+router = None
 
 
-def _build_app() -> FastAPI:
-    if FastAPI is None or router is None:  # pragma: no cover - guarded by pytestmark
+def _import_knowledge_router(monkeypatch, tmp_path: Path):
+    if FastAPI is None or TestClient is None:  # pragma: no cover - guarded by pytestmark
+        raise RuntimeError("fastapi is not installed")
+
+    config_module = importlib.import_module("deeptutor.services.config")
+    fake_settings_dir = tmp_path / "data" / "user" / "settings"
+    fake_settings_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(config_module, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        config_module,
+        "load_config_with_main",
+        lambda *_args, **_kwargs: {"paths": {"user_log_dir": str(tmp_path / "logs")}},
+    )
+
+    sys.modules.pop("deeptutor.api.routers.knowledge", None)
+    module = importlib.import_module("deeptutor.api.routers.knowledge")
+    return module
+
+
+def _build_app(knowledge_module) -> FastAPI:
+    if FastAPI is None or knowledge_module is None:  # pragma: no cover - guarded by pytestmark
         raise RuntimeError("fastapi is not installed")
     app = FastAPI()
-    app.include_router(router, prefix="/api/v1/knowledge")
+    app.include_router(knowledge_module.router, prefix="/api/v1/knowledge")
     return app
 
 
@@ -77,7 +94,10 @@ def _upload_payload() -> list[tuple[str, tuple[str, bytes, str]]]:
 
 
 def test_rag_providers_returns_llamaindex_only() -> None:
-    with TestClient(_build_app()) as client:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        knowledge_module = _import_knowledge_router(monkeypatch, Path.cwd())
+
+    with TestClient(_build_app(knowledge_module)) as client:
         response = client.get("/api/v1/knowledge/rag-providers")
 
     assert response.status_code == 200
@@ -94,18 +114,19 @@ def test_rag_providers_returns_llamaindex_only() -> None:
 
 
 def test_create_kb_does_not_require_llm_precheck(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
     manager = _FakeKBManager(tmp_path / "knowledge_bases")
-    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
-    monkeypatch.setattr(knowledge_router_module, "KnowledgeBaseInitializer", _FakeInitializer)
-    monkeypatch.setattr(knowledge_router_module, "get_llm_config", lambda: (_ for _ in ()).throw(RuntimeError("should not be called")), raising=False)
+    monkeypatch.setattr(knowledge_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(knowledge_module, "KnowledgeBaseInitializer", _FakeInitializer)
+    monkeypatch.setattr(knowledge_module, "get_llm_config", lambda: (_ for _ in ()).throw(RuntimeError("should not be called")), raising=False)
 
     async def _noop_init_task(*_args, **_kwargs):
         return None
 
-    monkeypatch.setattr(knowledge_router_module, "run_initialization_task", _noop_init_task)
-    monkeypatch.setattr(knowledge_router_module, "_kb_base_dir", tmp_path / "knowledge_bases")
+    monkeypatch.setattr(knowledge_module, "run_initialization_task", _noop_init_task)
+    monkeypatch.setattr(knowledge_module, "_kb_base_dir", tmp_path / "knowledge_bases")
 
-    with TestClient(_build_app()) as client:
+    with TestClient(_build_app(knowledge_module)) as client:
         response = client.post(
             "/api/v1/knowledge/create",
             data={"name": "kb-new", "rag_provider": "llamaindex"},
@@ -121,11 +142,12 @@ def test_create_kb_does_not_require_llm_precheck(monkeypatch, tmp_path: Path) ->
 
 
 def test_create_rejects_unregistered_provider(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
     manager = _FakeKBManager(tmp_path / "knowledge_bases")
-    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
-    monkeypatch.setattr(knowledge_router_module, "_kb_base_dir", tmp_path / "knowledge_bases")
+    monkeypatch.setattr(knowledge_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(knowledge_module, "_kb_base_dir", tmp_path / "knowledge_bases")
 
-    with TestClient(_build_app()) as client:
+    with TestClient(_build_app(knowledge_module)) as client:
         response = client.post(
             "/api/v1/knowledge/create",
             data={"name": "kb-invalid", "rag_provider": "lightrag"},
@@ -137,6 +159,7 @@ def test_create_rejects_unregistered_provider(monkeypatch, tmp_path: Path) -> No
 
 
 def test_upload_returns_409_when_kb_needs_reindex(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
     manager = _FakeKBManager(tmp_path / "knowledge_bases")
     manager.config["knowledge_bases"]["legacy-kb"] = {
         "path": "legacy-kb",
@@ -144,9 +167,9 @@ def test_upload_returns_409_when_kb_needs_reindex(monkeypatch, tmp_path: Path) -
         "needs_reindex": True,
         "status": "needs_reindex",
     }
-    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(knowledge_module, "get_kb_manager", lambda: manager)
 
-    with TestClient(_build_app()) as client:
+    with TestClient(_build_app(knowledge_module)) as client:
         response = client.post("/api/v1/knowledge/legacy-kb/upload", files=_upload_payload())
 
     assert response.status_code == 409
@@ -154,6 +177,7 @@ def test_upload_returns_409_when_kb_needs_reindex(monkeypatch, tmp_path: Path) -
 
 
 def test_upload_ready_kb_returns_task_id(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
     manager = _FakeKBManager(tmp_path / "knowledge_bases")
     manager.config["knowledge_bases"]["ready-kb"] = {
         "path": "ready-kb",
@@ -161,15 +185,15 @@ def test_upload_ready_kb_returns_task_id(monkeypatch, tmp_path: Path) -> None:
         "needs_reindex": False,
         "status": "ready",
     }
-    monkeypatch.setattr(knowledge_router_module, "get_kb_manager", lambda: manager)
-    monkeypatch.setattr(knowledge_router_module, "_kb_base_dir", tmp_path / "knowledge_bases")
+    monkeypatch.setattr(knowledge_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(knowledge_module, "_kb_base_dir", tmp_path / "knowledge_bases")
 
     async def _noop_upload_task(*_args, **_kwargs):
         return None
 
-    monkeypatch.setattr(knowledge_router_module, "run_upload_processing_task", _noop_upload_task)
+    monkeypatch.setattr(knowledge_module, "run_upload_processing_task", _noop_upload_task)
 
-    with TestClient(_build_app()) as client:
+    with TestClient(_build_app(knowledge_module)) as client:
         response = client.post("/api/v1/knowledge/ready-kb/upload", files=_upload_payload())
 
     assert response.status_code == 200
@@ -189,11 +213,10 @@ def test_update_config_rejects_unregistered_provider() -> None:
     fake_service = _FakeConfigService()
 
     config_module = importlib.import_module("deeptutor.services.config")
-    app = _build_app()
-
     with pytest.MonkeyPatch.context() as monkeypatch:
+        knowledge_module = _import_knowledge_router(monkeypatch, Path.cwd())
         monkeypatch.setattr(config_module, "get_kb_config_service", lambda: fake_service)
-        with TestClient(app) as client:
+        with TestClient(_build_app(knowledge_module)) as client:
             response = client.put(
                 "/api/v1/knowledge/demo/config",
                 json={"rag_provider": "raganything"},
@@ -201,3 +224,194 @@ def test_update_config_rejects_unregistered_provider() -> None:
 
     assert response.status_code == 400
     assert "Unsupported RAG provider" in response.json()["detail"]
+
+
+def test_update_config_persists_teacher_pack_metadata(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
+
+    class _FakeConfigService:
+        def __init__(self) -> None:
+            self.store = {
+                "demo": {
+                    "rag_provider": "llamaindex",
+                    "subject": "Old",
+                }
+            }
+
+        def set_kb_config(self, kb_name: str, config: dict) -> None:
+            current = self.store.get(kb_name, {})
+            current.update(config)
+            self.store[kb_name] = current
+
+        def get_kb_config(self, kb_name: str) -> dict:
+            return self.store.get(kb_name, {})
+
+    fake_service = _FakeConfigService()
+    config_module = importlib.import_module("deeptutor.services.config")
+
+    payload = {
+        "subject": "Math",
+        "grade": "10",
+        "curriculum": "Vietnam National Curriculum",
+        "learning_objectives": ["Quadratic equations", "Graph reading"],
+        "owner": "teacher-a",
+        "sharing_status": "private",
+    }
+
+    monkeypatch.setattr(config_module, "get_kb_config_service", lambda: fake_service)
+
+    with TestClient(_build_app(knowledge_module)) as client:
+        response = client.put("/api/v1/knowledge/demo/config", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["config"]["subject"] == "Math"
+    assert body["config"]["grade"] == "10"
+    assert body["config"]["curriculum"] == "Vietnam National Curriculum"
+    assert body["config"]["learning_objectives"] == ["Quadratic equations", "Graph reading"]
+    assert body["config"]["owner"] == "teacher-a"
+    assert body["config"]["sharing_status"] == "private"
+
+
+def test_get_knowledge_base_details_exposes_teacher_pack_metadata(
+    monkeypatch, tmp_path: Path
+) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
+
+    kb_root = tmp_path / "knowledge_bases"
+    kb_dir = kb_root / "demo"
+    (kb_dir / "llamaindex_storage").mkdir(parents=True, exist_ok=True)
+
+    manager_module = importlib.import_module("deeptutor.knowledge.manager")
+    manager = manager_module.KnowledgeBaseManager(base_dir=str(kb_root))
+    manager.config = {
+        "knowledge_bases": {
+            "demo": {
+                "path": "demo",
+                "description": "Knowledge base: demo",
+                "rag_provider": "llamaindex",
+                "subject": "Math",
+                "grade": "10",
+                "curriculum": "Vietnam National Curriculum",
+                "learning_objectives": ["Quadratic equations", "Graph reading"],
+                "owner": "teacher-a",
+                "sharing_status": "private",
+                "status": "ready",
+            }
+        }
+    }
+    manager._save_config()
+
+    monkeypatch.setattr(knowledge_module, "get_kb_manager", lambda: manager)
+
+    with TestClient(_build_app(knowledge_module)) as client:
+        response = client.get("/api/v1/knowledge/demo")
+
+    assert response.status_code == 200
+    metadata = response.json()["metadata"]
+    assert metadata["subject"] == "Math"
+    assert metadata["grade"] == "10"
+    assert metadata["curriculum"] == "Vietnam National Curriculum"
+    assert metadata["learning_objectives"] == ["Quadratic equations", "Graph reading"]
+    assert metadata["owner"] == "teacher-a"
+    assert metadata["sharing_status"] == "private"
+
+
+def test_list_knowledge_bases_includes_teacher_pack_metadata(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
+
+    class _MetadataAwareManager(_FakeKBManager):
+        def get_default(self) -> str | None:
+            return "demo"
+
+        def get_info(self, name: str) -> dict:
+            return {
+                "name": name,
+                "is_default": True,
+                "statistics": {"raw_documents": 1},
+                "status": "ready",
+                "progress": None,
+                "metadata": {
+                    "subject": "Math",
+                    "grade": "10",
+                    "curriculum": "Vietnam National Curriculum",
+                    "learning_objectives": ["Quadratic equations"],
+                    "owner": "teacher-a",
+                    "sharing_status": "private",
+                },
+            }
+
+    manager = _MetadataAwareManager(tmp_path / "knowledge_bases")
+    manager.config["knowledge_bases"]["demo"] = {"path": "demo"}
+    monkeypatch.setattr(knowledge_module, "get_kb_manager", lambda: manager)
+
+    with TestClient(_build_app(knowledge_module)) as client:
+        response = client.get("/api/v1/knowledge/list")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload[0]["metadata"]["subject"] == "Math"
+    assert payload[0]["metadata"]["grade"] == "10"
+    assert payload[0]["metadata"]["owner"] == "teacher-a"
+
+
+def test_update_config_rejects_invalid_sharing_status(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
+
+    class _FakeConfigService:
+        def __init__(self) -> None:
+            self.store = {"demo": {"rag_provider": "llamaindex"}}
+
+        def set_kb_config(self, kb_name: str, config: dict) -> None:
+            current = self.store.get(kb_name, {})
+            current.update(config)
+            self.store[kb_name] = current
+
+        def get_kb_config(self, kb_name: str) -> dict:
+            return self.store.get(kb_name, {})
+
+    fake_service = _FakeConfigService()
+    config_module = importlib.import_module("deeptutor.services.config")
+    monkeypatch.setattr(config_module, "get_kb_config_service", lambda: fake_service)
+
+    with TestClient(_build_app(knowledge_module)) as client:
+        response = client.put(
+            "/api/v1/knowledge/demo/config",
+            json={"sharing_status": "school"},
+        )
+
+    assert response.status_code == 400
+    assert "sharing_status" in response.json()["detail"]
+
+
+def test_update_config_normalizes_learning_objectives(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
+
+    class _FakeConfigService:
+        def __init__(self) -> None:
+            self.store = {"demo": {"rag_provider": "llamaindex"}}
+
+        def set_kb_config(self, kb_name: str, config: dict) -> None:
+            current = self.store.get(kb_name, {})
+            current.update(config)
+            self.store[kb_name] = current
+
+        def get_kb_config(self, kb_name: str) -> dict:
+            return self.store.get(kb_name, {})
+
+    fake_service = _FakeConfigService()
+    config_module = importlib.import_module("deeptutor.services.config")
+    monkeypatch.setattr(config_module, "get_kb_config_service", lambda: fake_service)
+
+    payload = {
+        "learning_objectives": ["  Quadratic equations  ", "", "  ", "Graph reading"],
+        "owner": " teacher-a ",
+    }
+
+    with TestClient(_build_app(knowledge_module)) as client:
+        response = client.put("/api/v1/knowledge/demo/config", json=payload)
+
+    assert response.status_code == 200
+    config = response.json()["config"]
+    assert config["learning_objectives"] == ["Quadratic equations", "Graph reading"]
+    assert config["owner"] == "teacher-a"

--- a/tests/knowledge/test_kb_metadata_normalization.py
+++ b/tests/knowledge/test_kb_metadata_normalization.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from deeptutor.knowledge.manager import KnowledgeBaseManager
+
+
+def test_get_info_normalizes_teacher_pack_metadata(tmp_path) -> None:
+    kb_root = tmp_path / "knowledge_bases"
+    kb_dir = kb_root / "demo"
+    (kb_dir / "llamaindex_storage").mkdir(parents=True, exist_ok=True)
+
+    manager = KnowledgeBaseManager(base_dir=str(kb_root))
+    manager.config = {
+        "knowledge_bases": {
+            "demo": {
+                "path": "demo",
+                "description": "Knowledge base: demo",
+                "rag_provider": "llamaindex",
+                "subject": "  Math  ",
+                "grade": "  10  ",
+                "curriculum": "  Vietnam National Curriculum  ",
+                "learning_objectives": ["  Quadratic equations  ", "", "Graph reading"],
+                "owner": "  teacher-a  ",
+                "sharing_status": "  private  ",
+                "status": "ready",
+            }
+        }
+    }
+    manager._save_config()
+
+    info = manager.get_info("demo")
+    metadata = info["metadata"]
+
+    assert metadata["subject"] == "Math"
+    assert metadata["grade"] == "10"
+    assert metadata["curriculum"] == "Vietnam National Curriculum"
+    assert metadata["learning_objectives"] == ["Quadratic equations", "Graph reading"]
+    assert metadata["owner"] == "teacher-a"
+    assert metadata["sharing_status"] == "private"

--- a/web/app/(utility)/knowledge/page.tsx
+++ b/web/app/(utility)/knowledge/page.tsx
@@ -28,6 +28,8 @@ import {
   invalidateKnowledgeCaches,
   listKnowledgeBases,
   listRagProviders,
+  type TeacherPackMetadata,
+  updateKnowledgeBaseConfig,
 } from "@/lib/knowledge-api";
 import {
   getNotebookDetail,
@@ -57,6 +59,7 @@ interface KnowledgeBase {
   is_default?: boolean;
   status?: string;
   progress?: ProgressInfo;
+  metadata?: TeacherPackMetadata | null;
   statistics?: {
     raw_documents?: number;
     rag_provider?: string;
@@ -127,6 +130,45 @@ const kbNeedsReindex = (kb: KnowledgeBase): boolean =>
 const kbIsUploadable = (kb: KnowledgeBase): boolean =>
   resolveKbStatus(kb) === "ready" && !kbNeedsReindex(kb);
 
+const parseLearningObjectives = (value: string): string[] =>
+  value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const formatLearningObjectives = (value?: string[] | null): string =>
+  Array.isArray(value) ? value.join("\n") : "";
+
+const normalizeSharingStatus = (value: string): "private" | "team" | "public" | null => {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "private" || normalized === "team" || normalized === "public") {
+    return normalized;
+  }
+  return null;
+};
+
+const buildTeacherPackMetadata = (input: {
+  subject: string;
+  grade: string;
+  curriculum: string;
+  learningObjectives: string;
+  owner: string;
+  sharingStatus: string;
+}): TeacherPackMetadata | null => {
+  const metadata: TeacherPackMetadata = {};
+  const learningObjectives = parseLearningObjectives(input.learningObjectives);
+
+  if (input.subject.trim()) metadata.subject = input.subject.trim();
+  if (input.grade.trim()) metadata.grade = input.grade.trim();
+  if (input.curriculum.trim()) metadata.curriculum = input.curriculum.trim();
+  if (learningObjectives.length) metadata.learning_objectives = learningObjectives;
+  if (input.owner.trim()) metadata.owner = input.owner.trim();
+  const sharingStatus = normalizeSharingStatus(input.sharingStatus);
+  if (sharingStatus) metadata.sharing_status = sharingStatus;
+
+  return Object.keys(metadata).length ? metadata : null;
+};
+
 export default function KnowledgePage() {
   const router = useRouter();
   const { t } = useTranslation();
@@ -142,6 +184,21 @@ export default function KnowledgePage() {
   const [newKbName, setNewKbName] = useState("");
   const [newKbFiles, setNewKbFiles] = useState<File[]>([]);
   const [selectedProvider, setSelectedProvider] = useState("llamaindex");
+  const [newKbSubject, setNewKbSubject] = useState("");
+  const [newKbGrade, setNewKbGrade] = useState("");
+  const [newKbCurriculum, setNewKbCurriculum] = useState("");
+  const [newKbLearningObjectives, setNewKbLearningObjectives] = useState("");
+  const [newKbOwner, setNewKbOwner] = useState("");
+  const [newKbSharingStatus, setNewKbSharingStatus] = useState<"private" | "team" | "public">("private");
+  const [editingKbName, setEditingKbName] = useState<string | null>(null);
+  const [editKbSubject, setEditKbSubject] = useState("");
+  const [editKbGrade, setEditKbGrade] = useState("");
+  const [editKbCurriculum, setEditKbCurriculum] = useState("");
+  const [editKbLearningObjectives, setEditKbLearningObjectives] = useState("");
+  const [editKbOwner, setEditKbOwner] = useState("");
+  const [editKbSharingStatus, setEditKbSharingStatus] = useState<"private" | "team" | "public">("private");
+  const [savingKbMetadata, setSavingKbMetadata] = useState(false);
+  const [editKbError, setEditKbError] = useState<string | null>(null);
   const [uploadTarget, setUploadTarget] = useState("");
   const [uploadFiles, setUploadFiles] = useState<File[]>([]);
   const [newNotebookName, setNewNotebookName] = useState("");
@@ -373,6 +430,14 @@ export default function KnowledgePage() {
     if (!newKbName.trim() || !newKbFiles.length) return;
     const kbName = newKbName.trim();
     const fileCount = newKbFiles.length;
+    const teacherPackMetadata = buildTeacherPackMetadata({
+      subject: newKbSubject,
+      grade: newKbGrade,
+      curriculum: newKbCurriculum,
+      learningObjectives: newKbLearningObjectives,
+      owner: newKbOwner,
+      sharingStatus: newKbSharingStatus,
+    });
     setCreating(true);
     try {
       const form = new FormData();
@@ -390,6 +455,19 @@ export default function KnowledgePage() {
       }
 
       const data = (await res.json()) as KnowledgeTaskResponse;
+      let metadataSyncError: string | null = null;
+
+      if (teacherPackMetadata) {
+        try {
+          await updateKnowledgeBaseConfig(kbName, teacherPackMetadata);
+        } catch (error) {
+          metadataSyncError =
+            error instanceof Error
+              ? error.message
+              : `Knowledge base '${kbName}' was created but teacher pack metadata could not be saved.`;
+        }
+      }
+
       invalidateKnowledgeCaches();
       if (data.task_id) {
         openTaskLogStream("create", data.task_id, `Create ${kbName}`);
@@ -411,8 +489,22 @@ export default function KnowledgePage() {
 
       setNewKbName("");
       setNewKbFiles([]);
+      setNewKbSubject("");
+      setNewKbGrade("");
+      setNewKbCurriculum("");
+      setNewKbLearningObjectives("");
+      setNewKbOwner("");
+      setNewKbSharingStatus("private");
       if (createFileRef.current) createFileRef.current.value = "";
       await loadAll();
+
+      if (metadataSyncError) {
+        setCreateProcess((prev) => ({
+          ...prev,
+          error: metadataSyncError,
+          label: prev.label || `Create ${kbName}`,
+        }));
+      }
     } catch (error) {
       setCreateProcess((prev) => ({
         ...prev,
@@ -490,6 +582,55 @@ export default function KnowledgePage() {
     await fetch(apiUrl(`/api/v1/knowledge/${kbName}`), { method: "DELETE" });
     invalidateKnowledgeCaches();
     await loadAll();
+  };
+
+  const startEditKnowledgePack = (kb: KnowledgeBase) => {
+    setEditingKbName(kb.name);
+    setEditKbError(null);
+    setEditKbSubject(kb.metadata?.subject ?? "");
+    setEditKbGrade(kb.metadata?.grade ?? "");
+    setEditKbCurriculum(kb.metadata?.curriculum ?? "");
+    setEditKbLearningObjectives(formatLearningObjectives(kb.metadata?.learning_objectives));
+    setEditKbOwner(kb.metadata?.owner ?? "");
+    const sharingStatus = kb.metadata?.sharing_status;
+    if (sharingStatus === "private" || sharingStatus === "team" || sharingStatus === "public") {
+      setEditKbSharingStatus(sharingStatus);
+    } else {
+      setEditKbSharingStatus("private");
+    }
+  };
+
+  const cancelEditKnowledgePack = () => {
+    setEditingKbName(null);
+    setEditKbError(null);
+    setSavingKbMetadata(false);
+  };
+
+  const saveKnowledgePackMetadata = async () => {
+    if (!editingKbName) return;
+
+    const learningObjectives = parseLearningObjectives(editKbLearningObjectives);
+    const payload: TeacherPackMetadata = {
+      subject: editKbSubject.trim() || null,
+      grade: editKbGrade.trim() || null,
+      curriculum: editKbCurriculum.trim() || null,
+      learning_objectives: learningObjectives.length ? learningObjectives : null,
+      owner: editKbOwner.trim() || null,
+      sharing_status: editKbSharingStatus,
+    };
+
+    setSavingKbMetadata(true);
+    setEditKbError(null);
+    try {
+      await updateKnowledgeBaseConfig(editingKbName, payload);
+      invalidateKnowledgeCaches();
+      await loadAll();
+      setEditingKbName(null);
+    } catch (error) {
+      setEditKbError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSavingKbMetadata(false);
+    }
   };
 
   const createNotebook = async () => {
@@ -653,6 +794,56 @@ export default function KnowledgePage() {
                     placeholder={t("Knowledge base name")}
                     className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
                   />
+
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <input
+                      value={newKbSubject}
+                      onChange={(event) => setNewKbSubject(event.target.value)}
+                      placeholder={t("Subject")}
+                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                    />
+                    <input
+                      value={newKbGrade}
+                      onChange={(event) => setNewKbGrade(event.target.value)}
+                      placeholder={t("Grade")}
+                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                    />
+                  </div>
+
+                  <input
+                    value={newKbCurriculum}
+                    onChange={(event) => setNewKbCurriculum(event.target.value)}
+                    placeholder={t("Curriculum")}
+                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                  />
+
+                  <textarea
+                    value={newKbLearningObjectives}
+                    onChange={(event) => setNewKbLearningObjectives(event.target.value)}
+                    placeholder={t("Learning objectives (one per line)")}
+                    rows={4}
+                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                  />
+
+                  <div className="grid gap-3 md:grid-cols-[1fr_180px]">
+                    <input
+                      value={newKbOwner}
+                      onChange={(event) => setNewKbOwner(event.target.value)}
+                      placeholder={t("Owner")}
+                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                    />
+                    <select
+                      value={newKbSharingStatus}
+                      onChange={(event) =>
+                        setNewKbSharingStatus(event.target.value as "private" | "team" | "public")
+                      }
+                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none"
+                    >
+                      <option value="private">{t("Private")}</option>
+                      <option value="team">{t("Team")}</option>
+                      <option value="public">{t("Public")}</option>
+                    </select>
+                  </div>
 
                   <select
                     value={selectedProvider}
@@ -914,9 +1105,49 @@ export default function KnowledgePage() {
                               </span>
                             )}
                           </div>
+                          {kb.metadata && (
+                            <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] text-[var(--muted-foreground)]">
+                              {kb.metadata.subject && (
+                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
+                                  {t("Subject")}: {kb.metadata.subject}
+                                </span>
+                              )}
+                              {kb.metadata.grade && (
+                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
+                                  {t("Grade")}: {kb.metadata.grade}
+                                </span>
+                              )}
+                              {kb.metadata.curriculum && (
+                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
+                                  {t("Curriculum")}: {kb.metadata.curriculum}
+                                </span>
+                              )}
+                              {kb.metadata.owner && (
+                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
+                                  {t("Owner")}: {kb.metadata.owner}
+                                </span>
+                              )}
+                              {kb.metadata.sharing_status && (
+                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
+                                  {t("Sharing")}: {kb.metadata.sharing_status}
+                                </span>
+                              )}
+                            </div>
+                          )}
+                          {kb.metadata?.learning_objectives?.length ? (
+                            <div className="mt-2 text-[11px] text-[var(--muted-foreground)]">
+                              {t("Learning objectives")}: {kb.metadata.learning_objectives.join(", ")}
+                            </div>
+                          ) : null}
                         </div>
 
                         <div className="flex items-center gap-1.5">
+                          <button
+                            onClick={() => startEditKnowledgePack(kb)}
+                            className="rounded-md border border-[var(--border)] px-2.5 py-1 text-[12px] text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]"
+                          >
+                            {t("Edit pack")}
+                          </button>
                           {!kb.is_default && (
                             <button
                               onClick={() => setDefaultKnowledgeBase(kb.name)}
@@ -947,6 +1178,93 @@ export default function KnowledgePage() {
                               />
                             </div>
                           )}
+                        </div>
+                      )}
+
+                      {editingKbName === kb.name && (
+                        <div className="mt-3 space-y-3 rounded-lg border border-[var(--border)] bg-[var(--card)] p-3">
+                          <div className="text-[12px] font-medium text-[var(--foreground)]">
+                            {t("Edit Knowledge Pack Metadata")}
+                          </div>
+
+                          <div className="grid gap-2 md:grid-cols-2">
+                            <input
+                              value={editKbSubject}
+                              onChange={(event) => setEditKbSubject(event.target.value)}
+                              placeholder={t("Subject")}
+                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                            />
+                            <input
+                              value={editKbGrade}
+                              onChange={(event) => setEditKbGrade(event.target.value)}
+                              placeholder={t("Grade")}
+                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                            />
+                          </div>
+
+                          <input
+                            value={editKbCurriculum}
+                            onChange={(event) => setEditKbCurriculum(event.target.value)}
+                            placeholder={t("Curriculum")}
+                            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                          />
+
+                          <textarea
+                            value={editKbLearningObjectives}
+                            onChange={(event) => setEditKbLearningObjectives(event.target.value)}
+                            placeholder={t("Learning objectives (one per line)")}
+                            rows={4}
+                            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                          />
+
+                          <div className="grid gap-2 md:grid-cols-[1fr_180px]">
+                            <input
+                              value={editKbOwner}
+                              onChange={(event) => setEditKbOwner(event.target.value)}
+                              placeholder={t("Owner")}
+                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                            />
+                            <select
+                              value={editKbSharingStatus}
+                              onChange={(event) =>
+                                setEditKbSharingStatus(event.target.value as "private" | "team" | "public")
+                              }
+                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none"
+                            >
+                              <option value="private">{t("Private")}</option>
+                              <option value="team">{t("Team")}</option>
+                              <option value="public">{t("Public")}</option>
+                            </select>
+                          </div>
+
+                          {editKbError && (
+                            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+                              {editKbError}
+                            </div>
+                          )}
+
+                          <div className="flex items-center gap-2">
+                            <button
+                              onClick={saveKnowledgePackMetadata}
+                              disabled={savingKbMetadata}
+                              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3.5 py-1.5 text-[13px] font-medium text-[var(--primary-foreground)] transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              {savingKbMetadata ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <PenLine size={14} />
+                              )}
+                              {t("Save metadata")}
+                            </button>
+
+                            <button
+                              onClick={cancelEditKnowledgePack}
+                              disabled={savingKbMetadata}
+                              className="rounded-lg border border-[var(--border)] px-3.5 py-1.5 text-[13px] text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              {t("Cancel")}
+                            </button>
+                          </div>
                         </div>
                       )}
                     </div>

--- a/web/lib/knowledge-api.ts
+++ b/web/lib/knowledge-api.ts
@@ -3,12 +3,22 @@ import { invalidateClientCache, withClientCache } from "@/lib/client-cache";
 
 const KNOWLEDGE_CACHE_PREFIX = "knowledge:";
 
+export interface TeacherPackMetadata {
+  subject?: string | null;
+  grade?: string | null;
+  curriculum?: string | null;
+  learning_objectives?: string[] | null;
+  owner?: string | null;
+  sharing_status?: "private" | "team" | "public" | null;
+}
+
 export interface KnowledgeBaseSummary {
   name: string;
   is_default?: boolean;
   status?: string;
   progress?: Record<string, unknown>;
   statistics?: Record<string, unknown>;
+  metadata?: TeacherPackMetadata | null;
 }
 
 export interface RagProviderSummary {
@@ -51,6 +61,27 @@ export async function listRagProviders(options?: { force?: boolean }) {
       force: options?.force,
     },
   );
+}
+
+export async function updateKnowledgeBaseConfig(
+  kbName: string,
+  config: TeacherPackMetadata | Record<string, unknown>,
+) {
+  const response = await fetch(apiUrl(`/api/v1/knowledge/${encodeURIComponent(kbName)}/config`), {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(config),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error?.detail || `Failed to update config for ${kbName}`);
+  }
+
+  invalidateKnowledgeCaches();
+  return response.json();
 }
 
 export function invalidateKnowledgeCaches() {


### PR DESCRIPTION
## Summary
- add Teacher Knowledge Pack metadata fields to KB config update flow
- expose metadata in KB detail/list responses and normalize read shape
- add Knowledge page create/edit UI for subject, grade, curriculum, learning objectives, owner, and sharing status
- add Pod A architecture note with Mermaid

## User-visible changes
- teachers can create or edit Knowledge Pack metadata from the Knowledge page
- metadata is returned by the backend and rendered in the Knowledge UI

## Tests run
- `pytest tests/api/test_knowledge_router.py -v` (11 passed)
- `pytest tests/knowledge -v` (3 passed)
- `python3 -m compileall deeptutor`
- `cd web && npm run build`

## Architecture note
- `docs/superpowers/pr-notes/pod-a-teacher-knowledge-pack-mvp.md`
- updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

## Scope notes
- Refs #2
- This clean branch intentionally excludes Pod B and unrelated changes from the existing dirty `pod-a/teacher-knowledge-pack-mvp` worktree.
- Unrelated local dirty files remain unstaged in the parent checkout: package lockfiles, `web/next-env.d.ts`, and `ai_first/2026-04-12-deeptutor-slimming/`.
