### PR TITLE
docs: move queue to pod b

### DIFF
--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -68,7 +68,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Pod A Teacher Knowledge Pack MVP is in progress on `pod-a/teacher-knowledge-pack-mvp-clean`. The clean branch contains only Pod A-owned changes copied from the dirty worktree plus the required architecture note and main system map update. The original dirty worktree still exists and should be preserved because it contains uncommitted Pod B and unrelated changes.
+Pod A Teacher Knowledge Pack MVP merged via PR `#6`. The current next task is Pod B: Assessment Builder and Student Tutor Workspace MVP from `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`. The preserved dirty `pod-a/teacher-knowledge-pack-mvp` worktree contains Pod B-owned changes that may be reused after audit, plus unrelated changes that must remain untouched.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,11 +6,12 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Finish and publish Pod A: Teacher Knowledge Pack MVP from `pod-a/teacher-knowledge-pack-mvp-clean`.
-2. Fix any Pod A CI, test, or review blockers before starting the next feature.
-3. After Pod A merges, start Pod B: Assessment Builder and Student Tutor Workspace MVP from `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
-4. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
-5. Preserve the original dirty `pod-a/teacher-knowledge-pack-mvp` worktree until its Pod B/unrelated changes are intentionally handled.
+1. Start Pod B: Assessment Builder and Student Tutor Workspace MVP from `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
+2. Reuse only relevant Pod B-owned changes from the preserved dirty `pod-a/teacher-knowledge-pack-mvp` worktree after auditing them against the Pod B task packet.
+3. Open a Pod B PR linked to GitHub issue `#3` with a PR architecture note and Mermaid diagram.
+4. Fix any Pod B CI, test, or review blockers before starting the next feature.
+5. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
+6. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -43,16 +43,18 @@
   - Passed: `cd web && npm run build`
 - Blockers:
   - Original dirty `pod-a/teacher-knowledge-pack-mvp` worktree still contains Pod B/unrelated changes and should be preserved until handled intentionally.
-- Next: Commit, push, open PR for Pod A, then fix CI/review if needed.
+- Next:
+  - PR `#6` merged into `main`.
+  - Move active queue to Pod B.
 
 ## Pod B
 
 - Branch: `pod-b/assessment-student-workspace-mvp`
-- Task: Not started in this checkout.
+- Task: Assessment Builder and Student Tutor Workspace MVP.
 - Done: Task packet exists at `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
 - Tests: Not run.
-- Blockers: Wait for Pod A Knowledge Pack metadata contract to stabilize.
-- Next: Start from the Pod B task packet after Pod A merges.
+- Blockers: None after Pod A PR `#6` merged.
+- Next: Start clean Pod B branch and reuse only audited Pod B-owned changes from the preserved dirty worktree.
 
 ## Human Review Needed
 


### PR DESCRIPTION
## Summary
- mark Pod A PR #6 as merged in the AI-first state mirrors
- move the active queue to Pod B
- preserve the dirty legacy worktree as an audit source rather than committing from it

## Scope
Docs/workflow only. No runtime or frontend behavior changes.

## Validation
- `rg -n "PR #6|Pod B|dirty|assessment|review blockers" ai_first/NEXT_ACTIONS.md ai_first/CURRENT_STATE.md ai_first/daily/2026-04-19.md`
- `git diff --check`

## Handoff
Next AI task is to start a clean Pod B branch and reuse only audited Pod B-owned changes from the preserved dirty worktree.
