### PR TITLE
feat: ground assessment in knowledge pack context

### DIFF
--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -68,7 +68,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Pod A Teacher Knowledge Pack MVP merged via PR `#6`. The current next task is Pod B: Assessment Builder and Student Tutor Workspace MVP from `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`. The preserved dirty `pod-a/teacher-knowledge-pack-mvp` worktree contains Pod B-owned changes that may be reused after audit, plus unrelated changes that must remain untouched.
+Pod B Assessment Builder and Student Tutor Workspace MVP is in progress on `pod-b/assessment-student-workspace-mvp`. The branch reuses only audited Pod B-owned/shared-contract changes from the preserved dirty worktree. Pod A Teacher Knowledge Pack MVP merged via PR `#6`.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,12 +6,11 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Start Pod B: Assessment Builder and Student Tutor Workspace MVP from `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
-2. Reuse only relevant Pod B-owned changes from the preserved dirty `pod-a/teacher-knowledge-pack-mvp` worktree after auditing them against the Pod B task packet.
-3. Open a Pod B PR linked to GitHub issue `#3` with a PR architecture note and Mermaid diagram.
-4. Fix any Pod B CI, test, or review blockers before starting the next feature.
-5. Keep GitHub issues `#2` and `#3` aligned with the task packets and implementation PRs.
-6. Preserve unrelated dirty files until they are intentionally handled.
+1. Finish and publish Pod B: Assessment Builder and Student Tutor Workspace MVP from `pod-b/assessment-student-workspace-mvp`.
+2. Fix any Pod B CI, test, or review blockers before starting the next feature.
+3. After Pod B merges, create the next task packet for Teacher Dashboard MVP.
+4. Keep GitHub issues `#2` and `#3` aligned with the implementation PRs.
+5. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -37,7 +37,9 @@ flowchart TD
   Product --> KnowledgePack["Knowledge Pack"]
   KnowledgePack --> KPMetaFlow["Metadata Create/Edit/Update Flow"]
   Product --> AssessmentBuilder["Assessment Builder"]
+  AssessmentBuilder --> QuizGrounding["Knowledge Pack Grounded Quiz Config"]
   Product --> StudentTutor["Student Tutor Workspace"]
+  StudentTutor --> TutorKBContext["Knowledge Pack Tutoring Context"]
   Product --> TeacherDashboard["Teacher Dashboard"]
 
   Project --> Data["Data Layer"]

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -51,10 +51,23 @@
 
 - Branch: `pod-b/assessment-student-workspace-mvp`
 - Task: Assessment Builder and Student Tutor Workspace MVP.
-- Done: Task packet exists at `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`.
-- Tests: Not run.
-- Blockers: None after Pod A PR `#6` merged.
-- Next: Start clean Pod B branch and reuse only audited Pod B-owned changes from the preserved dirty worktree.
+- Done:
+  - Started clean Pod B branch from current `main`.
+  - Reused audited Pod B-owned/shared-contract changes from the preserved dirty worktree.
+  - Added `subject` to deep question request config and quiz UI config.
+  - Added common-mistake extraction/rendering for quiz results.
+  - Added runtime test coverage for deep question subject config.
+  - Updated Pod B task packet ownership for `deeptutor/capabilities/request_contracts.py`.
+  - Added Pod B PR architecture note with Mermaid.
+  - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`.
+- Tests:
+  - Passed: `pytest tests/api/test_question_router.py -v` (1 passed)
+  - Passed after test-source fix: `pytest tests/api/test_unified_ws_turn_runtime.py -v` (6 passed)
+  - Passed: `python3 -m compileall deeptutor`
+  - Passed: `cd web && npm run build`
+- Blockers:
+  - None known after local validation.
+- Next: Commit, push, open PR for Pod B, then fix CI/review if needed.
 
 ## Human Review Needed
 
@@ -64,3 +77,4 @@
 ## Architecture Map Updates
 
 - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for `AI_FIRST_ROADMAP.md`, autonomous merge gates, review blockers, and next-task selection.
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for Knowledge Pack-grounded quiz config and tutoring context.

--- a/deeptutor/api/routers/question.py
+++ b/deeptutor/api/routers/question.py
@@ -427,12 +427,18 @@ async def websocket_question_generate(websocket: WebSocket):
                 preference = (
                     requirement.get("preference", "") if isinstance(requirement, dict) else ""
                 )
+                subject = (
+                    requirement.get("subject", "") if isinstance(requirement, dict) else ""
+                )
                 difficulty = (
                     requirement.get("difficulty", "") if isinstance(requirement, dict) else ""
                 )
                 question_type = (
                     requirement.get("question_type", "") if isinstance(requirement, dict) else ""
                 )
+
+                if subject:
+                    preference = "\n".join(part for part in [f"Subject: {subject}", preference] if part).strip()
 
                 logger.info(
                     f"Starting question generation for {count} question(s), topic: {user_topic}"

--- a/deeptutor/capabilities/deep_question.py
+++ b/deeptutor/capabilities/deep_question.py
@@ -79,10 +79,13 @@ class DeepQuestionCapability(BaseCapability):
 
         mode = str(overrides.get("mode", "custom") or "custom").strip().lower()
         topic = str(overrides.get("topic") or context.user_message or "").strip()
+        subject = str(overrides.get("subject") or "").strip()
         num_questions = int(overrides.get("num_questions", 1) or 1)
         difficulty = str(overrides.get("difficulty", "") or "")
         question_type = str(overrides.get("question_type", "") or "")
         preference = str(overrides.get("preference", "") or "")
+        if subject:
+            preference = "\n".join(part for part in [f"Subject: {subject}", preference] if part).strip()
         history_context = str(
             context.metadata.get("conversation_context_text", "") or ""
         ).strip()
@@ -355,9 +358,40 @@ class DeepQuestionCapability(BaseCapability):
             if explanation:
                 lines.append(f"\n**Explanation:** {explanation}")
 
+            validation = qa_pair.get("validation", {})
+            issues: list[str] = []
+            if isinstance(validation, dict):
+                raw_issues = validation.get("issues", [])
+                if isinstance(raw_issues, list):
+                    issues = [
+                        self._humanize_validation_issue(issue)
+                        for issue in raw_issues
+                        if str(issue or "").strip()
+                    ]
+            if issues:
+                lines.append("\n**Common mistakes to avoid:**")
+                for issue in issues:
+                    lines.append(f"- {issue}")
+
             lines.append("")
 
         return "\n".join(lines).strip()
+
+    @staticmethod
+    def _humanize_validation_issue(issue: Any) -> str:
+        normalized = str(issue or "").strip()
+        if not normalized:
+            return "Review the generated answer format."
+        mapping = {
+            "choice_missing_options": "Include answer choices A through D.",
+            "choice_options_must_be_a_to_d": "Use exactly the A, B, C, and D options.",
+            "choice_correct_answer_must_be_option_key": "Mark the correct choice with its option letter.",
+            "non_choice_payload_looks_like_multiple_choice": "If this is multiple choice, add explicit options.",
+            "missing_question": "Include a clear question stem.",
+            "missing_correct_answer": "Include the correct answer.",
+            "missing_explanation": "Add a short explanation.",
+        }
+        return mapping.get(normalized, normalized.replace("_", " ").capitalize())
 
     def _build_trace_bridge(self, stream: StreamBus):
         async def _trace_bridge(update: dict[str, Any]) -> None:

--- a/deeptutor/capabilities/request_contracts.py
+++ b/deeptutor/capabilities/request_contracts.py
@@ -33,6 +33,7 @@ class DeepQuestionRequestConfig(BaseModel):
 
     mode: Literal["custom", "mimic"] = "custom"
     topic: str = ""
+    subject: str = ""
     num_questions: int = Field(default=1, ge=1, le=50)
     difficulty: str = ""
     question_type: str = ""

--- a/docs/superpowers/pr-notes/pod-b-assessment-student-workspace-mvp.md
+++ b/docs/superpowers/pr-notes/pod-b-assessment-student-workspace-mvp.md
@@ -1,0 +1,61 @@
+# PR Architecture Note: Pod B Assessment and Student Workspace MVP
+
+## Summary
+
+Adds the first Knowledge Pack-grounded assessment controls and student tutoring context support for Pod B.
+
+## Scope
+
+- Deep question requests now accept `subject` and pass it into generation preference context.
+- Quiz UI exposes a subject control alongside count, difficulty, type, and preference.
+- Quiz results surface common mistakes derived from validation issues.
+- Unified turn runtime test coverage verifies `deep_question` config carries `subject` through to capability context.
+- The main workspace already supports selecting a Knowledge Pack when RAG is active; this PR keeps that contract and focuses on stable request/response behavior.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Teacher["Teacher"]
+  QuizPanel["Quiz Config Panel"]
+  WSConfig["buildQuizWSConfig"]
+  Runtime["TurnRuntimeManager"]
+  DeepQuestion["DeepQuestionCapability"]
+  QuizResult["Quiz Viewer"]
+  Student["Student"]
+  Composer["Workspace Composer"]
+  KB["Selected Knowledge Pack"]
+
+  Teacher --> QuizPanel
+  QuizPanel --> WSConfig
+  WSConfig --> Runtime
+  Runtime --> DeepQuestion
+  DeepQuestion --> QuizResult
+  Student --> Composer
+  Composer --> KB
+  KB --> Runtime
+```
+
+## Architecture Impact
+
+The Assessment Builder now carries subject context into deep question generation, and the Student Tutor Workspace keeps Knowledge Pack selection in the turn payload through the existing unified WebSocket flow. The main system map was updated for the grounded quiz and tutoring-context flow.
+
+## Data/API Changes
+
+- `DeepQuestionRequestConfig` now includes `subject`.
+- WebSocket question generation reads `subject` and folds it into generation preference text.
+- Quiz question UI model includes `common_mistakes`.
+
+## Tests
+
+```bash
+pytest tests/api/test_question_router.py -v
+pytest tests/api/test_unified_ws_turn_runtime.py -v
+python3 -m compileall deeptutor
+cd web && npm run build
+```
+
+## Main System Map Update
+
+- [ ] Not needed, because:
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

--- a/docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md
+++ b/docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md
@@ -18,6 +18,7 @@ Teachers can generate exercises from a selected Knowledge Pack with Vietnamese-f
 - `deeptutor/api/routers/unified_ws.py`
 - `deeptutor/capabilities/deep_question.py`
 - `deeptutor/capabilities/chat.py`
+- `deeptutor/capabilities/request_contracts.py`
 - `web/app/(workspace)/page.tsx`
 - `web/components/quiz/`
 - `web/components/chat/`

--- a/tests/api/test_question_router.py
+++ b/tests/api/test_question_router.py
@@ -136,6 +136,7 @@ def test_mimic_websocket_accepts_config_and_returns_messages(
                     "mode": "parsed",
                     "paper_path": str(tmp_path / "paper"),
                     "kb_name": "demo-kb",
+                    "subject": "Physics",
                     "max_questions": 3,
                 }
             )

--- a/tests/api/test_unified_ws_turn_runtime.py
+++ b/tests/api/test_unified_ws_turn_runtime.py
@@ -97,10 +97,84 @@ async def test_turn_runtime_replays_events_and_materializes_messages(
         "knowledge_bases": [],
         "language": "en",
     }
-
     persisted_turn = await store.get_turn(turn["id"])
     assert persisted_turn is not None
     assert persisted_turn["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_turn_runtime_passes_deep_question_subject_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    runtime = TurnRuntimeManager(store)
+    captured: dict[str, object] = {}
+
+    class FakeContextBuilder:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def build(self, **_kwargs):
+            return SimpleNamespace(
+                conversation_history=[],
+                conversation_summary="",
+                context_text="",
+                token_count=0,
+                budget=0,
+            )
+
+    class FakeOrchestrator:
+        async def handle(self, context):
+            captured["config_overrides"] = context.config_overrides
+            yield StreamEvent(
+                type=StreamEventType.CONTENT,
+                source="deep_question",
+                stage="writing",
+                content="Generated quiz",
+                metadata={"call_kind": "llm_final_response"},
+            )
+            yield StreamEvent(type=StreamEventType.DONE, source="deep_question")
+
+    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
+    monkeypatch.setattr("deeptutor.runtime.orchestrator.ChatOrchestrator", FakeOrchestrator)
+    monkeypatch.setattr(
+        "deeptutor.services.memory.get_memory_service",
+        lambda: SimpleNamespace(
+            build_memory_context=lambda: "",
+            refresh_from_turn=_noop_refresh,
+        ),
+    )
+
+    _session, turn = await runtime.start_turn(
+        {
+            "type": "start_turn",
+            "content": "make a quiz",
+            "session_id": None,
+            "capability": "deep_question",
+            "tools": ["rag"],
+            "knowledge_bases": ["math-pack"],
+            "attachments": [],
+            "language": "en",
+            "config": {
+                "mode": "custom",
+                "topic": "quadratic equations",
+                "subject": "Physics",
+                "num_questions": 3,
+                "difficulty": "medium",
+                "question_type": "choice",
+            },
+        }
+    )
+
+    events = []
+    async for event in runtime.subscribe_turn(turn["id"], after_seq=0):
+        events.append(event)
+
+    assert events[-1]["metadata"]["status"] == "completed"
+    assert captured["config_overrides"]["subject"] == "Physics"
+    assert captured["config_overrides"]["topic"] == "quadratic equations"
 
 
 @pytest.mark.asyncio

--- a/web/components/quiz/QuizConfigPanel.tsx
+++ b/web/components/quiz/QuizConfigPanel.tsx
@@ -90,6 +90,16 @@ export default function QuizConfigPanel({
             </select>
           </Field>
 
+          <Field label="Subject" width="w-[130px]">
+            <input
+              type="text"
+              value={value.subject}
+              onChange={(e) => update("subject", e.target.value)}
+              placeholder={t("e.g. Mathematics")}
+              className={`${INPUT_CLS} w-full`}
+            />
+          </Field>
+
           <Field label="Preference" width="min-w-[140px] flex-1">
             <input
               type="text"

--- a/web/components/quiz/QuizViewer.tsx
+++ b/web/components/quiz/QuizViewer.tsx
@@ -568,6 +568,21 @@ export default function QuizViewer({
                 </div>
               </div>
             )}
+            {q.common_mistakes && q.common_mistakes.length > 0 && (
+              <div>
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                  {t("Common mistakes to avoid")}
+                </div>
+                <ul className="space-y-1 text-[13px] leading-relaxed text-[var(--muted-foreground)]">
+                  {q.common_mistakes.map((mistake) => (
+                    <li key={mistake} className="flex gap-2">
+                      <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--primary)]/70" />
+                      <span>{mistake}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/web/lib/quiz-types.ts
+++ b/web/lib/quiz-types.ts
@@ -7,6 +7,7 @@ export type DeepQuestionMode = "custom" | "mimic";
 export interface DeepQuestionFormConfig {
   mode: DeepQuestionMode;
   topic: string;
+  subject: string;
   num_questions: number;
   difficulty: string;
   question_type: string;
@@ -18,6 +19,7 @@ export interface DeepQuestionFormConfig {
 export const DEFAULT_QUIZ_CONFIG: DeepQuestionFormConfig = {
   mode: "custom",
   topic: "",
+  subject: "",
   num_questions: 3,
   difficulty: "auto",
   question_type: "auto",
@@ -36,6 +38,7 @@ export interface QuizQuestion {
   difficulty?: string;
   concentration?: string;
   knowledge_context?: string;
+  common_mistakes?: string[];
 }
 
 export interface QuizFollowupContext {
@@ -78,6 +81,7 @@ export function extractQuizQuestions(
       explanation: String(qa.explanation ?? ""),
       difficulty: qa.difficulty ? String(qa.difficulty) : undefined,
       concentration: qa.concentration ? String(qa.concentration) : undefined,
+      common_mistakes: extractCommonMistakes(qa),
       knowledge_context:
         qa.metadata &&
         typeof qa.metadata === "object" &&
@@ -134,9 +138,50 @@ export function buildQuizWSConfig(
   }
   return {
     mode: "custom",
+    subject: cfg.subject.trim(),
     num_questions: cfg.num_questions,
     difficulty: cfg.difficulty === "auto" ? "" : cfg.difficulty,
     question_type: cfg.question_type === "auto" ? "" : cfg.question_type,
     preference: cfg.preference.trim(),
   };
+}
+
+function extractCommonMistakes(qa: Record<string, unknown>): string[] | undefined {
+  const directMistakes = qa.common_mistakes;
+  if (Array.isArray(directMistakes)) {
+    const normalized = directMistakes
+      .map((item) => humanizeValidationIssue(String(item ?? "")))
+      .filter((item) => item.length > 0);
+    if (normalized.length > 0) return normalized;
+  }
+
+  const validation = qa.validation as Record<string, unknown> | undefined;
+  const issues = validation?.issues;
+  if (!Array.isArray(issues) || issues.length === 0) return undefined;
+
+  const normalized = issues
+    .map((item) => humanizeValidationIssue(String(item ?? "")))
+    .filter((item) => item.length > 0);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function humanizeValidationIssue(issue: string): string {
+  switch (issue) {
+    case "choice_missing_options":
+      return "Include answer choices A through D.";
+    case "choice_options_must_be_a_to_d":
+      return "Use exactly the A, B, C, and D options.";
+    case "choice_correct_answer_must_be_option_key":
+      return "Mark the correct choice with its option letter.";
+    case "non_choice_payload_looks_like_multiple_choice":
+      return "If this is multiple choice, add explicit options.";
+    case "missing_question":
+      return "Include a clear question stem.";
+    case "missing_correct_answer":
+      return "Include the correct answer.";
+    case "missing_explanation":
+      return "Add a short explanation.";
+    default:
+      return issue.replaceAll("_", " ").trim();
+  }
 }


### PR DESCRIPTION
## Summary
- add subject context to deep question request/config handling
- expose subject input in quiz config and send it through WebSocket config
- render common mistakes from validation issues in quiz results
- add runtime coverage for deep_question subject config

## User-visible changes
- teachers can include a subject when generating assessments
- generated quiz results can show common mistakes to avoid
- student workspace continues to pass selected Knowledge Pack context through the unified WebSocket path when RAG is active

## Tests run
- `pytest tests/api/test_question_router.py -v` (1 passed)
- `pytest tests/api/test_unified_ws_turn_runtime.py -v` (6 passed)
- `python3 -m compileall deeptutor`
- `cd web && npm run build`

## Architecture note
- `docs/superpowers/pr-notes/pod-b-assessment-student-workspace-mvp.md`
- updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

## Scope notes
- Refs #3
- This branch intentionally excludes Pod A and unrelated changes from the preserved dirty worktree.
- The Pod B task packet was updated to include `deeptutor/capabilities/request_contracts.py` because `subject` is part of the shared deep-question request contract.
