### PR TITLE
docs: add teacher dashboard task packet

### DIFF
--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -61,14 +61,16 @@ Do not revert unrelated changes.
 
 - Pod A task packet: `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`
 - Pod B task packet: `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`
+- Teacher Dashboard task packet: `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`
 - Pod A GitHub issue: `#2`
 - Pod B GitHub issue: `#3`
+- Teacher Dashboard GitHub issue: `#9`
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Pod B Assessment Builder and Student Tutor Workspace MVP is in progress on `pod-b/assessment-student-workspace-mvp`. The branch reuses only audited Pod B-owned/shared-contract changes from the preserved dirty worktree. Pod A Teacher Knowledge Pack MVP merged via PR `#6`.
+Pod B Assessment Builder and Student Tutor Workspace MVP merged via PR `#8`. The current next task is Pod A: Teacher Dashboard MVP from `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`, mirrored by GitHub issue `#9`.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,22 +6,20 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Finish and publish Pod B: Assessment Builder and Student Tutor Workspace MVP from `pod-b/assessment-student-workspace-mvp`.
-2. Fix any Pod B CI, test, or review blockers before starting the next feature.
-3. After Pod B merges, create the next task packet for Teacher Dashboard MVP.
-4. Keep GitHub issues `#2` and `#3` aligned with the implementation PRs.
+1. Start Pod A: Teacher Dashboard MVP from `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`.
+2. Keep GitHub issue `#9` aligned with the dashboard implementation PR.
+3. Fix any dashboard CI, test, or review blockers before starting the next feature.
+4. Keep GitHub issues `#2` and `#3` linked to their completed implementation PRs.
 5. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 
-1. Add Teacher Dashboard MVP planning after Pod A ownership is stable.
-2. Keep the main system map updated when shared contracts change.
-3. Keep `ai_first/AI_FIRST_ROADMAP.md` current when the autonomous operating loop changes.
-4. Add reliable backend and frontend CI checks before allowing broader runtime auto-merge.
+1. Keep the main system map updated when shared contracts change.
+2. Keep `ai_first/AI_FIRST_ROADMAP.md` current when the autonomous operating loop changes.
+3. Add reliable backend and frontend CI checks before allowing broader runtime auto-merge.
 
 ## Human Review Needed
 
-- Confirm whether Teacher Dashboard should stay in a later Pod A packet or be folded into the same implementation branch.
 - Review product scope changes, credential/deployment decisions, or PRs marked blocked by the AI worker.
 
 ## Mirror Policy

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -69,10 +69,20 @@
   - None known after local validation.
 - Next: Commit, push, open PR for Pod B, then fix CI/review if needed.
 
+## Teacher Dashboard
+
+- Branch: `pod-a/teacher-dashboard-mvp`
+- Task: Teacher Dashboard MVP.
+- Done:
+  - Created task packet at `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`.
+  - Created GitHub issue `#9`.
+- Tests: Documentation-only task packet update; runtime tests not required.
+- Blockers: None known.
+- Next: Start dashboard implementation from the task packet.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.
-- Teacher Dashboard placement remains a product decision: later Pod A packet or folded into a later implementation branch.
 
 ## Architecture Map Updates
 

--- a/docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md
+++ b/docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md
@@ -1,0 +1,86 @@
+# Feature Pod Task: Teacher Dashboard MVP
+
+Owner: Pod A AI worker
+Branch: `pod-a/teacher-dashboard-mvp`
+GitHub Issue: `#9`
+
+## Goal
+
+Add the first teacher-facing dashboard that summarizes recent Knowledge Pack, assessment, and student tutoring activity for the contest demo.
+
+## User-visible outcome
+
+Teachers can open a Dashboard page and see a compact overview of recent learning activity: active Knowledge Packs, generated assessments, student tutoring sessions, and simple progress/status indicators.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/dashboard.py`
+- `deeptutor/api/routers/sessions.py`
+- `deeptutor/services/session/`
+- `web/app/(workspace)/dashboard/`
+- `web/lib/session-api.ts`
+- `web/lib/dashboard-api.ts`
+- `web/components/dashboard/`
+- `tests/api/test_dashboard_router.py`
+- `tests/services/session/`
+
+## Do-not-touch files/modules
+
+- `deeptutor/api/routers/knowledge.py`
+- `deeptutor/api/routers/question.py`
+- `deeptutor/api/routers/unified_ws.py`
+- `deeptutor/capabilities/deep_question.py`
+- `deeptutor/capabilities/chat.py`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/components/quiz/`
+- `web/lib/knowledge-api.ts`
+- `web/lib/quiz-types.ts`
+- `tests/api/test_knowledge_router.py`
+- `tests/api/test_question_router.py`
+- `tests/api/test_unified_ws_turn_runtime.py`
+
+## API/data contract
+
+- Extend or reuse the existing dashboard API to return:
+  - recent sessions grouped by capability or activity type;
+  - counts for tutoring sessions, generated assessments, and running/failed/completed activity;
+  - Knowledge Pack references from session preferences when available;
+  - timestamps and short summaries suitable for UI cards and tables.
+- Keep existing session identifiers stable.
+- Do not invent new persistence if SQLite session data already contains the needed information.
+
+## Acceptance criteria
+
+- A teacher can open the Dashboard page from the workspace navigation or direct route.
+- The dashboard shows recent activity from the unified session store.
+- The dashboard distinguishes assessment generation from student tutoring/chat activity.
+- The dashboard shows Knowledge Pack references when sessions used a selected Knowledge Pack.
+- Empty state is useful when no activity exists.
+- Existing session APIs and chat persistence continue to work.
+
+## Required tests
+
+- `pytest tests/api/test_dashboard_router.py -v`
+- `pytest tests/services/session -v`
+- `python3 -m compileall deeptutor`
+- `cd web && npm run build`
+
+## Manual verification
+
+- Start backend and frontend.
+- Generate an assessment from a Knowledge Pack.
+- Ask a student tutor question with a selected Knowledge Pack.
+- Open the Dashboard page.
+- Confirm recent assessment and tutoring activity appear with Knowledge Pack context where available.
+- Confirm empty/loading/error states are readable.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if dashboard routes, API shape, or session aggregation changes.
+
+## Handoff notes
+
+- Keep this task focused on read-only dashboard aggregation and display.
+- Do not add teacher analytics models, grading workflows, or long-term reporting unless this packet is explicitly expanded.
+- If the dashboard needs fields not present in session data, add the smallest session metadata extension and document it in the PR.


### PR DESCRIPTION
## Summary
- add Teacher Dashboard MVP task packet
- create GitHub issue #9 mirror and move queue to dashboard implementation
- update daily/current state after Pod B merge

## Scope
Docs/task workflow only. No runtime or frontend behavior changes.

## Validation
- `rg -n "Teacher Dashboard|#9|teacher-dashboard|dashboard implementation|GitHub Issue" ai_first docs/superpowers/tasks`
- `git diff --check`
- `gh issue view 9 --json number,title,state,labels,url`

## Handoff
Next AI task is dashboard implementation from `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`.
