### PR TITLE
feat: add teacher dashboard overview

### DIFF
--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -70,7 +70,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Pod B Assessment Builder and Student Tutor Workspace MVP merged via PR `#8`. The current next task is Pod A: Teacher Dashboard MVP from `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`, mirrored by GitHub issue `#9`.
+Teacher Dashboard MVP is in progress on `pod-a/teacher-dashboard-mvp`, mirrored by GitHub issue `#9`. The implementation is read-only and uses existing unified session data instead of adding new persistence.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,11 +6,12 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Start Pod A: Teacher Dashboard MVP from `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`.
+1. Finish and publish Pod A: Teacher Dashboard MVP from `pod-a/teacher-dashboard-mvp`.
 2. Keep GitHub issue `#9` aligned with the dashboard implementation PR.
 3. Fix any dashboard CI, test, or review blockers before starting the next feature.
-4. Keep GitHub issues `#2` and `#3` linked to their completed implementation PRs.
-5. Preserve unrelated dirty files until they are intentionally handled.
+4. After dashboard merges, create the next contest evidence/demo task packet.
+5. Keep GitHub issues `#2`, `#3`, and `#9` linked to their implementation PRs.
+6. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -41,6 +41,7 @@ flowchart TD
   Product --> StudentTutor["Student Tutor Workspace"]
   StudentTutor --> TutorKBContext["Knowledge Pack Tutoring Context"]
   Product --> TeacherDashboard["Teacher Dashboard"]
+  TeacherDashboard --> DashboardSummary["Session Activity Summary"]
 
   Project --> Data["Data Layer"]
   Data --> SQLite["data/user/chat_history.db"]

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -76,9 +76,17 @@
 - Done:
   - Created task packet at `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`.
   - Created GitHub issue `#9`.
-- Tests: Documentation-only task packet update; runtime tests not required.
+  - Added dashboard overview API backed by the unified session store.
+  - Added dashboard frontend API client and workspace route.
+  - Added Dashboard navigation item.
+  - Added API tests for overview aggregation and activity filtering.
+- Tests:
+  - Passed: `pytest tests/api/test_dashboard_router.py -v` (2 passed)
+  - Passed: `pytest tests/services/session -v` (2 passed)
+  - Passed: `python3 -m compileall deeptutor`
+  - Passed: `cd web && npm run build`
 - Blockers: None known.
-- Next: Start dashboard implementation from the task packet.
+- Next: Open PR and apply merge policy if eligible, then continue to contest evidence/demo task packet.
 
 ## Human Review Needed
 
@@ -88,3 +96,4 @@
 
 - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for `AI_FIRST_ROADMAP.md`, autonomous merge gates, review blockers, and next-task selection.
 - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for Knowledge Pack-grounded quiz config and tutoring context.
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for Teacher Dashboard session activity summary.

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -9,6 +9,42 @@ from deeptutor.services.session import get_sqlite_session_store
 router = APIRouter()
 
 
+def _activity_type(capability: str) -> str:
+    if capability == "deep_question":
+        return "assessment"
+    if capability in {"chat", ""}:
+        return "tutoring"
+    return capability.replace("deep_", "")
+
+
+def _session_knowledge_bases(session: dict[str, Any]) -> list[str]:
+    preferences = session.get("preferences")
+    if not isinstance(preferences, dict):
+        return []
+    raw_kbs = preferences.get("knowledge_bases", [])
+    if not isinstance(raw_kbs, list):
+        return []
+    return [str(kb).strip() for kb in raw_kbs if str(kb).strip()]
+
+
+def _activity_from_session(session: dict[str, Any]) -> dict[str, Any]:
+    capability = str(session.get("capability") or "chat")
+    knowledge_bases = _session_knowledge_bases(session)
+    return {
+        "id": session.get("session_id"),
+        "type": _activity_type(capability),
+        "capability": capability,
+        "title": session.get("title", "Untitled"),
+        "timestamp": session.get("updated_at", session.get("created_at", 0)),
+        "summary": (session.get("last_message") or "")[:160],
+        "session_ref": f"sessions/{session.get('session_id')}",
+        "message_count": session.get("message_count", 0),
+        "status": session.get("status", "idle"),
+        "active_turn_id": session.get("active_turn_id"),
+        "knowledge_bases": knowledge_bases,
+    }
+
+
 @router.get("/recent")
 async def get_recent_activities(limit: int = 50, type: str | None = None):
     store = get_sqlite_session_store()
@@ -16,26 +52,46 @@ async def get_recent_activities(limit: int = 50, type: str | None = None):
     activities: list[dict[str, Any]] = []
 
     for session in sessions:
-        capability = str(session.get("capability") or "chat")
-        activity_type = capability.replace("deep_", "")
-        if type is not None and activity_type != type:
+        activity = _activity_from_session(session)
+        if type is not None and activity["type"] != type:
             continue
-        activities.append(
-            {
-                "id": session.get("session_id"),
-                "type": activity_type,
-                "capability": capability,
-                "title": session.get("title", "Untitled"),
-                "timestamp": session.get("updated_at", session.get("created_at", 0)),
-                "summary": (session.get("last_message") or "")[:160],
-                "session_ref": f"sessions/{session.get('session_id')}",
-                "message_count": session.get("message_count", 0),
-                "status": session.get("status", "idle"),
-                "active_turn_id": session.get("active_turn_id"),
-            }
-        )
+        activities.append(activity)
 
     return activities[:limit]
+
+
+@router.get("/overview")
+async def get_dashboard_overview(limit: int = 50):
+    store = get_sqlite_session_store()
+    sessions = await store.list_sessions(limit=limit, offset=0)
+    activities = [_activity_from_session(session) for session in sessions]
+
+    knowledge_pack_counts: dict[str, int] = {}
+    status_counts: dict[str, int] = {}
+    for activity in activities:
+        status = str(activity.get("status") or "idle")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        for kb_name in activity["knowledge_bases"]:
+            knowledge_pack_counts[kb_name] = knowledge_pack_counts.get(kb_name, 0) + 1
+
+    return {
+        "totals": {
+            "total_sessions": len(activities),
+            "assessments": sum(1 for activity in activities if activity["type"] == "assessment"),
+            "tutoring_sessions": sum(1 for activity in activities if activity["type"] == "tutoring"),
+            "running": status_counts.get("running", 0),
+            "completed": status_counts.get("completed", 0),
+            "failed": status_counts.get("failed", 0),
+        },
+        "knowledge_packs": [
+            {"name": name, "session_count": count}
+            for name, count in sorted(
+                knowledge_pack_counts.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ],
+        "recent_activity": activities[:limit],
+    }
 
 
 @router.get("/{entry_id}")
@@ -48,10 +104,11 @@ async def get_activity_entry(entry_id: str):
     capability = str(session.get("capability") or "chat")
     return {
         "id": session.get("session_id"),
-        "type": capability.replace("deep_", ""),
+        "type": _activity_type(capability),
         "capability": capability,
         "title": session.get("title"),
         "timestamp": session.get("updated_at", session.get("created_at")),
+        "knowledge_bases": _session_knowledge_bases(session),
         "content": {
             "messages": session.get("messages", []),
             "active_turns": session.get("active_turns", []),

--- a/docs/superpowers/pr-notes/pod-a-teacher-dashboard-mvp.md
+++ b/docs/superpowers/pr-notes/pod-a-teacher-dashboard-mvp.md
@@ -1,0 +1,58 @@
+# PR Architecture Note: Pod A Teacher Dashboard MVP
+
+## Summary
+
+Adds a read-only Teacher Dashboard MVP that summarizes recent assessment and tutoring activity from the unified SQLite session store.
+
+## Scope
+
+- Dashboard API overview aggregation.
+- Dashboard frontend API client.
+- Workspace dashboard route.
+- Sidebar navigation entry.
+- API tests for dashboard overview and activity filtering.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Teacher["Teacher"]
+  DashboardPage["Dashboard Page"]
+  DashboardClient["web/lib/dashboard-api.ts"]
+  DashboardRouter["Dashboard Router"]
+  SessionStore["SQLite Session Store"]
+  Sessions["Sessions + Messages + Turns"]
+  Overview["Totals + Knowledge Pack Usage + Recent Activity"]
+
+  Teacher --> DashboardPage
+  DashboardPage --> DashboardClient
+  DashboardClient --> DashboardRouter
+  DashboardRouter --> SessionStore
+  SessionStore --> Sessions
+  Sessions --> Overview
+  Overview --> DashboardPage
+```
+
+## Architecture Impact
+
+The Teacher Dashboard now has a concrete read-only product route backed by the existing dashboard router and unified session store. No new persistence layer was added.
+
+## Data/API Changes
+
+- Adds `GET /api/v1/dashboard/overview`.
+- Extends dashboard recent activity entries with `knowledge_bases`.
+- Maps `deep_question` sessions to `assessment` and chat sessions to `tutoring`.
+
+## Tests
+
+```bash
+pytest tests/api/test_dashboard_router.py -v
+pytest tests/services/session -v
+python3 -m compileall deeptutor
+cd web && npm run build
+```
+
+## Main System Map Update
+
+- [ ] Not needed, because:
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - optional dependency in lightweight envs
+    FastAPI = None
+    TestClient = None
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+pytestmark = pytest.mark.skipif(FastAPI is None or TestClient is None, reason="fastapi not installed")
+
+
+def _build_app(store: SQLiteSessionStore, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from deeptutor.api.routers import dashboard
+
+    app = FastAPI()
+    app.include_router(dashboard.router, prefix="/api/v1/dashboard")
+    monkeypatch.setattr(dashboard, "get_sqlite_session_store", lambda: store)
+    return app
+
+
+async def _seed_session(
+    store: SQLiteSessionStore,
+    *,
+    session_id: str,
+    capability: str,
+    message: str,
+    knowledge_bases: list[str],
+    status: str = "completed",
+) -> None:
+    await store.create_session(session_id=session_id)
+    await store.update_session_preferences(
+        session_id,
+        {
+            "capability": capability,
+            "tools": ["rag"] if knowledge_bases else [],
+            "knowledge_bases": knowledge_bases,
+            "language": "en",
+        },
+    )
+    turn = await store.create_turn(session_id, capability=capability)
+    await store.add_message(session_id, "user", message, capability=capability)
+    await store.update_turn_status(turn["id"], status)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_groups_activity_and_knowledge_packs(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="quiz-session",
+        capability="deep_question",
+        message="Generate a quiz on quadratic equations",
+        knowledge_bases=["math-pack"],
+    )
+    await _seed_session(
+        store,
+        session_id="tutor-session",
+        capability="chat",
+        message="Help a student review linear functions",
+        knowledge_bases=["math-pack"],
+        status="running",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/overview")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["totals"]["total_sessions"] == 2
+    assert payload["totals"]["assessments"] == 1
+    assert payload["totals"]["tutoring_sessions"] == 1
+    assert payload["totals"]["running"] == 1
+    assert payload["knowledge_packs"] == [{"name": "math-pack", "session_count": 2}]
+    assert payload["recent_activity"][0]["knowledge_bases"] == ["math-pack"]
+    assert payload["recent_activity"][0]["type"] in {"assessment", "tutoring"}
+
+
+@pytest.mark.asyncio
+async def test_dashboard_recent_filters_assessment_activity(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="quiz-session",
+        capability="deep_question",
+        message="Generate a quiz",
+        knowledge_bases=["math-pack"],
+    )
+    await _seed_session(
+        store,
+        session_id="chat-session",
+        capability="chat",
+        message="Tutor a student",
+        knowledge_bases=["math-pack"],
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/recent?type=assessment")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["id"] == "quiz-session"
+    assert payload[0]["type"] == "assessment"

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Activity, BookOpen, CheckCircle2, Loader2, PenLine, Users } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  getDashboardOverview,
+  type DashboardActivity,
+  type DashboardOverview,
+} from "@/lib/dashboard-api";
+
+function formatTime(value: number): string {
+  if (!value) return "";
+  const timestamp = value < 10_000_000_000 ? value * 1000 : value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
+function activityLabel(activity: DashboardActivity): string {
+  if (activity.type === "assessment") return "Assessment";
+  if (activity.type === "tutoring") return "Tutoring";
+  return activity.type.replaceAll("_", " ");
+}
+
+export default function DashboardPage() {
+  const { t } = useTranslation();
+  const [overview, setOverview] = useState<DashboardOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getDashboardOverview()
+      .then((data) => {
+        if (!cancelled) {
+          setOverview(data);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const totals = overview?.totals;
+  const cards = useMemo(
+    () => [
+      {
+        label: t("Sessions"),
+        value: totals?.total_sessions ?? 0,
+        icon: Activity,
+      },
+      {
+        label: t("Assessments"),
+        value: totals?.assessments ?? 0,
+        icon: PenLine,
+      },
+      {
+        label: t("Tutoring"),
+        value: totals?.tutoring_sessions ?? 0,
+        icon: Users,
+      },
+      {
+        label: t("Running"),
+        value: totals?.running ?? 0,
+        icon: Loader2,
+      },
+    ],
+    [t, totals],
+  );
+
+  return (
+    <main className="h-full overflow-y-auto bg-[var(--background)]">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-6 px-6 py-8">
+        <header>
+          <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+            {t("Teacher Dashboard")}
+          </p>
+          <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
+            {t("Class activity")}
+          </h1>
+          <p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
+            {t("Review recent assessments, tutoring sessions, and Knowledge Pack usage.")}
+          </p>
+        </header>
+
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <section className="grid gap-3 md:grid-cols-4">
+          {cards.map((card) => (
+            <div
+              key={card.label}
+              className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-4 py-3"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[12px] font-medium text-[var(--muted-foreground)]">
+                  {card.label}
+                </span>
+                <card.icon size={16} className="text-[var(--muted-foreground)]" />
+              </div>
+              <div className="mt-3 text-[28px] font-semibold text-[var(--foreground)]">
+                {loading ? "-" : card.value}
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <section className="grid gap-5 lg:grid-cols-[1fr_320px]">
+          <div>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-[16px] font-semibold text-[var(--foreground)]">
+                {t("Recent activity")}
+              </h2>
+              {loading && (
+                <span className="flex items-center gap-2 text-[12px] text-[var(--muted-foreground)]">
+                  <Loader2 size={13} className="animate-spin" />
+                  {t("Loading")}
+                </span>
+              )}
+            </div>
+            <div className="overflow-hidden rounded-lg border border-[var(--border)]">
+              {(overview?.recent_activity ?? []).length > 0 ? (
+                overview?.recent_activity.map((activity) => (
+                  <div
+                    key={activity.id}
+                    className="border-b border-[var(--border)] bg-[var(--card)] px-4 py-3 last:border-b-0"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <div className="text-[14px] font-medium text-[var(--foreground)]">
+                          {activity.title || t("Untitled session")}
+                        </div>
+                        <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
+                          {t(activityLabel(activity))} - {activity.status} -{" "}
+                          {formatTime(activity.timestamp)}
+                        </div>
+                      </div>
+                      {activity.knowledge_bases.length > 0 && (
+                        <div className="flex flex-wrap gap-1">
+                          {activity.knowledge_bases.map((kb) => (
+                            <span
+                              key={`${activity.id}-${kb}`}
+                              className="rounded-md bg-[var(--muted)] px-2 py-1 text-[11px] text-[var(--muted-foreground)]"
+                            >
+                              {kb}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    {activity.summary && (
+                      <p className="mt-2 line-clamp-2 text-[13px] leading-5 text-[var(--muted-foreground)]">
+                        {activity.summary}
+                      </p>
+                    )}
+                  </div>
+                ))
+              ) : (
+                <div className="bg-[var(--card)] px-4 py-10 text-center text-[13px] text-[var(--muted-foreground)]">
+                  {loading
+                    ? t("Loading activity...")
+                    : t("No learning activity yet. Generate an assessment or start a tutoring chat.")}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <aside>
+            <h2 className="mb-3 text-[16px] font-semibold text-[var(--foreground)]">
+              {t("Knowledge Packs")}
+            </h2>
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--card)]">
+              {(overview?.knowledge_packs ?? []).length > 0 ? (
+                overview?.knowledge_packs.map((pack) => (
+                  <div
+                    key={pack.name}
+                    className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3 last:border-b-0"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <BookOpen size={15} className="shrink-0 text-[var(--muted-foreground)]" />
+                      <span className="truncate text-[13px] font-medium text-[var(--foreground)]">
+                        {pack.name}
+                      </span>
+                    </div>
+                    <span className="flex items-center gap-1 text-[12px] text-[var(--muted-foreground)]">
+                      <CheckCircle2 size={13} />
+                      {pack.session_count}
+                    </span>
+                  </div>
+                ))
+              ) : (
+                <div className="px-4 py-8 text-center text-[13px] text-[var(--muted-foreground)]">
+                  {t("Knowledge Pack activity will appear here.")}
+                </div>
+              )}
+            </div>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -7,6 +7,7 @@ import { useState, type ReactNode } from "react";
 import {
   BookOpen,
   Bot,
+  BarChart3,
   Brain,
   GraduationCap,
   MessageSquare,
@@ -33,6 +34,7 @@ const PRIMARY_NAV: NavEntry[] = [
   { href: "/agents", label: "TutorBot", icon: Bot },
   { href: "/co-writer", label: "Co-Writer", icon: PenLine },
   { href: "/guide", label: "Guided Learning", icon: GraduationCap },
+  { href: "/dashboard", label: "Dashboard", icon: BarChart3 },
   { href: "/knowledge", label: "Knowledge", icon: BookOpen },
   { href: "/memory", label: "Memory", icon: Brain },
 ];

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -1,0 +1,45 @@
+import { apiUrl } from "@/lib/api";
+
+export interface DashboardActivity {
+  id: string;
+  type: "assessment" | "tutoring" | string;
+  capability: string;
+  title: string;
+  timestamp: number;
+  summary: string;
+  session_ref: string;
+  message_count: number;
+  status: string;
+  active_turn_id?: string | null;
+  knowledge_bases: string[];
+}
+
+export interface DashboardOverview {
+  totals: {
+    total_sessions: number;
+    assessments: number;
+    tutoring_sessions: number;
+    running: number;
+    completed: number;
+    failed: number;
+  };
+  knowledge_packs: Array<{
+    name: string;
+    session_count: number;
+  }>;
+  recent_activity: DashboardActivity[];
+}
+
+async function expectJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function getDashboardOverview(limit = 50): Promise<DashboardOverview> {
+  const response = await fetch(apiUrl(`/api/v1/dashboard/overview?limit=${limit}`), {
+    cache: "no-store",
+  });
+  return expectJson<DashboardOverview>(response);
+}


### PR DESCRIPTION
## Summary
- add read-only Teacher Dashboard overview backed by the unified session store
- add dashboard frontend route, API client, and sidebar navigation
- add API tests for overview aggregation and assessment filtering

## Tests
- pytest tests/api/test_dashboard_router.py -v
- pytest tests/services/session -v
- python3 -m compileall deeptutor
- cd web && npm run build

## PR Note
- docs/superpowers/pr-notes/pod-a-teacher-dashboard-mvp.md

Refs #9