### PR TITLE
docs: add contest evidence demo packet

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -23,6 +23,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
+- Latest product status: Knowledge Pack, assessment generation, student tutoring context, and Teacher Dashboard MVPs are merged. The next packet should prepare contest evidence and demo readiness.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -99,6 +100,7 @@ Before handing off:
 1. Keep this file as the single entry point for future AI workers.
 2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
 3. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
-4. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
-5. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-6. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.
+4. Execute `docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md` before starting another product feature.
+5. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+6. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+7. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -31,7 +31,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Current branch for this docs update: `docs/post-pr4-next-actions`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
-- Current purpose: update the queue after PR `#4`, then continue with Pod A before Pod B.
+- Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard MVPs are merged.
+- Current purpose: prepare the contest evidence/demo packet so the next worker can package proof of the MVP.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -65,12 +66,13 @@ Do not revert unrelated changes.
 - Pod A GitHub issue: `#2`
 - Pod B GitHub issue: `#3`
 - Teacher Dashboard GitHub issue: `#9`
+- Contest evidence/demo GitHub issue: `#12`
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Teacher Dashboard MVP is in progress on `pod-a/teacher-dashboard-mvp`, mirrored by GitHub issue `#9`. The implementation is read-only and uses existing unified session data instead of adding new persistence.
+Contest evidence/demo packet is being prepared on `docs/contest-evidence-demo-packet`, mirrored by GitHub issue `#12`. After this docs PR merges, execute `docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md` before starting another product feature.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,12 +6,11 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Finish and publish Pod A: Teacher Dashboard MVP from `pod-a/teacher-dashboard-mvp`.
-2. Keep GitHub issue `#9` aligned with the dashboard implementation PR.
-3. Fix any dashboard CI, test, or review blockers before starting the next feature.
-4. After dashboard merges, create the next contest evidence/demo task packet.
-5. Keep GitHub issues `#2`, `#3`, and `#9` linked to their implementation PRs.
-6. Preserve unrelated dirty files until they are intentionally handled.
+1. Merge the docs-only contest evidence/demo packet PR when eligible.
+2. Execute `docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md`.
+3. Create `docs/contest/` evidence docs before starting another product feature.
+4. Keep GitHub issues `#2`, `#3`, `#9`, and `#12` linked to their implementation PRs.
+5. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -86,7 +86,22 @@
   - Passed: `python3 -m compileall deeptutor`
   - Passed: `cd web && npm run build`
 - Blockers: None known.
-- Next: Open PR and apply merge policy if eligible, then continue to contest evidence/demo task packet.
+- Next: PR `#11` merged into `main`. Continue to contest evidence/demo task packet.
+
+## Contest Evidence
+
+- Branch: `docs/contest-evidence-demo-packet`
+- Task: Create contest evidence/demo task packet.
+- Done:
+  - Created GitHub issue `#12`.
+  - Added task packet for `docs/contest/` evidence bundle, demo script, checklist, and validation report.
+  - Added docs-only PR architecture note with Mermaid.
+  - Updated operating/status mirrors so the next autonomous step executes the evidence packet.
+- Tests:
+  - Passed: `rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md docs/superpowers/pr-notes/contest-evidence-demo-packet.md`
+  - Passed: `git diff --check`
+- Blockers: None known.
+- Next: Commit, open docs PR, merge when eligible, then execute the evidence packet.
 
 ## Human Review Needed
 

--- a/docs/superpowers/pr-notes/contest-evidence-demo-packet.md
+++ b/docs/superpowers/pr-notes/contest-evidence-demo-packet.md
@@ -1,0 +1,50 @@
+# PR Architecture Note: Contest Evidence and Demo Packet
+
+## Summary
+
+Adds a docs-only task packet for preparing the contest evidence bundle and demo readiness materials.
+
+## Scope
+
+- Defines the next evidence/demo task.
+- Captures owned files and do-not-touch boundaries.
+- Defines acceptance criteria and validation commands for the future evidence bundle.
+- Updates AI-first status mirrors so the autonomous loop continues from this packet.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  Main["Merged MVP Features"]
+  Packet["Contest Evidence Task Packet"]
+  Docs["docs/contest Evidence Bundle"]
+  Validate["Validation Report"]
+  Review["Human Morning Review"]
+  Next["Next AI Task Selection"]
+
+  Main --> Packet
+  Packet --> Docs
+  Docs --> Validate
+  Validate --> Review
+  Validate --> Next
+```
+
+## Architecture Impact
+
+No runtime architecture changes. This PR only creates the execution packet for evidence and demo documentation.
+
+## Data/API Changes
+
+None.
+
+## Tests
+
+```bash
+rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md docs/superpowers/pr-notes/contest-evidence-demo-packet.md
+git diff --check
+```
+
+## Main System Map Update
+
+- [x] Not needed, because this is a docs-only task packet and does not change product architecture.
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

--- a/docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md
+++ b/docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md
@@ -1,0 +1,95 @@
+# Feature Pod Task: Contest Evidence and Demo Bundle
+
+Owner: Documentation / Evidence AI worker
+Branch: `docs/contest-evidence-demo`
+GitHub Issue: `#12`
+
+## Goal
+
+Prepare the contest evidence bundle that proves the MVP path works end to end:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+## User-visible outcome
+
+A human reviewer can open the repo docs and follow a clear demo script, evidence checklist, and validation report without asking the AI what was done or how to verify it.
+
+## Owned files/modules
+
+- `docs/contest/`
+- `docs/superpowers/pr-notes/contest-evidence-demo.md`
+- `ai_first/daily/YYYY-MM-DD.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/AI_OPERATING_PROMPT.md` if the operating queue changes
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `.env*`
+- `data/`
+
+## Evidence contract
+
+Create a compact `docs/contest/` evidence set with:
+
+- `DEMO_SCRIPT.md`: a step-by-step demo path for Knowledge Pack, assessment generation, student tutoring, and teacher dashboard review.
+- `EVIDENCE_CHECKLIST.md`: required screenshots, optional video capture, expected commands, and pass/fail evidence fields.
+- `VALIDATION_REPORT.md`: exact local validation commands, current known limitations, and manual verification results.
+- `README.md`: one-page entry point linking the evidence files and explaining how to update them after product changes.
+
+The docs should make clear which evidence is already validated locally and which evidence needs human capture, such as screenshots or video.
+
+## Acceptance criteria
+
+- `docs/contest/README.md` is the entry point for contest evidence.
+- The demo script covers the full MVP path in the product goal order.
+- The checklist separates required evidence from optional polish.
+- The validation report includes exact commands and a place to record results.
+- The task stays docs-only and does not modify product/runtime code.
+- The PR includes an architecture note with Mermaid.
+
+## Required validation
+
+- `rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/contest docs/superpowers/pr-notes`
+- `git diff --check`
+
+## Manual verification
+
+- Read `docs/contest/README.md` first.
+- Follow links to the demo script, checklist, and validation report.
+- Confirm a new AI worker can tell what evidence to capture next without reading old chat history.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Goal["Contest MVP Goal"]
+  Script["DEMO_SCRIPT.md"]
+  Checklist["EVIDENCE_CHECKLIST.md"]
+  Report["VALIDATION_REPORT.md"]
+  Reviewer["Human Reviewer"]
+  NextAI["Next AI Worker"]
+
+  Goal --> Script
+  Script --> Checklist
+  Checklist --> Report
+  Report --> Reviewer
+  Report --> NextAI
+```
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State that `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated because this packet creates documentation work, not a product architecture change.
+
+## Handoff notes
+
+- After this task packet PR merges, execute this packet before starting another product feature.
+- Keep screenshots and video assets small or link to externally hosted captures if repository size becomes a concern.
+- Do not add secrets, local user paths, real student data, or private credentials to evidence docs.


### PR DESCRIPTION
## Summary
- add a contest evidence/demo task packet for the next autonomous step
- add a docs-only PR architecture note with Mermaid
- update AI-first operating/status mirrors so the loop continues from issue #12

## Tests
- rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md docs/superpowers/pr-notes/contest-evidence-demo-packet.md
- git diff --check

## PR Note
- docs/superpowers/pr-notes/contest-evidence-demo-packet.md

Refs #12