### PR TITLE
docs: add contest evidence bundle

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -23,7 +23,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, assessment generation, student tutoring context, and Teacher Dashboard MVPs are merged. The next packet should prepare contest evidence and demo readiness.
+- Latest product status: Knowledge Pack, assessment generation, student tutoring context, and Teacher Dashboard MVPs are merged. Contest evidence docs are being prepared under `docs/contest/`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -100,7 +100,7 @@ Before handing off:
 1. Keep this file as the single entry point for future AI workers.
 2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
 3. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
-4. Execute `docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md` before starting another product feature.
+4. Finish and merge the contest evidence bundle under `docs/contest/`, then capture screenshot/video evidence when a local demo environment is available.
 5. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
 6. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
 7. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -32,7 +32,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard MVPs are merged.
-- Current purpose: prepare the contest evidence/demo packet so the next worker can package proof of the MVP.
+- Current purpose: create the `docs/contest/` evidence bundle so a reviewer can follow and verify the MVP story.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -72,7 +72,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Contest evidence/demo packet is being prepared on `docs/contest-evidence-demo-packet`, mirrored by GitHub issue `#12`. After this docs PR merges, execute `docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md` before starting another product feature.
+Contest evidence/demo bundle is being prepared on `docs/contest-evidence-demo`, mirrored by GitHub issue `#12`. After this docs PR merges, the next evidence step is screenshot/video capture from a local demo run.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,11 +6,10 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Merge the docs-only contest evidence/demo packet PR when eligible.
-2. Execute `docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md`.
-3. Create `docs/contest/` evidence docs before starting another product feature.
-4. Keep GitHub issues `#2`, `#3`, `#9`, and `#12` linked to their implementation PRs.
-5. Preserve unrelated dirty files until they are intentionally handled.
+1. Merge the docs-only contest evidence bundle PR when eligible.
+2. Capture or link demo screenshots/video for `docs/contest/EVIDENCE_CHECKLIST.md` when a local demo environment is available.
+3. Keep GitHub issues `#2`, `#3`, `#9`, and `#12` linked to their implementation PRs.
+4. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -103,6 +103,23 @@
 - Blockers: None known.
 - Next: Commit, open docs PR, merge when eligible, then execute the evidence packet.
 
+## Contest Evidence Bundle
+
+- Branch: `docs/contest-evidence-demo`
+- Task: Execute contest evidence/demo packet from `docs/superpowers/tasks/2026-04-19-contest-evidence-demo.md`.
+- Done:
+  - Added `docs/contest/README.md` as the evidence entry point.
+  - Added `docs/contest/DEMO_SCRIPT.md`.
+  - Added `docs/contest/EVIDENCE_CHECKLIST.md`.
+  - Added `docs/contest/VALIDATION_REPORT.md`.
+  - Added docs-only PR architecture note with Mermaid.
+  - Updated operating/status mirrors for the next screenshot/video evidence step.
+- Tests:
+  - Passed: `rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/contest docs/superpowers/pr-notes`
+  - Passed: `git diff --check`
+- Blockers: Screenshot and video evidence still require a local demo run.
+- Next: Validate docs, open PR, merge when eligible, then capture screenshots/video when environment is available.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/contest/DEMO_SCRIPT.md
+++ b/docs/contest/DEMO_SCRIPT.md
@@ -1,0 +1,93 @@
+# Demo Script
+
+Use this script to present the MVP in the same order as the project goal.
+
+## Setup
+
+1. Install backend and frontend dependencies according to the repository README.
+2. Start the API server.
+3. Start the web app.
+4. Open the web workspace in a browser.
+5. Use demo-safe sample content. Do not use private student data.
+
+## Demo Path
+
+### 1. Teacher Creates A Knowledge Pack
+
+Goal: show that a teacher can prepare class context before asking AI to generate learning activity.
+
+Steps:
+
+1. Open the Knowledge page.
+2. Create or select a Knowledge Pack.
+3. Fill the metadata fields:
+   - subject;
+   - grade;
+   - curriculum;
+   - learning objectives;
+   - owner;
+   - sharing status.
+4. Save the pack.
+5. Reload or revisit the page and confirm the metadata remains available.
+
+Evidence to capture:
+
+- Screenshot of the Knowledge page with demo-safe metadata.
+- Screenshot after reload showing persisted metadata.
+
+### 2. AI Generates An Assessment
+
+Goal: show that the assessment workflow can use the teacher's subject and Knowledge Pack context.
+
+Steps:
+
+1. Open the assessment or quiz generation UI.
+2. Select or reference the demo Knowledge Pack.
+3. Set subject and quiz parameters.
+4. Generate the assessment.
+5. Review generated questions and common-mistake feedback.
+
+Evidence to capture:
+
+- Screenshot of the quiz configuration.
+- Screenshot of generated questions.
+- Screenshot of common-mistake guidance.
+
+### 3. Student Learns With Tutor Agent
+
+Goal: show that the student can continue learning with Tutor Agent context after assessment generation.
+
+Steps:
+
+1. Open the student tutoring/chat workspace.
+2. Select the same Knowledge Pack when available.
+3. Ask a student-style follow-up question.
+4. Confirm the tutor response is grounded in the selected learning context.
+
+Evidence to capture:
+
+- Screenshot of the selected Knowledge Pack context.
+- Screenshot of student question and Tutor Agent answer.
+
+### 4. Teacher Reviews Dashboard
+
+Goal: show that the teacher can review recent assessment and tutoring activity.
+
+Steps:
+
+1. Open the Dashboard page.
+2. Confirm totals for sessions, assessments, tutoring, and running activity.
+3. Confirm recent activity distinguishes assessment and tutoring sessions.
+4. Confirm Knowledge Pack references appear when sessions used a selected pack.
+
+Evidence to capture:
+
+- Screenshot of the Dashboard summary cards.
+- Screenshot of recent activity with Knowledge Pack context.
+
+## Presenter Notes
+
+- Keep the demo short and linear.
+- Use one consistent sample topic across all screens.
+- If an external LLM provider is unavailable, explain the unavailable credential and show the local validation report instead of inventing evidence.
+- After the demo, open `VALIDATION_REPORT.md` to show exact commands and known limitations.

--- a/docs/contest/EVIDENCE_CHECKLIST.md
+++ b/docs/contest/EVIDENCE_CHECKLIST.md
@@ -1,0 +1,54 @@
+# Evidence Checklist
+
+Use this checklist after running the demo locally.
+
+## Required Screenshots
+
+| Area | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Pending capture | Use one consistent sample topic. |
+| Knowledge Pack | Metadata still visible after reload | Pending capture | Confirms persistence. |
+| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Pending capture | Avoid private source material. |
+| Assessment | Generated questions visible | Pending capture | Capture enough context to prove generation worked. |
+| Assessment | Common-mistake or feedback guidance visible | Pending capture | Shows learning support, not only question output. |
+| Tutor Agent | Student asks a follow-up question | Pending capture | Use a short student-style prompt. |
+| Tutor Agent | Tutor response with learning context | Pending capture | Confirm it is demo-safe. |
+| Dashboard | Summary cards visible | Pending capture | Include sessions, assessments, tutoring, and running activity. |
+| Dashboard | Recent activity includes assessment/tutoring distinction and Knowledge Pack reference | Pending capture | Shows the loop closes for the teacher. |
+
+## Required Command Evidence
+
+| Command | Status | Source |
+| --- | --- | --- |
+| `pytest tests/api/test_knowledge_router.py -v` | Passed in PR `#6` validation | See daily log and PR notes. |
+| `pytest tests/knowledge -v` | Passed in PR `#6` validation | See daily log and PR notes. |
+| `pytest tests/api/test_question_router.py -v` | Passed in PR `#8` validation | See daily log and PR notes. |
+| `pytest tests/api/test_unified_ws_turn_runtime.py -v` | Passed in PR `#8` validation | See daily log and PR notes. |
+| `pytest tests/api/test_dashboard_router.py -v` | Passed in PR `#11` validation | See daily log and PR notes. |
+| `pytest tests/services/session -v` | Passed in PR `#11` validation | See daily log and PR notes. |
+| `python3 -m compileall deeptutor` | Passed in PR `#6`, `#8`, and `#11` validation | See daily log and PR notes. |
+| `cd web && npm run build` | Passed in PR `#6`, `#8`, and `#11` validation | Build warns about multiple lockfiles; no build failure. |
+
+## Optional Video
+
+Capture one short video, ideally under five minutes:
+
+1. Knowledge Pack setup.
+2. Assessment generation.
+3. Student tutoring follow-up.
+4. Teacher Dashboard review.
+5. Validation report summary.
+
+Store large video files outside the repository and link them here:
+
+- Video link: Pending.
+
+## Pass/Fail Summary
+
+| Criterion | Status | Notes |
+| --- | --- | --- |
+| Full MVP story can be followed from docs | Pending final read-through | Start with `docs/contest/README.md`. |
+| Product commands have local validation evidence | Passed | See `VALIDATION_REPORT.md`. |
+| Screenshots are captured and linked | Pending capture | Requires running local app. |
+| Video is captured or explicitly deferred | Pending capture | Optional unless submission requires it. |
+| No secrets or private data in evidence | Pending review | Check before publishing. |

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -1,0 +1,41 @@
+# Contest Evidence Bundle
+
+This folder is the entry point for VnExpress Sang kien Khoa hoc 2026 demo evidence.
+
+## MVP Story
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+## Evidence Files
+
+- [`DEMO_SCRIPT.md`](./DEMO_SCRIPT.md): step-by-step demo path for a reviewer or presenter.
+- [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md): required screenshots, optional video, and pass/fail evidence fields.
+- [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md): local validation commands, results, limitations, and remaining capture work.
+
+## Current Status
+
+- Product MVP path is implemented through merged PRs for Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard.
+- Local command validation is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
+- Screenshot and video capture are still pending and should be completed after starting the backend and frontend locally.
+
+## Update Rules
+
+- Update this folder whenever the demo flow, API behavior, or UI route changes.
+- Keep evidence free of secrets, private data, local credentials, and real student information.
+- Store large videos outside the repository and link them from the checklist or validation report.
+
+## Evidence Flow
+
+```mermaid
+flowchart LR
+  Goal["Contest MVP Story"]
+  Demo["DEMO_SCRIPT.md"]
+  Checklist["EVIDENCE_CHECKLIST.md"]
+  Validation["VALIDATION_REPORT.md"]
+  Reviewer["Reviewer"]
+
+  Goal --> Demo
+  Demo --> Checklist
+  Checklist --> Validation
+  Validation --> Reviewer
+```

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -1,0 +1,62 @@
+# Validation Report
+
+Last updated: 2026-04-19
+
+## Scope
+
+This report covers the current contest MVP path:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+## Local Validation Summary
+
+| Area | Command | Result |
+| --- | --- | --- |
+| Knowledge Pack API | `pytest tests/api/test_knowledge_router.py -v` | Passed in PR `#6` validation: 11 passed. |
+| Knowledge Pack metadata | `pytest tests/knowledge -v` | Passed in PR `#6` validation: 3 passed. |
+| Assessment API | `pytest tests/api/test_question_router.py -v` | Passed in PR `#8` validation: 1 passed. |
+| Student tutor runtime contract | `pytest tests/api/test_unified_ws_turn_runtime.py -v` | Passed in PR `#8` validation: 6 passed. |
+| Teacher Dashboard API | `pytest tests/api/test_dashboard_router.py -v` | Passed in PR `#11` validation: 2 passed. |
+| Session persistence regression | `pytest tests/services/session -v` | Passed in PR `#11` validation: 2 passed. |
+| Backend syntax/import sweep | `python3 -m compileall deeptutor` | Passed in PR `#6`, `#8`, and `#11` validation. |
+| Frontend production build | `cd web && npm run build` | Passed in PR `#6`, `#8`, and `#11` validation. |
+
+## Current Known Limitations
+
+- Screenshot and video evidence are not captured yet.
+- The frontend build emits a Next.js warning about multiple lockfiles and inferred workspace root. The build still completes successfully.
+- Provider-backed AI quality depends on configured model credentials. If credentials are unavailable during a demo, use the command validation and recorded UI flow as fallback evidence.
+- This report uses demo-safe descriptions only. Do not add real student data.
+
+## Manual Verification Template
+
+Complete this section when the local app is running.
+
+| Step | Expected result | Status | Evidence link |
+| --- | --- | --- | --- |
+| Open Knowledge page | Teacher can create or edit Knowledge Pack metadata | Pending | Pending |
+| Reload Knowledge page | Metadata remains visible | Pending | Pending |
+| Generate assessment | Questions are generated from selected subject/context | Pending | Pending |
+| Review feedback | Common-mistake or guidance output is visible | Pending | Pending |
+| Ask Tutor Agent follow-up | Tutor responds to student question | Pending | Pending |
+| Open Dashboard | Recent assessment and tutoring activity appears | Pending | Pending |
+
+## PR Evidence Links
+
+- Knowledge Pack MVP: PR `#6`.
+- Assessment and Student Tutor Workspace MVP: PR `#8`.
+- Teacher Dashboard MVP: PR `#11`.
+- Contest evidence packet: PR `#13`.
+
+## Next Evidence Actions
+
+1. Start backend and frontend locally.
+2. Follow `DEMO_SCRIPT.md`.
+3. Capture required screenshots listed in `EVIDENCE_CHECKLIST.md`.
+4. Add links or lightweight image files to this folder.
+5. Re-run docs validation:
+
+```bash
+rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/contest docs/superpowers/pr-notes
+git diff --check
+```

--- a/docs/superpowers/pr-notes/contest-evidence-demo.md
+++ b/docs/superpowers/pr-notes/contest-evidence-demo.md
@@ -1,0 +1,53 @@
+# PR Architecture Note: Contest Evidence Demo Bundle
+
+## Summary
+
+Adds the contest evidence bundle entry point, demo script, evidence checklist, and validation report for the current MVP path.
+
+## Scope
+
+- `docs/contest/README.md`
+- `docs/contest/DEMO_SCRIPT.md`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- AI-first status mirror updates
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  MVP["Merged MVP Features"]
+  Readme["Contest README"]
+  Script["Demo Script"]
+  Checklist["Evidence Checklist"]
+  Report["Validation Report"]
+  Reviewer["Reviewer"]
+
+  MVP --> Readme
+  Readme --> Script
+  Readme --> Checklist
+  Readme --> Report
+  Script --> Reviewer
+  Checklist --> Reviewer
+  Report --> Reviewer
+```
+
+## Architecture Impact
+
+No runtime architecture changes. This PR adds documentation evidence for the existing MVP path.
+
+## Data/API Changes
+
+None.
+
+## Tests
+
+```bash
+rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/contest docs/superpowers/pr-notes
+git diff --check
+```
+
+## Main System Map Update
+
+- [x] Not needed, because this is a docs-only evidence bundle and does not change product architecture.
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`


### PR DESCRIPTION
## Summary
- add docs/contest entry point, demo script, evidence checklist, and validation report
- add docs-only PR architecture note with Mermaid
- update AI-first status mirrors for the next screenshot/video evidence step

## Tests
- rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/contest docs/superpowers/pr-notes
- git diff --check

## PR Note
- docs/superpowers/pr-notes/contest-evidence-demo.md

Refs #12