### PR TITLE
docs: add ci checks task packet

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -23,7 +23,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, and contest screenshot evidence are merged or in-flight. Next operating improvement: add reliable backend/frontend CI before broader runtime auto-merge.
+- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, and contest screenshot evidence are merged. Next operating improvement: add reliable backend/frontend CI before broader runtime auto-merge.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -100,7 +100,7 @@ Before handing off:
 1. Keep this file as the single entry point for future AI workers.
 2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
 3. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
-4. Finish and merge the contest screenshot evidence PR, then create the CI task packet before starting another product feature.
+4. Finish and merge the CI task packet, then implement reliable backend/frontend/docs CI before starting another product feature.
 5. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
 6. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
 7. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -67,12 +67,13 @@ Do not revert unrelated changes.
 - Pod B GitHub issue: `#3`
 - Teacher Dashboard GitHub issue: `#9`
 - Contest evidence/demo GitHub issue: `#12`
+- CI backend/frontend checks GitHub issue: `#16`
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Contest screenshot evidence is being prepared on `docs/contest-evidence-capture`, mirrored by GitHub issue `#12`. After this docs PR merges, create the CI task packet for reliable backend and frontend checks.
+CI task packet is being prepared on `docs/ci-task-packet`, mirrored by GitHub issue `#16`. After this docs PR merges, implement `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,9 +6,9 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Merge the docs-only contest screenshot evidence PR when eligible.
-2. Create the CI task packet for reliable backend and frontend checks.
-3. Keep GitHub issues `#2`, `#3`, `#9`, and `#12` linked to their implementation PRs.
+1. Merge the docs-only CI task packet PR when eligible.
+2. Implement reliable backend, frontend, and docs CI checks from `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
+3. Keep GitHub issues `#2`, `#3`, `#9`, `#12`, and `#16` linked to their implementation PRs.
 4. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -137,6 +137,21 @@
   - Video remains deferred unless final submission requires externally hosted video.
 - Next: Commit, open docs PR, merge when eligible, then create CI task packet.
 
+## CI Task Packet
+
+- Branch: `docs/ci-task-packet`
+- Task: Create backend/frontend/docs CI implementation task packet.
+- Done:
+  - Created GitHub issue `#16`.
+  - Added `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
+  - Added docs-only PR architecture note with Mermaid.
+  - Updated operating/status mirrors so the next task is CI implementation.
+- Tests:
+  - Passed: `rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md docs/superpowers/pr-notes/ci-backend-frontend-packet.md ai_first`
+  - Passed: `git diff --check`
+- Blockers: None known.
+- Next: Commit, open docs PR, merge when eligible, then implement CI.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/superpowers/pr-notes/ci-backend-frontend-packet.md
+++ b/docs/superpowers/pr-notes/ci-backend-frontend-packet.md
@@ -1,0 +1,46 @@
+# PR Architecture Note: Backend and Frontend CI Task Packet
+
+## Summary
+
+Adds the task packet for implementing reliable backend, frontend, and docs CI checks before broader runtime auto-merge.
+
+## Scope
+
+- Creates `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
+- Updates AI-first status mirrors so the autonomous queue moves to CI implementation.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Queue["AI-First Queue"]
+  Packet["CI Task Packet"]
+  Workflow["Future GitHub Actions Workflow"]
+  Checks["Backend + Frontend + Docs Checks"]
+  MergePolicy["Runtime Merge Policy"]
+
+  Queue --> Packet
+  Packet --> Workflow
+  Workflow --> Checks
+  Checks --> MergePolicy
+```
+
+## Architecture Impact
+
+No runtime architecture changes. This PR only creates the CI implementation task packet.
+
+## Data/API Changes
+
+None.
+
+## Tests
+
+```bash
+rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md docs/superpowers/pr-notes/ci-backend-frontend-packet.md ai_first
+git diff --check
+```
+
+## Main System Map Update
+
+- [x] Not needed, because this is a docs-only task packet and does not add the CI workflow yet.
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

--- a/docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md
+++ b/docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md
@@ -1,0 +1,113 @@
+# Feature Pod Task: Backend and Frontend CI Checks
+
+Owner: CI / Workflow AI worker
+Branch: `docs/ci-backend-frontend-checks` for packet; implementation branch should be `fix/ci-backend-frontend-checks`
+GitHub Issue: `#16`
+
+## Goal
+
+Add reliable automated checks so runtime/product PRs can be auto-merged only after backend and frontend validation pass.
+
+## User-visible outcome
+
+The GitHub PR page shows CI status for core backend tests, frontend build, and docs validation. AI workers can use those checks as merge gates instead of relying only on local validation.
+
+## Owned files/modules
+
+- `.github/workflows/`
+- `docs/superpowers/pr-notes/ci-backend-frontend-checks.md`
+- `ai_first/daily/YYYY-MM-DD.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/AI_OPERATING_PROMPT.md` if merge policy or next actions change
+
+## Do-not-touch files/modules
+
+- `deeptutor/` product/runtime code
+- `web/` product/runtime code
+- `data/`
+- `.env*`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- requirements files, unless CI dependency installation proves they are missing or inconsistent
+
+## CI contract
+
+Create one focused GitHub Actions workflow that runs on pull requests and pushes to `main`.
+
+Required jobs:
+
+- Backend:
+  - set up Python 3.12;
+  - install project with server/test dependencies using the existing repo dependency files or `pyproject.toml`;
+  - run:
+    - `pytest tests/api/test_knowledge_router.py -v`
+    - `pytest tests/knowledge -v`
+    - `pytest tests/api/test_question_router.py -v`
+    - `pytest tests/api/test_unified_ws_turn_runtime.py -v`
+    - `pytest tests/api/test_dashboard_router.py -v`
+    - `pytest tests/services/session -v`
+    - `python -m compileall deeptutor`
+- Frontend:
+  - set up Node using the version compatible with the current Next.js project;
+  - run `npm ci` in `web/`;
+  - run `npm run build` in `web/` with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
+- Docs:
+  - run `git diff --check`;
+  - run `rg -n "Mermaid|PR Architecture Note|Main System Map" docs/superpowers/pr-notes ai_first docs/contest`.
+
+## Acceptance criteria
+
+- A PR against `main` triggers backend, frontend, and docs checks.
+- Workflow names are readable from the PR checks list.
+- CI does not require real LLM credentials.
+- CI does not modify lockfiles.
+- If dependency installation fails, diagnose from logs and update only the narrow dependency setup needed.
+- The PR includes an architecture note with Mermaid.
+- `ai_first/AI_OPERATING_PROMPT.md` is updated only if CI check names or merge gates become authoritative.
+
+## Required local validation before PR
+
+- `git diff --check`
+- `rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" .github/workflows docs/superpowers/pr-notes ai_first`
+
+If local GitHub Actions emulation is available, optionally run the workflow with `act`, but do not make `act` a required dependency.
+
+## Manual verification
+
+- Open the PR checks list after pushing.
+- Confirm each job starts and reports a clear status.
+- If checks fail because of missing CI dependencies, fix that PR before starting another feature.
+- If checks pass, update `ai_first/NEXT_ACTIONS.md` to treat CI failures as the highest-priority next task.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  PR["Pull Request"]
+  CI["GitHub Actions CI"]
+  Backend["Backend Tests + Compile"]
+  Frontend["Frontend Build"]
+  Docs["Docs Validation"]
+  MergeGate["Runtime Auto-Merge Gate"]
+
+  PR --> CI
+  CI --> Backend
+  CI --> Frontend
+  CI --> Docs
+  Backend --> MergeGate
+  Frontend --> MergeGate
+  Docs --> MergeGate
+```
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed. It should not be needed unless the workflow is added to the architecture map.
+
+## Handoff notes
+
+- Start with a minimal workflow; do not add matrix builds until the single reliable lane is green.
+- Keep docs-only and runtime/product changes separated.
+- Do not broaden this into deployment, secrets management, or release automation.


### PR DESCRIPTION
## Summary
- add a task packet for reliable backend, frontend, and docs CI checks
- add a docs-only PR architecture note with Mermaid
- update AI-first status mirrors so the next autonomous task is CI implementation

## Tests
- rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md docs/superpowers/pr-notes/ci-backend-frontend-packet.md ai_first
- git diff --check

## PR Note
- docs/superpowers/pr-notes/ci-backend-frontend-packet.md

Refs #16