### PR TITLE
ci: add backend frontend docs checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
         run: git diff --check
 
       - name: Validate docs markers
-        run: rg -n "Mermaid|PR Architecture Note|Main System Map" docs/superpowers/pr-notes ai_first docs/contest
+        run: grep -R -nE "Mermaid|PR Architecture Note|Main System Map" docs/superpowers/pr-notes ai_first docs/contest
 
   summary:
     name: Summary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,144 +1,117 @@
-name: Tests
+name: CI Checks
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-    paths:
-      - "deeptutor/**"
-      - "deeptutor_cli/**"
-      - "tests/**"
-      - "requirements/**"
-      - "requirements.txt"
-      - "pyproject.toml"
-      - ".github/workflows/tests.yml"
   pull_request:
     branches:
       - main
-      - dev
-    paths:
-      - "deeptutor/**"
-      - "deeptutor_cli/**"
-      - "tests/**"
-      - "requirements/**"
-      - "requirements.txt"
-      - "pyproject.toml"
-      - ".github/workflows/tests.yml"
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  import-check:
-    name: Import Check (Python ${{ matrix.python-version }})
+  backend:
+    name: Backend
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
-      - name: Cache pip packages
+      - name: Cache pip
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements/server.txt', 'requirements/cli.txt') }}
+          key: ${{ runner.os }}-python-3.12-${{ hashFiles('requirements/*.txt', 'pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-python-3.12-
 
-      - name: Install minimal dependencies for import check
+      - name: Install backend test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/server.txt
+          pip install -r requirements/dev.txt
+          pip install -e .
+          pip install pytest-mock pytest-cov pytest-httpx respx dash anyio
 
-      - name: Check module imports
-        run: |
-          echo "🐍 Testing with Python ${{ matrix.python-version }}"
-          python -c "from deeptutor.runtime.orchestrator import ChatOrchestrator; print('✅ Orchestrator imports OK')"
-          python -c "from deeptutor.runtime.registry.tool_registry import get_tool_registry; print('✅ Tool registry imports OK')"
-          python -c "from deeptutor.runtime.registry.capability_registry import get_capability_registry; print('✅ Capability registry imports OK')"
-          python -c "from deeptutor.services.config.env_store import EnvStore; print('✅ EnvStore imports OK')"
-          python -c "from deeptutor.api.routers.unified_ws import unified_websocket; print('✅ Unified WS imports OK')"
-          python -c "from deeptutor.services.prompt.manager import PromptManager; print('✅ Prompt manager imports OK')"
-          python -c "from deeptutor.logging import get_logger; print('✅ Logging imports OK')"
+      - name: Run backend checks
         env:
           PYTHONPATH: ${{ github.workspace }}
+        run: |
+          pytest tests/api/test_knowledge_router.py -v
+          pytest tests/knowledge -v
+          pytest tests/api/test_question_router.py -v
+          pytest tests/api/test_unified_ws_turn_runtime.py -v
+          pytest tests/api/test_dashboard_router.py -v
+          pytest tests/services/session -v
+          python -m compileall deeptutor
 
-  smoke-tests:
-    name: Smoke Tests (Python 3.11)
+  frontend:
+    name: Frontend
     runs-on: ubuntu-latest
-    needs: import-check
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
         with:
-          python-version: "3.11"
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
 
-      - name: Cache pip packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('requirements/server.txt', 'requirements/cli.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-3.11-
+      - name: Install frontend dependencies
+        working-directory: web
+        run: npm ci
 
-      - name: Install smoke test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/server.txt
-          pip install pytest pytest-asyncio
-
-      - name: Create minimal runtime config
-        run: |
-          mkdir -p data/user/settings
-          cat > data/user/settings/main.yaml <<'YAML'
-          system:
-            language: en
-          logging:
-            level: WARNING
-          YAML
-
-      - name: Run smoke tests
-        run: |
-          echo "🧪 Running smoke test subset"
-          pytest -q --import-mode=importlib \
-            tests/api \
-            tests/cli \
-            tests/services/test_app_facade.py \
-            tests/services/test_model_catalog.py \
-            tests/services/test_path_service.py \
-            tests/services/memory \
-            tests/services/session \
-            tests/tools
+      - name: Build frontend
+        working-directory: web
         env:
-          PYTHONPATH: ${{ github.workspace }}
+          NEXT_PUBLIC_API_BASE: http://localhost:8001
+        run: npm run build
 
-  test-summary:
-    name: Test Summary
+  docs:
+    name: Docs
     runs-on: ubuntu-latest
-    needs: [import-check, smoke-tests]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check diff formatting
+        run: git diff --check
+
+      - name: Validate docs markers
+        run: rg -n "Mermaid|PR Architecture Note|Main System Map" docs/superpowers/pr-notes ai_first docs/contest
+
+  summary:
+    name: Summary
+    runs-on: ubuntu-latest
     if: always()
+    needs:
+      - backend
+      - frontend
+      - docs
 
     steps:
-      - name: Check test results
+      - name: Write summary
         run: |
-          echo "## 🧪 Test Results Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Import check (3.11/3.12) | ${{ needs.import-check.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Smoke tests (3.11) | ${{ needs.smoke-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "## CI Checks" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Backend | ${{ needs.backend.result == 'success' && 'Passed' || 'Failed' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Frontend | ${{ needs.frontend.result == 'success' && 'Passed' || 'Failed' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Docs | ${{ needs.docs.result == 'success' && 'Passed' || 'Failed' }} |" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Fail if tests failed
-        if: needs.import-check.result == 'failure' || needs.smoke-tests.result == 'failure'
+      - name: Fail if any required job failed
+        if: needs.backend.result != 'success' || needs.frontend.result != 'success' || needs.docs.result != 'success'
         run: exit 1

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -23,7 +23,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, and contest screenshot evidence are merged. Next operating improvement: add reliable backend/frontend CI before broader runtime auto-merge.
+- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, and contest screenshot evidence are merged. Reliable backend/frontend/docs CI is being implemented as the next runtime merge gate.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -100,7 +100,7 @@ Before handing off:
 1. Keep this file as the single entry point for future AI workers.
 2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
 3. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
-4. Finish and merge the CI task packet, then implement reliable backend/frontend/docs CI before starting another product feature.
+4. Finish and merge the CI implementation PR, then treat CI failures as the highest-priority next task before starting another product feature.
 5. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
 6. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
 7. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -73,7 +73,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-CI task packet is being prepared on `docs/ci-task-packet`, mirrored by GitHub issue `#16`. After this docs PR merges, implement `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
+CI implementation is in progress on `fix/ci-backend-frontend-checks`, mirrored by GitHub issue `#16`. The workflow changes should land only after backend, frontend, and docs checks are green on the PR.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,8 +6,8 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Merge the docs-only CI task packet PR when eligible.
-2. Implement reliable backend, frontend, and docs CI checks from `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
+1. Merge the runtime/workflow CI implementation PR only after backend, frontend, and docs checks pass.
+2. If CI fails, fix the failing workflow or dependency setup before starting another feature.
 3. Keep GitHub issues `#2`, `#3`, `#9`, `#12`, and `#16` linked to their implementation PRs.
 4. Preserve unrelated dirty files until they are intentionally handled.
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -152,6 +152,28 @@
 - Blockers: None known.
 - Next: Commit, open docs PR, merge when eligible, then implement CI.
 
+## CI Implementation
+
+- Branch: `fix/ci-backend-frontend-checks`
+- Task: Implement backend, frontend, and docs GitHub Actions checks.
+- Done:
+  - Replaced `.github/workflows/tests.yml` with a focused `Backend`, `Frontend`, `Docs`, and `Summary` workflow.
+  - Added runtime/workflow PR architecture note with Mermaid.
+  - Updated operating/status mirrors so CI failures become the next task before new feature work.
+- Tests:
+  - Passed: `pytest tests/api/test_knowledge_router.py -v` (11 passed)
+  - Passed: `pytest tests/knowledge -v` (3 passed)
+  - Passed: `pytest tests/api/test_question_router.py -v` (1 passed)
+  - Passed: `pytest tests/api/test_unified_ws_turn_runtime.py -v` (6 passed)
+  - Passed: `pytest tests/api/test_dashboard_router.py -v` (2 passed)
+  - Passed: `pytest tests/services/session -v` (2 passed)
+  - Passed: `.venv/bin/python -m compileall deeptutor`
+  - Passed with existing lockfile warning: `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+  - Passed: `rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" .github/workflows docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
+- Blockers: None known.
+- Next: Run local validation, open PR, wait for CI, fix failures if needed, then merge.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/superpowers/pr-notes/ci-backend-frontend-checks.md
+++ b/docs/superpowers/pr-notes/ci-backend-frontend-checks.md
@@ -1,0 +1,61 @@
+# PR Architecture Note: Backend and Frontend CI Checks
+
+## Summary
+
+Adds a single GitHub Actions workflow that runs backend tests, frontend build validation, and docs checks on pull requests and pushes to `main`.
+
+## Scope
+
+- `.github/workflows/tests.yml`
+- `docs/superpowers/pr-notes/ci-backend-frontend-checks.md`
+- AI-first status mirror updates
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  PR["Pull Request"]
+  Workflow["CI Checks Workflow"]
+  Backend["Backend Job"]
+  Frontend["Frontend Job"]
+  Docs["Docs Job"]
+  Summary["Summary Job"]
+  MergeGate["Runtime Merge Gate"]
+
+  PR --> Workflow
+  Workflow --> Backend
+  Workflow --> Frontend
+  Workflow --> Docs
+  Backend --> Summary
+  Frontend --> Summary
+  Docs --> Summary
+  Summary --> MergeGate
+```
+
+## Architecture Impact
+
+No product architecture changes. This PR adds repository-level merge gate automation through GitHub Actions.
+
+## Data/API Changes
+
+None.
+
+## Tests
+
+```bash
+pytest tests/api/test_knowledge_router.py -v
+pytest tests/knowledge -v
+pytest tests/api/test_question_router.py -v
+pytest tests/api/test_unified_ws_turn_runtime.py -v
+pytest tests/api/test_dashboard_router.py -v
+pytest tests/services/session -v
+python3 -m compileall deeptutor
+cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build
+rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" .github/workflows docs/superpowers/pr-notes ai_first
+git diff --check
+```
+
+## Main System Map Update
+
+- [x] Not needed, because this PR changes CI workflow policy rather than product architecture.
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`


### PR DESCRIPTION
## Summary
- replace the legacy tests workflow with explicit Backend, Frontend, Docs, and Summary jobs
- align AI-first status mirrors so CI failures block new feature work
- add a workflow PR architecture note with Mermaid

## Local Validation
- pytest tests/api/test_knowledge_router.py -v
- pytest tests/knowledge -v
- pytest tests/api/test_question_router.py -v
- pytest tests/api/test_unified_ws_turn_runtime.py -v
- pytest tests/api/test_dashboard_router.py -v
- pytest tests/services/session -v
- .venv/bin/python -m compileall deeptutor
- cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build
- rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" .github/workflows docs/superpowers/pr-notes ai_first
- git diff --check

## PR Note
- docs/superpowers/pr-notes/ci-backend-frontend-checks.md

Refs #16