### PR TITLE
docs: sync queue after ci merge

### DIFF
--- a/ai_first/AI_FIRST_ROADMAP.md
+++ b/ai_first/AI_FIRST_ROADMAP.md
@@ -55,17 +55,17 @@ Human review remains important for product direction, contest story, irreversibl
 
 ### Near Term
 
-- Merge the first task packet workflow PR.
-- Start Pod A and Pod B from their task packets.
+- Keep issue state aligned with merged PRs so completed work does not stay in the active queue.
+- Add a compact execution queue/status board packet for the next AI worker to implement.
 - Keep every PR tied to an architecture note with Mermaid.
 
 ### Mid Term
 
-- Add reliable CI checks for backend and frontend changes.
-- Tighten issue labels and PR status conventions for autonomous selection.
 - Keep evidence, demo scripts, and screenshots current for the contest.
+- Tighten issue labels and PR status conventions for autonomous selection.
+- Use the execution queue/status board to surface blockers, latest merges, and next recommended task.
 
 ### Later
 
 - Consider GitHub Actions or scripts for queue reporting after the manual loop is proven stable.
-- Add stronger automation only after merge gates, CI expectations, and review signals are reliable.
+- Add stronger automation only after merge gates, CI expectations, review signals, and queue hygiene are reliable.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -23,7 +23,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, and contest screenshot evidence are merged. Reliable backend/frontend/docs CI is being implemented as the next runtime merge gate.
+- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: the next docs/workflow task is to keep issue state aligned with merged PRs and add a compact execution queue/status board packet so future workers can choose the next task from one place.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -100,7 +101,8 @@ Before handing off:
 1. Keep this file as the single entry point for future AI workers.
 2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
 3. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
-4. Finish and merge the CI implementation PR, then treat CI failures as the highest-priority next task before starting another product feature.
-5. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
-6. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-7. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.
+4. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
+5. Implement the execution queue/status board packet from issue `#19` before broadening automation again.
+6. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+7. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+8. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/post-pr4-next-actions`
+- Current branch for this docs update: `docs/post-ci-state-sync`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
-- Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard MVPs are merged.
-- Current purpose: create the `docs/contest/` evidence bundle so a reviewer can follow and verify the MVP story.
+- Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
+- Current purpose: sync control-plane status after CI merge, close stale execution issues, and queue the next docs/workflow packet for a compact execution status board.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -60,20 +60,15 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Pod A task packet: `docs/superpowers/tasks/2026-04-13-teacher-knowledge-pack-pod-a.md`
-- Pod B task packet: `docs/superpowers/tasks/2026-04-13-assessment-student-workspace-pod-b.md`
-- Teacher Dashboard task packet: `docs/superpowers/tasks/2026-04-19-teacher-dashboard-pod-a.md`
-- Pod A GitHub issue: `#2`
-- Pod B GitHub issue: `#3`
-- Teacher Dashboard GitHub issue: `#9`
-- Contest evidence/demo GitHub issue: `#12`
-- CI backend/frontend checks GitHub issue: `#16`
+- Current open task packet: `docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md`
+- Current open GitHub issue: `#19`
+- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), and CI (`#17`, `#18`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-CI implementation is in progress on `fix/ci-backend-frontend-checks`, mirrored by GitHub issue `#16`. The workflow changes should land only after backend, frontend, and docs checks are green on the PR.
+Create and execute the execution queue/status board packet mirrored by GitHub issue `#19`, so future AI workers and humans have one compact place to inspect latest merges, blockers, and next recommended work.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,16 +6,16 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Merge the runtime/workflow CI implementation PR only after backend, frontend, and docs checks pass.
-2. If CI fails, fix the failing workflow or dependency setup before starting another feature.
-3. Keep GitHub issues `#2`, `#3`, `#9`, `#12`, and `#16` linked to their implementation PRs.
+1. Land the execution queue/status board packet from issue `#19`.
+2. Implement that packet before adding broader automation.
+3. Keep open issues aligned with active task packets and unfinished work only.
 4. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 
 1. Keep the main system map updated when shared contracts change.
 2. Keep `ai_first/AI_FIRST_ROADMAP.md` current when the autonomous operating loop changes.
-3. Implement reliable backend and frontend CI checks before allowing broader runtime auto-merge.
+3. Keep CI green and treat CI failures as the next task before starting another runtime/product feature.
 
 ## Human Review Needed
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -174,6 +174,26 @@
 - Blockers: None known.
 - Next: Run local validation, open PR, wait for CI, fix failures if needed, then merge.
 
+## Post-CI State Sync
+
+- Branch: `docs/post-ci-state-sync`
+- Task: Sync AI-first control-plane status after CI merge, close stale execution issues, and queue the next docs/workflow packet.
+- Done:
+  - Updated `AI_OPERATING_PROMPT.md`, `AI_FIRST_ROADMAP.md`, `CURRENT_STATE.md`, and `NEXT_ACTIONS.md` to reflect that contest MVP evidence and CI are merged into `main`.
+  - Added the next packet `docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md`.
+  - Added a docs-only PR architecture note with Mermaid for the state-sync change.
+  - Mirrored the next queue step to GitHub issue `#19`.
+  - Closed stale completed issues `#2`, `#3`, `#9`, `#12`, and `#16` with references to their merged PRs.
+- Tests:
+  - Passed: `rg -n "execution queue|status board|next task|blocker|GitHub Issue|Mermaid" ai_first docs/superpowers/tasks docs/superpowers/pr-notes`
+  - Passed: `git diff --check`
+  - Passed: `gh issue list --repo Creative-Science-Contest-2026/Multiagent-learning-platform --state open --limit 20`
+- Blockers:
+  - None known.
+- Next:
+  - Open docs PR for this state-sync change and auto-merge when eligible.
+  - Execute issue `#19` from the new task packet.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/superpowers/pr-notes/post-ci-state-sync.md
+++ b/docs/superpowers/pr-notes/post-ci-state-sync.md
@@ -1,0 +1,47 @@
+# PR Architecture Note: Post-CI State Sync
+
+## Summary
+
+This PR updates the AI-first control plane after the CI workflow landed in `main`, closes the gap between merged work and open execution issues, and queues the next docs/workflow packet for an execution status board.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  Merge["Merged MVP + CI PRs"]
+  Prompt["AI Operating Prompt"]
+  Mirrors["Current State + Next Actions + Roadmap"]
+  Issues["GitHub Issues"]
+  Packet["Execution Queue Packet"]
+
+  Merge --> Prompt
+  Prompt --> Mirrors
+  Prompt --> Issues
+  Mirrors --> Packet
+```
+
+## Files Changed
+
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/AI_FIRST_ROADMAP.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md`
+- `docs/superpowers/pr-notes/post-ci-state-sync.md`
+
+## Main System Map Update
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated. This PR syncs queue/reporting state and adds the next docs/workflow packet, but it does not change the product architecture or runtime topology.
+
+## Validation
+
+```bash
+rg -n "execution queue|status board|next task|blocker|GitHub Issue|Mermaid" ai_first docs/superpowers/tasks docs/superpowers/pr-notes
+git diff --check
+```
+
+## Handoff Notes
+
+- Close stale issues for merged work before treating them as active queue items.
+- Use issue `#19` and the new task packet as the next docs/workflow execution step.

--- a/docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md
+++ b/docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md
@@ -1,0 +1,94 @@
+# Feature Pod Task: Execution Queue and Status Board
+
+Owner: Documentation / Workflow AI worker
+Branch: `docs/execution-queue-status-board`
+GitHub Issue: `#19`
+
+## Goal
+
+Add one compact, human-readable execution queue and status board so AI workers can keep the next task, latest merge result, and active blockers in one place after each PR lands.
+
+## User-visible outcome
+
+A human can open one Markdown file and quickly see:
+
+- what merged most recently;
+- which issues or PRs are still active;
+- what the AI should do next;
+- whether any blocker needs human judgment.
+
+## Owned files/modules
+
+- `ai_first/`
+- `docs/superpowers/pr-notes/execution-queue-status-board.md`
+- `docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `requirements/`
+- `.github/workflows/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `.env*`
+- `data/`
+
+## Queue contract
+
+Create or update a compact queue/status document under `ai_first/` that:
+
+- names the latest merged PR or milestone update;
+- lists active issues or PRs still relevant to execution;
+- states the next recommended task in one short section;
+- separates blockers that need human review from blockers AI should resolve itself;
+- points back to `AI_OPERATING_PROMPT.md` as the authoritative control plane.
+
+The document must stay short enough that a new AI worker or a human can read it in under two minutes.
+
+## Acceptance criteria
+
+- There is one obvious Markdown entry point for execution status and next-task selection.
+- The status board does not duplicate the full operating prompt.
+- The queue stays consistent with open GitHub issues and active task packets.
+- The PR includes an architecture note with Mermaid.
+- The change stays docs/workflow-only.
+
+## Required validation
+
+- `rg -n "execution queue|status board|next task|blocker|GitHub Issue|Mermaid" ai_first docs/superpowers/tasks docs/superpowers/pr-notes`
+- `git diff --check`
+
+## Manual verification
+
+- Open the status board first without reading old chat history.
+- Confirm a new AI worker can identify the current next task in under two minutes.
+- Confirm the board points to the authoritative operating prompt for full rules.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Merge["Merged PR"]
+  Queue["Execution Queue / Status Board"]
+  Prompt["AI_OPERATING_PROMPT.md"]
+  Worker["Next AI Worker"]
+  Human["Human Check"]
+
+  Merge --> Queue
+  Queue --> Worker
+  Queue --> Human
+  Queue --> Prompt
+```
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State that `ai_first/architecture/MAIN_SYSTEM_MAP.md` does not need an update because this packet adds queue/reporting docs, not a product architecture change.
+
+## Handoff notes
+
+- Keep this packet small and operational.
+- Do not invent a second control plane.
+- Prefer updating or adding one compact status document over spreading queue state across many files.


### PR DESCRIPTION
## Summary
- sync AI-first control-plane docs after CI merged into `main`
- close stale execution issues and queue the next docs/workflow packet
- add the execution queue/status board task packet and PR architecture note

## Validation
- rg -n "execution queue|status board|next task|blocker|GitHub Issue|Mermaid" ai_first docs/superpowers/tasks docs/superpowers/pr-notes
- git diff --check
- gh issue list --repo Creative-Science-Contest-2026/Multiagent-learning-platform --state open --limit 20

## Main System Map
- Not updated; this PR syncs queue/reporting docs and adds the next task packet without changing product/runtime architecture.