### PR TITLE
docs: add execution queue status board

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -12,6 +12,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Compatibility model
 
 - `ai_first/AI_OPERATING_PROMPT.md` is the single entry point.
+- `ai_first/EXECUTION_QUEUE.md` is the compact queue/status board for humans and AI workers who need the shortest current read.
 - `ai_first/AI_FIRST_ROADMAP.md` is the human-facing roadmap for the autonomous AI-first loop and future operating improvements.
 - `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md` are compatibility snapshots only.
 - If a task packet exists, it remains the execution contract for the current feature pod.
@@ -24,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: the next docs/workflow task is to keep issue state aligned with merged PRs and add a compact execution queue/status board packet so future workers can choose the next task from one place.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, and workers should keep it current after merges so the next task can be chosen from one place.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -99,10 +100,12 @@ Before handing off:
 ## Next actions
 
 1. Keep this file as the single entry point for future AI workers.
-2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
-3. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
-4. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-5. Implement the execution queue/status board packet from issue `#19` before broadening automation again.
-6. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
-7. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-8. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.
+2. Use `ai_first/EXECUTION_QUEUE.md` as the shortest status board.
+3. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
+4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
+5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
+6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
+7. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
+8. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+9. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+10. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/post-ci-state-sync`
+- Current branch for this docs update: `docs/execution-queue-status-board`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: sync control-plane status after CI merge, close stale execution issues, and queue the next docs/workflow packet for a compact execution status board.
+- Current purpose: use a compact execution queue/status board under `ai_first/` so humans and AI workers can inspect latest merges, active queue, and next work from one short document.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -68,7 +68,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Create and execute the execution queue/status board packet mirrored by GitHub issue `#19`, so future AI workers and humans have one compact place to inspect latest merges, blockers, and next recommended work.
+Use `ai_first/EXECUTION_QUEUE.md` as the shortest read path before choosing the next feature or workflow packet. If the active queue becomes empty after issue `#19` is closed, create or update the next task packet before implementation starts.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -1,0 +1,37 @@
+# Execution Queue
+
+Last updated: 2026-04-19
+
+This is the compact status board for humans and AI workers.  
+The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
+
+## Latest merged result
+
+- Latest merged PR before the current active branch: `#20`, which synced queue state after the CI merge.
+- Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
+
+## Active queue
+
+- Open issue: `#19 docs: add execution queue and status board packet`
+- Active task packet: `docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md`
+- Expected branch: `docs/execution-queue-status-board`
+
+## Next recommended task
+
+Implement the status board packet by keeping this file short, current, and linked from the AI-first entry points.  
+Do not start a new runtime or product feature until this queue/reporting step lands.
+
+## AI-owned blockers
+
+- None currently. If CI, merge, or review blocks the active PR, fixing that blocker becomes the next task.
+
+## Human-review blockers
+
+- None currently. Human review is still required for product direction changes, deployment or credential decisions, and any PR explicitly marked blocked.
+
+## Read path
+
+1. `ai_first/AI_OPERATING_PROMPT.md`
+2. `ai_first/EXECUTION_QUEUE.md`
+3. Task packet for the active issue
+4. `ai_first/CURRENT_STATE.md` only if more context is needed

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,10 +6,11 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Land the execution queue/status board packet from issue `#19`.
-2. Implement that packet before adding broader automation.
-3. Keep open issues aligned with active task packets and unfinished work only.
-4. Preserve unrelated dirty files until they are intentionally handled.
+1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
+2. Use that board as the first stop before selecting the next feature or workflow packet.
+3. If the board shows no active queue item, derive the next short task from the MVP goal and create or update a task packet before implementation.
+4. Keep open issues aligned with active task packets and unfinished work only.
+5. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/README.md
+++ b/ai_first/README.md
@@ -5,9 +5,10 @@ This directory stores the long-term memory for the AI-first development process.
 AI workers must read these files before making changes:
 
 1. `AI_OPERATING_PROMPT.md`
-2. `AGENTS.md`
-3. `CURRENT_STATE.md`
-4. `NEXT_ACTIONS.md`
+2. `EXECUTION_QUEUE.md`
+3. `AGENTS.md`
+4. `CURRENT_STATE.md`
+5. `NEXT_ACTIONS.md`
 
 For day-to-day work, treat `AI_OPERATING_PROMPT.md` as the single entry point. The other files are compatibility snapshots and shortcuts.
 
@@ -20,6 +21,7 @@ Directory responsibilities:
 - `decisions/`: ADR-style decisions.
 - `daily/`: daily progress and handoff logs.
 - `evidence/`: demo scripts, screenshots, video notes, technical runbook.
+- `EXECUTION_QUEUE.md`: compact status board for latest merge result, active queue, and next task.
 - `prompts/`: important prompts and AI collaboration transcripts worth preserving.
 - `templates/`: reusable templates for AI workers and PRs.
 - `USAGE_GUIDE.md`: one-page quick start for humans and AI workers.

--- a/ai_first/USAGE_GUIDE.md
+++ b/ai_first/USAGE_GUIDE.md
@@ -5,9 +5,10 @@ This repository is designed so an AI worker can begin from one entry point and c
 ## What to read first
 
 1. `ai_first/AI_OPERATING_PROMPT.md`
-2. `AGENTS.md`
-3. `ai_first/CURRENT_STATE.md` if you need a compact status mirror
-4. `ai_first/NEXT_ACTIONS.md` if you need the current queue
+2. `ai_first/EXECUTION_QUEUE.md`
+3. `AGENTS.md`
+4. `ai_first/CURRENT_STATE.md` if you need a compact status mirror
+5. `ai_first/NEXT_ACTIONS.md` if you need the current queue
 
 ## How to start a task
 
@@ -20,6 +21,7 @@ This repository is designed so an AI worker can begin from one entry point and c
 ## How the repo is organized
 
 - `ai_first/AI_OPERATING_PROMPT.md`: the control plane and single entry point.
+- `ai_first/EXECUTION_QUEUE.md`: the shortest status board for latest merge result, active queue, and next task.
 - `ai_first/AI_FIRST_ROADMAP.md`: human-facing explanation of the autonomous AI loop and future operating direction.
 - `ai_first/CURRENT_STATE.md`: compact status mirror.
 - `ai_first/NEXT_ACTIONS.md`: compact queue mirror.

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -194,6 +194,23 @@
   - Open docs PR for this state-sync change and auto-merge when eligible.
   - Execute issue `#19` from the new task packet.
 
+## Execution Queue Status Board
+
+- Branch: `docs/execution-queue-status-board`
+- Task: Implement the compact execution queue/status board from issue `#19`.
+- Done:
+  - Added `ai_first/EXECUTION_QUEUE.md` as the shortest human/AI status board.
+  - Linked the new board from `AI_OPERATING_PROMPT.md`, `USAGE_GUIDE.md`, `README.md`, `CURRENT_STATE.md`, and `NEXT_ACTIONS.md`.
+  - Kept the prompt as the authoritative control plane while using the board as the shortest queue read path.
+- Tests:
+  - Passed: `rg -n "execution queue|status board|next task|blocker|GitHub Issue|Mermaid" ai_first docs/superpowers/tasks docs/superpowers/pr-notes`
+  - Passed: `git diff --check`
+- Blockers:
+  - None known.
+- Next:
+  - Validate docs changes, open PR, merge when eligible, then close issue `#19`.
+  - Use `ai_first/EXECUTION_QUEUE.md` to choose or create the next task packet.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/superpowers/pr-notes/execution-queue-status-board.md
+++ b/docs/superpowers/pr-notes/execution-queue-status-board.md
@@ -1,0 +1,48 @@
+# PR Architecture Note: Execution Queue Status Board
+
+## Summary
+
+This PR adds a compact `ai_first/EXECUTION_QUEUE.md` file and links it from the existing AI-first entry points so both humans and AI workers can see the latest merge result, active queue, and next recommended task without reading the full operating prompt first.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Prompt["AI_OPERATING_PROMPT.md"]
+  Queue["EXECUTION_QUEUE.md"]
+  Mirrors["CURRENT_STATE.md + NEXT_ACTIONS.md"]
+  Packet["Active Task Packet"]
+  Worker["Human or AI Worker"]
+
+  Prompt --> Queue
+  Queue --> Mirrors
+  Queue --> Packet
+  Queue --> Worker
+```
+
+## Files Changed
+
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/USAGE_GUIDE.md`
+- `ai_first/README.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `docs/superpowers/pr-notes/execution-queue-status-board.md`
+
+## Main System Map Update
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated. This PR adds queue/reporting documentation and entry-point links without changing product/runtime architecture.
+
+## Validation
+
+```bash
+rg -n "execution queue|status board|next task|blocker|GitHub Issue|Mermaid" ai_first docs/superpowers/tasks docs/superpowers/pr-notes
+git diff --check
+```
+
+## Handoff Notes
+
+- Keep `EXECUTION_QUEUE.md` short enough to read in under two minutes.
+- Update the board after merges instead of duplicating full status in multiple places.


### PR DESCRIPTION
## Summary
- add `ai_first/EXECUTION_QUEUE.md` as the shortest human/AI status board
- link the queue board from the AI-first entry points and mirrors
- keep the prompt authoritative while making next-task selection faster

## Validation
- rg -n "execution queue|status board|next task|blocker|GitHub Issue|Mermaid" ai_first docs/superpowers/tasks docs/superpowers/pr-notes
- git diff --check

## Main System Map
- Not updated; this PR adds queue/reporting docs and entry-point links without changing product/runtime architecture.