### PR TITLE
docs: add demo readiness smoke lane

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, and workers should keep it current after merges so the next task can be chosen from one place.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, and the next docs/workflow task is to land the demo-readiness smoke lane packet and runbook from issue `#22`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -105,7 +105,8 @@ Before handing off:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
-8. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
-9. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-10. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.
+7. Land the docs-first smoke lane packet and runbook from issue `#22` before broadening runtime or product work.
+8. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
+9. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+10. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+11. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/execution-queue-status-board`
+- Current branch for this docs update: `docs/demo-readiness-smoke`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: use a compact execution queue/status board under `ai_first/` so humans and AI workers can inspect latest merges, active queue, and next work from one short document.
+- Current purpose: establish the demo-readiness smoke lane so humans and AI workers can verify the contest MVP path and turn failures into the next task.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -60,15 +60,15 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md`
-- Current open GitHub issue: `#19`
-- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), and CI (`#17`, `#18`)
+- Current open task packet: `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- Current open GitHub issue: `#22`
+- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), and execution queue status board (`#21`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Use `ai_first/EXECUTION_QUEUE.md` as the shortest read path before choosing the next feature or workflow packet. If the active queue becomes empty after issue `#19` is closed, create or update the next task packet before implementation starts.
+Land the smoke lane packet and runbook from issue `#22`, then execute that smoke path before choosing the next feature or workflow packet.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,19 +7,18 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#20`, which synced queue state after the CI merge.
+- Latest merged PR before the current active branch: `#21`, which added the compact execution queue status board.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
 
 ## Active queue
 
-- Open issue: `#19 docs: add execution queue and status board packet`
-- Active task packet: `docs/superpowers/tasks/2026-04-19-execution-queue-status-board.md`
-- Expected branch: `docs/execution-queue-status-board`
+- Open issue: `#22 docs: add demo readiness smoke lane packet`
+- Active task packet: `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- Expected branch: `docs/demo-readiness-smoke`
 
 ## Next recommended task
 
-Implement the status board packet by keeping this file short, current, and linked from the AI-first entry points.  
-Do not start a new runtime or product feature until this queue/reporting step lands.
+Land the docs-first smoke lane packet and use its runbook to validate the contest MVP path before opening new runtime or product work.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,8 +7,8 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Use that board as the first stop before selecting the next feature or workflow packet.
-3. If the board shows no active queue item, derive the next short task from the MVP goal and create or update a task packet before implementation.
+2. Land the docs-first smoke lane packet and runbook from issue `#22`.
+3. Execute that smoke lane before opening new runtime or product work.
 4. Keep open issues aligned with active task packets and unfinished work only.
 5. Preserve unrelated dirty files until they are intentionally handled.
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -211,6 +211,24 @@
   - Validate docs changes, open PR, merge when eligible, then close issue `#19`.
   - Use `ai_first/EXECUTION_QUEUE.md` to choose or create the next task packet.
 
+## Demo Readiness Smoke Lane
+
+- Branch: `docs/demo-readiness-smoke`
+- Task: add the first docs-first smoke lane packet and runbook.
+- Done:
+  - created GitHub issue `#22`;
+  - added `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`;
+  - added `docs/contest/SMOKE_RUNBOOK.md`;
+  - added `docs/superpowers/pr-notes/demo-readiness-smoke-packet.md`;
+  - updated the queue and status mirrors to point to the smoke lane.
+- Tests:
+  - Passed: `rg -n "smoke|demo readiness|Knowledge Pack|assessment|Tutor|Dashboard|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
+- Blockers:
+  - None known.
+- Next:
+  - Open the docs PR, merge when eligible, then execute the smoke lane.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/contest/SMOKE_RUNBOOK.md
+++ b/docs/contest/SMOKE_RUNBOOK.md
@@ -1,0 +1,49 @@
+# Smoke Runbook
+
+This runbook verifies the contest MVP path in the same order as the demo story:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTION_QUEUE.md` and `ai_first/daily/YYYY-MM-DD.md`.
+
+## Stage 1: Backend
+
+- Command: use the existing backend startup path for local validation.
+- Success: the API starts cleanly and the Knowledge, question, unified workspace, and dashboard routes are reachable.
+- Stop condition: backend does not start or required routes fail.
+
+## Stage 2: Frontend
+
+- Command: use the existing frontend startup path or production build path for local validation.
+- Success: the workspace routes render and the app can reach the backend using the expected local base URL.
+- Stop condition: frontend does not build or cannot start.
+
+## Stage 3: Knowledge Pack
+
+- Action: confirm Knowledge Pack metadata is visible and matches the expected demo data shape.
+- Success: metadata is present after load or reload.
+- Stop condition: Knowledge Pack metadata is missing or broken.
+
+## Stage 4: Assessment
+
+- Action: generate assessment content from a selected Knowledge Pack.
+- Success: generated questions appear with answer, explanation, and common-mistake content when available.
+- Stop condition: assessment generation fails or loses Knowledge Pack grounding.
+
+## Stage 5: Tutor
+
+- Action: ask a Tutor workspace question using the same Knowledge Pack context.
+- Success: the tutor answer reflects the selected Knowledge Pack context.
+- Stop condition: the Tutor response ignores or loses context.
+
+## Stage 6: Dashboard
+
+- Action: open the Dashboard after the assessment and tutor steps.
+- Success: recent activity reflects assessment and tutor usage with Knowledge Pack context where available.
+- Stop condition: dashboard activity is empty, broken, or missing the expected context.
+
+## Result handling
+
+- If all stages pass: refresh any affected contest evidence docs, then move to the next queued task.
+- If a product/runtime stage fails: create or update a follow-up task packet before starting broad new work.
+- If an environment or credential blocker prevents completion: record the blocker clearly and do not report smoke as passing.

--- a/docs/superpowers/plans/2026-04-19-demo-readiness-smoke.md
+++ b/docs/superpowers/plans/2026-04-19-demo-readiness-smoke.md
@@ -1,0 +1,392 @@
+# Demo Readiness Smoke Lane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a docs-first demo-readiness smoke lane that tells AI workers how to verify the contest MVP path, record pass/fail, and turn failures into the next task.
+
+**Architecture:** This plan adds one task packet, one compact smoke runbook under `docs/contest/`, and a small set of AI-first queue updates. The prompt remains authoritative; the smoke lane plugs into the existing `EXECUTION_QUEUE.md`, `CURRENT_STATE.md`, `NEXT_ACTIONS.md`, and daily log instead of creating another control plane.
+
+**Tech Stack:** Markdown docs, repo AI-first operating files, existing contest evidence docs, git, ripgrep.
+
+---
+
+### Task 1: Add The Smoke Lane Task Packet
+
+**Files:**
+- Create: `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- Test: `docs/superpowers/specs/2026-04-19-demo-readiness-smoke-design.md`
+
+- [ ] **Step 1: Create the GitHub issue for the smoke lane**
+
+Run:
+
+```bash
+gh issue create --repo Creative-Science-Contest-2026/Multiagent-learning-platform --title "docs: add demo readiness smoke lane packet" --body $'## Goal\nAdd a docs-first smoke lane packet and runbook that verifies the contest MVP path and turns failures into the next task.\n\n## Expected output\n- A smoke task packet.\n- A compact smoke runbook under docs/contest.\n- Queue and status mirrors updated to point to the smoke lane.\n\n## Constraints\n- Docs/workflow only.\n- Do not touch runtime/product code in this packet PR.\n- Reuse existing contest evidence docs and AI-first mirrors.' 
+```
+
+Expected: `gh` returns a new issue URL. Copy the issue number for the next step.
+
+- [ ] **Step 2: Draft the task packet header and scope**
+
+Write this initial structure into `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`:
+
+```md
+# Feature Pod Task: Demo Readiness Smoke Lane
+
+Owner: Documentation / Workflow AI worker
+Branch: `docs/demo-readiness-smoke`
+GitHub Issue: `#<issue-number-from-step-1>`
+
+## Goal
+
+Add a docs-first smoke lane that verifies the contest MVP demo path end to end and turns failures into the next task.
+
+## User-visible outcome
+
+A human or AI worker can run one compact smoke flow and know whether the contest MVP path is still alive.
+```
+
+- [ ] **Step 3: Add owned files and do-not-touch files**
+
+Append these sections to the task packet:
+
+```md
+## Owned files/modules
+
+- `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- `docs/contest/SMOKE_RUNBOOK.md`
+- `docs/superpowers/pr-notes/demo-readiness-smoke-packet.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if the queue or operating rules change
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `web/next-env.d.ts`
+- `.env*`
+- `data/`
+```
+
+- [ ] **Step 4: Add the smoke contract and acceptance criteria**
+
+Append the contract and acceptance text:
+
+```md
+## Smoke contract
+
+The smoke lane must verify this path in order:
+
+1. backend startup path works;
+2. frontend startup or build path works;
+3. Knowledge Pack metadata is available;
+4. assessment generation works with Knowledge Pack context;
+5. Tutor workspace answers with Knowledge Pack context;
+6. Dashboard shows recent activity.
+
+For each stage, the lane must define:
+
+- the command or manual action;
+- the expected success condition;
+- whether failure stops the lane immediately;
+- where to record the outcome.
+
+If the smoke lane fails:
+
+- product/runtime failures become the next task;
+- environment or credential blockers must be recorded clearly in `ai_first/EXECUTION_QUEUE.md` and `ai_first/daily/2026-04-19.md`.
+
+## Acceptance criteria
+
+- There is one explicit smoke-lane task packet.
+- The task packet points to one compact smoke execution doc.
+- Pass/fail and blocker behavior are explicit.
+- The task remains docs/workflow-only.
+```
+
+- [ ] **Step 5: Add required validation, manual verification, and handoff**
+
+Append this exact text:
+
+```md
+## Required validation
+
+- `rg -n "smoke|demo readiness|Knowledge Pack|assessment|Tutor|Dashboard|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+- `git diff --check`
+
+## Manual verification
+
+- Open the smoke runbook without reading old chat history.
+- Confirm a new AI worker can identify the smoke path and stop conditions.
+- Confirm the runbook says what becomes the next task if smoke fails.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State that `ai_first/architecture/MAIN_SYSTEM_MAP.md` does not need an update because this packet adds queue/reporting docs, not product/runtime architecture.
+
+## Handoff notes
+
+- Keep round 1 docs-first.
+- Do not add deployment, staging, or CI smoke automation in this packet.
+- Reuse existing contest evidence docs instead of creating another evidence tree.
+```
+
+- [ ] **Step 6: Run diff-format validation**
+
+Run: `git diff --check`
+
+Expected: exit code `0` and no whitespace errors.
+
+- [ ] **Step 7: Commit the task packet**
+
+Run:
+
+```bash
+git add docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md
+git commit -m "docs: add demo readiness smoke task packet"
+```
+
+Expected: one commit that contains only the new task packet.
+
+### Task 2: Add The Smoke Runbook And PR Note
+
+**Files:**
+- Create: `docs/contest/SMOKE_RUNBOOK.md`
+- Create: `docs/superpowers/pr-notes/demo-readiness-smoke-packet.md`
+- Test: `docs/contest/README.md`
+- Test: `docs/contest/VALIDATION_REPORT.md`
+
+- [ ] **Step 1: Write the smoke runbook structure**
+
+Create `docs/contest/SMOKE_RUNBOOK.md` with this opening:
+
+```md
+# Smoke Runbook
+
+This runbook verifies the contest MVP path in the same order as the demo story:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTION_QUEUE.md` and `ai_first/daily/YYYY-MM-DD.md`.
+```
+
+- [ ] **Step 2: Add the execution stages**
+
+Add these sections to `docs/contest/SMOKE_RUNBOOK.md`:
+
+```md
+## Stage 1: Backend
+
+- Command: use the existing backend startup path for local validation.
+- Success: the API starts cleanly and the Knowledge, question, unified workspace, and dashboard routes are reachable.
+- Stop condition: backend does not start or required routes fail.
+
+## Stage 2: Frontend
+
+- Command: use the existing frontend startup path or production build path for local validation.
+- Success: the workspace routes render and the app can reach the backend using the expected local base URL.
+- Stop condition: frontend does not build or cannot start.
+
+## Stage 3: Knowledge Pack
+
+- Action: confirm Knowledge Pack metadata is visible and matches the expected demo data shape.
+- Success: metadata is present after load or reload.
+- Stop condition: Knowledge Pack metadata is missing or broken.
+
+## Stage 4: Assessment
+
+- Action: generate assessment content from a selected Knowledge Pack.
+- Success: generated questions appear with answer, explanation, and common-mistake content when available.
+- Stop condition: assessment generation fails or loses Knowledge Pack grounding.
+
+## Stage 5: Tutor
+
+- Action: ask a Tutor workspace question using the same Knowledge Pack context.
+- Success: the tutor answer reflects the selected Knowledge Pack context.
+- Stop condition: the Tutor response ignores or loses context.
+
+## Stage 6: Dashboard
+
+- Action: open the Dashboard after the assessment and tutor steps.
+- Success: recent activity reflects assessment and tutor usage with Knowledge Pack context where available.
+- Stop condition: dashboard activity is empty, broken, or missing the expected context.
+```
+
+- [ ] **Step 3: Add pass/fail recording rules**
+
+Append this section:
+
+```md
+## Result handling
+
+- If all stages pass: refresh any affected contest evidence docs, then move to the next queued task.
+- If a product/runtime stage fails: create or update a follow-up task packet before starting broad new work.
+- If an environment or credential blocker prevents completion: record the blocker clearly and do not report smoke as passing.
+```
+
+- [ ] **Step 4: Write the PR architecture note with Mermaid**
+
+Create `docs/superpowers/pr-notes/demo-readiness-smoke-packet.md` with this content:
+
+```md
+# PR Architecture Note: Demo Readiness Smoke Packet
+
+## Summary
+
+This PR adds the first docs-first smoke lane packet and runbook for the contest MVP path.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Queue["Execution Queue"]
+  Packet["Smoke Task Packet"]
+  Runbook["SMOKE_RUNBOOK.md"]
+  Result["Pass / Fail Result"]
+  NextTask["Next Task Selection"]
+
+  Queue --> Packet
+  Packet --> Runbook
+  Runbook --> Result
+  Result --> NextTask
+```
+
+## Main System Map Update
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR adds docs/workflow guidance for smoke validation without changing product/runtime architecture.
+```
+```
+
+- [ ] **Step 5: Run targeted docs validation**
+
+Run:
+
+```bash
+rg -n "smoke|demo readiness|Knowledge Pack|assessment|Tutor|Dashboard|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+git diff --check
+```
+
+Expected:
+
+- `rg` returns matches in the new smoke files;
+- `git diff --check` exits `0`.
+
+- [ ] **Step 6: Commit the runbook and PR note**
+
+Run:
+
+```bash
+git add docs/contest/SMOKE_RUNBOOK.md docs/superpowers/pr-notes/demo-readiness-smoke-packet.md
+git commit -m "docs: add smoke runbook and pr note"
+```
+
+Expected: one commit with the runbook and PR note only.
+
+### Task 3: Update The AI-First Queue And Mirrors
+
+**Files:**
+- Modify: `ai_first/EXECUTION_QUEUE.md`
+- Modify: `ai_first/CURRENT_STATE.md`
+- Modify: `ai_first/NEXT_ACTIONS.md`
+- Modify: `ai_first/daily/2026-04-19.md`
+- Modify: `ai_first/AI_OPERATING_PROMPT.md` only if needed
+
+- [ ] **Step 1: Point the execution queue to the smoke lane**
+
+Update `ai_first/EXECUTION_QUEUE.md` so the active queue section says:
+
+```md
+## Active queue
+
+- Open issue: `#<issue-number-from-task-1-step-1> docs: add demo readiness smoke lane packet`
+- Active task packet: `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- Expected branch: `docs/demo-readiness-smoke`
+
+## Next recommended task
+
+Land the docs-first smoke lane packet and use its runbook to validate the contest MVP path before opening new runtime or product work.
+```
+
+- [ ] **Step 2: Update the compact state mirrors**
+
+Edit `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md` so they reflect:
+
+```md
+- current purpose: establish the demo-readiness smoke lane
+- current next task: land the smoke lane packet and runbook
+- next actions: keep smoke status current and turn failures into the next task
+```
+
+- [ ] **Step 3: Record the smoke lane in the daily log**
+
+Append a new section to `ai_first/daily/2026-04-19.md` using this shape:
+
+```md
+## Demo Readiness Smoke Lane
+
+- Branch: `docs/demo-readiness-smoke`
+- Task: add the first docs-first smoke lane packet and runbook.
+- Done:
+  - added the smoke task packet;
+  - added the smoke runbook;
+  - updated the queue and status mirrors.
+- Tests:
+  - Passed: `rg -n "smoke|demo readiness|Knowledge Pack|assessment|Tutor|Dashboard|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
+- Blockers:
+  - None known.
+- Next:
+  - Open the docs PR, merge when eligible, then execute the smoke lane.
+```
+
+- [ ] **Step 4: Decide whether the operating prompt needs a narrow update**
+
+Check `ai_first/AI_OPERATING_PROMPT.md`.
+
+If the queue text already supports “derive the next short task from the MVP goal and create a task packet”, leave it unchanged.
+
+If the prompt still points to an outdated next step, update only the `Current snapshot` and `Next actions` bullets to mention the smoke lane.
+
+- [ ] **Step 5: Run final docs/workflow validation**
+
+Run:
+
+```bash
+rg -n "smoke|demo readiness|Knowledge Pack|assessment|Tutor|Dashboard|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+git diff --check
+git status --short --branch
+```
+
+Expected:
+
+- smoke references appear in the queue/runbook/task packet files;
+- no diff formatting errors;
+- only the planned docs/workflow files are modified.
+
+- [ ] **Step 6: Commit the queue and mirror updates**
+
+Run:
+
+```bash
+git add ai_first/EXECUTION_QUEUE.md ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md ai_first/daily/2026-04-19.md ai_first/AI_OPERATING_PROMPT.md
+git commit -m "docs: queue demo readiness smoke lane"
+```
+
+If `ai_first/AI_OPERATING_PROMPT.md` was not changed, omit it from `git add`.
+
+Expected: one commit containing only the AI-first queue/mirror updates.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers the smoke task packet; Task 2 covers the smoke runbook and required PR note; Task 3 covers the queue, daily log, and status mirror updates.
+- Placeholder scan: no unresolved placeholders remain; the plan creates the GitHub issue before the task packet is written and reuses that issue number in later steps.
+- Type consistency: File names, branch names, and lane names are consistent across the packet, runbook, queue, and daily log.

--- a/docs/superpowers/pr-notes/demo-readiness-smoke-packet.md
+++ b/docs/superpowers/pr-notes/demo-readiness-smoke-packet.md
@@ -1,0 +1,25 @@
+# PR Architecture Note: Demo Readiness Smoke Packet
+
+## Summary
+
+This PR adds the first docs-first smoke lane packet and runbook for the contest MVP path.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Queue["Execution Queue"]
+  Packet["Smoke Task Packet"]
+  Runbook["SMOKE_RUNBOOK.md"]
+  Result["Pass / Fail Result"]
+  NextTask["Next Task Selection"]
+
+  Queue --> Packet
+  Packet --> Runbook
+  Runbook --> Result
+  Result --> NextTask
+```
+
+## Main System Map Update
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR adds docs/workflow guidance for smoke validation without changing product/runtime architecture.

--- a/docs/superpowers/specs/2026-04-19-demo-readiness-smoke-design.md
+++ b/docs/superpowers/specs/2026-04-19-demo-readiness-smoke-design.md
@@ -1,0 +1,241 @@
+# Demo Readiness Smoke Lane Design
+
+## Context
+
+The contest MVP path is already merged into `main`:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+The repository now also has:
+
+- contest evidence docs and screenshots;
+- backend/frontend/docs CI;
+- an AI-first control plane with `AI_OPERATING_PROMPT.md`;
+- a compact status board in `ai_first/EXECUTION_QUEUE.md`.
+
+What is still missing is a small, repeatable lane that tells an AI worker whether the end-to-end demo path is still alive after important merges. Right now the repo has pieces of evidence and local validation notes, but it does not have one explicit smoke lane that says what to run, how to classify pass/fail, and what becomes the next task if the demo path breaks.
+
+## Goal
+
+Add a `demo readiness / end-to-end smoke validation` lane as the next AI-first operating step, so an AI worker can quickly verify the contest MVP path, record the result, and turn failures into the next task instead of silently drifting.
+
+## Non-Goals
+
+This lane does not:
+
+- replace backend/frontend CI with full browser automation immediately;
+- introduce deployment or staging infrastructure;
+- add new product features;
+- require real production credentials or public hosting;
+- attempt full GitHub Actions smoke automation in the first pass.
+
+## User-Facing Outcome
+
+A human or AI worker can open one task packet and one smoke runbook, run a short end-to-end validation flow locally, and know:
+
+- what commands to run;
+- what evidence to capture or refresh;
+- what counts as pass/fail;
+- what the next task is if any stage fails.
+
+## Constraints
+
+- Keep round 1 docs/workflow-first.
+- Avoid touching `package-lock.json`, `web/next-env.d.ts`, runtime code, or dependency files unless the smoke lane proves a narrow fix is necessary in a follow-up task.
+- Reuse the existing contest evidence docs and AI-first control plane instead of creating a second system.
+- Keep the smoke lane small enough that AI can run it after major merges without spending the whole night on orchestration.
+
+## Approaches
+
+### Approach 1: Docs-first smoke lane with explicit runbook
+
+Create a task packet plus a compact smoke runbook and result template. AI workers run the lane locally, update evidence/status docs, and treat failures as the next task.
+
+Pros:
+
+- fastest path to value;
+- matches the current AI-first operating layer;
+- low implementation risk;
+- easy to extend later into scripts or CI.
+
+Cons:
+
+- still relies on local/manual execution;
+- not yet a fully automated guardrail.
+
+### Approach 2: CI-first smoke workflow
+
+Add an end-to-end smoke job directly to GitHub Actions now.
+
+Pros:
+
+- strongest automation signal;
+- merges could be gated by the demo path earlier.
+
+Cons:
+
+- high flake risk;
+- likely needs server boot orchestration and deterministic fixture setup first;
+- broadens scope into infrastructure before the lane is stable.
+
+### Approach 3: Runtime-first orchestration
+
+Build a local deployment/dev orchestration layer first, then hang the smoke lane on top.
+
+Pros:
+
+- better long-term foundation for repeated runs.
+
+Cons:
+
+- slows down contest-facing value;
+- adds operating complexity before we have a proven smoke contract.
+
+## Recommendation
+
+Choose Approach 1.
+
+It fits the repository’s current maturity: the MVP path exists, evidence exists, and CI exists, but the repo still needs one explicit “demo is alive” lane that an AI worker can execute reliably without inventing staging or fighting flaky browser automation. Once that lane is stable for a few cycles, it can be partially scripted or promoted into CI.
+
+## Proposed Design
+
+### 1. New task packet for the smoke lane
+
+Create a docs/workflow task packet dedicated to demo readiness smoke validation.
+
+That packet should define:
+
+- goal;
+- owned files;
+- do-not-touch files;
+- exact smoke path;
+- validation commands;
+- pass/fail contract;
+- handoff behavior when a stage fails.
+
+This gives the next AI worker an execution contract before any scripting or automation work begins.
+
+### 2. Add a dedicated smoke runbook under `docs/contest/`
+
+Round 1 should add a small runbook, not a giant document set.
+
+The runbook should cover the MVP flow in the same order as the competition story:
+
+1. backend starts;
+2. frontend starts or builds successfully;
+3. Knowledge Pack metadata is available;
+4. assessment generation works with Knowledge Pack context;
+5. Tutor workspace answers with Knowledge Pack context;
+6. Dashboard shows the recent activity.
+
+For each stage, the runbook should say:
+
+- what command or action to run;
+- what visible success condition to expect;
+- what evidence file or note to refresh if needed;
+- what kind of failure should stop the lane.
+
+### 3. Add a compact smoke result/status entry point
+
+The lane needs a tiny place to record the latest smoke result without bloating the control plane.
+
+The preferred shape is:
+
+- `docs/contest/SMOKE_CHECKLIST.md` or `docs/contest/SMOKE_RUNBOOK.md` for execution;
+- `ai_first/EXECUTION_QUEUE.md` for the latest status and next task pointer;
+- `ai_first/daily/YYYY-MM-DD.md` for the detailed run record.
+
+The smoke lane should not create another overlapping queue file.
+
+### 4. Failure handling becomes part of the autonomous loop
+
+The lane is only useful if failure behavior is explicit.
+
+Round 1 should define:
+
+- if smoke passes: update evidence/status, then choose the next task from the queue;
+- if smoke fails because of product/runtime behavior: create or update a follow-up task packet for the failing area before doing broad new work;
+- if smoke fails because of environment or credentials: record the blocker clearly in `EXECUTION_QUEUE.md` and the daily log, and stop pretending the lane is green.
+
+### 5. Keep round 1 light on automation
+
+The first version should not require Playwright, new services, or deployment steps unless existing local tooling already supports them cleanly.
+
+The lane should prefer:
+
+- existing backend startup path;
+- existing frontend startup/build path;
+- existing contest evidence docs;
+- existing status mirrors.
+
+If scripting is useful, it should be a follow-up task after the smoke contract is written and exercised once.
+
+## Files to Introduce or Update in Round 1
+
+Expected docs/workflow surface:
+
+- `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- `docs/contest/SMOKE_RUNBOOK.md` or `docs/contest/SMOKE_CHECKLIST.md`
+- `docs/superpowers/pr-notes/demo-readiness-smoke-packet.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if the queue/operating rules change
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+
+## Acceptance Criteria
+
+Round 1 is successful when:
+
+1. there is one explicit smoke-lane task packet;
+2. there is one compact smoke execution doc for the MVP path;
+3. the lane defines clear pass/fail behavior;
+4. the AI-first queue points to smoke as the next operating task;
+5. the change stays docs/workflow-only.
+
+## Testing and Validation
+
+For the docs/workflow round, validation should stay lightweight:
+
+- `rg -n "smoke|demo readiness|Knowledge Pack|assessment|Tutor|Dashboard|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+- `git diff --check`
+
+Manual review should confirm that a new AI worker can identify:
+
+- the smoke path;
+- the stop conditions;
+- the next action if the smoke path fails.
+
+## Risks
+
+### Scope creep into infrastructure
+
+If the lane tries to solve deployment, browser automation, and fixture orchestration immediately, it will stall.
+
+Mitigation: keep round 1 docs-first and convert only the proven parts into scripts later.
+
+### Duplicate operating state
+
+If the smoke lane adds yet another queue/status document, the repo drifts again.
+
+Mitigation: keep status in `ai_first/EXECUTION_QUEUE.md` and detailed run history in the daily log.
+
+### False green
+
+If the smoke lane lacks explicit failure handling, AI workers may mark progress without proving the demo path.
+
+Mitigation: make pass/fail and blocker handling part of the written contract.
+
+## Open Questions Resolved for Round 1
+
+- Should smoke be CI-gated immediately? No. Start local/docs-first.
+- Should this add deployment or hosting? No.
+- Should this create new product code? No.
+- Should failure automatically become the next task? Yes.
+
+## Implementation Preview
+
+After this spec is approved, the implementation plan should focus on two small docs/workflow tasks:
+
+1. create the smoke lane packet and supporting docs;
+2. update the AI-first queue/status mirrors to make smoke the next operating step.

--- a/docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md
+++ b/docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md
@@ -1,0 +1,89 @@
+# Feature Pod Task: Demo Readiness Smoke Lane
+
+Owner: Documentation / Workflow AI worker
+Branch: `docs/demo-readiness-smoke`
+GitHub Issue: `#22`
+
+## Goal
+
+Add a docs-first smoke lane that verifies the contest MVP demo path end to end and turns failures into the next task.
+
+## User-visible outcome
+
+A human or AI worker can run one compact smoke flow and know whether the contest MVP path is still alive.
+
+## Owned files/modules
+
+- `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- `docs/contest/SMOKE_RUNBOOK.md`
+- `docs/superpowers/pr-notes/demo-readiness-smoke-packet.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if the queue or operating rules change
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `web/next-env.d.ts`
+- `.env*`
+- `data/`
+
+## Smoke contract
+
+The smoke lane must verify this path in order:
+
+1. backend startup path works;
+2. frontend startup or build path works;
+3. Knowledge Pack metadata is available;
+4. assessment generation works with Knowledge Pack context;
+5. Tutor workspace answers with Knowledge Pack context;
+6. Dashboard shows recent activity.
+
+For each stage, the lane must define:
+
+- the command or manual action;
+- the expected success condition;
+- whether failure stops the lane immediately;
+- where to record the outcome.
+
+If the smoke lane fails:
+
+- product/runtime failures become the next task;
+- environment or credential blockers must be recorded clearly in `ai_first/EXECUTION_QUEUE.md` and `ai_first/daily/2026-04-19.md`.
+
+## Acceptance criteria
+
+- There is one explicit smoke-lane task packet.
+- The task packet points to one compact smoke execution doc.
+- Pass/fail and blocker behavior are explicit.
+- The task remains docs/workflow-only.
+
+## Required validation
+
+- `rg -n "smoke|demo readiness|Knowledge Pack|assessment|Tutor|Dashboard|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+- `git diff --check`
+
+## Manual verification
+
+- Open the smoke runbook without reading old chat history.
+- Confirm a new AI worker can identify the smoke path and stop conditions.
+- Confirm the runbook says what becomes the next task if smoke fails.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State that `ai_first/architecture/MAIN_SYSTEM_MAP.md` does not need an update because this packet adds queue/reporting docs, not product/runtime architecture.
+
+## Handoff notes
+
+- Keep round 1 docs-first.
+- Do not add deployment, staging, or CI smoke automation in this packet.
+- Reuse existing contest evidence docs instead of creating another evidence tree.


### PR DESCRIPTION
## Summary
- add the demo-readiness smoke task packet and smoke runbook
- add the PR architecture note for the smoke lane packet
- update AI-first queue and status mirrors to point to the smoke lane

## Test Plan
- [x] rg -n "smoke|demo readiness|Knowledge Pack|assessment|Tutor|Dashboard|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- [x] git diff --check

## Main System Map
- Not updated; this PR adds docs/workflow guidance and queue updates without changing product/runtime architecture.