### PR TITLE
docs: record smoke execution result

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, and the next docs/workflow task is to land the demo-readiness smoke lane packet and runbook from issue `#22`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, and the demo-readiness smoke lane has passed against the current local demo dataset. The next task should now be derived from the MVP goal and captured in a new task packet.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -105,7 +105,7 @@ Before handing off:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Land the docs-first smoke lane packet and runbook from issue `#22` before broadening runtime or product work.
+7. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 8. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
 9. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
 10. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/demo-readiness-smoke`
+- Current branch for this docs update: `docs/demo-readiness-smoke-run`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: establish the demo-readiness smoke lane so humans and AI workers can verify the contest MVP path and turn failures into the next task.
+- Current purpose: record the first local smoke execution result after the smoke lane landed, then select the next short task from the MVP goal.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -60,15 +60,15 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
-- Current open GitHub issue: `#22`
-- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), and execution queue status board (`#21`)
+- Latest completed task packet: `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
+- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), and smoke lane packet (`#23`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Land the smoke lane packet and runbook from issue `#22`, then execute that smoke path before choosing the next feature or workflow packet.
+The smoke lane passed against the current local demo data. The next step is to derive the next short task from the MVP goal and create or update a task packet before implementation starts.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,22 +7,21 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#21`, which added the compact execution queue status board.
+- Latest merged PR before the current active branch: `#23`, which added the demo-readiness smoke lane packet and runbook.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
 
 ## Active queue
 
-- Open issue: `#22 docs: add demo readiness smoke lane packet`
-- Active task packet: `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
-- Expected branch: `docs/demo-readiness-smoke`
+- No active issue is queued right now.
+- The latest completed lane is `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`.
 
 ## Next recommended task
 
-Land the docs-first smoke lane packet and use its runbook to validate the contest MVP path before opening new runtime or product work.
+Demo-readiness smoke passed against the current local MVP data. Derive the next short task from the contest MVP goal and create a new task packet before opening new runtime or product work.
 
 ## AI-owned blockers
 
-- None currently. If CI, merge, or review blocks the active PR, fixing that blocker becomes the next task.
+- None currently. The local smoke lane passed with demo-safe data, backend startup, frontend production build, Knowledge Pack metadata, assessment session evidence, tutor session evidence, and dashboard activity.
 
 ## Human-review blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,8 +7,8 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Land the docs-first smoke lane packet and runbook from issue `#22`.
-3. Execute that smoke lane before opening new runtime or product work.
+2. Treat the smoke lane as passed for the current local demo dataset and environment.
+3. Derive the next short task from the MVP goal and create or update a task packet before new implementation starts.
 4. Keep open issues aligned with active task packets and unfinished work only.
 5. Preserve unrelated dirty files until they are intentionally handled.
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -229,6 +229,30 @@
 - Next:
   - Open the docs PR, merge when eligible, then execute the smoke lane.
 
+## Demo Readiness Smoke Execution
+
+- Branch: `docs/demo-readiness-smoke-run`
+- Task: execute the smoke lane against the current local demo dataset and record the result.
+- Done:
+  - started the backend with `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor.api.run_server`;
+  - confirmed `/api/v1/system/status` returns backend online and configured LLM metadata;
+  - confirmed `/api/v1/knowledge/list` exposes `contest-demo-quadratics` with teacher metadata;
+  - confirmed `/api/v1/dashboard/overview` and `/api/v1/dashboard/recent` show assessment and tutor activity grounded in `contest-demo-quadratics`;
+  - confirmed `/api/v1/sessions/contest-assessment-demo` and `/api/v1/sessions/contest-tutor-demo` contain the expected assessment and tutor evidence;
+  - ran `NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build` in `web/`.
+- Tests:
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/system/status`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/knowledge/list`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo`
+  - Passed with existing lockfile warning: `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+- Blockers:
+  - None for the current local demo dataset.
+- Next:
+  - Create the next short task packet from the MVP goal before starting another implementation lane.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.


### PR DESCRIPTION
## Summary
- record the first local smoke execution result for the contest MVP path
- update the AI-first queue and status mirrors after the smoke lane passed
- make the queue explicitly empty so the next task must be derived from the MVP goal

## Test Plan
- [x] curl -s http://127.0.0.1:8001/api/v1/system/status
- [x] curl -s http://127.0.0.1:8001/api/v1/knowledge/list
- [x] curl -s http://127.0.0.1:8001/api/v1/dashboard/overview
- [x] curl -s http://127.0.0.1:8001/api/v1/dashboard/recent
- [x] curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo
- [x] curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo
- [x] cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build
- [x] git diff --check

## Main System Map
- Not updated; this PR records smoke execution status and queue changes without changing product/runtime architecture.