### PR TITLE
[codex] add backend frontend docs ci checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,102 +1,40 @@
-name: Tests
+name: CI Checks
 
 on:
   push:
     branches:
       - main
-      - dev
-    paths:
-      - "deeptutor/**"
-      - "deeptutor_cli/**"
-      - "tests/**"
-      - "requirements/**"
-      - "requirements.txt"
-      - "pyproject.toml"
-      - ".github/workflows/tests.yml"
   pull_request:
     branches:
       - main
-      - dev
-    paths:
-      - "deeptutor/**"
-      - "deeptutor_cli/**"
-      - "tests/**"
-      - "requirements/**"
-      - "requirements.txt"
-      - "pyproject.toml"
-      - ".github/workflows/tests.yml"
 
 jobs:
-  import-check:
-    name: Import Check (Python ${{ matrix.python-version }})
+  backend:
+    name: Backend Tests + Compile
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Cache pip packages
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements/server.txt', 'requirements/cli.txt') }}
+          key: ${{ runner.os }}-pip-3.12-${{ hashFiles('requirements/dev.txt', 'requirements/server.txt', 'requirements/cli.txt', 'requirements.txt', 'pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-3.12-
 
-      - name: Install minimal dependencies for import check
+      - name: Install backend dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/server.txt
-
-      - name: Check module imports
-        run: |
-          echo "🐍 Testing with Python ${{ matrix.python-version }}"
-          python -c "from deeptutor.runtime.orchestrator import ChatOrchestrator; print('✅ Orchestrator imports OK')"
-          python -c "from deeptutor.runtime.registry.tool_registry import get_tool_registry; print('✅ Tool registry imports OK')"
-          python -c "from deeptutor.runtime.registry.capability_registry import get_capability_registry; print('✅ Capability registry imports OK')"
-          python -c "from deeptutor.services.config.env_store import EnvStore; print('✅ EnvStore imports OK')"
-          python -c "from deeptutor.api.routers.unified_ws import unified_websocket; print('✅ Unified WS imports OK')"
-          python -c "from deeptutor.services.prompt.manager import PromptManager; print('✅ Prompt manager imports OK')"
-          python -c "from deeptutor.logging import get_logger; print('✅ Logging imports OK')"
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-
-  smoke-tests:
-    name: Smoke Tests (Python 3.11)
-    runs-on: ubuntu-latest
-    needs: import-check
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Cache pip packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('requirements/server.txt', 'requirements/cli.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-3.11-
-
-      - name: Install smoke test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/server.txt
-          pip install pytest pytest-asyncio
+          pip install -r requirements/dev.txt
+          pip install -e .
 
       - name: Create minimal runtime config
         run: |
@@ -108,37 +46,53 @@ jobs:
             level: WARNING
           YAML
 
-      - name: Run smoke tests
+      - name: Run backend checks
         run: |
-          echo "🧪 Running smoke test subset"
-          pytest -q --import-mode=importlib \
-            tests/api \
-            tests/cli \
-            tests/services/test_app_facade.py \
-            tests/services/test_model_catalog.py \
-            tests/services/test_path_service.py \
-            tests/services/memory \
-            tests/services/session \
-            tests/tools
+          pytest tests/api/test_knowledge_router.py -v
+          pytest tests/knowledge -v
+          pytest tests/api/test_question_router.py -v
+          pytest tests/api/test_unified_ws_turn_runtime.py -v
+          pytest tests/api/test_dashboard_router.py -v
+          pytest tests/services/session -v
+          python -m compileall deeptutor
         env:
           PYTHONPATH: ${{ github.workspace }}
 
-  test-summary:
-    name: Test Summary
+  frontend:
+    name: Frontend Build
     runs-on: ubuntu-latest
-    needs: [import-check, smoke-tests]
-    if: always()
 
     steps:
-      - name: Check test results
-        run: |
-          echo "## 🧪 Test Results Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Import check (3.11/3.12) | ${{ needs.import-check.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Smoke tests (3.11) | ${{ needs.smoke-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Fail if tests failed
-        if: needs.import-check.result == 'failure' || needs.smoke-tests.result == 'failure'
-        run: exit 1
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: web
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_BASE: http://localhost:8001
+
+  docs:
+    name: Docs Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for whitespace errors
+        run: git diff --check
+
+      - name: Verify documentation markers
+        run: rg -n "Mermaid|PR Architecture Note|Main System Map" docs/superpowers/pr-notes ai_first docs/contest

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -23,7 +23,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, and contest screenshot evidence are merged. Next operating improvement: add reliable backend/frontend CI before broader runtime auto-merge.
+- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest screenshot evidence, and backend/frontend/docs CI checks are implemented. Next operating improvement: keep CI green and use those checks as the runtime auto-merge gate.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -100,7 +100,7 @@ Before handing off:
 1. Keep this file as the single entry point for future AI workers.
 2. Use `ai_first/USAGE_GUIDE.md` as the human-friendly quick start.
 3. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
-4. Finish and merge the CI task packet, then implement reliable backend/frontend/docs CI before starting another product feature.
+4. Keep backend/frontend/docs CI green; if any required check fails, fixing that failure is the next task before starting another product feature.
 5. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
 6. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
 7. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/post-pr4-next-actions`
+- Current branch for this workflow update: `fix/ci-backend-frontend-checks`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard MVPs are merged.
-- Current purpose: create the `docs/contest/` evidence bundle so a reviewer can follow and verify the MVP story.
+- Current purpose: keep the contest MVP merge-gated by reliable backend, frontend, and docs CI checks.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -73,7 +73,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-CI task packet is being prepared on `docs/ci-task-packet`, mirrored by GitHub issue `#16`. After this docs PR merges, implement `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
+Open and merge the CI implementation PR for `fix/ci-backend-frontend-checks`, then treat any failing required check as the highest-priority blocker before starting another feature.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,15 +7,16 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Merge the docs-only CI task packet PR when eligible.
-2. Implement reliable backend, frontend, and docs CI checks from `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
-3. Keep GitHub issues `#2`, `#3`, `#9`, `#12`, and `#16` linked to their implementation PRs.
-4. Preserve unrelated dirty files until they are intentionally handled.
+2. Open and merge the CI implementation PR from `fix/ci-backend-frontend-checks`.
+3. If any required backend, frontend, or docs check fails, fix that CI failure before starting another feature.
+4. Keep GitHub issues `#2`, `#3`, `#9`, `#12`, and `#16` linked to their implementation PRs.
+5. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 
 1. Keep the main system map updated when shared contracts change.
 2. Keep `ai_first/AI_FIRST_ROADMAP.md` current when the autonomous operating loop changes.
-3. Implement reliable backend and frontend CI checks before allowing broader runtime auto-merge.
+3. Keep reliable backend, frontend, and docs CI checks as the gate before broader runtime auto-merge.
 
 ## Human Review Needed
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -152,6 +152,29 @@
 - Blockers: None known.
 - Next: Commit, open docs PR, merge when eligible, then implement CI.
 
+## CI Checks Implementation
+
+- Branch: `fix/ci-backend-frontend-checks`
+- Task: Implement backend/frontend/docs CI checks from `docs/superpowers/tasks/2026-04-19-ci-backend-frontend.md`.
+- Done:
+  - Replaced the legacy Python-only smoke workflow in `.github/workflows/tests.yml` with one CI workflow containing `Backend Tests + Compile`, `Frontend Build`, and `Docs Validation`.
+  - Kept the workflow scoped to pull requests and pushes on `main`.
+  - Added `docs/superpowers/pr-notes/ci-backend-frontend-checks.md` with Mermaid architecture note.
+  - Updated AI-first operating/status mirrors so CI failures remain the highest-priority blocker before new feature work.
+- Tests:
+  - Passed: `python3 - <<'PY' ... yaml.safe_load('.github/workflows/tests.yml') ... PY`
+  - Passed: `rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" .github/workflows docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
+  - Passed: `source /tmp/deeptutor-ci-eUJerc/venv/bin/activate && export PYTHONPATH="$PWD" && pytest tests/api/test_knowledge_router.py -v && pytest tests/knowledge -v && pytest tests/api/test_question_router.py -v && pytest tests/api/test_unified_ws_turn_runtime.py -v && pytest tests/api/test_dashboard_router.py -v && pytest tests/services/session -v && python -m compileall deeptutor`
+  - Passed: `cd web && npm ci`
+  - Passed: `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+- Blockers:
+  - None known from local validation.
+  - Frontend build still emits the existing multiple-lockfiles warning from Next.js root detection, but the build completes successfully.
+- Next:
+  - Commit, open PR, and confirm GitHub Actions reports the three required checks on the PR.
+  - If any required check fails in GitHub, fix that CI failure before starting another feature.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/superpowers/pr-notes/ci-backend-frontend-checks.md
+++ b/docs/superpowers/pr-notes/ci-backend-frontend-checks.md
@@ -1,0 +1,56 @@
+# PR Architecture Note: Backend and Frontend CI Checks
+
+## Summary
+
+Replaces the legacy Python-only smoke workflow with a single CI workflow that runs backend validation, frontend production build, and docs policy checks on pull requests and pushes to `main`.
+
+## Scope
+
+- Updates `.github/workflows/tests.yml` to define the authoritative CI checks.
+- Keeps the change inside workflow/docs/AI-first ownership boundaries.
+- Leaves runtime and product code unchanged.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  PR["Pull Request or main push"]
+  CI["CI Checks workflow"]
+  Backend["Backend Tests + Compile"]
+  Frontend["Frontend Build"]
+  Docs["Docs Validation"]
+  Gate["Runtime merge gate"]
+
+  PR --> CI
+  CI --> Backend
+  CI --> Frontend
+  CI --> Docs
+  Backend --> Gate
+  Frontend --> Gate
+  Docs --> Gate
+```
+
+## Architecture Impact
+
+No product/runtime architecture change. This PR adds merge-gating workflow automation only.
+
+## Data/API Changes
+
+None.
+
+## Tests
+
+```bash
+python3 - <<'PY'
+import pathlib, yaml
+yaml.safe_load(pathlib.Path(".github/workflows/tests.yml").read_text())
+print("workflow-parse-ok")
+PY
+rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" .github/workflows docs/superpowers/pr-notes ai_first
+git diff --check
+```
+
+## Main System Map Update
+
+- [x] Not needed, because this PR changes CI workflow automation rather than shared runtime architecture.
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`


### PR DESCRIPTION
## Summary
- replace the legacy Python-only smoke workflow with one CI workflow that runs backend tests, frontend build, and docs validation
- add the required PR architecture note with Mermaid for the CI implementation
- update AI-first operating mirrors so CI failures stay the highest-priority blocker before new feature work

## Why
Reliable backend, frontend, and docs checks are now the intended merge gate for runtime/product PRs. This change makes that gate concrete in GitHub Actions and aligns the repo mirrors with the new operating state.

## Test Plan
- [x] `python3 - <<'PY' ... yaml.safe_load('.github/workflows/tests.yml') ... PY`
- [x] `rg -n "backend|frontend|pytest|npm run build|NEXT_PUBLIC_API_BASE|Mermaid" .github/workflows docs/superpowers/pr-notes ai_first`
- [x] `git diff --check`
- [x] `source /tmp/deeptutor-ci-eUJerc/venv/bin/activate && export PYTHONPATH="$PWD" && pytest tests/api/test_knowledge_router.py -v && pytest tests/knowledge -v && pytest tests/api/test_question_router.py -v && pytest tests/api/test_unified_ws_turn_runtime.py -v && pytest tests/api/test_dashboard_router.py -v && pytest tests/services/session -v && python -m compileall deeptutor`
- [x] `cd web && npm ci`
- [x] `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`

## Notes
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR changes CI workflow automation, not shared runtime architecture.
- Frontend build still shows the existing Next.js multiple-lockfiles warning, but the build completes successfully.
