### PR TITLE
docs: add contest evidence refresh packet

### DIFF
--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/demo-readiness-smoke-run`
+- Current branch for this docs update: `docs/evidence-refresh-packet`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: record the first local smoke execution result after the smoke lane landed, then select the next short task from the MVP goal.
+- Current purpose: queue the next short docs/workflow task so contest evidence stays aligned with the smoke-backed MVP path.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -60,15 +60,16 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Latest completed task packet: `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+- Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md`
+- Current open GitHub issue: `#26`
 - Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
-- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), and smoke lane packet (`#23`)
+- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), and smoke execution result (`#24`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-The smoke lane passed against the current local demo data. The next step is to derive the next short task from the MVP goal and create or update a task packet before implementation starts.
+Land the contest evidence refresh packet from issue `#26`, then use that packet to keep `docs/contest/` aligned with future smoke runs.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,17 +7,18 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#23`, which added the demo-readiness smoke lane packet and runbook.
+- Latest merged PR before the current active branch: `#24`, which recorded the first smoke execution result.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
 
 ## Active queue
 
-- No active issue is queued right now.
-- The latest completed lane is `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`.
+- Open issue: `#26 docs: add contest evidence refresh packet`
+- Active task packet: `docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md`
+- Expected branch: `docs/contest-evidence-refresh`
 
 ## Next recommended task
 
-Demo-readiness smoke passed against the current local MVP data. Derive the next short task from the contest MVP goal and create a new task packet before opening new runtime or product work.
+Land the contest evidence refresh packet, then use it to keep the evidence bundle aligned with smoke-backed MVP validation.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,8 +7,8 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Treat the smoke lane as passed for the current local demo dataset and environment.
-3. Derive the next short task from the MVP goal and create or update a task packet before new implementation starts.
+2. Land the contest evidence refresh packet from issue `#26`.
+3. Use that packet to keep `docs/contest/` aligned with smoke-backed validation.
 4. Keep open issues aligned with active task packets and unfinished work only.
 5. Preserve unrelated dirty files until they are intentionally handled.
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -253,6 +253,22 @@
 - Next:
   - Create the next short task packet from the MVP goal before starting another implementation lane.
 
+## Contest Evidence Refresh Packet
+
+- Branch: `docs/evidence-refresh-packet`
+- Task: add the contest evidence refresh packet after the first smoke pass.
+- Done:
+  - created GitHub issue `#26`;
+  - added `docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md`;
+  - added `docs/superpowers/pr-notes/contest-evidence-refresh-packet.md`;
+  - updated the queue and status mirrors to point to evidence refresh as the next short task.
+- Tests:
+  - Pending in this branch: docs grep validation and `git diff --check`.
+- Blockers:
+  - None known.
+- Next:
+  - Validate the packet, open the docs PR, and merge when eligible.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/superpowers/pr-notes/contest-evidence-refresh-packet.md
+++ b/docs/superpowers/pr-notes/contest-evidence-refresh-packet.md
@@ -1,0 +1,25 @@
+# PR Architecture Note: Contest Evidence Refresh Packet
+
+## Summary
+
+This PR adds a docs/workflow task packet for refreshing contest evidence after smoke runs so the evidence bundle stays aligned with the current MVP path.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Smoke["Smoke Result"]
+  Packet["Evidence Refresh Packet"]
+  Evidence["docs/contest"]
+  Queue["EXECUTION_QUEUE.md"]
+  NextTask["Next Task Selection"]
+
+  Smoke --> Packet
+  Packet --> Evidence
+  Evidence --> Queue
+  Queue --> NextTask
+```
+
+## Main System Map Update
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR adds docs/workflow guidance for evidence refresh without changing product/runtime architecture.

--- a/docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md
+++ b/docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md
@@ -1,0 +1,78 @@
+# Feature Pod Task: Contest Evidence Refresh
+
+Owner: Documentation / Workflow AI worker
+Branch: `docs/contest-evidence-refresh`
+GitHub Issue: `#26`
+
+## Goal
+
+Add a compact docs/workflow lane for refreshing contest evidence after smoke runs so the evidence bundle stays aligned with the current MVP path.
+
+## User-visible outcome
+
+A human or AI worker can tell what evidence should be refreshed after a smoke pass, what can stay as-is, and where to record the latest evidence status without reading old chat history.
+
+## Owned files/modules
+
+- `docs/contest/README.md`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- `docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md`
+- `docs/superpowers/pr-notes/contest-evidence-refresh-packet.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if the queue or operating rules change
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `web/next-env.d.ts`
+- `.env*`
+- `data/`
+
+## Evidence refresh contract
+
+The evidence refresh lane must define:
+
+1. what evidence is refreshed automatically after a smoke pass;
+2. what evidence still requires a human-triggered capture step;
+3. how to mark evidence as current, stale, or blocked;
+4. where the latest smoke-backed evidence status is recorded.
+
+The lane must reuse the current contest evidence bundle and smoke runbook. It must not create a second evidence tree.
+
+## Acceptance criteria
+
+- There is one explicit evidence-refresh task packet.
+- The packet points to the existing contest evidence bundle and smoke runbook.
+- The queue and status mirrors point to evidence refresh as the next short task.
+- The change stays docs/workflow-only.
+
+## Required validation
+
+- `rg -n "evidence refresh|smoke|validation|screenshot|video|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+- `git diff --check`
+
+## Manual verification
+
+- Open the packet and confirm a new AI worker can tell what evidence to refresh after a smoke pass.
+- Confirm the packet does not introduce another evidence or queue system.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State that `ai_first/architecture/MAIN_SYSTEM_MAP.md` does not need an update because this packet adds docs/workflow guidance, not product/runtime architecture.
+
+## Handoff notes
+
+- Keep this lane docs/workflow-only.
+- Reuse `docs/contest/` and `ai_first/EXECUTION_QUEUE.md`.
+- Prefer small, repeatable evidence updates over large manual refresh work.


### PR DESCRIPTION
## Summary
- add the contest evidence refresh task packet
- add the PR architecture note for the evidence refresh packet
- update AI-first queue and status mirrors to point to evidence refresh

## Test Plan
- [x] rg -n "evidence refresh|smoke|validation|screenshot|video|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- [x] git diff --check

## Main System Map
- Not updated; this PR adds docs/workflow guidance and queue updates without changing product/runtime architecture.