### PR TITLE
docs: refresh contest evidence workflow

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, and the demo-readiness smoke lane has passed against the current local demo dataset. The next task should now be derived from the MVP goal and captured in a new task packet.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` now carries the smoke-backed evidence refresh workflow. After this lane merges, the next task should be derived from the MVP goal and captured in a new task packet.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -106,7 +106,8 @@ Before handing off:
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
 7. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
-8. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
-9. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
-10. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-11. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.
+8. Keep `docs/contest/VALIDATION_REPORT.md` as the latest smoke-backed evidence freshness record, and update `EVIDENCE_CHECKLIST.md` when screenshot or video status changes.
+9. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
+10. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+11. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+12. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/evidence-refresh-packet`
+- Current branch for this docs update: `docs/evidence-refresh-run`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: queue the next short docs/workflow task so contest evidence stays aligned with the smoke-backed MVP path.
+- Current purpose: execute the contest evidence refresh lane so `docs/contest/` stays aligned with the smoke-backed MVP path.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -61,15 +61,15 @@ Do not revert unrelated changes.
 ## Active Execution
 
 - Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md`
-- Current open GitHub issue: `#26`
+- Current open GitHub issue: none currently. Issue `#26` was closed after PR `#27` merged the packet.
 - Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
-- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), and smoke execution result (`#24`)
+- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), and contest evidence refresh packet (`#27`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Land the contest evidence refresh packet from issue `#26`, then use that packet to keep `docs/contest/` aligned with future smoke runs.
+Merge the contest evidence refresh execution docs lane, then derive the next short task packet from the MVP goal.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,18 +7,19 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#24`, which recorded the first smoke execution result.
+- Latest merged PR before the current active branch: `#27`, which queued the contest evidence refresh packet.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
+- Smoke-backed evidence refresh rules now live in `docs/contest/` on the current branch and are waiting to merge.
 
 ## Active queue
 
-- Open issue: `#26 docs: add contest evidence refresh packet`
+- Open issue: none currently.
 - Active task packet: `docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md`
-- Expected branch: `docs/contest-evidence-refresh`
+- Expected branch: `docs/evidence-refresh-run`
 
 ## Next recommended task
 
-Land the contest evidence refresh packet, then use it to keep the evidence bundle aligned with smoke-backed MVP validation.
+Merge the contest evidence refresh execution lane, then derive the next short task packet from the MVP goal.
 
 ## AI-owned blockers
 
@@ -32,5 +33,5 @@ Land the contest evidence refresh packet, then use it to keep the evidence bundl
 
 1. `ai_first/AI_OPERATING_PROMPT.md`
 2. `ai_first/EXECUTION_QUEUE.md`
-3. Task packet for the active issue
+3. Task packet for the active branch
 4. `ai_first/CURRENT_STATE.md` only if more context is needed

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,10 +7,11 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Land the contest evidence refresh packet from issue `#26`.
-3. Use that packet to keep `docs/contest/` aligned with smoke-backed validation.
-4. Keep open issues aligned with active task packets and unfinished work only.
-5. Preserve unrelated dirty files until they are intentionally handled.
+2. Merge the contest evidence refresh execution lane.
+3. Derive the next short task packet from the MVP goal once the queue is empty again.
+4. Keep `docs/contest/` aligned with smoke-backed validation after each successful smoke run.
+5. Keep open issues aligned with active task packets and unfinished work only.
+6. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -269,6 +269,24 @@
 - Next:
   - Validate the packet, open the docs PR, and merge when eligible.
 
+## Contest Evidence Refresh Execution
+
+- Branch: `docs/evidence-refresh-run`
+- Task: execute the evidence refresh lane so the contest evidence bundle stays aligned with smoke-backed validation.
+- Done:
+  - updated `docs/contest/README.md` to anchor evidence refresh on `SMOKE_RUNBOOK.md` and define the freshness states `Current`, `Stale`, and `Blocked`;
+  - updated `docs/contest/EVIDENCE_CHECKLIST.md` to separate human-capture artifacts from auto-refreshed smoke evidence;
+  - updated `docs/contest/VALIDATION_REPORT.md` with a smoke-backed evidence freshness table and the latest 2026-04-19 smoke verification record;
+  - updated `ai_first/EXECUTION_QUEUE.md`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`, and `ai_first/AI_OPERATING_PROMPT.md` so the queue moves beyond evidence refresh once this lane merges;
+  - added a docs-only PR architecture note with Mermaid.
+- Tests:
+  - Passed: `rg -n "evidence refresh|smoke|validation|screenshot|video|Mermaid|Current|Stale|Blocked" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
+- Blockers:
+  - None known.
+- Next:
+  - Validate the docs changes, open the PR, merge when eligible, then derive the next short task packet from the MVP goal.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/contest/EVIDENCE_CHECKLIST.md
+++ b/docs/contest/EVIDENCE_CHECKLIST.md
@@ -4,30 +4,33 @@ Use this checklist after running the demo locally.
 
 ## Required Screenshots
 
-| Area | Evidence | Status | Notes |
-| --- | --- | --- | --- |
-| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Captured | [`01-knowledge-pack-metadata.png`](./screenshots/01-knowledge-pack-metadata.png) |
-| Knowledge Pack | Metadata still visible after reload | Captured | [`02-knowledge-pack-after-reload.png`](./screenshots/02-knowledge-pack-after-reload.png) |
-| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Captured | [`04-assessment-config.png`](./screenshots/04-assessment-config.png) |
-| Assessment | Generated questions visible | Captured | [`07-assessment-generated-questions.png`](./screenshots/07-assessment-generated-questions.png) |
-| Assessment | Common-mistake or feedback guidance visible | Captured | [`08-assessment-common-mistakes.png`](./screenshots/08-assessment-common-mistakes.png) |
-| Tutor Agent | Student asks a follow-up question | Captured | [`06-tutor-agent-answer.png`](./screenshots/06-tutor-agent-answer.png) |
-| Tutor Agent | Tutor response with learning context | Captured | [`06-tutor-agent-answer.png`](./screenshots/06-tutor-agent-answer.png) |
-| Dashboard | Summary cards visible | Captured | [`05-dashboard-summary-and-activity.png`](./screenshots/05-dashboard-summary-and-activity.png) |
-| Dashboard | Recent activity includes assessment/tutoring distinction and Knowledge Pack reference | Captured | [`05-dashboard-summary-and-activity.png`](./screenshots/05-dashboard-summary-and-activity.png) |
+Refresh these only when the UI changed or when the latest smoke-backed validation marks them stale or blocked.
+
+| Area | Evidence | Refresh mode | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Human capture | Current | [`01-knowledge-pack-metadata.png`](./screenshots/01-knowledge-pack-metadata.png) |
+| Knowledge Pack | Metadata still visible after reload | Human capture | Current | [`02-knowledge-pack-after-reload.png`](./screenshots/02-knowledge-pack-after-reload.png) |
+| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Human capture | Current | [`04-assessment-config.png`](./screenshots/04-assessment-config.png) |
+| Assessment | Generated questions visible | Human capture | Current | [`07-assessment-generated-questions.png`](./screenshots/07-assessment-generated-questions.png) |
+| Assessment | Common-mistake or feedback guidance visible | Human capture | Current | [`08-assessment-common-mistakes.png`](./screenshots/08-assessment-common-mistakes.png) |
+| Tutor Agent | Student asks a follow-up question | Human capture | Current | [`06-tutor-agent-answer.png`](./screenshots/06-tutor-agent-answer.png) |
+| Tutor Agent | Tutor response with learning context | Human capture | Current | [`06-tutor-agent-answer.png`](./screenshots/06-tutor-agent-answer.png) |
+| Dashboard | Summary cards visible | Human capture | Current | [`05-dashboard-summary-and-activity.png`](./screenshots/05-dashboard-summary-and-activity.png) |
+| Dashboard | Recent activity includes assessment/tutoring distinction and Knowledge Pack reference | Human capture | Current | [`05-dashboard-summary-and-activity.png`](./screenshots/05-dashboard-summary-and-activity.png) |
 
 ## Required Command Evidence
 
-| Command | Status | Source |
-| --- | --- | --- |
-| `pytest tests/api/test_knowledge_router.py -v` | Passed in PR `#6` validation | See daily log and PR notes. |
-| `pytest tests/knowledge -v` | Passed in PR `#6` validation | See daily log and PR notes. |
-| `pytest tests/api/test_question_router.py -v` | Passed in PR `#8` validation | See daily log and PR notes. |
-| `pytest tests/api/test_unified_ws_turn_runtime.py -v` | Passed in PR `#8` validation | See daily log and PR notes. |
-| `pytest tests/api/test_dashboard_router.py -v` | Passed in PR `#11` validation | See daily log and PR notes. |
-| `pytest tests/services/session -v` | Passed in PR `#11` validation | See daily log and PR notes. |
-| `python3 -m compileall deeptutor` | Passed in PR `#6`, `#8`, and `#11` validation | See daily log and PR notes. |
-| `cd web && npm run build` | Passed in PR `#6`, `#8`, and `#11` validation | Build warns about multiple lockfiles; no build failure. |
+Refresh these automatically after every successful smoke pass.
+
+| Command | Refresh mode | Status | Source |
+| --- | --- | --- | --- |
+| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
+| `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run with the existing lockfile warning. |
 
 ## Optional Video
 
@@ -43,12 +46,18 @@ Store large video files outside the repository and link them here:
 
 - Video link: Deferred. Screenshot evidence is complete; capture and link an external video only if the final contest submission requires it.
 
+Video status follows the same freshness states:
+
+- `Current`: a linked video still matches the latest successful smoke path.
+- `Stale`: smoke passed but the flow changed enough that the old video is misleading.
+- `Blocked`: smoke failed or no capture environment was available.
+
 ## Pass/Fail Summary
 
 | Criterion | Status | Notes |
 | --- | --- | --- |
 | Full MVP story can be followed from docs | Passed | Start with `docs/contest/README.md`. |
-| Product commands have local validation evidence | Passed | See `VALIDATION_REPORT.md`. |
-| Screenshots are captured and linked | Passed | See screenshot rows above. |
+| Product commands have smoke-backed validation evidence | Passed | See `VALIDATION_REPORT.md`. |
+| Screenshots are captured and linked | Passed | All screenshot entries are currently marked `Current`. |
 | Video is captured or explicitly deferred | Deferred | Optional unless submission requires it. |
 | No secrets or private data in evidence | Passed | Screenshots use demo-safe Knowledge Pack and session data. |

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -11,17 +11,33 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - [`DEMO_SCRIPT.md`](./DEMO_SCRIPT.md): step-by-step demo path for a reviewer or presenter.
 - [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md): required screenshots, optional video, and pass/fail evidence fields.
 - [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md): local validation commands, results, limitations, and remaining capture work.
+- [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md): smoke lane used to verify the MVP path before any evidence refresh.
 
 ## Current Status
 
 - Product MVP path is implemented through merged PRs for Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard.
-- Local command validation is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
+- The first smoke-backed MVP verification passed on 2026-04-19 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
 - Screenshot evidence is captured in [`screenshots/`](./screenshots/).
 - Video capture is optional and deferred to avoid storing large media in the repository.
+
+## Evidence Refresh Rules
+
+Run [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md) first, then refresh evidence using these rules:
+
+- Auto-refresh evidence: smoke-backed command results, API reachability checks, and the evidence status table in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
+- Human-triggered refresh: screenshots and any optional video, because they require an interactive capture step.
+- Status vocabulary:
+  - `Current`: evidence still matches the latest successful smoke run.
+  - `Stale`: the MVP path changed after the last capture or validation.
+  - `Blocked`: the evidence could not be refreshed because smoke failed or the environment was unavailable.
+- Source of truth for freshness:
+  - [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) records the latest smoke-backed evidence status.
+  - [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md) records which artifacts are current versus still awaiting manual recapture.
 
 ## Update Rules
 
 - Update this folder whenever the demo flow, API behavior, or UI route changes.
+- After every successful smoke pass, update the evidence status in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) before starting another docs or demo lane.
 - Keep evidence free of secrets, private data, local credentials, and real student information.
 - Store large videos outside the repository and link them from the checklist or validation report.
 
@@ -40,13 +56,16 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ```mermaid
 flowchart LR
   Goal["Contest MVP Story"]
+  Smoke["SMOKE_RUNBOOK.md"]
   Demo["DEMO_SCRIPT.md"]
   Checklist["EVIDENCE_CHECKLIST.md"]
   Validation["VALIDATION_REPORT.md"]
   Reviewer["Reviewer"]
 
+  Goal --> Smoke
+  Smoke --> Validation
+  Validation --> Checklist
   Goal --> Demo
   Demo --> Checklist
-  Checklist --> Validation
   Validation --> Reviewer
 ```

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -8,39 +8,66 @@ This report covers the current contest MVP path:
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
 
+## Evidence Freshness Status
+
+Latest smoke-backed refresh: 2026-04-19
+
+| Evidence group | Refresh mode | Status | Latest source |
+| --- | --- | --- | --- |
+| Backend and API reachability | Auto after smoke | Current | Smoke run recorded in PR `#24` and `ai_first/daily/2026-04-19.md`. |
+| Frontend production build | Auto after smoke | Current | `NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build` passed during the 2026-04-19 smoke run. |
+| Screenshot bundle | Human capture after smoke when the UI changes | Current | Existing contest screenshots still match the smoke-verified MVP path. |
+| Optional video | Human capture only | Deferred | No external video is required yet. |
+
+Use these status values consistently:
+
+- `Current`: still matches the latest successful smoke run.
+- `Stale`: the MVP path changed after the last successful capture or validation.
+- `Blocked`: refresh could not complete because smoke failed or the environment was unavailable.
+- `Deferred`: intentionally skipped because the artifact is optional.
+
 ## Local Validation Summary
 
 | Area | Command | Result |
 | --- | --- | --- |
-| Knowledge Pack API | `pytest tests/api/test_knowledge_router.py -v` | Passed in PR `#6` validation: 11 passed. |
-| Knowledge Pack metadata | `pytest tests/knowledge -v` | Passed in PR `#6` validation: 3 passed. |
-| Assessment API | `pytest tests/api/test_question_router.py -v` | Passed in PR `#8` validation: 1 passed. |
-| Student tutor runtime contract | `pytest tests/api/test_unified_ws_turn_runtime.py -v` | Passed in PR `#8` validation: 6 passed. |
-| Teacher Dashboard API | `pytest tests/api/test_dashboard_router.py -v` | Passed in PR `#11` validation: 2 passed. |
-| Session persistence regression | `pytest tests/services/session -v` | Passed in PR `#11` validation: 2 passed. |
-| Backend syntax/import sweep | `python3 -m compileall deeptutor` | Passed in PR `#6`, `#8`, and `#11` validation. |
-| Frontend production build | `cd web && npm run build` | Passed in PR `#6`, `#8`, and `#11` validation. |
+| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed in the 2026-04-19 smoke run. |
+| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed in the 2026-04-19 smoke run; `contest-demo-quadratics` was present with teacher metadata. |
+| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed in the 2026-04-19 smoke run. |
+| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed in the 2026-04-19 smoke run. |
+| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed in the 2026-04-19 smoke run. |
+| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed in the 2026-04-19 smoke run. |
+| Frontend production build | `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build` | Passed in the 2026-04-19 smoke run with the existing lockfile warning. |
 
 ## Current Known Limitations
 
 - Screenshot evidence is captured under `docs/contest/screenshots/`.
 - Video evidence is deferred unless the final contest submission requires it.
 - The frontend build emits a Next.js warning about multiple lockfiles and inferred workspace root. The build still completes successfully.
+- Screenshot freshness still requires a human capture step when the UI meaningfully changes.
 - Provider-backed AI quality depends on configured model credentials. If credentials are unavailable during a demo, use the command validation and recorded UI flow as fallback evidence.
 - This report uses demo-safe descriptions only. Do not add real student data.
 
 ## Local Demo Run
 
-The screenshot capture used local demo data only:
+The latest smoke-backed evidence refresh used local demo data only:
 
 - Backend: `.venv/bin/python -m deeptutor.api.run_server`
-- Frontend: `NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run dev`
+- Frontend validation: `NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
 - Knowledge Pack: `contest-demo-quadratics`
 - Demo sessions:
   - `contest-assessment-demo`
   - `contest-tutor-demo`
 
 The first attempt to run `python3 -m deeptutor.api.run_server` failed because `python3` resolved to a different virtual environment without `uvicorn`. The backend was then run successfully with the repository-local `.venv/bin/python`.
+
+## Smoke-backed Verification Record
+
+The 2026-04-19 smoke run verified the full MVP path in order:
+
+1. backend started successfully with the repository-local virtual environment;
+2. system status, knowledge list, dashboard overview, dashboard recent, assessment session, and tutor session endpoints all returned the expected demo-safe data;
+3. the frontend production build passed against `http://localhost:8001`;
+4. the existing screenshot bundle still matched the smoke-verified flow, so screenshot status remains `Current` instead of requiring immediate recapture.
 
 ## Manual Verification Template
 
@@ -61,14 +88,19 @@ Complete this section when the local app is running.
 - Assessment and Student Tutor Workspace MVP: PR `#8`.
 - Teacher Dashboard MVP: PR `#11`.
 - Contest evidence packet: PR `#13`.
+- Screenshot capture refresh: PR `#15`.
+- Demo-readiness smoke packet: PR `#23`.
+- Demo-readiness smoke execution result: PR `#24`.
+- Contest evidence refresh packet: PR `#27`.
 
 ## Next Evidence Actions
 
-1. Use these screenshots for the current repo evidence review.
-2. Capture and link an external video only if the final submission requires video.
-3. Re-run docs validation after evidence docs change:
+1. After each successful smoke run, update the evidence freshness table before changing screenshot status.
+2. Mark screenshots `Stale` or `Blocked` in `EVIDENCE_CHECKLIST.md` only when the smoke result or UI change requires it.
+3. Capture and link an external video only if the final submission requires video.
+4. Re-run docs validation after evidence docs change:
 
 ```bash
-rg -n "Knowledge Pack|assessment|Tutor|Dashboard|Mermaid|validation|screenshot|video" docs/contest docs/superpowers/pr-notes
+rg -n "evidence refresh|smoke|validation|screenshot|video|Current|Stale|Blocked" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
 git diff --check
 ```

--- a/docs/superpowers/pr-notes/contest-evidence-refresh-execution.md
+++ b/docs/superpowers/pr-notes/contest-evidence-refresh-execution.md
@@ -1,0 +1,28 @@
+# PR Note: Contest Evidence Refresh Execution
+
+## Summary
+
+- refreshes `docs/contest/` so smoke-backed evidence status is explicit;
+- separates auto-refreshed smoke evidence from human-capture screenshots and optional video;
+- updates AI-first queue mirrors so the next lane must be derived from the MVP goal after this merge.
+
+## Architecture Impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` does not need an update.
+- Reason: this PR changes docs/workflow guidance only and does not alter product/runtime architecture.
+
+## Evidence Refresh Flow
+
+```mermaid
+flowchart LR
+  Smoke["SMOKE_RUNBOOK.md"]
+  Validation["VALIDATION_REPORT.md"]
+  Checklist["EVIDENCE_CHECKLIST.md"]
+  Queue["EXECUTION_QUEUE.md"]
+  Next["Next task packet"]
+
+  Smoke --> Validation
+  Validation --> Checklist
+  Validation --> Queue
+  Queue --> Next
+```


### PR DESCRIPTION
## Summary
- make `docs/contest/` explicit about smoke-backed evidence refresh
- separate auto-refreshed smoke evidence from human-capture screenshot and video evidence
- move AI-first queue mirrors past this lane so the next task must be derived from the MVP goal

## Validation
- rg -n "evidence refresh|smoke|validation|screenshot|video|Mermaid|Current|Stale|Blocked" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- git diff --check

## Architecture
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated; this PR changes docs/workflow guidance only.
