### PR TITLE
docs: queue contest demo data reset

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` now carries the smoke-backed evidence refresh workflow. After this lane merges, the next task should be derived from the MVP goal and captured in a new task packet.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow. The next short task is to define a reproducible contest demo data reset lane instead of depending on pre-existing local demo state.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/evidence-refresh-run`
+- Current branch for this docs update: `docs/demo-data-reset-packet`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: execute the contest evidence refresh lane so `docs/contest/` stays aligned with the smoke-backed MVP path.
+- Current purpose: queue the next short docs/workflow lane so contest demo data becomes reproducible instead of remaining an implicit local prerequisite.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -60,16 +60,16 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md`
-- Current open GitHub issue: none currently. Issue `#26` was closed after PR `#27` merged the packet.
+- Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`
+- Current open GitHub issue: `#29`
 - Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
-- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), and contest evidence refresh packet (`#27`)
+- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), contest evidence refresh packet (`#27`), and contest evidence refresh execution (`#28`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Merge the contest evidence refresh execution docs lane, then derive the next short task packet from the MVP goal.
+Land the contest demo data reset packet from issue `#29`, then use that packet to make demo-safe state reproducible.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,19 +7,19 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#27`, which queued the contest evidence refresh packet.
+- Latest merged PR before the current active branch: `#28`, which refreshed the contest evidence workflow.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
-- Smoke-backed evidence refresh rules now live in `docs/contest/` on the current branch and are waiting to merge.
+- Smoke-backed evidence refresh rules now live in `docs/contest/` on `main`.
 
 ## Active queue
 
-- Open issue: none currently.
-- Active task packet: `docs/superpowers/tasks/2026-04-19-contest-evidence-refresh.md`
-- Expected branch: `docs/evidence-refresh-run`
+- Open issue: `#29 docs: add contest demo data reset packet`
+- Active task packet: `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`
+- Expected branch: `docs/contest-demo-data-reset`
 
 ## Next recommended task
 
-Merge the contest evidence refresh execution lane, then derive the next short task packet from the MVP goal.
+Land the contest demo data reset packet, then use it to make the MVP demo-safe state reproducible before the next smoke/evidence cycle.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,8 +7,8 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Merge the contest evidence refresh execution lane.
-3. Derive the next short task packet from the MVP goal once the queue is empty again.
+2. Land the contest demo data reset packet from issue `#29`.
+3. Use that packet to define how demo-safe Knowledge Pack and session state should be rebuilt before the next smoke/evidence cycle.
 4. Keep `docs/contest/` aligned with smoke-backed validation after each successful smoke run.
 5. Keep open issues aligned with active task packets and unfinished work only.
 6. Preserve unrelated dirty files until they are intentionally handled.

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -287,6 +287,23 @@
 - Next:
   - Validate the docs changes, open the PR, merge when eligible, then derive the next short task packet from the MVP goal.
 
+## Contest Demo Data Reset Packet
+
+- Branch: `docs/demo-data-reset-packet`
+- Task: add the next short docs/workflow packet so the contest MVP no longer depends on undocumented local demo data.
+- Done:
+  - created GitHub issue `#29`;
+  - added `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`;
+  - added `docs/superpowers/pr-notes/contest-demo-data-reset-packet.md`;
+  - updated the queue and status mirrors so demo data reset is the next short task after evidence refresh.
+- Tests:
+  - Passed: `rg -n "demo data|reset|smoke|evidence|Mermaid|Knowledge Pack|contest" docs/superpowers/tasks docs/superpowers/pr-notes ai_first docs/contest`
+  - Passed: `git diff --check`
+- Blockers:
+  - None known.
+- Next:
+  - Validate the packet, open the docs PR, and merge when eligible.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/superpowers/pr-notes/contest-demo-data-reset-packet.md
+++ b/docs/superpowers/pr-notes/contest-demo-data-reset-packet.md
@@ -1,0 +1,23 @@
+# PR Note: Contest Demo Data Reset Packet
+
+## Summary
+
+This PR queues the next short docs/workflow lane for making contest demo data reproducible after the smoke and evidence-refresh work.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Smoke["Smoke + Evidence State"]
+  Gap["Demo Data Still Local-only"]
+  Packet["Demo Data Reset Packet"]
+  Future["Future reset lane"]
+
+  Smoke --> Gap
+  Gap --> Packet
+  Packet --> Future
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR adds docs/workflow guidance for the next queue step without changing product/runtime architecture.

--- a/docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md
+++ b/docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md
@@ -1,0 +1,75 @@
+# Feature Pod Task: Contest Demo Data Reset
+
+Owner: Documentation / Workflow AI worker
+Branch: `docs/contest-demo-data-reset`
+GitHub Issue: `#29`
+
+## Goal
+
+Add a compact task packet for making the contest demo dataset reproducible so AI workers can rebuild the demo-safe state instead of depending on whatever local data already exists.
+
+## User-visible outcome
+
+A human or AI worker can tell what demo-safe data must exist for the contest MVP path, what must be recreated automatically versus checked manually, and where the reset procedure should live.
+
+## Owned files/modules
+
+- `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`
+- `docs/superpowers/pr-notes/contest-demo-data-reset-packet.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if the queue or operating guidance changes
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `web/next-env.d.ts`
+- `.env*`
+- `data/`
+
+## Demo reset contract
+
+The packet must define:
+
+1. the minimum demo-safe Knowledge Pack and session state required for the contest MVP path;
+2. which parts of that state should later be reset by script or seed workflow;
+3. which parts still require a manual verification step after reset;
+4. where the future reset runbook or script should be recorded.
+
+The lane must reuse the current contest evidence bundle, smoke runbook, and AI-first control plane. It must not invent a second queue or evidence system.
+
+## Acceptance criteria
+
+- There is one explicit task packet for contest demo data reset.
+- The packet points to the existing contest demo flow and smoke/evidence docs.
+- The queue and status mirrors point to demo data reset as the next short task.
+- The change stays docs/workflow-only.
+
+## Required validation
+
+- `rg -n "demo data|reset|smoke|evidence|Mermaid|Knowledge Pack|contest" docs/superpowers/tasks docs/superpowers/pr-notes ai_first docs/contest`
+- `git diff --check`
+
+## Manual verification
+
+- Open the packet and confirm a new AI worker can tell why reproducible demo data is the next lane.
+- Confirm the packet does not create a second evidence, smoke, or queue system.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State that `ai_first/architecture/MAIN_SYSTEM_MAP.md` does not need an update because this packet adds docs/workflow guidance, not product/runtime architecture.
+
+## Handoff notes
+
+- Keep this lane docs/workflow-only.
+- Reuse `docs/contest/` and `ai_first/EXECUTION_QUEUE.md`.
+- Target a future implementation lane that makes demo-safe state reproducible before another smoke/evidence cycle depends on it.


### PR DESCRIPTION
## Summary
- queue the next short task packet for reproducible contest demo data
- point the AI-first queue and status mirrors at the new demo data reset lane
- keep the next implementation step grounded in the existing smoke and evidence flow

## Validation
- rg -n "demo data|reset|smoke|evidence|Mermaid|Knowledge Pack|contest" docs/superpowers/tasks docs/superpowers/pr-notes ai_first docs/contest
- git diff --check

## Architecture
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated; this PR changes docs/workflow guidance only.
