### PR TITLE
docs: add contest demo data reset runbook

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow. The next short task is to define a reproducible contest demo data reset lane instead of depending on pre-existing local demo state.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow. The active short task is to implement the contest demo data reset runbook so smoke/evidence refresh does not depend on undocumented local state.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -106,8 +106,9 @@ Before handing off:
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
 7. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
-8. Keep `docs/contest/VALIDATION_REPORT.md` as the latest smoke-backed evidence freshness record, and update `EVIDENCE_CHECKLIST.md` when screenshot or video status changes.
-9. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
-10. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
-11. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-12. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.
+8. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
+9. Keep `docs/contest/VALIDATION_REPORT.md` as the latest smoke-backed evidence freshness record, and update `EVIDENCE_CHECKLIST.md` when screenshot or video status changes.
+10. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
+11. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+12. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+13. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/demo-data-reset-packet`
+- Current branch for this docs update: `docs/contest-demo-data-reset-run`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: queue the next short docs/workflow lane so contest demo data becomes reproducible instead of remaining an implicit local prerequisite.
+- Current purpose: implement the contest demo data reset runbook so local demo-safe state can be rebuilt or verified before smoke/evidence refresh.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -61,7 +61,7 @@ Do not revert unrelated changes.
 ## Active Execution
 
 - Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`
-- Current open GitHub issue: `#29`
+- Current open GitHub issue: `#31`
 - Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
 - Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), contest evidence refresh packet (`#27`), and contest evidence refresh execution (`#28`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
@@ -69,7 +69,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Land the contest demo data reset packet from issue `#29`, then use that packet to make demo-safe state reproducible.
+Land the contest demo data reset runbook from issue `#31`, then run it before the next smoke/evidence cycle whenever local demo state may be stale.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,19 +7,19 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#28`, which refreshed the contest evidence workflow.
+- Latest merged PR before the current active branch: `#30`, which queued the contest demo data reset lane.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
 - Smoke-backed evidence refresh rules now live in `docs/contest/` on `main`.
 
 ## Active queue
 
-- Open issue: `#29 docs: add contest demo data reset packet`
+- Open issue: `#31 docs: implement contest demo data reset runbook`
 - Active task packet: `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`
-- Expected branch: `docs/contest-demo-data-reset`
+- Expected branch: `docs/contest-demo-data-reset-run`
 
 ## Next recommended task
 
-Land the contest demo data reset packet, then use it to make the MVP demo-safe state reproducible before the next smoke/evidence cycle.
+Land the contest demo data reset runbook, then use `docs/contest/DEMO_DATA_RESET.md` before the next smoke/evidence cycle whenever local demo state may be stale.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,8 +7,8 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Land the contest demo data reset packet from issue `#29`.
-3. Use that packet to define how demo-safe Knowledge Pack and session state should be rebuilt before the next smoke/evidence cycle.
+2. Land the contest demo data reset runbook from issue `#31`.
+3. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
 4. Keep `docs/contest/` aligned with smoke-backed validation after each successful smoke run.
 5. Keep open issues aligned with active task packets and unfinished work only.
 6. Preserve unrelated dirty files until they are intentionally handled.

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -263,7 +263,8 @@
   - added `docs/superpowers/pr-notes/contest-evidence-refresh-packet.md`;
   - updated the queue and status mirrors to point to evidence refresh as the next short task.
 - Tests:
-  - Pending in this branch: docs grep validation and `git diff --check`.
+  - Passed: `rg -n "demo data|reset|smoke|evidence|Mermaid|Knowledge Pack|contest" docs/superpowers/tasks docs/superpowers/pr-notes ai_first docs/contest`
+  - Passed: `git diff --check`
 - Blockers:
   - None known.
 - Next:
@@ -303,6 +304,22 @@
   - None known.
 - Next:
   - Validate the packet, open the docs PR, and merge when eligible.
+
+## Contest Demo Data Reset Runbook
+
+- Branch: `docs/contest-demo-data-reset-run`
+- Task: implement the contest demo data reset runbook from issue `#31`.
+- Done:
+  - added `docs/contest/DEMO_DATA_RESET.md` with demo-safe Knowledge Pack and session state inventory;
+  - linked the reset runbook from `docs/contest/README.md`, `SMOKE_RUNBOOK.md`, and `VALIDATION_REPORT.md`;
+  - updated the task packet, execution queue, current state, next actions, and operating prompt for the runbook lane;
+  - added a docs-only PR architecture note with Mermaid.
+- Tests:
+  - Pending in this branch: docs grep validation and `git diff --check`.
+- Blockers:
+  - None known.
+- Next:
+  - Validate the docs changes, open PR, merge when eligible, then close issue `#31`.
 
 ## Human Review Needed
 

--- a/docs/contest/DEMO_DATA_RESET.md
+++ b/docs/contest/DEMO_DATA_RESET.md
@@ -1,0 +1,109 @@
+# Demo Data Reset Runbook
+
+Use this runbook before a smoke run or evidence refresh when the local demo state may be missing, stale, or private. It defines the demo-safe state required for the contest MVP path:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+This is a docs/workflow runbook. It does not add a seed script yet. If a future lane adds automation, keep this file as the human-readable contract.
+
+## Demo-Safe State Inventory
+
+| State | Required value | Why it exists |
+| --- | --- | --- |
+| Knowledge Pack identifier | `contest-demo-quadratics` | Shared context for Knowledge Pack, assessment, tutor, and dashboard evidence. |
+| Subject | `Mathematics` | Keeps the assessment and tutor story consistent. |
+| Grade | `Grade 9` | Gives the demo a realistic classroom level. |
+| Curriculum | `Vietnam secondary algebra` | Makes the contest story local and teacher-oriented. |
+| Learning objective | Solve quadratic equations and explain common mistakes | Connects generated assessment, feedback, and tutoring. |
+| Owner | `Contest Demo Teacher` | Shows teacher-owned pack metadata without private data. |
+| Sharing status | `demo` or equivalent non-private status | Makes clear that this is safe public demo data. |
+| Assessment session | `contest-assessment-demo` | Lets smoke checks confirm assessment activity exists. |
+| Tutor session | `contest-tutor-demo` | Lets smoke checks confirm student tutoring activity exists. |
+| Dashboard activity | Assessment and tutor records referencing the demo Knowledge Pack | Proves the teacher can review recent learning activity. |
+
+Do not use real student names, private class data, API keys, or provider credentials in demo data.
+
+## Reset Modes
+
+Use the safest available mode for the environment.
+
+| Mode | Current status | Use when |
+| --- | --- | --- |
+| Manual UI reset | Available | You are preparing an interactive demo and can use the web app. |
+| Manual API/database reset | Allowed only for local demo data | You need to recreate demo-safe sessions before smoke. |
+| Scripted seed/reset | Future lane | The manual process is proven and should be automated. |
+
+## Manual UI Reset
+
+1. Start the backend using the repository-local environment.
+2. Start or build the frontend with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
+3. Open the Knowledge page.
+4. Create or update the `contest-demo-quadratics` Knowledge Pack with the inventory above.
+5. Reload the Knowledge page and confirm metadata persists.
+6. Open the assessment workflow and generate or verify a demo assessment using the same Knowledge Pack.
+7. Open the Tutor workspace and ask one student-style follow-up question using the same Knowledge Pack.
+8. Open the Dashboard and confirm recent assessment and tutor activity is visible.
+9. Run `SMOKE_RUNBOOK.md`.
+10. Update `VALIDATION_REPORT.md` only after smoke passes.
+
+## Manual Local Data Reset
+
+Use this only for local demo data that can be safely recreated.
+
+1. Back up any local data you may need before changing `data/`.
+2. Remove or replace only demo-specific records for:
+   - Knowledge Pack `contest-demo-quadratics`;
+   - session `contest-assessment-demo`;
+   - session `contest-tutor-demo`.
+3. Recreate the inventory in this runbook through the UI or local API.
+4. Re-run the smoke runbook.
+5. If smoke fails, record the failure as `Blocked` in the validation report instead of marking evidence current.
+
+This repository intentionally does not commit local `data/` changes as evidence.
+
+## Future Script Contract
+
+If this lane is automated later, the script should:
+
+- create or update only demo-safe records;
+- be idempotent;
+- avoid provider credentials and private data;
+- print the Knowledge Pack id and session ids it created;
+- refuse to run against production or unknown environments;
+- leave screenshots and optional video as manual refresh steps.
+
+Recommended future location:
+
+- runbook stays here: `docs/contest/DEMO_DATA_RESET.md`;
+- script, if added later: `scripts/contest/reset_demo_data.py` or another explicit contest/demo path.
+
+## Verification Checklist
+
+| Check | Expected result | Evidence file |
+| --- | --- | --- |
+| Knowledge Pack exists | `contest-demo-quadratics` appears with demo-safe metadata | `VALIDATION_REPORT.md` |
+| Assessment session exists | `contest-assessment-demo` can be fetched locally | `VALIDATION_REPORT.md` |
+| Tutor session exists | `contest-tutor-demo` can be fetched locally | `VALIDATION_REPORT.md` |
+| Dashboard sees activity | Dashboard overview and recent endpoints show demo context | `VALIDATION_REPORT.md` |
+| Screenshots remain meaningful | Existing screenshot status is `Current`, or updated to `Stale`/`Blocked` | `EVIDENCE_CHECKLIST.md` |
+
+## Mermaid Flow
+
+```mermaid
+flowchart TD
+  Reset["Demo data reset"]
+  Pack["Knowledge Pack: contest-demo-quadratics"]
+  Assessment["Assessment session"]
+  Tutor["Tutor session"]
+  Dashboard["Dashboard activity"]
+  Smoke["SMOKE_RUNBOOK.md"]
+  Evidence["VALIDATION_REPORT.md"]
+
+  Reset --> Pack
+  Pack --> Assessment
+  Pack --> Tutor
+  Assessment --> Dashboard
+  Tutor --> Dashboard
+  Dashboard --> Smoke
+  Smoke --> Evidence
+```

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -12,6 +12,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md): required screenshots, optional video, and pass/fail evidence fields.
 - [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md): local validation commands, results, limitations, and remaining capture work.
 - [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md): smoke lane used to verify the MVP path before any evidence refresh.
+- [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md): demo-safe data inventory and reset runbook before smoke/evidence refresh.
 
 ## Current Status
 
@@ -22,7 +23,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Evidence Refresh Rules
 
-Run [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md) first, then refresh evidence using these rules:
+Run [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) first when local demo data may be stale, then run [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md), then refresh evidence using these rules:
 
 - Auto-refresh evidence: smoke-backed command results, API reachability checks, and the evidence status table in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
 - Human-triggered refresh: screenshots and any optional video, because they require an interactive capture step.
@@ -56,13 +57,15 @@ Run [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md) first, then refresh evidence using 
 ```mermaid
 flowchart LR
   Goal["Contest MVP Story"]
+  Reset["DEMO_DATA_RESET.md"]
   Smoke["SMOKE_RUNBOOK.md"]
   Demo["DEMO_SCRIPT.md"]
   Checklist["EVIDENCE_CHECKLIST.md"]
   Validation["VALIDATION_REPORT.md"]
   Reviewer["Reviewer"]
 
-  Goal --> Smoke
+  Goal --> Reset
+  Reset --> Smoke
   Smoke --> Validation
   Validation --> Checklist
   Goal --> Demo

--- a/docs/contest/SMOKE_RUNBOOK.md
+++ b/docs/contest/SMOKE_RUNBOOK.md
@@ -4,6 +4,8 @@ This runbook verifies the contest MVP path in the same order as the demo story:
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
 
+If local demo data may be stale, missing, or private, run `DEMO_DATA_RESET.md` before starting this smoke lane.
+
 Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTION_QUEUE.md` and `ai_first/daily/YYYY-MM-DD.md`.
 
 ## Stage 1: Backend
@@ -47,3 +49,4 @@ Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTIO
 - If all stages pass: refresh any affected contest evidence docs, then move to the next queued task.
 - If a product/runtime stage fails: create or update a follow-up task packet before starting broad new work.
 - If an environment or credential blocker prevents completion: record the blocker clearly and do not report smoke as passing.
+- If demo data is missing: use `DEMO_DATA_RESET.md`, then restart the smoke lane from Stage 1.

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -58,6 +58,8 @@ The latest smoke-backed evidence refresh used local demo data only:
   - `contest-assessment-demo`
   - `contest-tutor-demo`
 
+Before future smoke or evidence refresh runs, use `DEMO_DATA_RESET.md` when local demo state may be missing or stale.
+
 The first attempt to run `python3 -m deeptutor.api.run_server` failed because `python3` resolved to a different virtual environment without `uvicorn`. The backend was then run successfully with the repository-local `.venv/bin/python`.
 
 ## Smoke-backed Verification Record
@@ -96,9 +98,10 @@ Complete this section when the local app is running.
 ## Next Evidence Actions
 
 1. After each successful smoke run, update the evidence freshness table before changing screenshot status.
-2. Mark screenshots `Stale` or `Blocked` in `EVIDENCE_CHECKLIST.md` only when the smoke result or UI change requires it.
-3. Capture and link an external video only if the final submission requires video.
-4. Re-run docs validation after evidence docs change:
+2. Run `DEMO_DATA_RESET.md` first when demo-safe Knowledge Pack or session data may be stale.
+3. Mark screenshots `Stale` or `Blocked` in `EVIDENCE_CHECKLIST.md` only when the smoke result or UI change requires it.
+4. Capture and link an external video only if the final submission requires video.
+5. Re-run docs validation after evidence docs change:
 
 ```bash
 rg -n "evidence refresh|smoke|validation|screenshot|video|Current|Stale|Blocked" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first

--- a/docs/superpowers/pr-notes/contest-demo-data-reset-run.md
+++ b/docs/superpowers/pr-notes/contest-demo-data-reset-run.md
@@ -1,0 +1,37 @@
+# PR Note: Contest Demo Data Reset Runbook
+
+## Summary
+
+This PR implements the demo data reset lane by adding a compact `docs/contest/DEMO_DATA_RESET.md` runbook and linking it into the existing contest evidence and smoke workflow.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Reset["DEMO_DATA_RESET.md"]
+  Smoke["SMOKE_RUNBOOK.md"]
+  Evidence["VALIDATION_REPORT.md"]
+  Checklist["EVIDENCE_CHECKLIST.md"]
+  Queue["EXECUTION_QUEUE.md"]
+
+  Reset --> Smoke
+  Smoke --> Evidence
+  Evidence --> Checklist
+  Queue --> Reset
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR adds docs/workflow guidance for reproducible local demo state and does not change product/runtime architecture.
+
+## Validation
+
+```bash
+rg -n "demo data|reset|smoke|evidence|Mermaid|Knowledge Pack|contest" docs/superpowers/tasks docs/superpowers/pr-notes ai_first docs/contest
+git diff --check
+```
+
+## Handoff Notes
+
+- Use `DEMO_DATA_RESET.md` before smoke when local data may be missing, stale, or private.
+- A future runtime lane may automate the reset after the manual contract is proven useful.

--- a/docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md
+++ b/docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md
@@ -1,12 +1,12 @@
 # Feature Pod Task: Contest Demo Data Reset
 
 Owner: Documentation / Workflow AI worker
-Branch: `docs/contest-demo-data-reset`
-GitHub Issue: `#29`
+Branch: `docs/contest-demo-data-reset-run`
+GitHub Issue: `#31`
 
 ## Goal
 
-Add a compact task packet for making the contest demo dataset reproducible so AI workers can rebuild the demo-safe state instead of depending on whatever local data already exists.
+Implement the contest demo data reset lane so AI workers can rebuild or verify the demo-safe state instead of depending on whatever local data already exists.
 
 ## User-visible outcome
 
@@ -14,8 +14,12 @@ A human or AI worker can tell what demo-safe data must exist for the contest MVP
 
 ## Owned files/modules
 
+- `docs/contest/DEMO_DATA_RESET.md`
+- `docs/contest/README.md`
+- `docs/contest/SMOKE_RUNBOOK.md`
+- `docs/contest/VALIDATION_REPORT.md`
 - `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`
-- `docs/superpowers/pr-notes/contest-demo-data-reset-packet.md`
+- `docs/superpowers/pr-notes/contest-demo-data-reset-run.md`
 - `ai_first/EXECUTION_QUEUE.md`
 - `ai_first/CURRENT_STATE.md`
 - `ai_first/NEXT_ACTIONS.md`
@@ -37,7 +41,7 @@ A human or AI worker can tell what demo-safe data must exist for the contest MVP
 
 ## Demo reset contract
 
-The packet must define:
+The reset runbook must define:
 
 1. the minimum demo-safe Knowledge Pack and session state required for the contest MVP path;
 2. which parts of that state should later be reset by script or seed workflow;
@@ -48,9 +52,9 @@ The lane must reuse the current contest evidence bundle, smoke runbook, and AI-f
 
 ## Acceptance criteria
 
-- There is one explicit task packet for contest demo data reset.
-- The packet points to the existing contest demo flow and smoke/evidence docs.
-- The queue and status mirrors point to demo data reset as the next short task.
+- There is one explicit contest demo data reset runbook.
+- The runbook points to the existing contest demo flow and smoke/evidence docs.
+- The queue and status mirrors point to demo data reset execution and the next post-merge action.
 - The change stays docs/workflow-only.
 
 ## Required validation
@@ -60,8 +64,8 @@ The lane must reuse the current contest evidence bundle, smoke runbook, and AI-f
 
 ## Manual verification
 
-- Open the packet and confirm a new AI worker can tell why reproducible demo data is the next lane.
-- Confirm the packet does not create a second evidence, smoke, or queue system.
+- Open the runbook and confirm a new AI worker can tell how to rebuild or verify demo-safe data before smoke.
+- Confirm the runbook does not create a second evidence, smoke, or queue system.
 
 ## PR architecture note
 
@@ -72,4 +76,4 @@ The lane must reuse the current contest evidence bundle, smoke runbook, and AI-f
 
 - Keep this lane docs/workflow-only.
 - Reuse `docs/contest/` and `ai_first/EXECUTION_QUEUE.md`.
-- Target a future implementation lane that makes demo-safe state reproducible before another smoke/evidence cycle depends on it.
+- A future runtime lane may add a script or seed command after this runbook is proven useful.


### PR DESCRIPTION
## Summary
- add `docs/contest/DEMO_DATA_RESET.md` with demo-safe Knowledge Pack/session inventory
- link reset before smoke/evidence refresh in contest docs
- update AI-first queue/status mirrors for issue #31

Closes #31.

## Validation
- rg -n "demo data|reset|smoke|evidence|Mermaid|Knowledge Pack|contest" docs/superpowers/tasks docs/superpowers/pr-notes ai_first docs/contest
- git diff --check

## Main System Map
- Not updated; this PR is docs/workflow-only and does not change product/runtime architecture.