### PR TITLE
docs: queue scripted demo data reset utility

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow. The active short task is to implement the contest demo data reset runbook so smoke/evidence refresh does not depend on undocumented local state.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow. The active short task is to queue a scripted local demo data reset utility so smoke/evidence refresh can rebuild demo-safe state without manual local data setup.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/contest-demo-data-reset-run`
+- Current branch for this docs update: `docs/scripted-demo-data-reset-packet`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: implement the contest demo data reset runbook so local demo-safe state can be rebuilt or verified before smoke/evidence refresh.
+- Current purpose: queue the next implementation lane for a scripted local contest demo data reset utility.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -60,8 +60,8 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`
-- Current open GitHub issue: `#31`
+- Current open task packet: `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
+- Current open GitHub issue: `#33`
 - Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
 - Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), contest evidence refresh packet (`#27`), and contest evidence refresh execution (`#28`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
@@ -69,7 +69,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Land the contest demo data reset runbook from issue `#31`, then run it before the next smoke/evidence cycle whenever local demo state may be stale.
+Land the scripted demo data reset utility packet from issue `#33`, then implement the local reset utility from that packet.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,19 +7,19 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#30`, which queued the contest demo data reset lane.
+- Latest merged PR before the current active branch: `#32`, which added the contest demo data reset runbook.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
 - Smoke-backed evidence refresh rules now live in `docs/contest/` on `main`.
 
 ## Active queue
 
-- Open issue: `#31 docs: implement contest demo data reset runbook`
-- Active task packet: `docs/superpowers/tasks/2026-04-19-contest-demo-data-reset.md`
-- Expected branch: `docs/contest-demo-data-reset-run`
+- Open issue: `#33 docs: add scripted demo data reset utility packet`
+- Active task packet: `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
+- Expected branch: `docs/scripted-demo-data-reset-packet`
 
 ## Next recommended task
 
-Land the contest demo data reset runbook, then use `docs/contest/DEMO_DATA_RESET.md` before the next smoke/evidence cycle whenever local demo state may be stale.
+Land the scripted demo data reset task packet, then implement a local idempotent reset utility before the next smoke/evidence cycle depends on manual local data.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,11 +7,12 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Land the contest demo data reset runbook from issue `#31`.
-3. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
-4. Keep `docs/contest/` aligned with smoke-backed validation after each successful smoke run.
-5. Keep open issues aligned with active task packets and unfinished work only.
-6. Preserve unrelated dirty files until they are intentionally handled.
+2. Land the scripted demo data reset utility packet from issue `#33`.
+3. Implement the local idempotent reset utility from that packet.
+4. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
+5. Keep `docs/contest/` aligned with smoke-backed validation after each successful smoke run.
+6. Keep open issues aligned with active task packets and unfinished work only.
+7. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -315,11 +315,28 @@
   - updated the task packet, execution queue, current state, next actions, and operating prompt for the runbook lane;
   - added a docs-only PR architecture note with Mermaid.
 - Tests:
-  - Pending in this branch: docs grep validation and `git diff --check`.
+  - Passed: `rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
 - Blockers:
   - None known.
 - Next:
   - Validate the docs changes, open PR, merge when eligible, then close issue `#31`.
+
+## Scripted Demo Data Reset Packet
+
+- Branch: `docs/scripted-demo-data-reset-packet`
+- Task: create the next task packet for a local idempotent contest demo data reset utility.
+- Done:
+  - created GitHub issue `#33`;
+  - added `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`;
+  - added a docs-only PR architecture note with Mermaid;
+  - updated queue/status mirrors so the next lane implements the utility.
+- Tests:
+  - Pending in this branch: docs grep validation and `git diff --check`.
+- Blockers:
+  - None known.
+- Next:
+  - Validate the packet, open the docs PR, and merge when eligible.
 
 ## Human Review Needed
 

--- a/docs/superpowers/pr-notes/scripted-demo-data-reset-packet.md
+++ b/docs/superpowers/pr-notes/scripted-demo-data-reset-packet.md
@@ -1,0 +1,38 @@
+# PR Note: Scripted Demo Data Reset Packet
+
+## Summary
+
+This PR queues the next short implementation lane: a local idempotent utility for rebuilding contest demo-safe Knowledge Pack and session state before smoke/evidence refresh.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Runbook["DEMO_DATA_RESET.md"]
+  Packet["Scripted reset task packet"]
+  Utility["Future local reset utility"]
+  Smoke["SMOKE_RUNBOOK.md"]
+  Evidence["VALIDATION_REPORT.md"]
+
+  Runbook --> Packet
+  Packet --> Utility
+  Utility --> Smoke
+  Smoke --> Evidence
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR adds docs/workflow guidance for a future local demo helper and does not change product/runtime architecture.
+
+## Validation
+
+```bash
+rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+git diff --check
+```
+
+## Handoff Notes
+
+- Implement the utility only after this packet lands.
+- Keep generated `data/` changes out of commits.
+- Update `DEMO_DATA_RESET.md` with the final command when the utility exists.

--- a/docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md
+++ b/docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md
@@ -1,0 +1,94 @@
+# Feature Pod Task: Scripted Contest Demo Data Reset
+
+Owner: Documentation / Workflow AI worker
+Branch: `docs/scripted-demo-data-reset`
+GitHub Issue: `#33`
+
+## Goal
+
+Create a local, idempotent reset or seed utility for contest demo-safe data so smoke and evidence refresh runs can rebuild the MVP demo state without relying on pre-existing local `data/` contents.
+
+## User-visible outcome
+
+A human or AI worker can run one explicit local command to recreate the demo-safe Knowledge Pack and session evidence required by `docs/contest/DEMO_DATA_RESET.md`, then run the smoke lane against known data.
+
+## Owned files/modules
+
+- `scripts/contest/` or another explicit contest/demo script path chosen during implementation
+- `tests/` for the reset utility if implementation adds Python code
+- `docs/contest/DEMO_DATA_RESET.md`
+- `docs/contest/SMOKE_RUNBOOK.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- `docs/superpowers/pr-notes/scripted-demo-data-reset.md`
+- `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if operating guidance changes
+
+## Do-not-touch files/modules
+
+- `deeptutor/` product/runtime code unless the implementation proves a narrow reusable helper is required and updates this packet first
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `web/next-env.d.ts`
+- `.env*`
+- committed `data/` files or private local data
+
+## Utility contract
+
+The implementation should add a local-only command or script that:
+
+1. creates or updates only demo-safe records;
+2. is idempotent across repeated runs;
+3. creates or verifies Knowledge Pack `contest-demo-quadratics`;
+4. creates or verifies sessions `contest-assessment-demo` and `contest-tutor-demo`;
+5. leaves enough dashboard activity for smoke checks to confirm assessment and tutor context;
+6. prints the ids and paths it touched;
+7. refuses to run against production, unknown remote URLs, or environments that look unsafe;
+8. does not require real LLM credentials;
+9. does not commit generated `data/` changes.
+
+The utility should follow the manual contract in `docs/contest/DEMO_DATA_RESET.md` and update that runbook with the final command.
+
+## Acceptance criteria
+
+- One explicit local command can rebuild or verify the demo-safe dataset.
+- The command can run repeatedly without duplicating or corrupting demo data.
+- The implementation has focused tests for idempotency and safety gates when practical.
+- Smoke docs point to the command before smoke execution.
+- No secrets, credentials, or private student data are added.
+- The PR includes an architecture note with Mermaid.
+
+## Required validation
+
+- Relevant utility tests added by the implementation
+- `rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" scripts tests docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+- `git diff --check`
+
+If implementation touches Python code, also run:
+
+- `python -m compileall scripts deeptutor`
+
+## Manual verification
+
+- Run the reset command in a local demo environment.
+- Confirm it reports the Knowledge Pack and session ids.
+- Run `docs/contest/SMOKE_RUNBOOK.md`.
+- Update `docs/contest/VALIDATION_REPORT.md` only after smoke passes.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed. It should not need a map update if the utility is a local docs/demo helper.
+
+## Handoff notes
+
+- Keep this utility local and demo-only.
+- Prefer a small script with explicit file/API boundaries over broad product changes.
+- If a script cannot safely be implemented without runtime changes, stop and update this packet before editing runtime code.


### PR DESCRIPTION
## Summary
- add task packet for an idempotent local contest demo data reset/seed utility
- update AI-first queue/status mirrors to point to issue #33
- add docs-only PR note with Mermaid

Closes #33.

## Validation
- rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- git diff --check

## Main System Map
- Not updated; this PR only queues a future local helper and does not change product/runtime architecture.