### PR TITLE
feat: add scripted demo data reset utility

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow. The active short task is to queue a scripted local demo data reset utility so smoke/evidence refresh can rebuild demo-safe state without manual local data setup.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow. The active short task is to land a scripted local demo data reset utility so smoke/evidence refresh can rebuild demo-safe state without manual local data setup.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/scripted-demo-data-reset-packet`
+- Current branch for this docs update: `docs/scripted-demo-data-reset`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: queue the next implementation lane for a scripted local contest demo data reset utility.
+- Current purpose: implement a scripted local contest demo data reset utility.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -61,7 +61,7 @@ Do not revert unrelated changes.
 ## Active Execution
 
 - Current open task packet: `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
-- Current open GitHub issue: `#33`
+- Current open GitHub issue: `#35`
 - Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
 - Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), contest evidence refresh packet (`#27`), and contest evidence refresh execution (`#28`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
@@ -69,7 +69,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Land the scripted demo data reset utility packet from issue `#33`, then implement the local reset utility from that packet.
+Land the scripted demo data reset utility from issue `#35`, then use it before smoke/evidence refresh when local demo state may be stale.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,19 +7,19 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#32`, which added the contest demo data reset runbook.
+- Latest merged PR before the current active branch: `#34`, which queued the scripted contest demo data reset utility.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
 - Smoke-backed evidence refresh rules now live in `docs/contest/` on `main`.
 
 ## Active queue
 
-- Open issue: `#33 docs: add scripted demo data reset utility packet`
+- Open issue: `#35 feat: implement scripted contest demo data reset`
 - Active task packet: `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
-- Expected branch: `docs/scripted-demo-data-reset-packet`
+- Expected branch: `docs/scripted-demo-data-reset`
 
 ## Next recommended task
 
-Land the scripted demo data reset task packet, then implement a local idempotent reset utility before the next smoke/evidence cycle depends on manual local data.
+Land the scripted demo data reset utility, then use it before smoke/evidence refresh whenever local demo state may be stale.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,8 +7,8 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Land the scripted demo data reset utility packet from issue `#33`.
-3. Implement the local idempotent reset utility from that packet.
+2. Land the scripted demo data reset utility from issue `#35`.
+3. Use the local idempotent reset utility before smoke/evidence refresh when demo state may be stale.
 4. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
 5. Keep `docs/contest/` aligned with smoke-backed validation after each successful smoke run.
 6. Keep open issues aligned with active task packets and unfinished work only.

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -338,6 +338,26 @@
 - Next:
   - Validate the packet, open the docs PR, and merge when eligible.
 
+## Scripted Demo Data Reset Utility
+
+- Branch: `docs/scripted-demo-data-reset`
+- Task: implement the local idempotent contest demo data reset utility from issue `#35`.
+- Done:
+  - added `scripts/contest/reset_demo_data.py`;
+  - added focused reset utility tests for creation, idempotency, and local-only API safety;
+  - updated `DEMO_DATA_RESET.md`, `SMOKE_RUNBOOK.md`, and `VALIDATION_REPORT.md` with the final command;
+  - updated queue/status mirrors and added a PR architecture note with Mermaid.
+- Tests:
+  - Passed: `pytest tests/scripts/test_reset_demo_data.py -v`
+  - Passed: `rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" scripts tests docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+  - Passed: `python3 -m compileall scripts deeptutor`
+  - Passed: `python3 -m scripts.contest.reset_demo_data --project-root /tmp/deeptutor-contest-demo-reset-smoke --api-base http://localhost:8001`
+  - Passed: `git diff --check`
+- Blockers:
+  - None known.
+- Next:
+  - Open PR, wait for CI, and merge when eligible.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/docs/contest/DEMO_DATA_RESET.md
+++ b/docs/contest/DEMO_DATA_RESET.md
@@ -4,7 +4,7 @@ Use this runbook before a smoke run or evidence refresh when the local demo stat
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
 
-This is a docs/workflow runbook. It does not add a seed script yet. If a future lane adds automation, keep this file as the human-readable contract.
+This runbook is backed by a local demo-safe reset utility. It writes only local demo data under the selected repository root.
 
 ## Demo-Safe State Inventory
 
@@ -31,7 +31,25 @@ Use the safest available mode for the environment.
 | --- | --- | --- |
 | Manual UI reset | Available | You are preparing an interactive demo and can use the web app. |
 | Manual API/database reset | Allowed only for local demo data | You need to recreate demo-safe sessions before smoke. |
-| Scripted seed/reset | Future lane | The manual process is proven and should be automated. |
+| Scripted seed/reset | Available | You need a repeatable local reset before smoke or evidence refresh. |
+
+## Scripted Local Reset
+
+Run this from the repository root:
+
+```bash
+python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
+```
+
+The command:
+
+- validates that `--api-base` is local;
+- creates or updates Knowledge Pack `contest-demo-quadratics`;
+- creates or replaces sessions `contest-assessment-demo` and `contest-tutor-demo`;
+- prints the ids and local paths it touched;
+- can be run repeatedly without duplicating demo sessions.
+
+Generated local `data/` changes are not committed.
 
 ## Manual UI Reset
 
@@ -61,9 +79,9 @@ Use this only for local demo data that can be safely recreated.
 
 This repository intentionally does not commit local `data/` changes as evidence.
 
-## Future Script Contract
+## Script Contract
 
-If this lane is automated later, the script should:
+The reset script must:
 
 - create or update only demo-safe records;
 - be idempotent;
@@ -72,10 +90,10 @@ If this lane is automated later, the script should:
 - refuse to run against production or unknown environments;
 - leave screenshots and optional video as manual refresh steps.
 
-Recommended future location:
+Current location:
 
 - runbook stays here: `docs/contest/DEMO_DATA_RESET.md`;
-- script, if added later: `scripts/contest/reset_demo_data.py` or another explicit contest/demo path.
+- script: `scripts/contest/reset_demo_data.py`.
 
 ## Verification Checklist
 

--- a/docs/contest/SMOKE_RUNBOOK.md
+++ b/docs/contest/SMOKE_RUNBOOK.md
@@ -4,7 +4,11 @@ This runbook verifies the contest MVP path in the same order as the demo story:
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
 
-If local demo data may be stale, missing, or private, run `DEMO_DATA_RESET.md` before starting this smoke lane.
+If local demo data may be stale, missing, or private, run `DEMO_DATA_RESET.md` before starting this smoke lane. The scripted local reset command is:
+
+```bash
+python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
+```
 
 Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTION_QUEUE.md` and `ai_first/daily/YYYY-MM-DD.md`.
 

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -60,6 +60,12 @@ The latest smoke-backed evidence refresh used local demo data only:
 
 Before future smoke or evidence refresh runs, use `DEMO_DATA_RESET.md` when local demo state may be missing or stale.
 
+The local reset command is:
+
+```bash
+python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
+```
+
 The first attempt to run `python3 -m deeptutor.api.run_server` failed because `python3` resolved to a different virtual environment without `uvicorn`. The backend was then run successfully with the repository-local `.venv/bin/python`.
 
 ## Smoke-backed Verification Record

--- a/docs/superpowers/pr-notes/scripted-demo-data-reset.md
+++ b/docs/superpowers/pr-notes/scripted-demo-data-reset.md
@@ -1,0 +1,44 @@
+# PR Note: Scripted Demo Data Reset Utility
+
+## Summary
+
+This PR implements a local idempotent contest demo data reset utility. The utility creates or updates the demo-safe Knowledge Pack and session evidence used by smoke and contest evidence refresh docs.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Command["python3 -m scripts.contest.reset_demo_data"]
+  KB["contest-demo-quadratics"]
+  Assessment["contest-assessment-demo"]
+  Tutor["contest-tutor-demo"]
+  Smoke["SMOKE_RUNBOOK.md"]
+  Evidence["VALIDATION_REPORT.md"]
+
+  Command --> KB
+  Command --> Assessment
+  Command --> Tutor
+  KB --> Smoke
+  Assessment --> Smoke
+  Tutor --> Smoke
+  Smoke --> Evidence
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR adds a local contest/demo helper script and docs, not product/runtime architecture.
+
+## Validation
+
+```bash
+pytest tests/scripts/test_reset_demo_data.py -v
+rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" scripts tests docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+python3 -m compileall scripts deeptutor
+python3 -m scripts.contest.reset_demo_data --project-root /tmp/deeptutor-contest-demo-reset-smoke --api-base http://localhost:8001
+git diff --check
+```
+
+## Handoff Notes
+
+- Run `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` before smoke when demo state is stale.
+- Keep generated local `data/` changes out of commits.

--- a/docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md
+++ b/docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md
@@ -2,7 +2,7 @@
 
 Owner: Documentation / Workflow AI worker
 Branch: `docs/scripted-demo-data-reset`
-GitHub Issue: `#33`
+GitHub Issue: `#35`
 
 ## Goal
 
@@ -20,6 +20,7 @@ A human or AI worker can run one explicit local command to recreate the demo-saf
 - `docs/contest/SMOKE_RUNBOOK.md`
 - `docs/contest/VALIDATION_REPORT.md`
 - `docs/superpowers/pr-notes/scripted-demo-data-reset.md`
+- `docs/superpowers/pr-notes/scripted-demo-data-reset-packet.md`
 - `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
 - `ai_first/EXECUTION_QUEUE.md`
 - `ai_first/CURRENT_STATE.md`
@@ -67,13 +68,13 @@ The utility should follow the manual contract in `docs/contest/DEMO_DATA_RESET.m
 
 ## Required validation
 
-- Relevant utility tests added by the implementation
+- `pytest tests/scripts/test_reset_demo_data.py -v`
 - `rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" scripts tests docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
 - `git diff --check`
 
 If implementation touches Python code, also run:
 
-- `python -m compileall scripts deeptutor`
+- `python3 -m compileall scripts deeptutor`
 
 ## Manual verification
 

--- a/scripts/contest/__init__.py
+++ b/scripts/contest/__init__.py
@@ -1,0 +1,1 @@
+"""Contest demo helper scripts."""

--- a/scripts/contest/reset_demo_data.py
+++ b/scripts/contest/reset_demo_data.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+
+DEMO_KB_ID = "contest-demo-quadratics"
+ASSESSMENT_SESSION_ID = "contest-assessment-demo"
+TUTOR_SESSION_ID = "contest-tutor-demo"
+
+DEMO_METADATA = {
+    "subject": "Mathematics",
+    "grade": "Grade 9",
+    "curriculum": "Vietnam secondary algebra",
+    "learning_objectives": [
+        "Solve quadratic equations",
+        "Explain common mistakes",
+    ],
+    "owner": "Contest Demo Teacher",
+    "sharing_status": "demo",
+}
+
+
+def _validate_local_api_base(api_base: str) -> None:
+    parsed = urlparse(api_base)
+    if parsed.scheme != "http" or parsed.hostname not in {"localhost", "127.0.0.1"}:
+        raise ValueError("Use a local API base such as http://localhost:8001")
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _seed_knowledge_pack(project_root: Path) -> Path:
+    kb_root = project_root / "data" / "knowledge_bases"
+    kb_dir = kb_root / DEMO_KB_ID
+    (kb_dir / "llamaindex_storage").mkdir(parents=True, exist_ok=True)
+    (kb_dir / "raw").mkdir(parents=True, exist_ok=True)
+
+    metadata = {
+        "name": DEMO_KB_ID,
+        "description": "Contest demo Knowledge Pack for quadratic equations.",
+        "rag_provider": "llamaindex",
+        "status": "ready",
+        **DEMO_METADATA,
+    }
+    _write_json(kb_dir / "metadata.json", metadata)
+
+    config_path = kb_root / "kb_config.json"
+    if config_path.exists():
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8") or "{}")
+        except json.JSONDecodeError:
+            config = {}
+    else:
+        config = {}
+    config.setdefault("knowledge_bases", {})
+    config["knowledge_bases"][DEMO_KB_ID] = {
+        "path": DEMO_KB_ID,
+        "description": metadata["description"],
+        "rag_provider": "llamaindex",
+        "status": "ready",
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        **DEMO_METADATA,
+    }
+    _write_json(config_path, config)
+    return kb_dir
+
+
+def _insert_session(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    title: str,
+    capability: str,
+    user_message: str,
+    assistant_message: str,
+) -> None:
+    now = time.time()
+    preferences = {
+        "capability": capability,
+        "tools": ["rag"],
+        "knowledge_bases": [DEMO_KB_ID],
+        "language": "en",
+        "demo": True,
+    }
+    turn_id = f"turn-{session_id}"
+
+    conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+    conn.execute(
+        """
+        INSERT INTO sessions (
+            id, title, created_at, updated_at, compressed_summary, summary_up_to_msg_id, preferences_json
+        ) VALUES (?, ?, ?, ?, '', 0, ?)
+        """,
+        (session_id, title, now, now, json.dumps(preferences, ensure_ascii=False)),
+    )
+    conn.execute(
+        """
+        INSERT INTO messages (
+            session_id, role, content, capability, events_json, attachments_json, created_at
+        ) VALUES (?, 'user', ?, ?, '[]', '[]', ?)
+        """,
+        (session_id, user_message, capability, now),
+    )
+    conn.execute(
+        """
+        INSERT INTO messages (
+            session_id, role, content, capability, events_json, attachments_json, created_at
+        ) VALUES (?, 'assistant', ?, ?, '[]', '[]', ?)
+        """,
+        (session_id, assistant_message, capability, now + 1),
+    )
+    conn.execute(
+        """
+        INSERT INTO turns (id, session_id, capability, status, error, created_at, updated_at, finished_at)
+        VALUES (?, ?, ?, 'completed', '', ?, ?, ?)
+        """,
+        (turn_id, session_id, capability, now, now + 1, now + 1),
+    )
+
+
+def _seed_sessions(project_root: Path) -> Path:
+    db_path = project_root / "data" / "user" / "chat_history.db"
+    SQLiteSessionStore(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        _insert_session(
+            conn,
+            session_id=ASSESSMENT_SESSION_ID,
+            title="Contest Demo Assessment",
+            capability="deep_question",
+            user_message="Generate Grade 9 quadratic equation questions from contest-demo-quadratics.",
+            assistant_message=(
+                "Generated demo-safe questions with answers, explanations, and common mistakes "
+                "for solving quadratic equations."
+            ),
+        )
+        _insert_session(
+            conn,
+            session_id=TUTOR_SESSION_ID,
+            title="Contest Demo Tutor",
+            capability="chat",
+            user_message="Help a student understand a common quadratic equation mistake.",
+            assistant_message=(
+                "The Tutor Agent explains how to check factoring steps and compare both roots "
+                "against the original equation."
+            ),
+        )
+        conn.commit()
+    return db_path
+
+
+def reset_demo_data(project_root: str | Path = ".", *, api_base: str = "http://localhost:8001") -> dict:
+    _validate_local_api_base(api_base)
+    root = Path(project_root).expanduser().resolve()
+    kb_dir = _seed_knowledge_pack(root)
+    db_path = _seed_sessions(root)
+    return {
+        "knowledge_pack": DEMO_KB_ID,
+        "sessions": [ASSESSMENT_SESSION_ID, TUTOR_SESSION_ID],
+        "paths": {
+            "knowledge_pack": str(kb_dir),
+            "session_db": str(db_path),
+        },
+        "api_base": api_base,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Reset local contest demo-safe data.")
+    parser.add_argument("--project-root", default=".", help="Repository root to write demo data under.")
+    parser.add_argument("--api-base", default="http://localhost:8001", help="Local API base safety check.")
+    args = parser.parse_args()
+    result = reset_demo_data(args.project_root, api_base=args.api_base)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_reset_demo_data.py
+++ b/tests/scripts/test_reset_demo_data.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.contest.reset_demo_data import (
+    ASSESSMENT_SESSION_ID,
+    DEMO_KB_ID,
+    TUTOR_SESSION_ID,
+    reset_demo_data,
+)
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _count_rows(db_path: Path, table: str) -> int:
+    with sqlite3.connect(db_path) as conn:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
+def test_reset_demo_data_creates_expected_kb_and_sessions(tmp_path: Path) -> None:
+    result = reset_demo_data(tmp_path, api_base="http://localhost:8001")
+
+    kb_root = tmp_path / "data" / "knowledge_bases"
+    config = _read_json(kb_root / "kb_config.json")
+    kb_entry = config["knowledge_bases"][DEMO_KB_ID]
+    metadata = _read_json(kb_root / DEMO_KB_ID / "metadata.json")
+    db_path = tmp_path / "data" / "user" / "chat_history.db"
+
+    assert result["knowledge_pack"] == DEMO_KB_ID
+    assert result["sessions"] == [ASSESSMENT_SESSION_ID, TUTOR_SESSION_ID]
+    assert kb_entry["subject"] == "Mathematics"
+    assert kb_entry["grade"] == "Grade 9"
+    assert metadata["owner"] == "Contest Demo Teacher"
+    assert (kb_root / DEMO_KB_ID / "llamaindex_storage").is_dir()
+    assert _count_rows(db_path, "sessions") == 2
+    assert _count_rows(db_path, "messages") == 4
+    assert _count_rows(db_path, "turns") == 2
+
+
+def test_reset_demo_data_is_idempotent(tmp_path: Path) -> None:
+    first = reset_demo_data(tmp_path, api_base="http://127.0.0.1:8001")
+    second = reset_demo_data(tmp_path, api_base="http://127.0.0.1:8001")
+
+    db_path = tmp_path / "data" / "user" / "chat_history.db"
+    config = _read_json(tmp_path / "data" / "knowledge_bases" / "kb_config.json")
+
+    assert first["sessions"] == second["sessions"]
+    assert list(config["knowledge_bases"]) == [DEMO_KB_ID]
+    assert _count_rows(db_path, "sessions") == 2
+    assert _count_rows(db_path, "messages") == 4
+    assert _count_rows(db_path, "turns") == 2
+
+
+def test_reset_demo_data_rejects_non_local_api_base(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="local API base"):
+        reset_demo_data(tmp_path, api_base="https://example.com")
+
+    assert not (tmp_path / "data").exists()


### PR DESCRIPTION
## Summary
- add a local idempotent contest demo data reset utility under scripts/contest
- seed demo-safe Knowledge Pack metadata and assessment/tutor session evidence
- update contest smoke/evidence docs, AI-first queue mirrors, and PR architecture note

Closes #35.

## Validation
- pytest tests/scripts/test_reset_demo_data.py -v
- rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" scripts tests docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- python3 -m compileall scripts deeptutor
- python3 -m scripts.contest.reset_demo_data --project-root /tmp/deeptutor-contest-demo-reset-smoke --api-base http://localhost:8001
- git diff --check

## Main System Map
- Not updated. This adds a local contest/demo helper script and docs, not product/runtime architecture.