### PR TITLE
docs: queue contest smoke scripted reset

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow. The active short task is to land a scripted local demo data reset utility so smoke/evidence refresh can rebuild demo-safe state without manual local data setup.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow plus the scripted local demo data reset utility. The active short task is to run the contest smoke lane after executing that reset command.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -107,8 +107,9 @@ Before handing off:
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
 7. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 8. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
-9. Keep `docs/contest/VALIDATION_REPORT.md` as the latest smoke-backed evidence freshness record, and update `EVIDENCE_CHECKLIST.md` when screenshot or video status changes.
-10. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
-11. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
-12. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
-13. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.
+9. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.
+10. Keep `docs/contest/VALIDATION_REPORT.md` as the latest smoke-backed evidence freshness record, and update `EVIDENCE_CHECKLIST.md` when screenshot or video status changes.
+11. If the execution queue becomes empty, derive the next short task from the MVP goal and create or update a task packet before implementation.
+12. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
+13. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
+14. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/scripted-demo-data-reset`
+- Current branch for this docs update: `docs/contest-smoke-scripted-reset-packet`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: implement a scripted local contest demo data reset utility.
+- Current purpose: queue the next smoke execution lane using the scripted local contest demo data reset utility.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -60,8 +60,8 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
-- Current open GitHub issue: `#35`
+- Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md`
+- Current open GitHub issue: `#37`
 - Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
 - Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), contest evidence refresh packet (`#27`), and contest evidence refresh execution (`#28`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
@@ -69,7 +69,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Land the scripted demo data reset utility from issue `#35`, then use it before smoke/evidence refresh when local demo state may be stale.
+Run the contest smoke lane after executing the scripted demo reset utility, then refresh evidence docs or create the next bug/task from the first hard failure.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,19 +7,19 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#34`, which queued the scripted contest demo data reset utility.
+- Latest merged PR before the current active branch: `#36`, which added the scripted contest demo data reset utility.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
-- Smoke-backed evidence refresh rules now live in `docs/contest/` on `main`.
+- Smoke-backed evidence refresh rules and the local demo reset command now live in `docs/contest/` on `main`.
 
 ## Active queue
 
-- Open issue: `#35 feat: implement scripted contest demo data reset`
-- Active task packet: `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
-- Expected branch: `docs/scripted-demo-data-reset`
+- Open issue: `#37 docs: run contest smoke with scripted demo reset`
+- Active task packet: `docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md`
+- Expected branch: `docs/contest-smoke-scripted-reset`
 
 ## Next recommended task
 
-Land the scripted demo data reset utility, then use it before smoke/evidence refresh whenever local demo state may be stale.
+Run the contest smoke lane after executing `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`, then refresh evidence docs or create a bug task from the first hard failure.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,10 +7,10 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Land the scripted demo data reset utility from issue `#35`.
-3. Use the local idempotent reset utility before smoke/evidence refresh when demo state may be stale.
-4. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
-5. Keep `docs/contest/` aligned with smoke-backed validation after each successful smoke run.
+2. Run the contest smoke lane from issue `#37` after executing the scripted demo reset command.
+3. Refresh `docs/contest/VALIDATION_REPORT.md` and related evidence docs only after smoke passes.
+4. If smoke fails, create or update the next focused product/runtime bug task from the first hard failure.
+5. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
 6. Keep open issues aligned with active task packets and unfinished work only.
 7. Preserve unrelated dirty files until they are intentionally handled.
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -332,7 +332,8 @@
   - added a docs-only PR architecture note with Mermaid;
   - updated queue/status mirrors so the next lane implements the utility.
 - Tests:
-  - Pending in this branch: docs grep validation and `git diff --check`.
+  - Passed: `rg -n "scripted|reset|smoke|evidence|Knowledge Pack|contest|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
 - Blockers:
   - None known.
 - Next:
@@ -356,7 +357,23 @@
 - Blockers:
   - None known.
 - Next:
-  - Open PR, wait for CI, and merge when eligible.
+  - Merged as PR `#36`; next task is to run smoke with the scripted reset utility.
+
+## Contest Smoke Scripted Reset Packet
+
+- Branch: `docs/contest-smoke-scripted-reset-packet`
+- Task: create the next smoke execution packet for issue `#37`.
+- Done:
+  - created GitHub issue `#37`;
+  - added `docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md`;
+  - added a docs-only PR architecture note with Mermaid;
+  - updated queue/status mirrors so the next lane runs smoke after the scripted reset command.
+- Tests:
+  - Pending in this branch: docs grep validation and `git diff --check`.
+- Blockers:
+  - None known.
+- Next:
+  - Validate the packet, open PR, merge when eligible, then execute the smoke lane from the new task packet.
 
 ## Human Review Needed
 

--- a/docs/superpowers/pr-notes/contest-smoke-scripted-reset-packet.md
+++ b/docs/superpowers/pr-notes/contest-smoke-scripted-reset-packet.md
@@ -1,0 +1,38 @@
+# PR Note: Contest Smoke Scripted Reset Packet
+
+## Summary
+
+This PR queues the next short execution lane: run the contest smoke path after executing the scripted local demo data reset utility merged in PR `#36`.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Utility["Scripted reset utility"]
+  Packet["Smoke execution packet"]
+  Smoke["SMOKE_RUNBOOK.md"]
+  Pass["Refresh validation evidence"]
+  Fail["Create focused bug task"]
+
+  Utility --> Packet
+  Packet --> Smoke
+  Smoke --> Pass
+  Smoke --> Fail
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR adds a docs/workflow task packet and queue sync, not product/runtime architecture.
+
+## Validation
+
+```bash
+rg -n "scripted|reset|smoke|evidence|Knowledge Pack|contest|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+git diff --check
+```
+
+## Handoff Notes
+
+- Next branch: `docs/contest-smoke-scripted-reset`.
+- Start by running `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`.
+- Keep generated local `data/` changes out of commits.

--- a/docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md
+++ b/docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md
@@ -1,0 +1,82 @@
+# Feature Pod Task: Contest Smoke With Scripted Demo Reset
+
+Owner: Documentation / Workflow AI worker
+Branch: `docs/contest-smoke-scripted-reset`
+GitHub Issue: `#37`
+
+## Goal
+
+Run the contest smoke lane using the scripted local demo data reset utility so the MVP evidence path proves the reset command works before future demo or submission work.
+
+## User-visible outcome
+
+A human or AI worker can read one execution packet, run the reset command, run the smoke lane, and know whether to refresh evidence docs or create the next focused bug task.
+
+## Owned files/modules
+
+- `docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md`
+- `docs/superpowers/pr-notes/contest-smoke-scripted-reset-packet.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- `docs/contest/EVIDENCE_CHECKLIST.md` only if screenshot or video status changes
+- `docs/contest/SMOKE_RUNBOOK.md` only if the smoke procedure needs a correction
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if repo-level status or next actions change
+
+## Do-not-touch files/modules
+
+- `deeptutor/` product/runtime code in this task-packet PR
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `web/next-env.d.ts`
+- `.env*`
+- committed `data/` files or private local data
+
+## Execution contract
+
+The smoke execution worker must:
+
+1. start from a clean branch `docs/contest-smoke-scripted-reset`;
+2. run `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`;
+3. keep generated local `data/` changes out of commits;
+4. run the smoke lane in `docs/contest/SMOKE_RUNBOOK.md` from Stage 1 through Stage 6;
+5. stop on the first hard failure;
+6. record commands, pass/fail result, and blocker details in `ai_first/daily/2026-04-19.md`;
+7. update `docs/contest/VALIDATION_REPORT.md` only if smoke passes;
+8. update `docs/contest/EVIDENCE_CHECKLIST.md` only if screenshot or video freshness changes;
+9. create or update the next focused bug/task if smoke fails.
+
+## Acceptance criteria
+
+- The reset command is run before smoke.
+- Smoke result is recorded with concrete commands and dates.
+- Evidence docs are refreshed only after a successful smoke pass.
+- Failure handling points to one next focused task instead of vague follow-up work.
+- The PR includes an architecture note with Mermaid.
+
+## Required validation
+
+- `rg -n "scripted|reset|smoke|evidence|Knowledge Pack|contest|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+- `git diff --check`
+
+## Manual verification for execution PR
+
+- Confirm the reset command reports `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`.
+- Confirm backend, frontend, Knowledge Pack, assessment, tutor, and dashboard stages pass or stop on the first hard failure.
+- Confirm no generated local `data/` files are committed.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed. This packet PR should not need a map update because it queues a smoke execution workflow, not product/runtime architecture.
+
+## Handoff notes
+
+- The immediate next worker should implement this packet, not invent another queue lane.
+- If local dependencies or environment setup block smoke, record the blocker clearly and leave evidence docs unchanged.


### PR DESCRIPTION
## Summary
- add the task packet for running contest smoke after the scripted demo reset utility
- update AI-first queue/status mirrors after PR #36
- add a docs-only PR architecture note with Mermaid

Closes #37.

## Validation
- rg -n "scripted|reset|smoke|evidence|Knowledge Pack|contest|Mermaid" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- git diff --check

## Main System Map
- Not updated. This PR queues a docs/workflow smoke execution lane and does not change product/runtime architecture.