### PR TITLE
Teacher assessment review MVP and local sync

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,7 +24,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, Teacher Assessment Review drill-down, contest evidence screenshots, and backend/frontend/docs CI are merged or ready in the active PR flow.
 - Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the latest smoke-backed evidence refresh record. The active short task is to merge the contest submission package, then handle final human-review items.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -31,8 +31,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Current branch for this docs update: `docs/contest-submission-package`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
-- Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: create the contest submission package.
+- Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, Teacher Assessment Review drill-down, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged or ready in the active PR flow.
+- Current purpose: clear active draft PRs, merge the Teacher Assessment Review MVP when checks pass, and keep the contest submission package ready for human review.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -69,7 +69,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Merge the contest submission package from issue `#41`, then review IP commitment, final product description wording, and optional video requirements.
+Clear active draft PRs, merge the Teacher Assessment Review MVP when checks pass, then review IP commitment, final product description wording, and optional video requirements.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,13 +7,13 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Merge the contest submission package from issue `#41` when checks pass.
+2. Clear active draft PRs: close superseded workflow drafts and merge the Teacher Assessment Review MVP only after checks pass.
 3. Review IP commitment, final product description wording, and optional video requirements.
 4. If optional video is required, create a separate focused video capture task.
 5. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
 6. If a future smoke fails, create or update the next focused product/runtime bug task from the first hard failure.
-6. Keep open issues aligned with active task packets and unfinished work only.
-7. Preserve unrelated dirty files until they are intentionally handled.
+7. Keep open issues aligned with active task packets and unfinished work only.
+8. Preserve unrelated dirty files until they are intentionally handled.
 
 ## After Milestone 0
 

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -42,6 +42,9 @@ flowchart TD
   StudentTutor --> TutorKBContext["Knowledge Pack Tutoring Context"]
   Product --> TeacherDashboard["Teacher Dashboard"]
   TeacherDashboard --> DashboardSummary["Session Activity Summary"]
+  TeacherDashboard --> AssessmentReview["Assessment Review Drill-down"]
+  AssessmentReview --> ReviewRoute["/dashboard/assessments/[sessionId]"]
+  AssessmentReview --> ReviewAPI["/api/v1/sessions/{session_id}/assessment-review"]
 
   Project --> Data["Data Layer"]
   Data --> SQLite["data/user/chat_history.db"]

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -440,6 +440,29 @@
 - Next:
   - Validate docs/status updates, open PR, merge when eligible, then handle human-review items or optional video task if required.
 
+## Teacher Assessment Review MVP
+
+- Branch: `pod-a/teacher-assessment-review-main-sync`
+- Task: Add Dashboard drill-down and dedicated assessment review page.
+- Done:
+  - Added `docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md`.
+  - Added assessment review extraction from session quiz-result messages.
+  - Added `/api/v1/sessions/{session_id}/assessment-review`.
+  - Enriched Dashboard activity rows with `assessment_summary` and `review_ref`.
+  - Added Dashboard drill-down links and `/dashboard/assessments/[sessionId]` review page.
+  - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`.
+  - Rebuilt the PR branch from current `origin/main` and closed the superseded CI draft PR `#25`.
+- Tests:
+  - Passed: `pytest tests/api/test_dashboard_router.py tests/api/test_session_review_router.py tests/scripts/test_reset_demo_data.py -v` (7 passed)
+  - Passed: `python3 -m compileall deeptutor scripts`
+  - Passed after `npm ci` in the clean worktree: `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+  - Passed: `rg -n "Assessment Review|assessment-review|dashboard/assessments|Teacher Assessment|Mermaid" docs/superpowers/pr-notes ai_first web deeptutor tests`
+  - Passed: `git diff --check`
+- Blockers:
+  - PR `#39` must pass GitHub backend, frontend, and docs checks before runtime/product auto-merge.
+- Next:
+  - Push the clean branch to PR `#39`, mark it ready, and merge only if required checks pass.
+
 ## Human Review Needed
 
 - Review product scope changes, credential/deployment decisions, or any PR blocked by CI/review.

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
-from deeptutor.services.session import get_sqlite_session_store
+from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
 
 router = APIRouter()
 
@@ -27,7 +27,10 @@ def _session_knowledge_bases(session: dict[str, Any]) -> list[str]:
     return [str(kb).strip() for kb in raw_kbs if str(kb).strip()]
 
 
-def _activity_from_session(session: dict[str, Any]) -> dict[str, Any]:
+def _activity_from_session(
+    session: dict[str, Any],
+    assessment_review: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     capability = str(session.get("capability") or "chat")
     knowledge_bases = _session_knowledge_bases(session)
     return {
@@ -42,7 +45,23 @@ def _activity_from_session(session: dict[str, Any]) -> dict[str, Any]:
         "status": session.get("status", "idle"),
         "active_turn_id": session.get("active_turn_id"),
         "knowledge_bases": knowledge_bases,
+        "assessment_summary": assessment_review["summary"] if assessment_review else None,
+        "review_ref": (
+            f"dashboard/assessments/{session.get('session_id')}" if assessment_review else None
+        ),
     }
+
+
+async def _activity_with_review(
+    store,
+    session: dict[str, Any],
+) -> dict[str, Any]:
+    capability = str(session.get("capability") or "chat")
+    if capability != "deep_question":
+        return _activity_from_session(session)
+    detail = await store.get_session_with_messages(str(session.get("session_id") or session.get("id")))
+    review = extract_assessment_review(detail) if detail else None
+    return _activity_from_session(session, review)
 
 
 @router.get("/recent")
@@ -52,7 +71,7 @@ async def get_recent_activities(limit: int = 50, type: str | None = None):
     activities: list[dict[str, Any]] = []
 
     for session in sessions:
-        activity = _activity_from_session(session)
+        activity = await _activity_with_review(store, session)
         if type is not None and activity["type"] != type:
             continue
         activities.append(activity)
@@ -64,7 +83,7 @@ async def get_recent_activities(limit: int = 50, type: str | None = None):
 async def get_dashboard_overview(limit: int = 50):
     store = get_sqlite_session_store()
     sessions = await store.list_sessions(limit=limit, offset=0)
-    activities = [_activity_from_session(session) for session in sessions]
+    activities = [await _activity_with_review(store, session) for session in sessions]
 
     knowledge_pack_counts: dict[str, int] = {}
     status_counts: dict[str, int] = {}
@@ -102,6 +121,7 @@ async def get_activity_entry(entry_id: str):
         raise HTTPException(status_code=404, detail="Entry not found")
 
     capability = str(session.get("capability") or "chat")
+    review = extract_assessment_review(session) if capability == "deep_question" else None
     return {
         "id": session.get("session_id"),
         "type": _activity_type(capability),
@@ -109,6 +129,7 @@ async def get_activity_entry(entry_id: str):
         "title": session.get("title"),
         "timestamp": session.get("updated_at", session.get("created_at")),
         "knowledge_bases": _session_knowledge_bases(session),
+        "assessment_summary": review["summary"] if review else None,
         "content": {
             "messages": session.get("messages", []),
             "active_turns": session.get("active_turns", []),

--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 from fastapi import APIRouter, HTTPException, Query
 
-from deeptutor.services.session import get_sqlite_session_store
+from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
 
 router = APIRouter()
 
@@ -63,6 +63,18 @@ async def get_session(session_id: str):
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
     return session
+
+
+@router.get("/{session_id}/assessment-review")
+async def get_assessment_review(session_id: str):
+    store = get_sqlite_session_store()
+    session = await store.get_session_with_messages(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    review = extract_assessment_review(session)
+    if review is None:
+        raise HTTPException(status_code=404, detail="Assessment review not found")
+    return review
 
 
 @router.patch("/{session_id}")

--- a/deeptutor/services/session/__init__.py
+++ b/deeptutor/services/session/__init__.py
@@ -20,6 +20,7 @@ Usage:
         # ... implement other abstract methods
 """
 
+from .assessment_review import extract_assessment_review
 from .base_session_manager import BaseSessionManager
 from .sqlite_store import SQLiteSessionStore, get_sqlite_session_store
 from .turn_runtime import TurnRuntimeManager, get_turn_runtime_manager
@@ -28,6 +29,7 @@ __all__ = [
     "BaseSessionManager",
     "SQLiteSessionStore",
     "TurnRuntimeManager",
+    "extract_assessment_review",
     "get_sqlite_session_store",
     "get_turn_runtime_manager",
 ]

--- a/deeptutor/services/session/assessment_review.py
+++ b/deeptutor/services/session/assessment_review.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+QUIZ_PREFIX = "[Quiz Performance]"
+QUESTION_RE = re.compile(
+    r"^\d+\.\s+(?:\[(?P<question_id>[^\]]*)\]\s+)?Q:\s+(?P<question>.+?)\s+->\s+Answered:\s+(?P<answer>.+?)\s+\((?P<status>Correct|Incorrect)(?:,\s+correct:\s+(?P<correct_answer>.+?))?\)$"
+)
+SCORE_RE = re.compile(r"^Score:\s+(?P<correct>\d+)/(?P<total>\d+)\s+\((?P<percent>\d+)%\)$")
+
+
+def _session_knowledge_bases(session: dict[str, Any]) -> list[str]:
+    preferences = session.get("preferences")
+    if not isinstance(preferences, dict):
+        return []
+    raw_kbs = preferences.get("knowledge_bases", [])
+    if not isinstance(raw_kbs, list):
+        return []
+    return [str(kb).strip() for kb in raw_kbs if str(kb).strip()]
+
+
+def extract_assessment_review(session: dict[str, Any]) -> dict[str, Any] | None:
+    messages = session.get("messages", [])
+    review_message = None
+    for message in reversed(messages):
+        content = str(message.get("content") or "")
+        if content.startswith(QUIZ_PREFIX):
+            review_message = content
+            break
+    if review_message is None:
+        return None
+
+    results: list[dict[str, Any]] = []
+    score_percent = 0
+    correct_count = 0
+    total_questions = 0
+
+    for raw_line in review_message.splitlines()[1:]:
+        line = raw_line.strip()
+        if not line:
+            continue
+        score_match = SCORE_RE.match(line)
+        if score_match:
+            correct_count = int(score_match.group("correct"))
+            total_questions = int(score_match.group("total"))
+            score_percent = int(score_match.group("percent"))
+            continue
+        question_match = QUESTION_RE.match(line)
+        if not question_match:
+            continue
+        results.append(
+            {
+                "question_id": (question_match.group("question_id") or "").strip(),
+                "question": question_match.group("question").strip(),
+                "user_answer": question_match.group("answer").strip(),
+                "correct_answer": (question_match.group("correct_answer") or "").strip(),
+                "is_correct": question_match.group("status") == "Correct",
+            }
+        )
+
+    if total_questions == 0:
+        total_questions = len(results)
+        correct_count = sum(1 for item in results if item["is_correct"])
+        score_percent = round((correct_count / total_questions) * 100) if total_questions else 0
+
+    incorrect_count = max(total_questions - correct_count, 0)
+    return {
+        "session_id": session.get("session_id") or session.get("id"),
+        "title": session.get("title") or "Untitled session",
+        "timestamp": session.get("updated_at", session.get("created_at", 0)),
+        "status": session.get("status", "idle"),
+        "knowledge_bases": _session_knowledge_bases(session),
+        "summary": {
+            "total_questions": total_questions,
+            "correct_count": correct_count,
+            "incorrect_count": incorrect_count,
+            "score_percent": score_percent,
+        },
+        "results": results,
+    }

--- a/docs/superpowers/plans/2026-04-19-teacher-assessment-review-mvp.md
+++ b/docs/superpowers/plans/2026-04-19-teacher-assessment-review-mvp.md
@@ -1,0 +1,757 @@
+# Teacher Assessment Review MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a teacher-facing assessment review flow where Dashboard stays summary-first and drills down into a dedicated review page for one assessment session.
+
+**Architecture:** Reuse the existing SQLite session store and quiz-result write path, add one shared backend extraction layer for assessment review data, expose that data through dashboard APIs, and render it through a new workspace route under Dashboard. Keep the Dashboard compact and push detailed per-question review into the dedicated page.
+
+**Tech Stack:** FastAPI, SQLite session store, React/Next.js App Router, TypeScript, existing dashboard/session API clients, pytest
+
+---
+
+## File Structure
+
+- Create: `docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md`
+- Create: `docs/superpowers/pr-notes/teacher-assessment-review-packet.md`
+- Create: `deeptutor/services/session/assessment_review.py`
+- Modify: `deeptutor/api/routers/dashboard.py`
+- Modify: `deeptutor/api/routers/sessions.py`
+- Modify: `deeptutor/services/session/__init__.py`
+- Modify: `tests/api/test_dashboard_router.py`
+- Create: `tests/api/test_session_review_router.py`
+- Modify: `web/lib/dashboard-api.ts`
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+- Create: `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- Create: `ai_first/daily/2026-04-19.md` entry update
+- Modify: `ai_first/AI_OPERATING_PROMPT.md` only if repo-level next actions or ownership rules change
+- Modify: `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md` only if compact mirrors are still useful after the feature starts
+- Modify: `ai_first/architecture/MAIN_SYSTEM_MAP.md` if the new review route/API is treated as a material product structure change
+
+### Task 1: Create The Shared Feature Packet
+
+**Files:**
+- Create: `docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md`
+- Create: `docs/superpowers/pr-notes/teacher-assessment-review-packet.md`
+
+- [ ] **Step 1: Write the failing docs validation expectation**
+
+```bash
+test -f docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md
+```
+
+Expected: FAIL with exit code `1` because the task packet does not exist yet.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `test -f docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md`
+Expected: non-zero exit status
+
+- [ ] **Step 3: Write the minimal packet and packet PR note**
+
+Create `docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md` with:
+
+```markdown
+# Feature Pod Task: Teacher Assessment Review MVP
+
+Owner: Pod A + Pod B coordinated AI workers
+Branch: `docs/teacher-assessment-review-packet` for packet; implementation branches should be `pod-a/teacher-assessment-review-backend` and `pod-b/teacher-assessment-review-ui`
+GitHub Issue: `#<fill when created>`
+
+## Goal
+
+Add a teacher-facing review flow from Dashboard into a dedicated assessment session review page.
+
+## User-visible outcome
+
+Teachers can open Dashboard, identify assessment sessions, and drill into one review page that shows score, correct/incorrect counts, question-level results, and Knowledge Pack context.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/dashboard.py`
+- `deeptutor/api/routers/sessions.py`
+- `deeptutor/services/session/assessment_review.py`
+- `deeptutor/services/session/__init__.py`
+- `tests/api/test_dashboard_router.py`
+- `tests/api/test_session_review_router.py`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- `web/lib/dashboard-api.ts`
+- `docs/superpowers/pr-notes/teacher-assessment-review-*.md`
+- `ai_first/daily/YYYY-MM-DD.md`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` if route/API structure changes materially
+
+## Do-not-touch files/modules
+
+- `deeptutor/knowledge/`
+- `deeptutor/services/rag/`
+- `web/app/(utility)/knowledge/page.tsx`
+- lockfiles unless dependency installation proves they must change
+- `.env*`
+- `data/`
+
+## Acceptance criteria
+
+- Dashboard keeps summary-first behavior.
+- Assessment rows link to a dedicated review page.
+- Review page shows score, correct count, incorrect count, per-question results, and Knowledge Pack names when available.
+- Legacy sessions without structured review data fail gracefully.
+```
+
+Create `docs/superpowers/pr-notes/teacher-assessment-review-packet.md` with:
+
+```markdown
+# PR Architecture Note: Teacher Assessment Review Packet
+
+## Summary
+
+Adds the feature packet for teacher-facing assessment review from Dashboard into a dedicated assessment session page.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Dashboard["Dashboard Summary"]
+  Review["Assessment Review Page"]
+  Session["Assessment Session Data"]
+
+  Dashboard --> Review
+  Session --> Review
+```
+
+## Main System Map Update
+
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- [x] Not needed for packet-only docs PR
+```
+
+- [ ] **Step 4: Run docs validation to verify it passes**
+
+Run: `rg -n "Teacher Assessment Review MVP|Assessment Review Page|Mermaid" docs/superpowers/tasks docs/superpowers/pr-notes`
+Expected: PASS with matches in the new packet and PR note
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md docs/superpowers/pr-notes/teacher-assessment-review-packet.md
+git commit -m "docs: add teacher assessment review packet"
+```
+
+### Task 2: Add Backend Assessment Review Extraction
+
+**Files:**
+- Create: `deeptutor/services/session/assessment_review.py`
+- Modify: `deeptutor/services/session/__init__.py`
+- Test: `tests/api/test_session_review_router.py`
+
+- [ ] **Step 1: Write the failing backend test**
+
+Create `tests/api/test_session_review_router.py` with:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except Exception:
+    FastAPI = None
+    TestClient = None
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+pytestmark = pytest.mark.skipif(FastAPI is None or TestClient is None, reason="fastapi not installed")
+
+
+def _build_app(store: SQLiteSessionStore, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from deeptutor.api.routers import sessions
+
+    app = FastAPI()
+    app.include_router(sessions.router, prefix="/api/v1/sessions")
+    monkeypatch.setattr(sessions, "get_sqlite_session_store", lambda: store)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_get_assessment_review_returns_structured_score(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await store.create_session(session_id="quiz-review-session")
+    await store.update_session_preferences(
+        "quiz-review-session",
+        {
+            "capability": "deep_question",
+            "tools": ["rag"],
+            "knowledge_bases": ["math-pack"],
+            "language": "en",
+        },
+    )
+    await store.add_message(
+        "quiz-review-session",
+        "user",
+        "[Quiz Performance]\\n1. [q1] Q: 2+2 -> Answered: 4 (Correct)\\n2. [q2] Q: 5-1 -> Answered: 3 (Incorrect, correct: 4)\\nScore: 1/2 (50%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/sessions/quiz-review-session/assessment-review")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["session_id"] == "quiz-review-session"
+    assert payload["knowledge_bases"] == ["math-pack"]
+    assert payload["summary"]["total_questions"] == 2
+    assert payload["summary"]["correct_count"] == 1
+    assert payload["summary"]["incorrect_count"] == 1
+    assert payload["summary"]["score_percent"] == 50
+    assert payload["results"][0]["question_id"] == "q1"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/api/test_session_review_router.py::test_get_assessment_review_returns_structured_score -v`
+Expected: FAIL with `404` for the missing route or import error for missing helper
+
+- [ ] **Step 3: Write minimal extraction helper**
+
+Create `deeptutor/services/session/assessment_review.py` with:
+
+```python
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+QUIZ_PREFIX = "[Quiz Performance]"
+QUESTION_RE = re.compile(
+    r"^\d+\.\s+(?:\[(?P<question_id>[^\]]*)\]\s+)?Q:\s+(?P<question>.+?)\s+->\s+Answered:\s+(?P<answer>.+?)\s+\((?P<status>Correct|Incorrect)(?:,\s+correct:\s+(?P<correct_answer>.+?))?\)$"
+)
+SCORE_RE = re.compile(r"^Score:\s+(?P<correct>\d+)/(?P<total>\d+)\s+\((?P<percent>\d+)%\)$")
+
+
+def extract_assessment_review(session: dict[str, Any]) -> dict[str, Any] | None:
+    messages = session.get("messages", [])
+    review_message = None
+    for message in reversed(messages):
+        content = str(message.get("content") or "")
+        if content.startswith(QUIZ_PREFIX):
+            review_message = content
+            break
+    if review_message is None:
+        return None
+
+    results: list[dict[str, Any]] = []
+    score_percent = 0
+    correct_count = 0
+    total_questions = 0
+
+    for raw_line in review_message.splitlines()[1:]:
+        line = raw_line.strip()
+        if not line:
+            continue
+        score_match = SCORE_RE.match(line)
+        if score_match:
+            correct_count = int(score_match.group("correct"))
+            total_questions = int(score_match.group("total"))
+            score_percent = int(score_match.group("percent"))
+            continue
+        question_match = QUESTION_RE.match(line)
+        if not question_match:
+            continue
+        status = question_match.group("status") == "Correct"
+        results.append(
+            {
+                "question_id": (question_match.group("question_id") or "").strip(),
+                "question": question_match.group("question").strip(),
+                "user_answer": question_match.group("answer").strip(),
+                "correct_answer": (question_match.group("correct_answer") or "").strip(),
+                "is_correct": status,
+            }
+        )
+
+    if total_questions == 0:
+        total_questions = len(results)
+        correct_count = sum(1 for item in results if item["is_correct"])
+        score_percent = round((correct_count / total_questions) * 100) if total_questions else 0
+
+    incorrect_count = max(total_questions - correct_count, 0)
+    preferences = session.get("preferences") or {}
+
+    return {
+        "session_id": session.get("session_id"),
+        "title": session.get("title") or "Untitled session",
+        "timestamp": session.get("updated_at", session.get("created_at", 0)),
+        "status": session.get("status", "idle"),
+        "knowledge_bases": list(preferences.get("knowledge_bases") or []),
+        "summary": {
+            "total_questions": total_questions,
+            "correct_count": correct_count,
+            "incorrect_count": incorrect_count,
+            "score_percent": score_percent,
+        },
+        "results": results,
+    }
+```
+
+Update `deeptutor/services/session/__init__.py` to export the helper:
+
+```python
+from .assessment_review import extract_assessment_review
+from .sqlite_store import SQLiteSessionStore, get_sqlite_session_store
+
+__all__ = [
+    "SQLiteSessionStore",
+    "get_sqlite_session_store",
+    "extract_assessment_review",
+]
+```
+
+- [ ] **Step 4: Run test to verify helper still fails only on missing route**
+
+Run: `pytest tests/api/test_session_review_router.py::test_get_assessment_review_returns_structured_score -v`
+Expected: FAIL with `404` for the missing `/assessment-review` route
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deeptutor/services/session/assessment_review.py deeptutor/services/session/__init__.py tests/api/test_session_review_router.py
+git commit -m "feat: add assessment review extractor"
+```
+
+### Task 3: Expose Backend Review Endpoints And Dashboard Summary
+
+**Files:**
+- Modify: `deeptutor/api/routers/sessions.py`
+- Modify: `deeptutor/api/routers/dashboard.py`
+- Modify: `tests/api/test_dashboard_router.py`
+- Test: `tests/api/test_session_review_router.py`
+
+- [ ] **Step 1: Write the failing dashboard summary test**
+
+Append to `tests/api/test_dashboard_router.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_dashboard_overview_includes_assessment_summary(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="quiz-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "quiz-session",
+        "user",
+        "[Quiz Performance]\\n1. [q1] Q: 1+1 -> Answered: 2 (Correct)\\nScore: 1/1 (100%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/overview")
+
+    payload = response.json()
+    assessment_row = payload["recent_activity"][0]
+    assert assessment_row["assessment_summary"]["score_percent"] == 100
+    assert assessment_row["assessment_summary"]["total_questions"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/api/test_dashboard_router.py::test_dashboard_overview_includes_assessment_summary tests/api/test_session_review_router.py::test_get_assessment_review_returns_structured_score -v`
+Expected: FAIL because overview rows do not include `assessment_summary` and the session review route does not exist
+
+- [ ] **Step 3: Add the review route and enrich dashboard rows**
+
+Update `deeptutor/api/routers/sessions.py` by importing the helper and adding:
+
+```python
+from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
+
+
+@router.get("/{session_id}/assessment-review")
+async def get_assessment_review(session_id: str):
+    store = get_sqlite_session_store()
+    session = await store.get_session_with_messages(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    review = extract_assessment_review(session)
+    if review is None:
+        raise HTTPException(status_code=404, detail="Assessment review not found")
+    return review
+```
+
+Update `deeptutor/api/routers/dashboard.py` by importing the helper and enriching `_activity_from_session`:
+
+```python
+from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
+
+
+def _activity_from_session(session: dict[str, Any]) -> dict[str, Any]:
+    capability = str(session.get("capability") or "chat")
+    knowledge_bases = _session_knowledge_bases(session)
+    review = extract_assessment_review(session) if capability == "deep_question" else None
+    return {
+        "id": session.get("session_id"),
+        "type": _activity_type(capability),
+        "capability": capability,
+        "title": session.get("title", "Untitled"),
+        "timestamp": session.get("updated_at", session.get("created_at", 0)),
+        "summary": (session.get("last_message") or "")[:160],
+        "session_ref": f"sessions/{session.get('session_id')}",
+        "message_count": session.get("message_count", 0),
+        "status": session.get("status", "idle"),
+        "active_turn_id": session.get("active_turn_id"),
+        "knowledge_bases": knowledge_bases,
+        "assessment_summary": review["summary"] if review else None,
+        "review_ref": f"dashboard/assessments/{session.get('session_id')}" if review else None,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/api/test_dashboard_router.py tests/api/test_session_review_router.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deeptutor/api/routers/dashboard.py deeptutor/api/routers/sessions.py tests/api/test_dashboard_router.py tests/api/test_session_review_router.py
+git commit -m "feat: add assessment review api"
+```
+
+### Task 4: Add Frontend Dashboard Drill-down And Review Page
+
+**Files:**
+- Modify: `web/lib/dashboard-api.ts`
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+- Create: `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+
+- [ ] **Step 1: Write the failing frontend contract expectation**
+
+Add the following interface extensions to `web/lib/dashboard-api.ts` as the target shape:
+
+```ts
+export interface AssessmentSummary {
+  total_questions: number;
+  correct_count: number;
+  incorrect_count: number;
+  score_percent: number;
+}
+
+export interface AssessmentReviewResult {
+  question_id: string;
+  question: string;
+  user_answer: string;
+  correct_answer: string;
+  is_correct: boolean;
+}
+
+export interface AssessmentReview {
+  session_id: string;
+  title: string;
+  timestamp: number;
+  status: string;
+  knowledge_bases: string[];
+  summary: AssessmentSummary;
+  results: AssessmentReviewResult[];
+}
+```
+
+Expected current state before implementation: imports/usages for these types do not exist yet.
+
+- [ ] **Step 2: Run frontend build to verify it fails after dashboard/review references are added**
+
+After adding imports in the new page and dashboard update, run:
+`cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+Expected: FAIL before the API client functions and UI code are complete
+
+- [ ] **Step 3: Write minimal frontend API client support**
+
+Update `web/lib/dashboard-api.ts` with:
+
+```ts
+export interface AssessmentSummary {
+  total_questions: number;
+  correct_count: number;
+  incorrect_count: number;
+  score_percent: number;
+}
+
+export interface AssessmentReviewResult {
+  question_id: string;
+  question: string;
+  user_answer: string;
+  correct_answer: string;
+  is_correct: boolean;
+}
+
+export interface AssessmentReview {
+  session_id: string;
+  title: string;
+  timestamp: number;
+  status: string;
+  knowledge_bases: string[];
+  summary: AssessmentSummary;
+  results: AssessmentReviewResult[];
+}
+
+export interface DashboardActivity {
+  id: string;
+  type: "assessment" | "tutoring" | string;
+  capability: string;
+  title: string;
+  timestamp: number;
+  summary: string;
+  session_ref: string;
+  message_count: number;
+  status: string;
+  active_turn_id?: string | null;
+  knowledge_bases: string[];
+  assessment_summary?: AssessmentSummary | null;
+  review_ref?: string | null;
+}
+
+export async function getAssessmentReview(sessionId: string): Promise<AssessmentReview> {
+  const response = await fetch(apiUrl(`/api/v1/sessions/${sessionId}/assessment-review`), {
+    cache: "no-store",
+  });
+  return expectJson<AssessmentReview>(response);
+}
+```
+
+- [ ] **Step 4: Write minimal dashboard drill-down UI**
+
+Update the assessment row block in `web/app/(workspace)/dashboard/page.tsx` so that assessment rows render a link:
+
+```tsx
+import Link from "next/link";
+```
+
+Inside the activity map:
+
+```tsx
+const reviewHref =
+  activity.type === "assessment" && activity.review_ref
+    ? `/${activity.review_ref}`
+    : null;
+```
+
+Replace the title block with:
+
+```tsx
+{reviewHref ? (
+  <Link href={reviewHref} className="text-[14px] font-medium text-[var(--foreground)] underline-offset-4 hover:underline">
+    {activity.title || t("Untitled session")}
+  </Link>
+) : (
+  <div className="text-[14px] font-medium text-[var(--foreground)]">
+    {activity.title || t("Untitled session")}
+  </div>
+)}
+```
+
+Render summary badge when available:
+
+```tsx
+{activity.assessment_summary && (
+  <div className="mt-2 text-[12px] text-[var(--muted-foreground)]">
+    {t("Score")}: {activity.assessment_summary.score_percent}% · {activity.assessment_summary.correct_count}/{activity.assessment_summary.total_questions}
+  </div>
+)}
+```
+
+- [ ] **Step 5: Write minimal dedicated review page**
+
+Create `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx` with:
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { ArrowLeft, CheckCircle2, XCircle } from "lucide-react";
+import { getAssessmentReview, type AssessmentReview } from "@/lib/dashboard-api";
+
+export default function AssessmentReviewPage() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const [review, setReview] = useState<AssessmentReview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getAssessmentReview(sessionId)
+      .then((data) => {
+        if (!cancelled) {
+          setReview(data);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  if (loading) return <main className="p-6">Loading assessment review...</main>;
+  if (error) return <main className="p-6">Failed to load assessment review: {error}</main>;
+  if (!review) return <main className="p-6">Assessment review not found.</main>;
+
+  return (
+    <main className="mx-auto max-w-[1080px] px-6 py-8">
+      <Link href="/dashboard" className="inline-flex items-center gap-2 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
+        <ArrowLeft size={16} />
+        Back to Dashboard
+      </Link>
+
+      <h1 className="mt-4 text-3xl font-semibold text-[var(--foreground)]">{review.title}</h1>
+      <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+        Score: {review.summary.score_percent}% · Correct {review.summary.correct_count} · Incorrect {review.summary.incorrect_count}
+      </p>
+      {review.knowledge_bases.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {review.knowledge_bases.map((kb) => (
+            <span key={kb} className="rounded-md bg-[var(--muted)] px-2 py-1 text-xs text-[var(--muted-foreground)]">
+              {kb}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <section className="mt-6 space-y-4">
+        {review.results.map((result, index) => (
+          <article key={result.question_id || `${index}`} className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="text-base font-medium text-[var(--foreground)]">{result.question}</h2>
+              {result.is_correct ? (
+                <CheckCircle2 className="text-emerald-600" size={18} />
+              ) : (
+                <XCircle className="text-red-600" size={18} />
+              )}
+            </div>
+            <p className="mt-3 text-sm text-[var(--muted-foreground)]">Student answer: {result.user_answer || "(blank)"}</p>
+            <p className="mt-1 text-sm text-[var(--muted-foreground)]">Correct answer: {result.correct_answer || "(not recorded)"}</p>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 6: Run frontend build to verify it passes**
+
+Run: `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/lib/dashboard-api.ts web/app/'(workspace)'/dashboard/page.tsx web/app/'(workspace)'/dashboard/assessments/[sessionId]/page.tsx
+git commit -m "feat: add assessment review ui"
+```
+
+### Task 5: Update AI-First Records And Final Verification
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-19.md`
+- Modify: `ai_first/AI_OPERATING_PROMPT.md` only if next-task ordering changes
+- Modify: `ai_first/CURRENT_STATE.md`
+- Modify: `ai_first/NEXT_ACTIONS.md`
+- Modify: `ai_first/architecture/MAIN_SYSTEM_MAP.md` if route/API shape changed materially
+- Create: `docs/superpowers/pr-notes/teacher-assessment-review-mvp.md`
+
+- [ ] **Step 1: Write the PR architecture note**
+
+Create `docs/superpowers/pr-notes/teacher-assessment-review-mvp.md` with:
+
+```markdown
+# PR Architecture Note: Teacher Assessment Review MVP
+
+## Summary
+
+Adds Dashboard drill-down into a dedicated assessment session review page backed by structured assessment review data extracted from session history.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  Dashboard["Dashboard"]
+  ReviewRoute["/dashboard/assessments/[sessionId]"]
+  DashboardAPI["Dashboard API"]
+  SessionAPI["Assessment Review API"]
+  SessionStore["SQLite Session Store"]
+
+  Dashboard --> ReviewRoute
+  Dashboard --> DashboardAPI
+  ReviewRoute --> SessionAPI
+  DashboardAPI --> SessionStore
+  SessionAPI --> SessionStore
+```
+
+## Main System Map Update
+
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- [x] Not needed if the route/API addition is considered a contained MVP extension
+```
+
+- [ ] **Step 2: Run final verification**
+
+Run:
+
+```bash
+pytest tests/api/test_dashboard_router.py tests/api/test_session_review_router.py -v
+python3 -m compileall deeptutor
+cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build
+git diff --check
+rg -n "Assessment Review|assessment-review|dashboard/assessments|Mermaid" docs/superpowers/pr-notes ai_first web deeptutor tests
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Update AI-first records**
+
+Append a new section in `ai_first/daily/2026-04-19.md` describing:
+
+```markdown
+## Teacher Assessment Review MVP
+
+- Branch: `<implementation branch>`
+- Task: Add Dashboard drill-down and dedicated assessment review page.
+- Done:
+  - Added structured assessment review extraction from session data.
+  - Added backend assessment review endpoint and dashboard summary enrichment.
+  - Added Dashboard drill-down and review page UI.
+- Tests:
+  - Passed: `pytest tests/api/test_dashboard_router.py tests/api/test_session_review_router.py -v`
+  - Passed: `python3 -m compileall deeptutor`
+  - Passed: `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+- Blockers:
+  - None known after local validation.
+- Next:
+  - Open PR and treat any CI failure as the highest-priority blocker.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ai_first/daily/2026-04-19.md docs/superpowers/pr-notes/teacher-assessment-review-mvp.md
+git commit -m "docs: record teacher assessment review mvp"
+```
+
+## Self-Review
+
+- Spec coverage: The plan covers Dashboard summary behavior, dedicated review route, structured backend review contract, Knowledge Pack context, empty/error handling, and testing.
+- Placeholder scan: No `TODO`, `TBD`, or deferred implementation markers remain in executable steps.
+- Type consistency: `assessment_summary`, `AssessmentReview`, and `/assessment-review` are used consistently across backend and frontend tasks.

--- a/docs/superpowers/pr-notes/teacher-assessment-review-mvp.md
+++ b/docs/superpowers/pr-notes/teacher-assessment-review-mvp.md
@@ -1,0 +1,43 @@
+# PR Architecture Note: Teacher Assessment Review MVP
+
+## Summary
+
+Adds Dashboard drill-down into a dedicated assessment session review page backed by structured assessment review data extracted from session history.
+
+## Scope
+
+- Adds assessment review extraction from quiz-result session messages.
+- Adds `/api/v1/sessions/{session_id}/assessment-review`.
+- Enriches Dashboard activity rows with assessment summary data and review links.
+- Adds `/dashboard/assessments/[sessionId]` for teacher-facing per-question review.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  Dashboard["Dashboard"]
+  ReviewRoute["/dashboard/assessments/[sessionId]"]
+  DashboardAPI["Dashboard API"]
+  SessionAPI["Assessment Review API"]
+  SessionStore["SQLite Session Store"]
+
+  Dashboard --> ReviewRoute
+  Dashboard --> DashboardAPI
+  ReviewRoute --> SessionAPI
+  DashboardAPI --> SessionStore
+  SessionAPI --> SessionStore
+```
+
+## Architecture Impact
+
+Adds a teacher-facing review route and one session API endpoint. No new storage table is introduced; the MVP reuses existing session history.
+
+## Data/API Changes
+
+- New response shape includes session metadata, Knowledge Pack names, score summary, and ordered question results.
+- Existing Dashboard overview activity rows may include `assessment_summary` and `review_ref`.
+
+## Main System Map Update
+
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- [ ] Not needed

--- a/docs/superpowers/pr-notes/teacher-assessment-review-packet.md
+++ b/docs/superpowers/pr-notes/teacher-assessment-review-packet.md
@@ -1,0 +1,31 @@
+# PR Architecture Note: Teacher Assessment Review Packet
+
+## Summary
+
+Adds the feature packet for teacher-facing assessment review from Dashboard into a dedicated assessment session page.
+
+## Scope
+
+- Defines owned files and do-not-touch boundaries for the Teacher Assessment Review MVP.
+- Keeps Dashboard as the summary surface and the dedicated review route as the detail surface.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Dashboard["Dashboard Summary"]
+  Review["Assessment Review Page"]
+  Session["Assessment Session Data"]
+
+  Dashboard --> Review
+  Session --> Review
+```
+
+## Architecture Impact
+
+Packet-only documentation. Runtime/API architecture changes happen in the implementation PR.
+
+## Main System Map Update
+
+- [x] Not needed for packet-only docs.
+- [ ] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

--- a/docs/superpowers/specs/2026-04-19-teacher-assessment-review-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-19-teacher-assessment-review-mvp-design.md
@@ -1,0 +1,207 @@
+# Teacher Assessment Review MVP Design
+
+## Summary
+
+Add a teacher-facing assessment review flow that starts from the existing Dashboard and drills down into a dedicated review page for one assessment session.
+
+This closes the current contest MVP gap between "AI generated an assessment" and "teacher can see what the student actually got right or wrong." The result should support the full story:
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student answers assessment -> Teacher reviews assessment results.
+
+## Problem
+
+The current product stores quiz results, but the teacher-facing product surface only exposes session-level activity. Teachers can see that an assessment session happened, but they cannot review score, correct versus incorrect answers, or the session's assessment details in a structured way.
+
+That weakens the contest story because the product demonstrates generation and tutoring, but not clear instructional feedback after assessment completion.
+
+## Goals
+
+- Keep the current Dashboard as a summary surface.
+- Add a drill-down review page for a single assessment session.
+- Show score, correct count, incorrect count, and question-level review data.
+- Preserve the existing Knowledge Pack linkage so teachers can understand which pack informed the assessment.
+- Reuse the current session storage model as much as possible for MVP speed and low risk.
+
+## Non-Goals
+
+- Do not add assignment, class roster, or multi-student management.
+- Do not redesign the whole Dashboard information architecture.
+- Do not add a new analytics warehouse or reporting subsystem.
+- Do not require live provider calls to review past assessment results.
+- Do not broaden this into a general-purpose session transcript viewer for every capability.
+
+## User Flow
+
+### Dashboard Summary
+
+The teacher opens Dashboard and sees:
+
+- overall session totals as today;
+- recent activity including assessment sessions;
+- assessment-specific summary information surfaced more clearly for assessment rows, such as score or answered-question count when available.
+
+From a recent assessment row, the teacher can open a dedicated review page.
+
+### Assessment Review Page
+
+The teacher opens one assessment session review page and sees:
+
+- assessment title or session name;
+- timestamp and session status;
+- linked Knowledge Pack names;
+- score percentage;
+- count of correct and incorrect answers;
+- per-question review cards with question text, learner answer, correct answer, and correctness state.
+
+The page should be understandable without reading raw session transcript text.
+
+## Product Requirements
+
+### 1. Structured Assessment Review Contract
+
+The backend must expose an assessment-review response object for one session. At minimum it should include:
+
+- session id;
+- title;
+- timestamp;
+- status;
+- Knowledge Pack names;
+- total questions;
+- correct count;
+- incorrect count;
+- score percentage;
+- ordered question results.
+
+Each question result should include:
+
+- question id when available;
+- question text;
+- learner answer;
+- correct answer;
+- correctness boolean.
+
+### 2. Dashboard Drill-down Link
+
+Recent assessment activity on Dashboard must link to the dedicated assessment review page.
+
+The Dashboard stays summary-first. It should not inline the entire review experience.
+
+### 3. Dedicated Review Route
+
+Add a new teacher-facing route under the existing workspace/dashboard area for a single assessment session review.
+
+The route should load directly from session id so it is shareable within the local product context and easy to link from Dashboard.
+
+### 4. Knowledge Pack Context
+
+If the reviewed assessment session used one or more Knowledge Packs, show those names in both summary and detail views when present.
+
+### 5. Empty/Error States
+
+If a session exists but does not have structured assessment result data, the review page should show a clear fallback state instead of crashing.
+
+If the session id is missing or not found, show a clean not-found or request-failed state.
+
+## Data Strategy
+
+For MVP, do not introduce a new database table unless current session data proves insufficient.
+
+Preferred approach:
+
+1. Reuse the existing session store.
+2. Extract assessment result structure from the quiz-result data already recorded for assessment sessions.
+3. Centralize extraction logic in a helper close to session/dashboard APIs so both the overview and drill-down endpoints use the same parser.
+
+If the current stored representation is too lossy, add the smallest compatible enrichment needed at the session-writing layer so future assessments retain structured result data without breaking old sessions.
+
+## Technical Design
+
+### Backend
+
+Add backend support in the dashboard/session surface for:
+
+- deriving structured assessment review data from one session;
+- exposing a dedicated endpoint for one assessment review;
+- optionally enriching dashboard overview rows for assessment sessions with review summary fields when available.
+
+The extraction logic should not live inline in the route handler. Put it in a focused helper so tests can cover old and new session shapes independently.
+
+### Frontend
+
+Update Dashboard to:
+
+- recognize assessment rows as drill-down targets;
+- show a clear affordance to open review details;
+- optionally surface a compact score badge or answered count if available.
+
+Add a dedicated assessment review page that renders:
+
+- metadata header;
+- summary metric cards;
+- ordered question review list.
+
+Keep the page visually aligned with the current workspace/dashboard language rather than inventing a new design system.
+
+## Backward Compatibility
+
+- Existing sessions without structured quiz review data must not break the Dashboard.
+- Review endpoints should degrade gracefully for old sessions.
+- Existing tutoring and non-assessment session behavior must remain unchanged.
+
+## Testing
+
+### Backend
+
+Add coverage for:
+
+- dashboard overview with assessment summary data;
+- dedicated review endpoint for a valid assessment session;
+- graceful fallback when session exists without review payload;
+- not-found behavior for missing session id.
+
+### Frontend
+
+Validate:
+
+- Dashboard renders review links for assessment rows;
+- review page loads session review data and renders summary plus question list;
+- loading, empty, and error states are readable.
+
+### Regression
+
+Keep current dashboard and session persistence tests green.
+
+## Task Decomposition Recommendation
+
+Split execution into three packets:
+
+1. Docs packet:
+   create the feature task packet and shared handoff contract.
+2. Backend/shared-contract packet:
+   session review extraction, dashboard API enrichment, dedicated review endpoint, backend tests.
+3. Frontend packet:
+   dashboard drill-down UI, new review page, frontend API client updates, manual verification notes.
+
+This split reduces conflict risk for multiple AI workers because backend and frontend ownership stay mostly separate.
+
+## Risks
+
+- Current quiz results may be stored in a text-heavy shape that is harder to parse reliably for legacy sessions.
+- Dashboard and review page can drift if they compute assessment summaries differently.
+- Too much dashboard detail would blur the separation between summary and drill-down.
+
+## Mitigations
+
+- Use one shared backend extraction path for both summary and detail.
+- Keep Dashboard compact and push detail into the review page.
+- Treat legacy sessions as partial-review capable rather than forcing perfect reconstruction.
+
+## Acceptance Snapshot
+
+The feature is successful when:
+
+- a teacher can see that an assessment occurred from Dashboard;
+- the teacher can open a dedicated review page for that assessment session;
+- the review page shows score and per-question correctness in a structured way;
+- the session still shows Knowledge Pack context when applicable;
+- the feature remains compatible with the current contest MVP flow and AI-first execution model.

--- a/docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md
+++ b/docs/superpowers/tasks/2026-04-19-teacher-assessment-review-mvp.md
@@ -1,0 +1,64 @@
+# Feature Pod Task: Teacher Assessment Review MVP
+
+Owner: Pod A + Pod B coordinated AI workers
+Branch: `pod-a/teacher-assessment-review-mvp`
+GitHub Issue: create or link after opening the implementation PR
+
+## Goal
+
+Add a teacher-facing review flow from Dashboard into a dedicated assessment session review page.
+
+## User-visible outcome
+
+Teachers can open Dashboard, identify assessment sessions, and drill into one review page that shows score, correct/incorrect counts, question-level results, and Knowledge Pack context.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/dashboard.py`
+- `deeptutor/api/routers/sessions.py`
+- `deeptutor/services/session/assessment_review.py`
+- `deeptutor/services/session/__init__.py`
+- `tests/api/test_dashboard_router.py`
+- `tests/api/test_session_review_router.py`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- `web/lib/dashboard-api.ts`
+- `docs/superpowers/pr-notes/teacher-assessment-review-*.md`
+- `ai_first/daily/YYYY-MM-DD.md`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` if route/API structure changes materially
+
+## Do-not-touch files/modules
+
+- `deeptutor/knowledge/`
+- `deeptutor/services/rag/`
+- `web/app/(utility)/knowledge/page.tsx`
+- lockfiles unless dependency installation proves they must change
+- `.env*`
+- `data/`
+
+## Acceptance criteria
+
+- Dashboard keeps summary-first behavior.
+- Assessment rows link to a dedicated review page.
+- Review page shows score, correct count, incorrect count, per-question results, and Knowledge Pack names when available.
+- Legacy sessions without structured review data fail gracefully.
+- Existing Dashboard and session persistence tests stay green.
+
+## Required validation
+
+- `pytest tests/api/test_dashboard_router.py tests/api/test_session_review_router.py -v`
+- `python3 -m compileall deeptutor`
+- `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+- `git diff --check`
+- `rg -n "Assessment Review|assessment-review|dashboard/assessments|Mermaid" docs/superpowers/pr-notes ai_first web deeptutor tests`
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- Keep Dashboard compact; per-question detail belongs on the review page.
+- Use one backend extraction path for Dashboard summary and the dedicated review endpoint.
+- Do not add class roster, assignments, or multi-student management in this task.

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -110,3 +110,36 @@ async def test_dashboard_recent_filters_assessment_activity(
     assert len(payload) == 1
     assert payload[0]["id"] == "quiz-session"
     assert payload[0]["type"] == "assessment"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_includes_assessment_summary(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="quiz-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "quiz-session",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: 1+1 -> Answered: 2 (Correct)\n"
+        "Score: 1/1 (100%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/overview")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assessment_row = payload["recent_activity"][0]
+    assert assessment_row["review_ref"] == "dashboard/assessments/quiz-session"
+    assert assessment_row["assessment_summary"]["score_percent"] == 100
+    assert assessment_row["assessment_summary"]["total_questions"] == 1

--- a/tests/api/test_session_review_router.py
+++ b/tests/api/test_session_review_router.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - optional dependency in lightweight envs
+    FastAPI = None
+    TestClient = None
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+pytestmark = pytest.mark.skipif(FastAPI is None or TestClient is None, reason="fastapi not installed")
+
+
+def _build_app(store: SQLiteSessionStore, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from deeptutor.api.routers import sessions
+
+    app = FastAPI()
+    app.include_router(sessions.router, prefix="/api/v1/sessions")
+    monkeypatch.setattr(sessions, "get_sqlite_session_store", lambda: store)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_get_assessment_review_returns_structured_score(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await store.create_session(session_id="quiz-review-session")
+    await store.update_session_preferences(
+        "quiz-review-session",
+        {
+            "capability": "deep_question",
+            "tools": ["rag"],
+            "knowledge_bases": ["math-pack"],
+            "language": "en",
+        },
+    )
+    await store.add_message(
+        "quiz-review-session",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: 2+2 -> Answered: 4 (Correct)\n"
+        "2. [q2] Q: 5-1 -> Answered: 3 (Incorrect, correct: 4)\n"
+        "Score: 1/2 (50%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/sessions/quiz-review-session/assessment-review")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["session_id"] == "quiz-review-session"
+    assert payload["knowledge_bases"] == ["math-pack"]
+    assert payload["summary"]["total_questions"] == 2
+    assert payload["summary"]["correct_count"] == 1
+    assert payload["summary"]["incorrect_count"] == 1
+    assert payload["summary"]["score_percent"] == 50
+    assert payload["results"][0]["question_id"] == "q1"
+

--- a/tests/api/test_session_review_router.py
+++ b/tests/api/test_session_review_router.py
@@ -61,4 +61,3 @@ async def test_get_assessment_review_returns_structured_score(
     assert payload["summary"]["incorrect_count"] == 1
     assert payload["summary"]["score_percent"] == 50
     assert payload["results"][0]["question_id"] == "q1"
-

--- a/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
+++ b/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { ArrowLeft, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { getAssessmentReview, type AssessmentReview } from "@/lib/dashboard-api";
+
+function formatTime(value: number): string {
+  if (!value) return "";
+  const timestamp = value < 10_000_000_000 ? value * 1000 : value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
+export default function AssessmentReviewPage() {
+  const { t } = useTranslation();
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const [review, setReview] = useState<AssessmentReview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getAssessmentReview(sessionId)
+      .then((data) => {
+        if (!cancelled) {
+          setReview(data);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  if (loading) {
+    return (
+      <main className="flex h-full items-center justify-center bg-[var(--background)] text-[var(--muted-foreground)]">
+        <Loader2 size={18} className="mr-2 animate-spin" />
+        {t("Loading assessment review...")}
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="h-full overflow-y-auto bg-[var(--background)] px-6 py-8">
+        <div className="mx-auto max-w-[900px] rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+          {t("Failed to load assessment review")}: {error}
+        </div>
+      </main>
+    );
+  }
+
+  if (!review) {
+    return (
+      <main className="h-full overflow-y-auto bg-[var(--background)] px-6 py-8">
+        <div className="mx-auto max-w-[900px] text-sm text-[var(--muted-foreground)]">
+          {t("Assessment review not found.")}
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="h-full overflow-y-auto bg-[var(--background)]">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-6 px-6 py-8">
+        <Link
+          href="/dashboard"
+          className="inline-flex w-fit items-center gap-2 text-[13px] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+        >
+          <ArrowLeft size={15} />
+          {t("Back to Dashboard")}
+        </Link>
+
+        <header>
+          <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+            {t("Assessment Review")}
+          </p>
+          <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
+            {review.title || t("Untitled assessment")}
+          </h1>
+          <p className="mt-2 text-[14px] text-[var(--muted-foreground)]">
+            {formatTime(review.timestamp)} - {review.status}
+          </p>
+          {review.knowledge_bases.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {review.knowledge_bases.map((kb) => (
+                <span
+                  key={kb}
+                  className="rounded-md bg-[var(--muted)] px-2 py-1 text-[12px] text-[var(--muted-foreground)]"
+                >
+                  {kb}
+                </span>
+              ))}
+            </div>
+          )}
+        </header>
+
+        <section className="grid gap-3 md:grid-cols-4">
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <p className="text-[12px] text-[var(--muted-foreground)]">{t("Score")}</p>
+            <p className="mt-2 text-[28px] font-semibold text-[var(--foreground)]">
+              {review.summary.score_percent}%
+            </p>
+          </div>
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <p className="text-[12px] text-[var(--muted-foreground)]">{t("Correct")}</p>
+            <p className="mt-2 text-[28px] font-semibold text-emerald-600">
+              {review.summary.correct_count}
+            </p>
+          </div>
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <p className="text-[12px] text-[var(--muted-foreground)]">{t("Incorrect")}</p>
+            <p className="mt-2 text-[28px] font-semibold text-red-600">
+              {review.summary.incorrect_count}
+            </p>
+          </div>
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <p className="text-[12px] text-[var(--muted-foreground)]">{t("Questions")}</p>
+            <p className="mt-2 text-[28px] font-semibold text-[var(--foreground)]">
+              {review.summary.total_questions}
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          {review.results.length > 0 ? (
+            review.results.map((result, index) => (
+              <article
+                key={result.question_id || `${index}`}
+                className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-[12px] text-[var(--muted-foreground)]">
+                      {t("Question")} {index + 1}
+                    </p>
+                    <h2 className="mt-1 text-[15px] font-medium leading-6 text-[var(--foreground)]">
+                      {result.question}
+                    </h2>
+                  </div>
+                  {result.is_correct ? (
+                    <CheckCircle2 size={19} className="shrink-0 text-emerald-600" />
+                  ) : (
+                    <XCircle size={19} className="shrink-0 text-red-600" />
+                  )}
+                </div>
+                <div className="mt-3 grid gap-2 text-[13px] text-[var(--muted-foreground)] md:grid-cols-2">
+                  <p>
+                    <span className="font-medium text-[var(--foreground)]">
+                      {t("Student answer")}:
+                    </span>{" "}
+                    {result.user_answer || t("(blank)")}
+                  </p>
+                  <p>
+                    <span className="font-medium text-[var(--foreground)]">
+                      {t("Correct answer")}:
+                    </span>{" "}
+                    {result.correct_answer || t("(not recorded)")}
+                  </p>
+                </div>
+              </article>
+            ))
+          ) : (
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 text-center text-[13px] text-[var(--muted-foreground)]">
+              {t("This assessment session does not have question-level review data yet.")}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { Activity, BookOpen, CheckCircle2, Loader2, PenLine, Users } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -135,20 +136,41 @@ export default function DashboardPage() {
             </div>
             <div className="overflow-hidden rounded-lg border border-[var(--border)]">
               {(overview?.recent_activity ?? []).length > 0 ? (
-                overview?.recent_activity.map((activity) => (
-                  <div
-                    key={activity.id}
-                    className="border-b border-[var(--border)] bg-[var(--card)] px-4 py-3 last:border-b-0"
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <div>
-                        <div className="text-[14px] font-medium text-[var(--foreground)]">
-                          {activity.title || t("Untitled session")}
-                        </div>
+                overview?.recent_activity.map((activity) => {
+                  const reviewHref =
+                    activity.type === "assessment" && activity.review_ref
+                      ? `/${activity.review_ref}`
+                      : null;
+                  return (
+                    <div
+                      key={activity.id}
+                      className="border-b border-[var(--border)] bg-[var(--card)] px-4 py-3 last:border-b-0"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div>
+                          {reviewHref ? (
+                            <Link
+                              href={reviewHref}
+                              className="text-[14px] font-medium text-[var(--foreground)] underline-offset-4 hover:underline"
+                            >
+                              {activity.title || t("Untitled session")}
+                            </Link>
+                          ) : (
+                            <div className="text-[14px] font-medium text-[var(--foreground)]">
+                              {activity.title || t("Untitled session")}
+                            </div>
+                          )}
                         <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
                           {t(activityLabel(activity))} - {activity.status} -{" "}
                           {formatTime(activity.timestamp)}
                         </div>
+                        {activity.assessment_summary && (
+                          <div className="mt-2 text-[12px] text-[var(--muted-foreground)]">
+                            {t("Score")}: {activity.assessment_summary.score_percent}% -{" "}
+                            {activity.assessment_summary.correct_count}/
+                            {activity.assessment_summary.total_questions}
+                          </div>
+                        )}
                       </div>
                       {activity.knowledge_bases.length > 0 && (
                         <div className="flex flex-wrap gap-1">
@@ -163,13 +185,14 @@ export default function DashboardPage() {
                         </div>
                       )}
                     </div>
-                    {activity.summary && (
-                      <p className="mt-2 line-clamp-2 text-[13px] leading-5 text-[var(--muted-foreground)]">
-                        {activity.summary}
-                      </p>
-                    )}
-                  </div>
-                ))
+                      {activity.summary && (
+                        <p className="mt-2 line-clamp-2 text-[13px] leading-5 text-[var(--muted-foreground)]">
+                          {activity.summary}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })
               ) : (
                 <div className="bg-[var(--card)] px-4 py-10 text-center text-[13px] text-[var(--muted-foreground)]">
                   {loading

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -1,5 +1,30 @@
 import { apiUrl } from "@/lib/api";
 
+export interface AssessmentSummary {
+  total_questions: number;
+  correct_count: number;
+  incorrect_count: number;
+  score_percent: number;
+}
+
+export interface AssessmentReviewResult {
+  question_id: string;
+  question: string;
+  user_answer: string;
+  correct_answer: string;
+  is_correct: boolean;
+}
+
+export interface AssessmentReview {
+  session_id: string;
+  title: string;
+  timestamp: number;
+  status: string;
+  knowledge_bases: string[];
+  summary: AssessmentSummary;
+  results: AssessmentReviewResult[];
+}
+
 export interface DashboardActivity {
   id: string;
   type: "assessment" | "tutoring" | string;
@@ -12,6 +37,8 @@ export interface DashboardActivity {
   status: string;
   active_turn_id?: string | null;
   knowledge_bases: string[];
+  assessment_summary?: AssessmentSummary | null;
+  review_ref?: string | null;
 }
 
 export interface DashboardOverview {
@@ -42,4 +69,11 @@ export async function getDashboardOverview(limit = 50): Promise<DashboardOvervie
     cache: "no-store",
   });
   return expectJson<DashboardOverview>(response);
+}
+
+export async function getAssessmentReview(sessionId: string): Promise<AssessmentReview> {
+  const response = await fetch(apiUrl(`/api/v1/sessions/${sessionId}/assessment-review`), {
+    cache: "no-store",
+  });
+  return expectJson<AssessmentReview>(response);
 }


### PR DESCRIPTION
## Summary

- Add Teacher Assessment Review MVP so teachers can drill down from dashboard assessment activity into a dedicated session review page.
- Add backend assessment review extraction/API, dashboard enrichment, frontend review route, tests, AI-first status updates, and architecture notes.
- Merge latest `origin/main` locally, preserving the scripted demo data reset utility and historical DeepTutor slimming analysis.

## Validation

- `pytest tests/api/test_dashboard_router.py tests/api/test_session_review_router.py tests/scripts/test_reset_demo_data.py -v` -> 7 passed
- `python3 -m compileall deeptutor scripts` -> passed
- `NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build` -> passed
- `git diff --check` -> passed

## Notes

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated for the assessment review drill-down route and API.
- This PR is draft because local `main` had accumulated feature commits and remote sync merge commits; review should confirm the combined scope is acceptable before merge.
