### PR TITLE
docs: record contest smoke scripted reset

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the demo-readiness smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the smoke-backed evidence refresh workflow plus the scripted local demo data reset utility. The active short task is to run the contest smoke lane after executing that reset command.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the latest smoke-backed evidence refresh record. The active short task is to merge that smoke execution result, then derive the next contest task from the MVP goal.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/contest-smoke-scripted-reset-packet`
+- Current branch for this docs update: `docs/contest-smoke-scripted-reset`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: queue the next smoke execution lane using the scripted local contest demo data reset utility.
+- Current purpose: record the scripted-reset contest smoke execution result.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -62,14 +62,14 @@ Do not revert unrelated changes.
 
 - Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md`
 - Current open GitHub issue: `#37`
-- Latest completed smoke run result: backend online, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
+- Latest completed smoke run result: scripted reset passed, backend online through the CLI server path, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
 - Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), contest evidence refresh packet (`#27`), and contest evidence refresh execution (`#28`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Run the contest smoke lane after executing the scripted demo reset utility, then refresh evidence docs or create the next bug/task from the first hard failure.
+Merge the scripted-reset smoke execution result from issue `#37`, then derive the next short contest task from the MVP goal.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#36`, which added the scripted contest demo data reset utility.
+- Latest merged PR before the current active branch: `#38`, which queued the scripted-reset smoke execution lane.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
 - Smoke-backed evidence refresh rules and the local demo reset command now live in `docs/contest/` on `main`.
 
@@ -19,11 +19,11 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Next recommended task
 
-Run the contest smoke lane after executing `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`, then refresh evidence docs or create a bug task from the first hard failure.
+Merge the scripted-reset smoke execution result when checks pass. After merge, derive the next short contest task from the MVP goal, likely final submission packaging or optional demo video capture.
 
 ## AI-owned blockers
 
-- None currently. The local smoke lane passed with demo-safe data, backend startup, frontend production build, Knowledge Pack metadata, assessment session evidence, tutor session evidence, and dashboard activity.
+- None currently. The scripted-reset smoke lane passed with demo-safe reset output, backend startup through the CLI server path, frontend production build, Knowledge Pack metadata, assessment session evidence, tutor session evidence, and dashboard activity.
 
 ## Human-review blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,10 +7,10 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Run the contest smoke lane from issue `#37` after executing the scripted demo reset command.
-3. Refresh `docs/contest/VALIDATION_REPORT.md` and related evidence docs only after smoke passes.
-4. If smoke fails, create or update the next focused product/runtime bug task from the first hard failure.
-5. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
+2. Merge the scripted-reset smoke execution result from issue `#37` when checks pass.
+3. After merge, derive the next short contest task from the MVP goal, likely final submission packaging or optional demo video capture.
+4. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
+5. If a future smoke fails, create or update the next focused product/runtime bug task from the first hard failure.
 6. Keep open issues aligned with active task packets and unfinished work only.
 7. Preserve unrelated dirty files until they are intentionally handled.
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -373,7 +373,37 @@
 - Blockers:
   - None known.
 - Next:
-  - Validate the packet, open PR, merge when eligible, then execute the smoke lane from the new task packet.
+  - Merged as PR `#38`; next task is to execute the smoke lane from the new task packet.
+
+## Contest Smoke Scripted Reset Execution
+
+- Branch: `docs/contest-smoke-scripted-reset`
+- Task: run the contest smoke lane from issue `#37` after scripted demo reset.
+- Done:
+  - ran `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`;
+  - confirmed reset output for `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`;
+  - started backend with `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`;
+  - confirmed system status, Knowledge Pack list, dashboard overview, dashboard recent, assessment session, and tutor session endpoints;
+  - ran frontend production build from `web/`;
+  - refreshed `docs/contest/VALIDATION_REPORT.md` and `docs/contest/EVIDENCE_CHECKLIST.md`;
+  - added a PR architecture note with Mermaid.
+- Tests:
+  - Passed: `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/system/status`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/knowledge/list`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo`
+  - Passed: `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo`
+  - Passed after network permission for Google Fonts: `cd web && npm run build`
+- Notes:
+  - `.venv/bin/python -m deeptutor.api.run_server` failed before binding because the installed `uvicorn` rejects absolute `reload_excludes` glob patterns.
+  - The first frontend build attempt failed in sandbox because Google Fonts could not be fetched; the same build passed with network permission.
+  - Generated local `data/`, `web/.next`, and temporary dependency artifacts were kept out of commits.
+- Blockers:
+  - None known.
+- Next:
+  - Validate docs/status updates, open PR, merge when eligible, then derive the next contest task from the MVP goal.
 
 ## Human Review Needed
 

--- a/docs/contest/EVIDENCE_CHECKLIST.md
+++ b/docs/contest/EVIDENCE_CHECKLIST.md
@@ -24,13 +24,14 @@ Refresh these automatically after every successful smoke pass.
 
 | Command | Refresh mode | Status | Source |
 | --- | --- | --- | --- |
-| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run; see `VALIDATION_REPORT.md`. |
-| `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build` | Auto after smoke | Current | Passed in the 2026-04-19 smoke run with the existing lockfile warning. |
+| `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Auto before smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
+| `cd web && npm run build` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing lockfile warning. |
 
 ## Optional Video
 

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -14,8 +14,8 @@ Latest smoke-backed refresh: 2026-04-19
 
 | Evidence group | Refresh mode | Status | Latest source |
 | --- | --- | --- | --- |
-| Backend and API reachability | Auto after smoke | Current | Smoke run recorded in PR `#24` and `ai_first/daily/2026-04-19.md`. |
-| Frontend production build | Auto after smoke | Current | `NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build` passed during the 2026-04-19 smoke run. |
+| Backend and API reachability | Auto after smoke | Current | Scripted-reset smoke run recorded in `ai_first/daily/2026-04-19.md`. |
+| Frontend production build | Auto after smoke | Current | `npm run build` passed with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` during the scripted-reset smoke run. |
 | Screenshot bundle | Human capture after smoke when the UI changes | Current | Existing contest screenshots still match the smoke-verified MVP path. |
 | Optional video | Human capture only | Deferred | No external video is required yet. |
 
@@ -30,13 +30,14 @@ Use these status values consistently:
 
 | Area | Command | Result |
 | --- | --- | --- |
-| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed in the 2026-04-19 smoke run. |
-| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed in the 2026-04-19 smoke run; `contest-demo-quadratics` was present with teacher metadata. |
-| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed in the 2026-04-19 smoke run. |
-| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed in the 2026-04-19 smoke run. |
-| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed in the 2026-04-19 smoke run. |
-| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed in the 2026-04-19 smoke run. |
-| Frontend production build | `cd web && NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build` | Passed in the 2026-04-19 smoke run with the existing lockfile warning. |
+| Scripted demo reset | `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Passed in the 2026-04-19 scripted-reset smoke run; it reported `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`. |
+| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed in the 2026-04-19 scripted-reset smoke run. |
+| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed in the 2026-04-19 scripted-reset smoke run; `contest-demo-quadratics` was present with teacher metadata. |
+| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed in the 2026-04-19 scripted-reset smoke run with one assessment and one tutoring session. |
+| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed in the 2026-04-19 scripted-reset smoke run with assessment and tutor activity grounded in `contest-demo-quadratics`. |
+| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed in the 2026-04-19 scripted-reset smoke run. |
+| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed in the 2026-04-19 scripted-reset smoke run. |
+| Frontend production build | `cd web && npm run build` | Passed in the 2026-04-19 scripted-reset smoke run with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing multiple-lockfile warning. |
 
 ## Current Known Limitations
 
@@ -51,8 +52,9 @@ Use these status values consistently:
 
 The latest smoke-backed evidence refresh used local demo data only:
 
-- Backend: `.venv/bin/python -m deeptutor.api.run_server`
-- Frontend validation: `NEXT_PUBLIC_API_BASE=http://localhost:8001 npm run build`
+- Reset: `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
+- Backend: `.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`
+- Frontend validation: `npm run build` in `web/` with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local`
 - Knowledge Pack: `contest-demo-quadratics`
 - Demo sessions:
   - `contest-assessment-demo`
@@ -66,16 +68,19 @@ The local reset command is:
 python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
 ```
 
-The first attempt to run `python3 -m deeptutor.api.run_server` failed because `python3` resolved to a different virtual environment without `uvicorn`. The backend was then run successfully with the repository-local `.venv/bin/python`.
+The first backend attempt with `.venv/bin/python -m deeptutor.api.run_server` failed before binding because the reload configuration passed absolute `reload_excludes` paths to the installed `uvicorn`, which rejects non-relative glob patterns. The smoke run used the existing CLI server path with reload disabled instead.
+
+The first frontend build attempt failed in sandbox because Next.js could not fetch Google Fonts. Re-running the same build with network permission passed. The build still emits the existing multiple-lockfile warning.
 
 ## Smoke-backed Verification Record
 
-The 2026-04-19 smoke run verified the full MVP path in order:
+The 2026-04-19 scripted-reset smoke run verified the full MVP path in order:
 
-1. backend started successfully with the repository-local virtual environment;
-2. system status, knowledge list, dashboard overview, dashboard recent, assessment session, and tutor session endpoints all returned the expected demo-safe data;
-3. the frontend production build passed against `http://localhost:8001`;
-4. the existing screenshot bundle still matched the smoke-verified flow, so screenshot status remains `Current` instead of requiring immediate recapture.
+1. scripted reset recreated the demo-safe Knowledge Pack and assessment/tutor sessions;
+2. backend started successfully with the repository-local virtual environment through the CLI server path;
+3. system status, knowledge list, dashboard overview, dashboard recent, assessment session, and tutor session endpoints all returned the expected demo-safe data;
+4. the frontend production build passed against `http://localhost:8001`;
+5. the existing screenshot bundle still matched the smoke-verified flow, so screenshot status remains `Current` instead of requiring immediate recapture.
 
 ## Manual Verification Template
 
@@ -100,6 +105,8 @@ Complete this section when the local app is running.
 - Demo-readiness smoke packet: PR `#23`.
 - Demo-readiness smoke execution result: PR `#24`.
 - Contest evidence refresh packet: PR `#27`.
+- Scripted demo reset utility: PR `#36`.
+- Contest smoke scripted reset packet: PR `#38`.
 
 ## Next Evidence Actions
 

--- a/docs/superpowers/pr-notes/contest-smoke-scripted-reset.md
+++ b/docs/superpowers/pr-notes/contest-smoke-scripted-reset.md
@@ -1,0 +1,50 @@
+# PR Note: Contest Smoke Scripted Reset Execution
+
+## Summary
+
+This PR records the contest smoke run after executing the scripted local demo reset utility. The smoke run refreshed command evidence for the demo-safe Knowledge Pack, assessment session, tutor session, dashboard activity, and frontend production build.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Reset["Scripted demo reset"]
+  Backend["Backend API smoke"]
+  Evidence["Assessment and Tutor sessions"]
+  Dashboard["Dashboard activity"]
+  Frontend["Frontend build"]
+  Report["Validation report"]
+
+  Reset --> Backend
+  Backend --> Evidence
+  Backend --> Dashboard
+  Backend --> Frontend
+  Evidence --> Report
+  Dashboard --> Report
+  Frontend --> Report
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR records smoke/evidence execution only and does not change product/runtime architecture.
+
+## Validation
+
+```bash
+python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
+curl -s http://127.0.0.1:8001/api/v1/system/status
+curl -s http://127.0.0.1:8001/api/v1/knowledge/list
+curl -s http://127.0.0.1:8001/api/v1/dashboard/overview
+curl -s http://127.0.0.1:8001/api/v1/dashboard/recent
+curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo
+curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo
+cd web && npm run build
+rg -n "scripted|reset|smoke|evidence|Knowledge Pack|contest|Mermaid|Current|Passed" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+git diff --check
+```
+
+## Handoff Notes
+
+- Backend smoke used `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`.
+- `.venv/bin/python -m deeptutor.api.run_server` still fails with the installed `uvicorn` because reload excludes are absolute patterns.
+- The first frontend build failed without network access while fetching Google Fonts; the same build passed with network permission.

--- a/docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md
+++ b/docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md
@@ -80,3 +80,5 @@ The smoke execution worker must:
 
 - The immediate next worker should implement this packet, not invent another queue lane.
 - If local dependencies or environment setup block smoke, record the blocker clearly and leave evidence docs unchanged.
+- Execution result: passed on 2026-04-19 with scripted reset, backend CLI server path, smoke API endpoints, and frontend production build.
+- The backend `deeptutor.api.run_server` path still has a reload/absolute-pattern incompatibility with the installed `uvicorn`; smoke used `deeptutor_cli.main serve` with reload disabled.


### PR DESCRIPTION
## Summary
- record the scripted-reset contest smoke execution for issue #37
- refresh validation report and evidence checklist with reset, backend API, dashboard, session, and frontend build results
- update AI-first queue/status mirrors and add a PR architecture note with Mermaid

Closes #37.

## Validation
- python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
- curl -s http://127.0.0.1:8001/api/v1/system/status
- curl -s http://127.0.0.1:8001/api/v1/knowledge/list
- curl -s http://127.0.0.1:8001/api/v1/dashboard/overview
- curl -s http://127.0.0.1:8001/api/v1/dashboard/recent
- curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo
- curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo
- cd web && npm run build
- rg -n "scripted|reset|smoke|evidence|Knowledge Pack|contest|Mermaid|Current|Passed" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- git diff --check

## Main System Map
- Not updated. This records smoke/evidence execution and does not change product/runtime architecture.

## Notes
- Backend smoke used .venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001.
- deeptutor.api.run_server still fails with this uvicorn version because reload excludes are absolute patterns.
- Frontend build required network permission to fetch Google Fonts.