### PR TITLE
docs: queue contest submission package

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the latest smoke-backed evidence refresh record. The active short task is to merge that smoke execution result, then derive the next contest task from the MVP goal.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the latest smoke-backed evidence refresh record. The active short task is to prepare the contest submission package.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/contest-smoke-scripted-reset`
+- Current branch for this docs update: `docs/contest-submission-package-packet`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: record the scripted-reset contest smoke execution result.
+- Current purpose: queue the contest submission package lane.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -60,8 +60,8 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md`
-- Current open GitHub issue: `#37`
+- Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-submission-package.md`
+- Current open GitHub issue: `#41`
 - Latest completed smoke run result: scripted reset passed, backend online through the CLI server path, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
 - Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), contest evidence refresh packet (`#27`), and contest evidence refresh execution (`#28`)
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
@@ -69,7 +69,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Merge the scripted-reset smoke execution result from issue `#37`, then derive the next short contest task from the MVP goal.
+Create the contest submission package from issue `#41`, then review whether optional video capture is required.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,19 +7,19 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#38`, which queued the scripted-reset smoke execution lane.
+- Latest merged PR before the current active branch: `#40`, which recorded the scripted-reset smoke execution result.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
-- Smoke-backed evidence refresh rules and the local demo reset command now live in `docs/contest/` on `main`.
+- Smoke-backed evidence refresh rules, the local demo reset command, and the scripted-reset smoke result now live in `docs/contest/` on `main`.
 
 ## Active queue
 
-- Open issue: `#37 docs: run contest smoke with scripted demo reset`
-- Active task packet: `docs/superpowers/tasks/2026-04-19-contest-smoke-scripted-reset.md`
-- Expected branch: `docs/contest-smoke-scripted-reset`
+- Open issue: `#41 docs: prepare contest submission package`
+- Active task packet: `docs/superpowers/tasks/2026-04-19-contest-submission-package.md`
+- Expected branch: `docs/contest-submission-package`
 
 ## Next recommended task
 
-Merge the scripted-reset smoke execution result when checks pass. After merge, derive the next short contest task from the MVP goal, likely final submission packaging or optional demo video capture.
+Create the contest submission package that links the pitch, demo story, evidence checklist, validation report, screenshots, smoke notes, known limitations, and final submission checklist.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,10 +7,11 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Merge the scripted-reset smoke execution result from issue `#37` when checks pass.
-3. After merge, derive the next short contest task from the MVP goal, likely final submission packaging or optional demo video capture.
-4. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
-5. If a future smoke fails, create or update the next focused product/runtime bug task from the first hard failure.
+2. Create the contest submission package from issue `#41`.
+3. Link the pitch, demo story, evidence checklist, validation report, screenshots, smoke notes, known limitations, and final submission checklist from one short read path.
+4. Review whether optional video capture is required after the package exists.
+5. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
+6. If a future smoke fails, create or update the next focused product/runtime bug task from the first hard failure.
 6. Keep open issues aligned with active task packets and unfinished work only.
 7. Preserve unrelated dirty files until they are intentionally handled.
 

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -369,7 +369,8 @@
   - added a docs-only PR architecture note with Mermaid;
   - updated queue/status mirrors so the next lane runs smoke after the scripted reset command.
 - Tests:
-  - Pending in this branch: docs grep validation and `git diff --check`.
+  - Passed: `rg -n "submission|package|pitch|evidence|smoke|screenshot|video|Mermaid|contest" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
 - Blockers:
   - None known.
 - Next:
@@ -403,7 +404,23 @@
 - Blockers:
   - None known.
 - Next:
-  - Validate docs/status updates, open PR, merge when eligible, then derive the next contest task from the MVP goal.
+  - Merged as PR `#40`; next task is to prepare the contest submission package.
+
+## Contest Submission Package Packet
+
+- Branch: `docs/contest-submission-package-packet`
+- Task: create the next task packet for issue `#41`.
+- Done:
+  - created GitHub issue `#41`;
+  - added `docs/superpowers/tasks/2026-04-19-contest-submission-package.md`;
+  - added a docs-only PR architecture note with Mermaid;
+  - updated queue/status mirrors so the next lane prepares the submission package.
+- Tests:
+  - Pending in this branch: docs grep validation and `git diff --check`.
+- Blockers:
+  - None known.
+- Next:
+  - Validate the packet, open PR, merge when eligible, then create the submission package.
 
 ## Human Review Needed
 

--- a/docs/superpowers/pr-notes/contest-submission-package-packet.md
+++ b/docs/superpowers/pr-notes/contest-submission-package-packet.md
@@ -1,0 +1,38 @@
+# PR Note: Contest Submission Package Packet
+
+## Summary
+
+This PR queues the next short contest documentation lane: prepare a compact submission package that links the MVP story, pitch, smoke-backed evidence, screenshots, known limitations, and final checklist.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Smoke["Scripted-reset smoke result"]
+  Evidence["Evidence docs"]
+  Pitch["Pitch notes"]
+  Checklist["Submission checklist"]
+  Packet["Submission package task"]
+
+  Smoke --> Packet
+  Evidence --> Packet
+  Pitch --> Packet
+  Checklist --> Packet
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR queues a docs/workflow packaging task and does not change product/runtime architecture.
+
+## Validation
+
+```bash
+rg -n "submission|package|pitch|evidence|smoke|screenshot|video|Mermaid|contest" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+git diff --check
+```
+
+## Handoff Notes
+
+- Next branch: `docs/contest-submission-package`.
+- Keep the final package short and link-heavy.
+- Do not add large video files or generated local data.

--- a/docs/superpowers/tasks/2026-04-19-contest-submission-package.md
+++ b/docs/superpowers/tasks/2026-04-19-contest-submission-package.md
@@ -1,0 +1,90 @@
+# Feature Pod Task: Contest Submission Package
+
+Owner: Documentation / Workflow AI worker
+Branch: `docs/contest-submission-package`
+GitHub Issue: `#41`
+
+## Goal
+
+Create a compact contest submission package so a human or AI worker can review the MVP story, evidence, smoke status, screenshots, known limitations, and final submission checklist from one read path.
+
+## User-visible outcome
+
+The contest package should make it possible to open one Markdown entry point and answer:
+
+1. what the product demo story is;
+2. what evidence proves the MVP path works;
+3. which screenshots and optional video artifacts are ready;
+4. what known limitations or environment notes remain;
+5. what still needs human review before submission.
+
+## Owned files/modules
+
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `docs/contest/README.md`
+- `ai_first/competition/submission-checklist.md`
+- `ai_first/competition/pitch-notes.md` only if links or status need updating
+- `docs/superpowers/tasks/2026-04-19-contest-submission-package.md`
+- `docs/superpowers/pr-notes/contest-submission-package.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-19.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if repo-level status or next actions change
+
+## Do-not-touch files/modules
+
+- `deeptutor/` product/runtime code
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `web/next-env.d.ts`
+- `.env*`
+- committed `data/` files or private local data
+- large video files
+
+## Package contract
+
+The package must link, not duplicate, the current authoritative materials:
+
+1. demo story and submission narrative;
+2. pitch notes and contest rules summary;
+3. validation report and evidence checklist;
+4. screenshot inventory;
+5. scripted demo reset and smoke runbook;
+6. latest scripted-reset smoke result;
+7. known limitations and human-review items;
+8. final submission checklist.
+
+## Acceptance criteria
+
+- One Markdown package entry point exists under `docs/contest/`.
+- `docs/contest/README.md` links to the package.
+- The package clearly marks what is ready, deferred, or needs human review.
+- The package references the scripted-reset smoke result from PR `#40`.
+- The PR includes an architecture note with Mermaid.
+
+## Required validation
+
+- `rg -n "submission|package|pitch|evidence|smoke|screenshot|video|Mermaid|contest" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+- `git diff --check`
+
+## Manual verification
+
+- Open `docs/contest/SUBMISSION_PACKAGE.md`.
+- Confirm a new reviewer can follow the demo, evidence, validation, and remaining human-review items without reading old chat history.
+- Confirm no private data, credentials, generated local data, or large video files were added.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- State whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed. This task should not need a map update because it is contest documentation packaging, not product/runtime architecture.
+
+## Handoff notes
+
+- Keep this package short and link-heavy.
+- Do not recapture screenshots or video in this task unless the package reveals a clear gap.
+- If optional video becomes required, create a separate focused capture task.


### PR DESCRIPTION
## Summary
- add the task packet for preparing the contest submission package
- update AI-first queue/status mirrors after scripted-reset smoke PR #40
- add a docs-only PR architecture note with Mermaid

Closes #41.

## Validation
- rg -n "submission|package|pitch|evidence|smoke|screenshot|video|Mermaid|contest" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- git diff --check

## Main System Map
- Not updated. This queues a docs/workflow packaging task and does not change product/runtime architecture.