### PR TITLE
docs: add contest submission package

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, assessment generation, student tutoring context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the latest smoke-backed evidence refresh record. The active short task is to prepare the contest submission package.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, and `docs/contest/` carries the latest smoke-backed evidence refresh record. The active short task is to merge the contest submission package, then handle final human-review items.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,11 +28,11 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Current branch for this docs update: `docs/contest-submission-package-packet`
+- Current branch for this docs update: `docs/contest-submission-package`
 - Milestone 0 status: merged into `main` via PR #1 on 2026-04-13
 - PR `#4 docs: add first feature pod task packets` merged into `main` on 2026-04-18.
 - Product MVP path status: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and runtime/backend/frontend/docs CI are merged.
-- Current purpose: queue the contest submission package lane.
+- Current purpose: create the contest submission package.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -69,7 +69,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Create the contest submission package from issue `#41`, then review whether optional video capture is required.
+Merge the contest submission package from issue `#41`, then review IP commitment, final product description wording, and optional video requirements.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR before the current active branch: `#40`, which recorded the scripted-reset smoke execution result.
+- Latest merged PR before the current active branch: `#42`, which queued the contest submission package lane.
 - Core MVP path is already in `main`: Knowledge Pack, Assessment Builder, Student Tutor context, Teacher Dashboard, contest evidence screenshots, and backend/frontend/docs CI.
 - Smoke-backed evidence refresh rules, the local demo reset command, and the scripted-reset smoke result now live in `docs/contest/` on `main`.
 
@@ -19,7 +19,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Next recommended task
 
-Create the contest submission package that links the pitch, demo story, evidence checklist, validation report, screenshots, smoke notes, known limitations, and final submission checklist.
+Merge the contest submission package when checks pass. After merge, the remaining near-term work is human review of IP commitment, final product description wording, and whether optional video is required.
 
 ## AI-owned blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -7,9 +7,9 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Immediate
 
 1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Create the contest submission package from issue `#41`.
-3. Link the pitch, demo story, evidence checklist, validation report, screenshots, smoke notes, known limitations, and final submission checklist from one short read path.
-4. Review whether optional video capture is required after the package exists.
+2. Merge the contest submission package from issue `#41` when checks pass.
+3. Review IP commitment, final product description wording, and optional video requirements.
+4. If optional video is required, create a separate focused video capture task.
 5. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
 6. If a future smoke fails, create or update the next focused product/runtime bug task from the first hard failure.
 6. Keep open issues aligned with active task packets and unfinished work only.

--- a/ai_first/competition/submission-checklist.md
+++ b/ai_first/competition/submission-checklist.md
@@ -2,19 +2,20 @@
 
 ## Product
 
-- [ ] Stable local demo runs.
-- [ ] Teacher Knowledge Pack flow works.
-- [ ] Assessment generation flow works.
-- [ ] Student Tutor flow works.
-- [ ] Teacher Dashboard flow works.
+- [x] Stable local demo runs.
+- [x] Teacher Knowledge Pack flow works.
+- [x] Assessment generation flow works.
+- [x] Student Tutor flow works.
+- [x] Teacher Dashboard flow works.
 
 ## Evidence
 
-- [ ] Demo script complete.
-- [ ] Screenshots captured.
-- [ ] Demo video recorded.
-- [ ] Technical runbook complete.
-- [ ] Architecture map up to date.
+- [x] Demo script complete.
+- [x] Screenshots captured.
+- [ ] Demo video recorded. Deferred unless final submission requires video.
+- [x] Technical runbook complete.
+- [x] Architecture map up to date.
+- [x] Contest submission package drafted.
 
 ## Legal and attribution
 
@@ -27,6 +28,6 @@
 ## Submission
 
 - [ ] Product description drafted.
-- [ ] Technical requirements drafted.
+- [x] Technical requirements drafted.
 - [ ] IP commitment reviewed.
 - [ ] Final package reviewed by humans.

--- a/ai_first/daily/2026-04-19.md
+++ b/ai_first/daily/2026-04-19.md
@@ -416,11 +416,29 @@
   - added a docs-only PR architecture note with Mermaid;
   - updated queue/status mirrors so the next lane prepares the submission package.
 - Tests:
-  - Pending in this branch: docs grep validation and `git diff --check`.
+  - Passed: `rg -n "submission|package|pitch|evidence|smoke|screenshot|video|Mermaid|contest" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+  - Passed: `git diff --check`
 - Blockers:
   - None known.
 - Next:
-  - Validate the packet, open PR, merge when eligible, then create the submission package.
+  - Merged as PR `#42`; next task is to create the submission package.
+
+## Contest Submission Package
+
+- Branch: `docs/contest-submission-package`
+- Task: create the contest submission package from issue `#41`.
+- Done:
+  - added `docs/contest/SUBMISSION_PACKAGE.md`;
+  - linked the package from `docs/contest/README.md`;
+  - updated `ai_first/competition/submission-checklist.md` with current evidence status;
+  - added a PR architecture note with Mermaid;
+  - updated queue/status mirrors and the task packet handoff.
+- Tests:
+  - Pending in this branch: docs grep validation and `git diff --check`.
+- Blockers:
+  - Human review remains needed for IP commitment, final product description wording, and optional video requirement.
+- Next:
+  - Validate docs/status updates, open PR, merge when eligible, then handle human-review items or optional video task if required.
 
 ## Human Review Needed
 

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -8,6 +8,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Evidence Files
 
+- [`SUBMISSION_PACKAGE.md`](./SUBMISSION_PACKAGE.md): compact final review path for contest submission.
 - [`DEMO_SCRIPT.md`](./DEMO_SCRIPT.md): step-by-step demo path for a reviewer or presenter.
 - [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md): required screenshots, optional video, and pass/fail evidence fields.
 - [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md): local validation commands, results, limitations, and remaining capture work.
@@ -17,7 +18,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Current Status
 
 - Product MVP path is implemented through merged PRs for Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard.
-- The first smoke-backed MVP verification passed on 2026-04-19 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
+- The latest scripted-reset smoke-backed MVP verification passed on 2026-04-19 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
 - Screenshot evidence is captured in [`screenshots/`](./screenshots/).
 - Video capture is optional and deferred to avoid storing large media in the repository.
 

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -1,0 +1,79 @@
+# Contest Submission Package
+
+Use this as the short review path before submitting the VnExpress Sang kien Khoa hoc 2026 MVP.
+
+## Submission Story
+
+Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+
+One-line pitch:
+
+An AI-first learning platform where Vietnamese teachers create Knowledge Packs and teaching skills, then AI Tutor Agents help students learn, practice, and improve from teacher-approved materials.
+
+Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/competition/pitch-notes.md).
+
+## Ready Evidence
+
+| Item | Status | Source |
+| --- | --- | --- |
+| Demo script | Ready | [`DEMO_SCRIPT.md`](./DEMO_SCRIPT.md) |
+| Smoke-backed validation | Ready | [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) |
+| Evidence checklist | Ready | [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md) |
+| Screenshot bundle | Ready | [`screenshots/`](./screenshots/) |
+| Demo-safe reset command | Ready | [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) |
+| Smoke procedure | Ready | [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md) |
+| Contest rules summary | Ready | [`ai_first/competition/vnexpress-rules-summary.md`](../../ai_first/competition/vnexpress-rules-summary.md) |
+| Final checklist | In review | [`ai_first/competition/submission-checklist.md`](../../ai_first/competition/submission-checklist.md) |
+| Optional video | Deferred | Record only if final submission requires a video artifact. |
+
+## Latest Validation
+
+The latest smoke-backed refresh passed on 2026-04-19 after running the scripted local reset. It verified:
+
+- demo-safe Knowledge Pack `contest-demo-quadratics`;
+- assessment session `contest-assessment-demo`;
+- tutor session `contest-tutor-demo`;
+- dashboard overview and recent activity;
+- frontend production build with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
+
+Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The execution PR is `#40`.
+
+## Human Review Checklist
+
+Before final submission, a human should review:
+
+- product description and category fit for the Education field;
+- intellectual property commitment;
+- whether optional video is required;
+- screenshots for clarity and absence of private data;
+- known limitations and environment notes in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md);
+- Apache 2.0 license and HKUDS/DeepTutor attribution.
+
+## Known Limitations
+
+- Optional video is deferred to avoid storing large media in the repository.
+- Provider-backed AI quality depends on configured model credentials.
+- The backend `deeptutor.api.run_server` path has a reload/absolute-pattern incompatibility with the installed `uvicorn`; latest smoke used the CLI server path with reload disabled.
+- Frontend build may need network access to fetch Google Fonts.
+- Screenshots should be recaptured only if the UI meaningfully changes.
+
+## Review Flow
+
+```mermaid
+flowchart TD
+  Package["SUBMISSION_PACKAGE.md"]
+  Pitch["Pitch notes"]
+  Demo["Demo script"]
+  Evidence["Evidence checklist"]
+  Validation["Validation report"]
+  Screenshots["Screenshots"]
+  Human["Human final review"]
+
+  Package --> Pitch
+  Package --> Demo
+  Package --> Evidence
+  Package --> Validation
+  Evidence --> Screenshots
+  Validation --> Human
+  Screenshots --> Human
+```

--- a/docs/superpowers/pr-notes/contest-submission-package.md
+++ b/docs/superpowers/pr-notes/contest-submission-package.md
@@ -1,0 +1,39 @@
+# PR Note: Contest Submission Package
+
+## Summary
+
+This PR adds a compact contest submission package that links the MVP pitch, demo story, smoke-backed validation, evidence checklist, screenshots, known limitations, and final submission checklist.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Package["Submission package"]
+  Pitch["Pitch notes"]
+  Demo["Demo script"]
+  Evidence["Evidence checklist"]
+  Validation["Validation report"]
+  Review["Human final review"]
+
+  Package --> Pitch
+  Package --> Demo
+  Package --> Evidence
+  Package --> Validation
+  Package --> Review
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This PR packages contest documentation and does not change product/runtime architecture.
+
+## Validation
+
+```bash
+rg -n "submission|package|pitch|evidence|smoke|screenshot|video|Mermaid|contest" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+git diff --check
+```
+
+## Handoff Notes
+
+- Human review is still needed for IP commitment, final product description wording, and whether optional video is required.
+- Do not store large video files in the repository.

--- a/docs/superpowers/tasks/2026-04-19-contest-submission-package.md
+++ b/docs/superpowers/tasks/2026-04-19-contest-submission-package.md
@@ -88,3 +88,4 @@ The package must link, not duplicate, the current authoritative materials:
 - Keep this package short and link-heavy.
 - Do not recapture screenshots or video in this task unless the package reveals a clear gap.
 - If optional video becomes required, create a separate focused capture task.
+- Execution result: package created at `docs/contest/SUBMISSION_PACKAGE.md`; remaining items are human review of IP commitment, final wording, and optional video requirement.


### PR DESCRIPTION
## Summary
- add docs/contest/SUBMISSION_PACKAGE.md as the final contest review path
- link the package from docs/contest/README.md
- update the submission checklist and AI-first queue/status mirrors
- add a PR architecture note with Mermaid

Closes #41.

## Validation
- rg -n "submission|package|pitch|evidence|smoke|screenshot|video|Mermaid|contest" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes ai_first
- git diff --check

## Main System Map
- Not updated. This packages contest documentation and does not change product/runtime architecture.

## Human Review Remaining
- IP commitment
- final product description wording
- whether optional video is required