### PR TITLE
feat: complete autopilot batch for marketplace import, API throttling, and route resilience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ While working:
 
 - Do not push directly to `main`.
 - Work on a branch named `pod-a/<feature>`, `pod-b/<feature>`, `docs/<topic>`, or `fix/<topic>`.
+- Open PRs in review mode (create as Draft first, then move to Ready for review after self-review).
+- Merge is allowed only when all required CI checks have passed.
 - Do not modify files outside the assigned task scope unless the task packet is updated first.
 - Preserve Apache 2.0 license and upstream HKUDS/DeepTutor credit.
 - If adding, removing, or materially changing a feature, update `ai_first/architecture/MAIN_SYSTEM_MAP.md`.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -42,6 +42,8 @@ Before edits:
 
 - Never push directly to `main`.
 - Use a focused branch.
+- Open every PR in review mode: create as Draft first, then move to Ready for review after self-review.
+- Do not merge any PR unless all required CI checks are green.
 - Respect `Owned files/modules` and `Do-not-touch files/modules`.
 - For bootstrap tasks before task packets exist, use the current plan task's `Files:` section as the owned-file contract.
 - Do not revert user or other-agent changes.
@@ -65,8 +67,10 @@ Before edits:
 
 After opening or updating a PR, classify it before handing off:
 
-- Docs, task, and workflow PRs may be auto-merged when the PR is mergeable, non-draft, and has no blocking review or unresolved required discussion.
-- Runtime and product PRs may be auto-merged only when relevant tests or required checks pass and there is no blocking review.
+- Every PR must start as Draft and only move to Ready for review after local validation and checklist completion.
+- No PR may be merged unless all required CI checks have passed.
+- Docs, task, and workflow PRs may be auto-merged only when the PR is mergeable, non-draft, CI is green, and there is no blocking review or unresolved required discussion.
+- Runtime and product PRs may be auto-merged only when relevant tests and required checks pass, CI is green, and there is no blocking review.
 - If CI fails, fixing CI is the next task. Do not start a new feature until the failing PR is fixed or explicitly deferred.
 - If review blocks the PR, address the review before merging or continuing.
 - After a successful merge, sync from `main`, update the daily log and compact status mirrors when useful, then select the next task.
@@ -94,8 +98,10 @@ Before handing off:
 2. Record tests and failures.
 3. Update `ai_first/daily/YYYY-MM-DD.md`.
 4. Update this file if status, workflow, or next actions changed.
-5. Check whether the PR is eligible for autonomous merge under the merge policy.
-6. Add handoff notes with changed files, risks, merge status, and the next recommended read path.
+5. Confirm the PR is Ready for review (not Draft) before requesting merge.
+6. Confirm all required CI checks are green before merge.
+7. Check whether the PR is eligible for autonomous merge under the merge policy.
+8. Add handoff notes with changed files, risks, merge status, and the next recommended read path.
 ## Task Tracking System
 
 The project uses a structured task registry to track MVP gaps, priorities, and progress:
@@ -155,8 +161,6 @@ When starting a new feature or fix:
 - Every PR updates corresponding task status in JSON
 - Daily logs reference task IDs for tracking progress
 - Architecture changes trigger MAIN_SYSTEM_MAP.md updates per the task scope
-
-@@## Next actions
 
 ## Next actions
 

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -96,6 +96,67 @@ Before handing off:
 4. Update this file if status, workflow, or next actions changed.
 5. Check whether the PR is eligible for autonomous merge under the merge policy.
 6. Add handoff notes with changed files, risks, merge status, and the next recommended read path.
+## Task Tracking System
+
+The project uses a structured task registry to track MVP gaps, priorities, and progress:
+
+### Key Files
+
+- `ai_first/TASK_REGISTRY.json` - Authoritative task list with metadata, priorities, and dependencies
+- `ai_first/MVP_GAP_ANALYSIS.md` - Detailed audit report with issue descriptions, risk assessment, and roadmap
+
+### Task Status Workflow
+
+Tasks flow through states:
+- **not-started**: Issue identified, not yet assigned
+- **in-progress**: Active work, updated daily
+- **completed**: Merged to main or stable branch
+
+### Task Priority Levels
+
+- **P1 Critical**: Blockers for contest submission, MVP incomplete
+- **P2-P3 High**: Essential for MVP, fix next
+- **P4-P10 Medium**: Important UX/features, schedule for later
+- **P11-P27 Low**: Nice-to-have, polish items
+
+### Workflow: MVP Gap Analysis to Execution
+
+1. **Discovery**: Read `ai_first/MVP_GAP_ANALYSIS.md` for complete audit
+2. **Selection**: Choose next task from Phase 1 (critical path) in JSON registry
+3. **Planning**: Create or update task packet in `docs/superpowers/tasks/`
+4. **Execution**: Follow Execution Contract rules above
+5. **Tracking**: Update `TASK_REGISTRY.json` status field as work progresses
+6. **Mirror**: Keep GitHub issues in sync with `TASK_REGISTRY.json` status
+
+### AI Worker Quick Start
+
+When starting a new feature or fix:
+1. Check `ai_first/TASK_REGISTRY.json` for matching task ID
+2. Note the priority, effort estimate, and file scope
+3. Read the related section in `ai_first/MVP_GAP_ANALYSIS.md`
+4. Create feature branch: `pod-a/<task-name>`, `pod-b/<task-name>`, or `fix/<task-name>`
+5. Create GitHub issue using template from JSON `github_issues_template` section
+6. Link PR to issue
+7. Update JSON status → "in-progress" when starting
+8. Update JSON status → "completed" when merged to main
+
+### Critical P1 Tasks (Block before contest submission)
+
+| Task ID | Title | Blocker | Phase |
+|---------|-------|---------|-------|
+| T009 | Marketplace Import | Fake placeholder only | 1 |
+| T010 | Assessment Feedback | Minimal recommendations | 1 |
+| T018 | Vietnamese Prompts | English-only LLM responses | 1 |
+| T028 | Rate Limiting | API abuse risk | 1 |
+
+### Integration with Existing Rules
+
+- Task packets created from TASK_REGISTRY inherit `Files:` field as owned-file contract
+- Every PR updates corresponding task status in JSON
+- Daily logs reference task IDs for tracking progress
+- Architecture changes trigger MAIN_SYSTEM_MAP.md updates per the task scope
+
+@@## Next actions
 
 ## Next actions
 

--- a/ai_first/AUDIT_SUMMARY.md
+++ b/ai_first/AUDIT_SUMMARY.md
@@ -1,0 +1,323 @@
+# MVP Audit Complete: Executive Summary & Next Steps
+
+**Generated:** 2026-04-20  
+**Status:** ✅ Audit Complete, Ready for Phase 1 Execution
+
+---
+
+## 📊 Audit Results: 27 Issues Identified
+
+### Status Overview
+- **Completed & Merged**: 8 tasks ✅
+- **In Progress**: 0 tasks
+- **Pending**: 19 tasks (4 critical blockers, 6 high priority)
+
+### Completion Rate
+```
+MVP Progress: ████████░░ 70%
+Feature Pack 3 Implementation: ✅ DONE
+Critical Path Tasks: ⏳ READY TO START
+```
+
+---
+
+## 🚨 CRITICAL BLOCKERS (Must Fix First)
+
+### 1. **T009: Marketplace Import is FAKE** ⚠️
+- **Issue**: Import button shows success but doesn't copy pack
+- **File**: `web/app/(utility)/marketplace/page.tsx` line 60-75
+- **Impact**: Contest demo fails
+- **Fix Time**: 4 hours
+- **Status**: Not Started
+
+### 2. **T010: Assessment Feedback Incomplete** ⚠️
+- **Issue**: No topic breakdown, lacks learning recommendations
+- **Impact**: Poor learning experience
+- **Fix Time**: 6 hours
+- **Status**: Not Started
+
+### 3. **T018: Vietnamese Prompts Missing** ⚠️
+- **Issue**: UI is Vietnamese but LLM responses are English
+- **Missing**: `deeptutor/agents/*/prompts/vi/` files
+- **Impact**: Judges see English responses in contest
+- **Fix Time**: 4 hours
+- **Status**: Not Started
+
+### 4. **T028: API Rate Limiting Missing** ⚠️
+- **Issue**: API unprotected against DoS/abuse
+- **Fix Time**: 2 hours
+- **Status**: Not Started
+
+---
+
+## 📁 Key Deliverables Created
+
+### 1. **`ai_first/MVP_GAP_ANALYSIS.md`** (350+ lines)
+Complete audit report with:
+- Executive summary
+- 27 detailed issue descriptions (P1-P27)
+- Issues organized by category
+- Risk assessment matrix
+- File-level gaps
+- 3-phase implementation roadmap
+- Effort estimates and dependencies
+
+**👉 READ THIS FIRST for full context**
+
+### 2. **`ai_first/TASK_REGISTRY.json`** (JSON, 400+ lines)
+Structured task database with:
+- 35 tasks with full metadata (ID, priority, hours, scope, files)
+- Task categories (completed, in-progress, blocked, pending)
+- Dependency graph
+- Risk mitigation strategies
+- 3-phase milestones
+- GitHub issue templates for automation
+
+**👉 USE THIS to create GitHub issues and track progress**
+
+### 3. **`ai_first/AI_OPERATING_PROMPT.md`** (Enhanced)
+Updated with new "Task Tracking System" section:
+- Workflow guide (discovery → execution)
+- AI worker quick start
+- Critical tasks table
+- Integration with existing rules
+
+**👉 REFERENCE THIS when starting new tasks**
+
+### 4. **`ai_first/EXECUTION_QUEUE.md`** (Updated)
+Updated with:
+- Critical blockers list (T009, T010, T018, T028)
+- Phase 1 execution table (6 tasks, ~20 hours)
+- Status update for 2026-04-20
+- Resource links
+
+**👉 CHECK THIS for current priorities**
+
+### 5. **`ai_first/daily/2026-04-20-MVP-AUDIT.md`** (Detailed Log)
+Full documentation of:
+- Audit findings and evidence
+- Risk assessment
+- Testing methodology
+- Next actions
+- Handoff notes
+
+---
+
+## 📋 What's Working (8 Completed Tasks)
+
+| Feature | Status | Details |
+|---------|--------|---------|
+| Marketplace API | ✅ Complete | List/detail endpoints working |
+| Marketplace UI | ✅ Complete | Browse, filter, pagination functional |
+| Learning Experience | ✅ Complete | ProgressIndicator component present |
+| Assessment Review | ✅ Complete | Integrated with dashboard |
+| Vietnamese UI | ✅ Complete | 176 lines of Vietnamese translation |
+| Backend i18n | ✅ Complete | Language detection, fallback chains |
+| Contest Evidence | ✅ Complete | Screenshots captured |
+| CI/CD Setup | ✅ Complete | Backend/frontend CI working |
+
+---
+
+## ⚡ What Needs Work (19 Pending Tasks)
+
+### Phase 1: Critical Path (Next 2 Weeks) - 20 Hours
+**Must-do to unblock MVP:**
+- T009: Marketplace Import Implementation (4h)
+- T010: Assessment Feedback with Analysis (6h)
+- T018: Vietnamese LLM Prompts (4h)
+- T022: Error Boundaries (2h)
+- T028: Rate Limiting (2h)
+- T011: KB Context Badges (2h)
+
+### Phase 2: High Priority (Weeks 3-4) - 32.5 Hours
+- T012-T023: Feature enhancements (sharing, preview, dashboard, analytics, etc.)
+
+### Phase 3: Polish & Advanced (Weeks 5+) - 46 Hours
+- T024-T035: Advanced features (team sharing, offline mode, learning paths, versioning, etc.)
+
+---
+
+## 🎯 Implementation Roadmap
+
+### This Week (2026-04-20 to 2026-04-26)
+```
+[T009 Marketplace Import ████████████ 4h - BLOCKING]
+[T018 Vietnamese Prompts ████████ 4h - parallel]
+[T022 Error Boundaries ██ 2h - parallel]
+[T028 Rate Limiting ██ 2h - parallel]
+```
+
+### Week 2 (2026-04-27 to 2026-05-03)
+```
+[T010 Assessment Feedback ██████ 6h - blocker]
+[T012-T023 High Priority features ████████████████ 16.5h - parallel]
+```
+
+### Week 3-4 (2026-05-04 to 2026-05-18)
+- Continue Phase 2: High-priority features completion
+- Start Phase 3: Advanced feature planning
+
+---
+
+## 📊 Categories of Issues
+
+| Category | Count | Examples | Total Hours |
+|----------|-------|----------|------------|
+| Incomplete Features | 5 | Import, feedback, preview, sharing | 16h |
+| Missing Services | 6 | Analytics, recommendations, dashboard | 32h |
+| UI/UX Improvements | 7 | Error handling, mobile, filtering | 16h |
+| i18n Completion | 1 | Vietnamese prompts | 4h |
+| Security/Performance | 2 | Rate limiting, caching | 4h |
+| Advanced Features | 6 | Versioning, learning paths, offline | 26h |
+
+**Total Effort**: ~98 hours for all issues (can be parallelized)
+
+---
+
+## 🔗 File References
+
+### Read First
+1. `ai_first/MVP_GAP_ANALYSIS.md` - Full audit report
+2. `ai_first/TASK_REGISTRY.json` - Task database
+
+### Implementation Resources
+- `docs/superpowers/tasks/` - Task packet templates
+- `docs/superpowers/pr-notes/` - PR architecture templates
+- `ai_first/AI_OPERATING_PROMPT.md` - Operating rules
+- `ai_first/EXECUTION_QUEUE.md` - Status board
+
+### Code Files to Modify (Phase 1)
+| Task | File | Work |
+|------|------|------|
+| T009 | `web/app/(utility)/marketplace/page.tsx` | Implement real import |
+| T009 | `deeptutor/api/routers/marketplace.py` | Add import endpoint |
+| T010 | `web/components/assessment/ProgressIndicator.tsx` | Expand feedback |
+| T010 | `deeptutor/api/routers/dashboard.py` | Add analysis endpoint |
+| T018 | `deeptutor/agents/*/prompts/vi/` | Create Vietnamese YAML files |
+
+---
+
+## ✅ Next Actions (Prioritized)
+
+### Today/Tomorrow
+- [ ] **Review this summary** with team
+- [ ] **Read** `ai_first/MVP_GAP_ANALYSIS.md`
+- [ ] **Create GitHub issues** for P1 tasks (use TASK_REGISTRY.json templates)
+
+### This Week
+- [ ] **Start T009** (Marketplace Import) - Branch: `pod-a/marketplace-pack-import`
+- [ ] **Start T018** (Vietnamese Prompts) - Branch: `pod-a/vietnamese-prompts`
+- [ ] **Start T022** (Error Boundaries) - Branch: `fix/error-boundaries`
+- [ ] **Start T028** (Rate Limiting) - Branch: `fix/api-rate-limiting`
+
+### Create Task Packets
+- [ ] `docs/superpowers/tasks/2026-04-20-T009-marketplace-import.md`
+- [ ] `docs/superpowers/tasks/2026-04-20-T018-vietnamese-prompts.md`
+- [ ] `docs/superpowers/tasks/2026-04-20-T022-error-boundaries.md`
+- [ ] `docs/superpowers/tasks/2026-04-20-T028-rate-limiting.md`
+
+### Update Task Registry
+- [ ] Set T009 status → "in-progress" when starting branch
+- [ ] Set T010 status → "in-progress" after T009 completes
+- [ ] Update JSON after each merge to main
+- [ ] Keep EXECUTION_QUEUE.md mirrored with active tasks
+
+---
+
+## 🎓 AI Worker Quick Start
+
+If you're implementing a task from this registry:
+
+1. **Find the task** in `ai_first/TASK_REGISTRY.json` (search by ID)
+2. **Read the details**:
+   - What's broken (description)
+   - Which files to modify (scope.frontend/backend)
+   - Complexity & effort estimate
+   - Dependencies
+3. **Create the task packet**:
+   - Copy template from `docs/superpowers/tasks/`
+   - Name it: `2026-04-20-T<ID>-<name>.md`
+   - Include acceptance criteria from JSON
+4. **Create feature branch**:
+   - `pod-a/<task-name>` (feature)
+   - `fix/<task-name>` (bug fix)
+   - `docs/<task-name>` (documentation)
+5. **Work on code** following execution contract
+6. **Update task status** in JSON registry
+7. **Create PR** with architecture note and link to issue
+
+**Example**: Implementing T009
+```bash
+# 1. Create branch
+git checkout -b pod-a/marketplace-pack-import
+
+# 2. Read the task
+cat ai_first/MVP_GAP_ANALYSIS.md | grep -A 20 "T009"
+
+# 3. Implement (modify 2 frontend files, 1 backend file, 1 API client)
+# 4. Commit with architecture note
+# 5. Push and create PR
+
+# 6. Update registry when merged
+```
+
+---
+
+## 🏆 Success Criteria
+
+**Phase 1 Complete** (by 2026-05-04):
+- [ ] T009 Marketplace Import working end-to-end
+- [ ] T010 Assessment feedback shows analysis
+- [ ] T018 Vietnamese LLM responses in Vietnamese
+- [ ] T022 Error boundaries prevent crashes
+- [ ] T028 API rate limiting active
+- [ ] All P1 issues resolved
+
+**Contest Demo Ready**:
+- [ ] Marketplace import works (can demo importing a pack)
+- [ ] Assessment feedback shows learning insights
+- [ ] Vietnamese users get Vietnamese responses
+- [ ] UI stable without crashes
+- [ ] API protected from abuse
+
+---
+
+## 📞 Key Contacts & References
+
+- **Project**: VnExpress Sáng kiến Khoa học 2026
+- **Repository**: Creative-Science-Contest-2026/Multiagent-learning-platform
+- **Base**: HKUDS/DeepTutor (Apache 2.0 licensed)
+- **Operating Model**: AI-first with Markdown source of truth
+
+---
+
+## 📝 Document Map
+
+```
+ai_first/
+├── MVP_GAP_ANALYSIS.md ..................... Full audit (READ FIRST)
+├── TASK_REGISTRY.json ...................... Task database (USE TO PLAN)
+├── AI_OPERATING_PROMPT.md .................. Operating rules (REFERENCE)
+├── EXECUTION_QUEUE.md ...................... Status board (CHECK WEEKLY)
+└── daily/
+    └── 2026-04-20-MVP-AUDIT.md ............ Detailed log (HANDOFF NOTES)
+
+docs/superpowers/
+├── tasks/ ................................ Task packet templates
+├── pr-notes/ ............................. PR architecture notes
+└── specs/ ................................ Feature specifications
+
+web/app/(utility)/
+└── marketplace/page.tsx ................... T009 work file
+
+deeptutor/api/routers/
+└── marketplace.py ......................... T009 work file
+```
+
+---
+
+**Report Generated:** 2026-04-20  
+**Status:** ✅ COMPLETE  
+**Ready for:** Phase 1 Implementation  
+**Questions?** Refer to `ai_first/MVP_GAP_ANALYSIS.md` for detailed answers
+

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -13,22 +13,24 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Active queue
 
-- Active PR (Draft): `#44 feat: complete autopilot batch for marketplace import, API throttling, and route resilience`
+- Active PR (Draft): `#44 feat: complete autopilot batch for marketplace import, API throttling, route resilience, assessment insights, and KB context badges`
 - PR URL: `https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/44`
 - Active branch: `pod-a/marketplace-pack-import`
-- Active task packet: `docs/superpowers/tasks/2026-04-20-T009-marketplace-import.md`
-- Focus set: `T009`, `T022`, `T028` (implemented and pushed; waiting CI/review gate)
+- Active task packet: `docs/superpowers/tasks/2026-04-20-T011-kb-context-badges.md`
+- Focus set: `T009`, `T010`, `T011`, `T022`, `T028` (implemented and pushed; waiting CI/review gate)
 
 ## Next recommended task
 
-Keep PR `#44` in Draft until CI checks are green and self-review is complete, then move to Ready for review. After merge, proceed to `T010_ASSESSMENT_FEEDBACK_DETAILS`.
+Keep PR `#44` in Draft until CI checks are green and self-review is complete, then move to Ready for review. After merge, proceed to the next pending item from `ai_first/TASK_REGISTRY.json` in strict sequence.
 
 ## Status Update (2026-04-20)
 
 **MVP Audit Execution Progress**:
 1. **T009: Marketplace Import** - Implemented real import flow with KB clone + registry update
-2. **T022: Error Boundaries** - Added route-level fallbacks for marketplace + assessment routes
-3. **T028: Rate Limiting** - Added API middleware with 429 + Retry-After
+2. **T010: Assessment Feedback Details** - Added topic-level assessment analytics API + UI integration
+3. **T011: KB Context Badges** - Added request-snapshot KB chips in user and paired assistant chat blocks
+4. **T022: Error Boundaries** - Added route-level fallbacks for marketplace + assessment routes
+5. **T028: Rate Limiting** - Added API middleware with 429 + Retry-After
 
 **Current Gate**:
 - PR is opened in Draft mode and pushed to origin.
@@ -39,8 +41,8 @@ Keep PR `#44` in Draft until CI checks are green and self-review is complete, th
 **UPDATED**: Active execution is now on PR `#44` for the autopilot technical batch.
 
 - Previous: MVP audit and policy hardening committed
-- Current: T009/T022/T028 implemented on `pod-a/marketplace-pack-import`
-- Next after merge: Start `T010` implementation packet and execution
+- Current: T009/T010/T011/T022/T028 implemented on `pod-a/marketplace-pack-import`
+- Next after merge: Continue with next pending backlog task by registry order
 
 ## AI-owned blockers
 
@@ -64,8 +66,8 @@ Keep PR `#44` in Draft until CI checks are green and self-review is complete, th
 | Task | Status | Hours | Blocker | Start |
 |------|--------|-------|---------|-------|
 | T009: Marketplace Import | In Progress (PR #44) | 4 | YES | Done |
-| T010: Assessment Feedback | Not Started | 6 | YES | After T009 |
-| T011: KB Context Badges | Not Started | 2 | NO | Parallel |
+| T010: Assessment Feedback | In Progress (PR #44) | 6 | YES | Done |
+| T011: KB Context Badges | In Progress (PR #44) | 2 | NO | Done |
 | T018: Vietnamese Prompts | Not Started | 4 | YES | Parallel |
 | T022: Error Boundaries | In Progress (PR #44) | 2 | NO | Done |
 | T028: Rate Limiting | In Progress (PR #44) | 2 | YES | Done |

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -21,6 +21,34 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 Merge the contest submission package when checks pass. After merge, the remaining near-term work is human review of IP commitment, final product description wording, and whether optional video is required.
 
+-## Status Update (2026-04-20)
+-
+-**MVP Audit Complete**: Comprehensive gap analysis identified 27 actionable issues (8 completed, 19 pending).
+-
+-**Critical Blockers Discovered**:
+-1. **T009: Marketplace Import** - Button shows success but doesn't import pack (FAKE PLACEHOLDER)
+-2. **T010: Assessment Feedback** - Lacks detailed topic breakdown and learning recommendations
+-3. **T018: Vietnamese Prompts** - All LLM responses still English despite UI translation
+-4. **T028: Rate Limiting** - API unprotected against abuse/DoS
+-
+-**Next Immediate Actions**:
+-1. Create GitHub issues from TASK_REGISTRY.json templates (P1 tasks)
+-2. Start Feature Pod: T009 Marketplace Import Implementation (blocking contest demo)
+-3. Parallel: T018 Vietnamese Prompts, T022 Error Boundaries, T028 Rate Limiting
+-4. Update daily log when starting each pod
+-
+-**Status**: Ready for Phase 1 (Critical Path) execution. Phase 1 target: 2 weeks to complete 6 P1 tasks (~20 hours total).
+
+## Active queue
+
+**UPDATED**: Continuing MVP gap fixes after completion of Feature Pack 3 merge.
+
+- Previous: Contest submission package merged
+- Current: MVP gap analysis audit completed (see `ai_first/MVP_GAP_ANALYSIS.md`)
+- Focus: Phase 1 critical path fixes (T009, T010, T018, T022, T028)
+- Active task packet: Will be created for T009 Marketplace Import (blocking item)
+- Expected branch: `pod-a/marketplace-pack-import`
+
 ## AI-owned blockers
 
 - None currently. The scripted-reset smoke lane passed with demo-safe reset output, backend startup through the CLI server path, frontend production build, Knowledge Pack metadata, assessment session evidence, tutor session evidence, and dashboard activity.
@@ -35,3 +63,18 @@ Merge the contest submission package when checks pass. After merge, the remainin
 2. `ai_first/EXECUTION_QUEUE.md`
 3. Task packet for the active branch
 4. `ai_first/CURRENT_STATE.md` only if more context is needed
+
+---
+
+## Critical Path Phase 1 (Next 2 Weeks)
+
+| Task | Status | Hours | Blocker | Start |
+|------|--------|-------|---------|-------|
+| T009: Marketplace Import | Not Started | 4 | YES | ASAP |
+| T010: Assessment Feedback | Not Started | 6 | YES | After T009 |
+| T011: KB Context Badges | Not Started | 2 | NO | Parallel |
+| T018: Vietnamese Prompts | Not Started | 4 | YES | Parallel |
+| T022: Error Boundaries | Not Started | 2 | NO | Parallel |
+| T028: Rate Limiting | Not Started | 2 | YES | Parallel |
+
+**Resources**: See `ai_first/TASK_REGISTRY.json` (full task list with effort estimates) and `ai_first/MVP_GAP_ANALYSIS.md` (detailed audit with risk assessment).

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -1,6 +1,6 @@
 # Execution Queue
 
-Last updated: 2026-04-19
+Last updated: 2026-04-20
 
 This is the compact status board for humans and AI workers.  
 The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
@@ -13,41 +13,34 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Active queue
 
-- Open issue: `#41 docs: prepare contest submission package`
-- Active task packet: `docs/superpowers/tasks/2026-04-19-contest-submission-package.md`
-- Expected branch: `docs/contest-submission-package`
+- Active PR (Draft): `#44 feat: complete autopilot batch for marketplace import, API throttling, and route resilience`
+- PR URL: `https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/44`
+- Active branch: `pod-a/marketplace-pack-import`
+- Active task packet: `docs/superpowers/tasks/2026-04-20-T009-marketplace-import.md`
+- Focus set: `T009`, `T022`, `T028` (implemented and pushed; waiting CI/review gate)
 
 ## Next recommended task
 
-Merge the contest submission package when checks pass. After merge, the remaining near-term work is human review of IP commitment, final product description wording, and whether optional video is required.
+Keep PR `#44` in Draft until CI checks are green and self-review is complete, then move to Ready for review. After merge, proceed to `T010_ASSESSMENT_FEEDBACK_DETAILS`.
 
--## Status Update (2026-04-20)
--
--**MVP Audit Complete**: Comprehensive gap analysis identified 27 actionable issues (8 completed, 19 pending).
--
--**Critical Blockers Discovered**:
--1. **T009: Marketplace Import** - Button shows success but doesn't import pack (FAKE PLACEHOLDER)
--2. **T010: Assessment Feedback** - Lacks detailed topic breakdown and learning recommendations
--3. **T018: Vietnamese Prompts** - All LLM responses still English despite UI translation
--4. **T028: Rate Limiting** - API unprotected against abuse/DoS
--
--**Next Immediate Actions**:
--1. Create GitHub issues from TASK_REGISTRY.json templates (P1 tasks)
--2. Start Feature Pod: T009 Marketplace Import Implementation (blocking contest demo)
--3. Parallel: T018 Vietnamese Prompts, T022 Error Boundaries, T028 Rate Limiting
--4. Update daily log when starting each pod
--
--**Status**: Ready for Phase 1 (Critical Path) execution. Phase 1 target: 2 weeks to complete 6 P1 tasks (~20 hours total).
+## Status Update (2026-04-20)
+
+**MVP Audit Execution Progress**:
+1. **T009: Marketplace Import** - Implemented real import flow with KB clone + registry update
+2. **T022: Error Boundaries** - Added route-level fallbacks for marketplace + assessment routes
+3. **T028: Rate Limiting** - Added API middleware with 429 + Retry-After
+
+**Current Gate**:
+- PR is opened in Draft mode and pushed to origin.
+- Merge is blocked until required CI checks pass and review gate is cleared.
 
 ## Active queue
 
-**UPDATED**: Continuing MVP gap fixes after completion of Feature Pack 3 merge.
+**UPDATED**: Active execution is now on PR `#44` for the autopilot technical batch.
 
-- Previous: Contest submission package merged
-- Current: MVP gap analysis audit completed (see `ai_first/MVP_GAP_ANALYSIS.md`)
-- Focus: Phase 1 critical path fixes (T009, T010, T018, T022, T028)
-- Active task packet: Will be created for T009 Marketplace Import (blocking item)
-- Expected branch: `pod-a/marketplace-pack-import`
+- Previous: MVP audit and policy hardening committed
+- Current: T009/T022/T028 implemented on `pod-a/marketplace-pack-import`
+- Next after merge: Start `T010` implementation packet and execution
 
 ## AI-owned blockers
 
@@ -70,11 +63,11 @@ Merge the contest submission package when checks pass. After merge, the remainin
 
 | Task | Status | Hours | Blocker | Start |
 |------|--------|-------|---------|-------|
-| T009: Marketplace Import | Not Started | 4 | YES | ASAP |
+| T009: Marketplace Import | In Progress (PR #44) | 4 | YES | Done |
 | T010: Assessment Feedback | Not Started | 6 | YES | After T009 |
 | T011: KB Context Badges | Not Started | 2 | NO | Parallel |
 | T018: Vietnamese Prompts | Not Started | 4 | YES | Parallel |
-| T022: Error Boundaries | Not Started | 2 | NO | Parallel |
-| T028: Rate Limiting | Not Started | 2 | YES | Parallel |
+| T022: Error Boundaries | In Progress (PR #44) | 2 | NO | Done |
+| T028: Rate Limiting | In Progress (PR #44) | 2 | YES | Done |
 
 **Resources**: See `ai_first/TASK_REGISTRY.json` (full task list with effort estimates) and `ai_first/MVP_GAP_ANALYSIS.md` (detailed audit with risk assessment).

--- a/ai_first/MVP_GAP_ANALYSIS.md
+++ b/ai_first/MVP_GAP_ANALYSIS.md
@@ -1,0 +1,425 @@
+# MVP Gap Analysis & Issue Audit Report
+**Date:** 2026-04-20  
+**Project:** Multiagent Learning Platform - VnExpress Science Innovation Contest 2026  
+**Status:** Active Development  
+**Total Issues Identified:** 27 (8 completed, 0 in-progress, 19 pending)
+
+---
+
+## Executive Summary
+
+The MVP Feature Pack 3 (merged to main on 2026-04-20) successfully implements three major checkpoints:
+1. **Knowledge Pack Marketplace** - Browse & filter UI complete, but **import functionality is placeholder only**
+2. **Student Learning Experience** - Progress visualization complete, but **detailed feedback & recommendations missing**
+3. **Vietnamese Localization** - UI translation done, but **LLM prompts not translated**
+
+**Critical Gaps Identified:** 27 actionable issues across 6 categories:
+- **Incomplete Features (5):** Marketplace import, assessment feedback, KB context, sharing UI, pack preview
+- **Backend Services Missing (6):** Assessment analytics, recommendations engine, student dashboard, teacher analytics
+- **UI/UX Improvements (7):** Error handling, mobile responsiveness, filtering, time tracking, follow-ups
+- **i18n Completion (1):** Vietnamese prompts for all agents
+- **Performance & Security (2):** Rate limiting, caching optimization
+- **Advanced Features (6):** Versioning, learning paths, offline mode, replay, team sharing, adaptive difficulty
+
+**Risk Level:** Moderate - Marketplace import placeholder is a blocker for contest demo
+
+---
+
+## Critical Priority Issues (P1-P3)
+
+### P1 Issues: MVP Blockers (Do First)
+
+#### T009: Implement Marketplace Pack Import
+- **Status:** Not Started
+- **Effort:** 4 hours
+- **Blocker:** Marketplace import button currently shows success but doesn't copy pack
+- **Scope:**
+  - File: `web/app/(utility)/marketplace/page.tsx:60-75` - Replace `handleImportPack` placeholder
+  - File: `deeptutor/api/routers/marketplace.py` - Add `POST /api/v1/marketplace/import/{pack_name}`
+  - File: `web/lib/marketplace-api.ts` - Add `importMarketplacePack()` client function
+- **Test Cases:**
+  - Import creates copy in user's `knowledge_bases/` directory
+  - Pack metadata, documents, config all copied
+  - Success/error message shown
+  - Imported pack appears in Knowledge Pack list
+- **Notes:** Need to handle pack structure (metadata.yaml + document files)
+
+**View Code:** [marketplace/page.tsx](web/app/(utility)/marketplace/page.tsx#L60-L75)
+
+#### T010: Enhance Assessment Feedback with Analysis
+- **Status:** Not Started
+- **Effort:** 6 hours
+- **Issue:** Assessment review shows score but lacks detailed topic breakdown and learning recommendations
+- **Scope:**
+  - File: `web/components/assessment/ProgressIndicator.tsx:40-80` - Expand recommendations section
+  - New Backend: `deeptutor/api/routers/dashboard.py` - Add `GET /api/v1/dashboard/assessment-analysis/{session_id}`
+  - Database: Extend `assessment_results` schema with `performance_by_topic`, `common_mistakes`
+- **Missing Components:**
+  - Topic-level performance breakdown
+  - Mistake pattern analysis
+  - Score-based learning paths
+  - Visualization (pie chart/heat map)
+- **Notes:** Requires LLM analysis of question-level performance
+
+**View Code:** [ProgressIndicator.tsx](web/components/assessment/ProgressIndicator.tsx#L40-L80)
+
+#### T011: Add KB Context Badges to Tutoring Session
+- **Status:** Not Started  
+- **Effort:** 2 hours
+- **Issue:** Student doesn't see which knowledge pack a tutor response comes from
+- **Scope:**
+  - File: `web/components/chat/ChatMessageList.tsx` - Add KB badge display
+  - Extract KB context from `UnifiedContext` in API response
+- **Visual:** Show colored badge like "📚 Algebra Pack" near tutor messages
+- **Notes:** Simple addition, high UX value
+
+**View Code:** [ChatMessageList.tsx](web/components/chat/ChatMessageList.tsx)
+
+#### T012: Teacher Knowledge Pack Sharing UI
+- **Status:** Not Started
+- **Effort:** 3 hours  
+- **Issue:** Teachers can't mark packs as public/team/private in UI
+- **Scope:**
+  - File: `web/app/(workspace)/knowledge` - Add sharing settings panel
+  - File: `deeptutor/api/routers/knowledge.py` - Extend pack update endpoint
+  - Update: `pack_metadata.yaml` with `sharing_status`, `shared_with` fields
+- **Missing UI:** Sharing dropdown (private/team/public), access list editor
+- **Notes:** Prerequisite for marketplace import to work
+
+#### T013: Marketplace Pack Preview Modal  
+- **Status:** Not Started
+- **Effort:** 3 hours
+- **Issue:** Users can't preview pack contents before importing
+- **Scope:**
+  - File: `web/app/(utility)/marketplace/page.tsx` - Add modal component
+  - Backend: `GET /api/v1/marketplace/{pack_name}/preview`
+- **Preview Contents:** First 3 sample questions, learning objectives, document count
+- **Notes:** Improves user confidence before import
+
+---
+
+### P2-P3 Issues: High Priority (Next Week)
+
+#### T014: Student Progress Tracking Dashboard
+- **Status:** Not Started | **Effort:** 5 hours | **Complexity:** High
+- **Issue:** Students lack visibility into progress across all assessments
+- **Scope:** Create `web/app/(workspace)/dashboard/student` with charts
+- **Missing:** Timeline chart, topic mastery heatmap, learning streaks, recent assessments
+
+#### T015: AI-Powered Assessment Recommendations  
+- **Status:** Not Started | **Effort:** 6 hours | **Complexity:** High
+- **Issue:** No personalized recommendations for next assessment
+- **Scope:** New service `deeptutor/services/assessment/recommendation_engine.py`
+- **Missing:** LLM-powered next-topic suggestion based on performance
+
+#### T016: Marketplace Pack Ratings & Reviews
+- **Status:** Not Started | **Effort:** 4 hours | **Complexity:** Medium
+- **Issue:** No way for teachers to rate/review packs
+- **Scope:** Add 5-star rating UI, backend rating storage
+- **Missing:** Rating database table, display in pack cards
+
+#### T017: Assessment History Filtering & Search
+- **Status:** Not Started | **Effort:** 2 hours | **Complexity:** Low
+- **Issue:** Teacher dashboard lacks filters for session history
+- **Scope:** Add filter panel to dashboard, extend API query parameters
+- **Missing:** Date range, KB, student, score filters
+
+#### T018: Vietnamese LLM Prompt Variants
+- **Status:** Not Started | **Effort:** 4 hours | **Complexity:** Medium
+- **Issue:** Vietnamese UI works but all LLM responses are still in English
+- **Scope:** Create `deeptutor/agents/*/prompts/vi/` YAML files
+- **Missing:** Vietnamese prompts for solve, question generation, tutoring, research
+- **Risk:** Contest judges may expect Vietnamese responses
+
+---
+
+## High Priority Issues (P4-P10)
+
+#### T019: Marketplace Sorting Options
+- **Effort:** 1.5 hours | **Quick Win**
+- **Missing:** Sort by popularity, recent, rating, objectives
+
+#### T020: Assessment Export to PDF
+- **Effort:** 3 hours | **Medium**
+- **Missing:** Export button in assessment review, PDF generation endpoint
+
+#### T021: Session Replay/Timeline
+- **Effort:** 3 hours | **Medium**
+- **Missing:** Timeline view of tutoring conversation, useful for teacher review
+
+#### T022: Error Boundary Handling  
+- **Effort:** 2 hours | **Important for Stability**
+- **Missing:** React error boundaries for marketplace, assessment pages
+
+#### T023: Marketplace Caching & Pagination Optimization
+- **Effort:** 2 hours | **Performance**
+- **Missing:** Client-side cache, stale-while-revalidate pattern
+
+#### T024: Teacher Team Invitation System
+- **Effort:** 6 hours | **Complex**
+- **Missing:** Team creation, email invitations, shared pack access control
+
+#### T025: Assessment Difficulty Adaptive Adjustment
+- **Effort:** 5 hours | **Advanced**
+- **Missing:** CAT-style difficulty tracking and adjustment
+
+---
+
+## Medium Priority Issues (P11-P20)
+
+#### T026: Mobile-First Responsive Design
+- **Effort:** 1 hour | **Quick Win**
+- **Issue:** Marketplace filters not well-optimized for mobile
+- **Missing:** Responsive filter panel for small screens
+
+#### T027: Teacher Analytics Dashboard
+- **Effort:** 8 hours | **Complex**
+- **Missing:** Comprehensive charts: student engagement, assessment trends, common difficulties
+
+#### T028: API Rate Limiting & Throttling
+- **Effort:** 2 hours | **Security**
+- **Issue:** No protection against API abuse
+- **Missing:** Rate limiter middleware, configure per endpoint
+
+#### T029: Full-Text Search for Marketplace
+- **Effort:** 3 hours | **Performance**
+- **Missing:** Search across pack description, objectives, questions
+
+#### T030: Assessment Time Tracking & Analytics
+- **Effort:** 2 hours | **Easy Add**
+- **Missing:** Track time per question, show time-based insights
+
+#### T031: Smart Tutor Follow-Up Questions
+- **Effort:** 3 hours | **UX**
+- **Missing:** Tutor suggests 1-3 follow-up questions when student answers incorrectly
+
+---
+
+## Lower Priority Issues (P21-P27)
+
+#### T032: Knowledge Pack Versioning System  
+- **Effort:** 4 hours | **Maintenance**
+
+#### T033: Learning Path Sequencing
+- **Effort:** 6 hours | **Advanced**
+
+#### T034: Batch Import Multiple Packs
+- **Effort:** 2 hours | **Quick Add**
+
+#### T035: Offline Mode for Downloaded Packs
+- **Effort:** 6 hours | **Advanced**
+
+---
+
+## Issues by Category
+
+### 1. Incomplete Feature Implementations (5 issues)
+These are features that have UI/API stubs but missing core logic:
+
+| Issue | Status | Hours | Risk |
+|-------|--------|-------|------|
+| T009: Marketplace Import | Placeholder | 4 | **CRITICAL** |
+| T010: Assessment Feedback | Partial | 6 | **HIGH** |
+| T011: KB Context Badges | Not Started | 2 | Medium |
+| T012: Sharing UI | Not Started | 3 | High |
+| T013: Pack Preview | Not Started | 3 | High |
+
+**Action:** Fix T009 before contest submission (currently just shows fake success)
+
+### 2. Missing Backend Services (6 issues)
+New API endpoints and business logic needed:
+
+| Service | Purpose | Hours | Files |
+|---------|---------|-------|-------|
+| Assessment Analytics | Score breakdown by topic | 6 | `deeptutor/api/routers/dashboard.py` |
+| Student Dashboard | Progress tracking API | 5 | `deeptutor/api/routers/dashboard.py` |
+| Recommendation Engine | AI-powered next assessment | 6 | `deeptutor/services/assessment/` |
+| Teacher Analytics | Engagement & trend charts | 8 | `deeptutor/services/analytics/` |
+| Team Management | Invitation & sharing | 6 | `deeptutor/api/routers/teams.py` |
+| Learning Paths | Prerequisite sequencing | 6 | `deeptutor/services/learning_paths.py` |
+
+### 3. UI/UX Issues (7 issues)
+Frontend improvements and polish:
+
+| Issue | Type | Hours | Impact |
+|-------|------|-------|--------|
+| T022: Error Boundaries | Stability | 2 | Prevents blank screens |
+| T026: Mobile Responsive | UX | 1 | Better experience on phones |
+| T017: Filter/Search | UX | 2 | Better dashboard usability |
+| T019: Marketplace Sort | UX | 1.5 | Better pack discovery |
+| T020: Export PDF | Feature | 3 | Teacher needs |
+| T021: Session Replay | Teacher Tool | 3 | Useful for analysis |
+| T031: Follow-Up Questions | Learning | 3 | Better pedagogy |
+
+### 4. i18n Completion (1 issue)
+
+| Issue | Status | Hours | Scope |
+|-------|--------|-------|-------|
+| T018: Vietnamese Prompts | Not Started | 4 | 4-5 agent prompt files |
+
+**Impact:** Without this, Vietnamese students will get English responses from LLM
+
+### 5. Performance & Security (2 issues)
+
+| Issue | Type | Hours | Risk |
+|-------|------|-------|------|
+| T028: Rate Limiting | Security | 2 | **HIGH** - API abuse risk |
+| T023: Caching | Performance | 2 | Better UX on slow networks |
+
+### 6. Advanced Features (6 issues)
+
+| Feature | Hours | Complexity | Value |
+|---------|-------|-----------|-------|
+| T024: Team Sharing | 6 | High | Collaboration |
+| T025: Adaptive Difficulty | 5 | High | Better Learning |
+| T032: Versioning | 4 | Medium | Maintenance |
+| T033: Learning Paths | 6 | High | Smart Learning |
+| T034: Batch Import | 2 | Low | Quick Win |
+| T035: Offline Mode | 6 | High | Mobile Use |
+
+---
+
+## Risk Assessment Matrix
+
+### High Risk - Must Address Before Contest
+
+| Risk | Issue | Impact | Mitigation |
+|------|-------|--------|-----------|
+| Marketplace import is fake | T009 | Demo fails | Implement real import |
+| Assessment feedback incomplete | T010 | Poor learning experience | Add analysis & recommendations |
+| No Vietnamese responses | T018 | Judges expect Vietnamese | Translate LLM prompts |
+| API can be DoS'd | T028 | Service downtime | Add rate limiting |
+| App crashes on errors | T022 | Bad UX | Add error boundaries |
+
+### Medium Risk - Nice to Have Soon
+
+| Risk | Issue | Mitigation |
+|------|-------|-----------|
+| Marketplace slow with many packs | T023, T029 | Implement caching + search |
+| Mobile UI breaks on small screens | T026 | Responsive redesign |
+| No teacher analytics | T027 | Add analytics dashboard |
+
+### Low Risk - Polish Items
+
+| Risk | Issue | Mitigation |
+|------|-------|-----------|
+| Students don't understand KB context | T011 | Add badges |
+| Teachers can't rate packs | T016 | Add rating system |
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Critical Path (Next 2 weeks)
+**Goal:** Fix blockers, get to contest-ready state
+- [ ] T009: Marketplace Import Implementation (4h)
+- [ ] T010: Assessment Feedback with Analysis (6h)
+- [ ] T011: KB Context Badges (2h)
+- [ ] T018: Vietnamese LLM Prompts (4h)
+- [ ] T022: Error Boundaries (2h)
+- [ ] T028: Rate Limiting (2h)
+
+**Total:** ~20 hours | **Target:** 2026-05-04
+
+### Phase 2: High Priority Features (Weeks 3-4)
+- [ ] T012: Sharing UI (3h)
+- [ ] T013: Pack Preview (3h)
+- [ ] T014: Student Dashboard (5h)
+- [ ] T015: Assessment Recommendations (6h)
+- [ ] T016: Pack Ratings (4h)
+- [ ] T017: Dashboard Filters (2h)
+- [ ] T019: Marketplace Sort (1.5h)
+- [ ] T020: PDF Export (3h)
+- [ ] T021: Session Replay (3h)
+- [ ] T023: Caching Optimization (2h)
+
+**Total:** ~32.5 hours | **Target:** 2026-05-18
+
+### Phase 3: Polish & Advanced Features (Weeks 5+)
+- [ ] T024: Team Sharing (6h)
+- [ ] T025: Adaptive Difficulty (5h)
+- [ ] T026: Mobile Responsive (1h)
+- [ ] T027: Teacher Analytics (8h)
+- [ ] T029: Full-Text Search (3h)
+- [ ] T030: Time Tracking (2h)
+- [ ] T031: Follow-Up Questions (3h)
+- [ ] T032: Versioning (4h)
+- [ ] T033: Learning Paths (6h)
+- [ ] T034: Batch Import (2h)
+- [ ] T035: Offline Mode (6h)
+
+**Total:** ~46 hours | **Target:** 2026-06-01
+
+---
+
+## File-Level Gaps
+
+### Frontend Files Needing Work
+
+| File | Issues | Status |
+|------|--------|--------|
+| `web/app/(utility)/marketplace/page.tsx` | T009, T013, T019, T024 | Partially done |
+| `web/components/assessment/ProgressIndicator.tsx` | T010, T030 | Needs enhancement |
+| `web/components/chat/ChatMessageList.tsx` | T011, T031 | Needs badges/follow-ups |
+| `web/app/(workspace)/dashboard/page.tsx` | T014, T017, T027 | Needs student view & analytics |
+| `web/app/(workspace)/knowledge/page.tsx` | T012, T016 | Needs sharing UI |
+
+### Backend Files Needing Work
+
+| File | Issues | Status |
+|------|--------|--------|
+| `deeptutor/api/routers/marketplace.py` | T009, T013, T019, T029 | Partial (list/detail OK) |
+| `deeptutor/api/routers/dashboard.py` | T010, T014, T017, T020, T027 | Minimal implementation |
+| `deeptutor/api/routers/knowledge.py` | T012, T016 | Needs sharing endpoints |
+| `deeptutor/services/assessment/` | T010, T015, T025, T030 | Mostly missing |
+| `deeptutor/agents/*/prompts/vi/` | T018 | Missing entirely |
+
+### Database/Schema Issues
+
+| Issue | Current | Missing |
+|-------|---------|---------|
+| Pack metadata | Basic | `sharing_status`, `ratings_count`, `download_count` |
+| Assessment results | Sessions only | `performance_by_topic`, `time_per_question`, `mistake_patterns` |
+| User data | Minimal | Team membership, preferences |
+
+---
+
+## Next Steps & Action Items
+
+### Immediate (This Week)
+1. **Review & Approve Audit** - Validate all 27 issues with team
+2. **Create GitHub Issues** - Convert JSON registry to GitHub issues
+3. **Assign Priority** - Confirm P1-P3 are top focus
+4. **Estimate Stories** - Break down large tasks into 2-3 day chunks
+
+### This Sprint (Next 2 Weeks)
+1. Start T009 (Marketplace Import) - **BLOCKER**
+2. Parallel: T010, T018, T022 (High impact)
+3. Integrate into AI-first OPERATING_PROMPT.md
+4. Update daily logs with progress
+
+### Success Metrics
+- [ ] T009 complete before contest submission
+- [ ] Phase 1 complete: 6 critical tasks done
+- [ ] Phase 2 started: First high-priority features in progress
+- [ ] All GitHub issues created with acceptance criteria
+- [ ] JSON registry updated daily with progress
+
+---
+
+## Appendix: JSON Task Registry
+
+See: [ai_first/TASK_REGISTRY.json](ai_first/TASK_REGISTRY.json)
+
+The JSON file contains:
+- 35 detailed task objects with IDs, priorities, effort estimates, and file references
+- Dependency graph showing task relationships
+- Risk mitigation strategies
+- Milestone definitions with target dates
+- GitHub issue templates for quick issue creation
+
+---
+
+**Report Generated:** 2026-04-20  
+**Next Review:** 2026-04-27 (weekly)  
+**Prepared By:** GitHub Copilot MVP Audit Agent

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -22,9 +22,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 2,
+      "count": 3,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
+        "T022_ERROR_BOUNDARY_HANDLING",
         "T028_API_RATE_LIMITING"
       ]
     },
@@ -35,7 +36,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 25,
+      "count": 24,
       "tasks": []
     }
   },
@@ -278,8 +279,8 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["React"],
-      "status": "not-started",
-      "notes": "Catch and display user-friendly error messages instead of blank screens"
+      "status": "in-progress",
+      "notes": "Route-level error boundaries added for marketplace and assessment pages. Pending extension to additional high-traffic routes and UX copy parity across locales."
     },
     {
       "id": "T023_MARKETPLACE_CACHE_OPTIMIZATION",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,0 +1,599 @@
+{
+  "metadata": {
+    "last_updated": "2026-04-20T10:00:00Z",
+    "project": "Multiagent Learning Platform - VnExpress Contest MVP",
+    "status": "Active Development",
+    "total_tasks": 35
+  },
+  "task_categories": {
+    "completed": {
+      "description": "Features fully implemented and merged to main",
+      "count": 8,
+      "tasks": [
+        "T001_MARKETPLACE_API_LIST",
+        "T002_MARKETPLACE_API_DETAIL",
+        "T003_MARKETPLACE_UI_BROWSE",
+        "T004_PROGRESS_INDICATOR_COMPONENT",
+        "T005_LEARNING_JOURNEY_COMPONENT",
+        "T006_ASSESSMENT_REVIEW_INTEGRATION",
+        "T007_VIETNAMESE_UI_TRANSLATION",
+        "T008_VIETNAMESE_BACKEND_SUPPORT"
+      ]
+    },
+    "in_progress": {
+      "description": "Features partially implemented, need completion",
+      "count": 0,
+      "tasks": []
+    },
+    "blocked": {
+      "description": "Tasks blocked by dependencies",
+      "count": 0,
+      "tasks": []
+    },
+    "pending": {
+      "description": "Tasks not started, ordered by priority",
+      "count": 27,
+      "tasks": []
+    }
+  },
+  "tasks": [
+    {
+      "id": "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
+      "category": "Critical",
+      "priority": 1,
+      "title": "Implement Marketplace Pack Import",
+      "description": "Replace placeholder import logic with actual pack copying to user workspace. Currently shows success but doesn't import.",
+      "scope": {
+        "frontend": "web/app/(utility)/marketplace/page.tsx - handleImportPack function",
+        "backend": "deeptutor/api/routers/marketplace.py - new endpoint /import/{pack_name}",
+        "api_client": "web/lib/marketplace-api.ts - add importMarketplacePack function"
+      },
+      "affected_features": ["Marketplace Browse & Import"],
+      "complexity": "High",
+      "estimated_hours": 4,
+      "dependencies": ["Knowledge Pack Manager API"],
+      "status": "not-started",
+      "notes": "Need to copy pack metadata, documents, and configuration to user's knowledge_bases directory"
+    },
+    {
+      "id": "T010_ASSESSMENT_FEEDBACK_DETAILS",
+      "category": "Critical",
+      "priority": 2,
+      "title": "Enhance Assessment Feedback with Analysis",
+      "description": "Add detailed analysis breakdown, performance by topic, and learning recommendations in assessment review",
+      "scope": {
+        "frontend": "web/components/assessment/ProgressIndicator.tsx - expand recommendations",
+        "backend": "deeptutor/api/routers/dashboard.py - add assessment analytics endpoint",
+        "database": "Extend assessment_results schema with analysis data"
+      },
+      "affected_features": ["Student Learning Experience", "Assessment Review"],
+      "complexity": "High",
+      "estimated_hours": 6,
+      "dependencies": ["Assessment Generation API"],
+      "status": "not-started",
+      "notes": "Need ML/heuristic analysis of question performance by topic, difficulty, and learning standard"
+    },
+    {
+      "id": "T011_KB_CONTEXT_BADGES",
+      "category": "Critical",
+      "priority": 3,
+      "title": "Add KB Context Badges to Tutoring Session",
+      "description": "Display active knowledge base context during tutoring to help students understand learning sources",
+      "scope": {
+        "frontend": "web/components/chat/ChatComposer.tsx, ChatMessageList.tsx",
+        "display": "Show KB badges near tutor messages or in session header"
+      },
+      "affected_features": ["Student Tutor Workspace"],
+      "complexity": "Medium",
+      "estimated_hours": 2,
+      "dependencies": ["Chat Context System"],
+      "status": "not-started",
+      "notes": "Extract KB context from UnifiedContext and display with visual styling"
+    },
+    {
+      "id": "T012_TEACHER_PACK_SHARING_UI",
+      "category": "High",
+      "priority": 4,
+      "title": "Teacher Knowledge Pack Sharing UI",
+      "description": "Add UI for teachers to mark packs as public/team/private and configure sharing settings",
+      "scope": {
+        "frontend": "web/app/(workspace)/knowledge - add sharing settings panel",
+        "backend": "deeptutor/api/routers/knowledge.py - extend update endpoint with sharing_status"
+      },
+      "affected_features": ["Knowledge Pack Management"],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": ["Knowledge Manager API"],
+      "status": "not-started",
+      "notes": "Update metadata sharing_status, owner, and access control rules"
+    },
+    {
+      "id": "T013_MARKETPLACE_PACK_PREVIEW",
+      "category": "High",
+      "priority": 5,
+      "title": "Marketplace Pack Preview Modal",
+      "description": "Show detailed preview of pack contents before import: documents, assessment samples, learning objectives",
+      "scope": {
+        "frontend": "web/app/(utility)/marketplace/page.tsx - add modal component",
+        "api": "GET /api/v1/marketplace/{pack_name}/preview"
+      },
+      "affected_features": ["Marketplace Browse"],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": ["Marketplace API"],
+      "status": "not-started",
+      "notes": "Show first 3 questions, objectives, document count, and metadata preview"
+    },
+    {
+      "id": "T014_STUDENT_PROGRESS_DASHBOARD",
+      "category": "High",
+      "priority": 6,
+      "title": "Student Progress Tracking Dashboard",
+      "description": "Add student-view dashboard showing progress across all assessments, trending topics, and mastery levels",
+      "scope": {
+        "frontend": "web/app/(workspace)/dashboard/student - new page",
+        "backend": "deeptutor/api/routers/dashboard.py - GET /student-progress endpoint"
+      },
+      "affected_features": ["Student Dashboard"],
+      "complexity": "High",
+      "estimated_hours": 5,
+      "dependencies": ["Assessment Analytics"],
+      "status": "not-started",
+      "notes": "Show progress over time, topic mastery chart, recent assessments, learning streak"
+    },
+    {
+      "id": "T015_ASSESSMENT_RECOMMENDATIONS",
+      "category": "High",
+      "priority": 7,
+      "title": "AI-Powered Assessment Recommendations",
+      "description": "Generate personalized next assessment recommendations based on student performance and learning gaps",
+      "scope": {
+        "backend": "deeptutor/services/assessment - new recommendation service",
+        "api": "POST /api/v1/assessment/recommend"
+      },
+      "affected_features": ["Student Learning Experience"],
+      "complexity": "High",
+      "estimated_hours": 6,
+      "dependencies": ["LLM Service", "Assessment Analytics"],
+      "status": "not-started",
+      "notes": "Analyze performance data and suggest next topics to study or practice"
+    },
+    {
+      "id": "T016_MARKETPLACE_RATINGS",
+      "category": "Medium",
+      "priority": 8,
+      "title": "Add Pack Ratings & Reviews System",
+      "description": "Allow teachers/students to rate and review knowledge packs in marketplace",
+      "scope": {
+        "frontend": "web/app/(utility)/marketplace - add rating UI",
+        "backend": "deeptutor/api/routers/marketplace.py - new endpoints for ratings",
+        "database": "Add marketplace_ratings table"
+      },
+      "affected_features": ["Marketplace"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["Database Schema"],
+      "status": "not-started",
+      "notes": "5-star rating system with optional comments, show average rating in pack cards"
+    },
+    {
+      "id": "T017_ASSESSMENT_HISTORY_FILTERING",
+      "category": "Medium",
+      "priority": 9,
+      "title": "Assessment History Filtering & Search",
+      "description": "Add filters and search to teacher dashboard assessment history by date, KB, student, score range",
+      "scope": {
+        "frontend": "web/app/(workspace)/dashboard - add filter panel",
+        "api": "GET /api/v1/dashboard/sessions with query filters"
+      },
+      "affected_features": ["Teacher Dashboard"],
+      "complexity": "Low",
+      "estimated_hours": 2,
+      "dependencies": ["Dashboard API"],
+      "status": "not-started",
+      "notes": "Reuse existing session query parameters, add UI for common filters"
+    },
+    {
+      "id": "T018_VIETNAMESE_PROMPT_VARIANTS",
+      "category": "High",
+      "priority": 10,
+      "title": "Vietnamese LLM Prompt Variants",
+      "description": "Add Vietnamese language variants for all LLM prompts in agents (solve, question, research, co_writer)",
+      "scope": {
+        "backend": "deeptutor/agents/*/prompts/vi/ - create Vietnamese YAML files",
+        "system": "deeptutor/services/prompt/manager.py - already supports vi fallback chain"
+      },
+      "affected_features": ["Vietnamese i18n", "All AI Agents"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["i18n System"],
+      "status": "not-started",
+      "notes": "Translate prompt templates for solve, question generation, research, co-writing agents"
+    },
+    {
+      "id": "T019_MARKETPLACE_SORTING",
+      "category": "Medium",
+      "priority": 11,
+      "title": "Add Marketplace Pack Sorting Options",
+      "description": "Add sort options: popularity (downloads), recent, rating, most_objectives",
+      "scope": {
+        "frontend": "web/app/(utility)/marketplace - add sort dropdown",
+        "api": "GET /api/v1/marketplace/list - add sort_by parameter"
+      },
+      "affected_features": ["Marketplace Browse"],
+      "complexity": "Low",
+      "estimated_hours": 1.5,
+      "dependencies": ["Marketplace API"],
+      "status": "not-started",
+      "notes": "Implement server-side sorting, maintain download_count and rating metadata"
+    },
+    {
+      "id": "T020_ASSESSMENT_EXPORT_PDF",
+      "category": "Medium",
+      "priority": 12,
+      "title": "Assessment Results Export to PDF",
+      "description": "Allow students/teachers to export assessment results and feedback as PDF report",
+      "scope": {
+        "frontend": "web/app/(workspace)/dashboard/assessments - add Export PDF button",
+        "backend": "deeptutor/api/routers/dashboard.py - new endpoint /sessions/{id}/export-pdf"
+      },
+      "affected_features": ["Assessment Review"],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": ["PDF Generation Library"],
+      "status": "not-started",
+      "notes": "Include score, questions, explanations, and recommendations in PDF"
+    },
+    {
+      "id": "T021_SESSION_REPLAY",
+      "category": "Medium",
+      "priority": 13,
+      "title": "Tutoring Session Replay Feature",
+      "description": "Show timeline/replay of chat conversation in session review, useful for teacher analysis",
+      "scope": {
+        "frontend": "web/app/(workspace)/dashboard - session replay component",
+        "display": "Timeline view of user messages and tutor responses with timestamps"
+      },
+      "affected_features": ["Teacher Dashboard"],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": ["Session Storage"],
+      "status": "not-started",
+      "notes": "Reconstruct conversation flow, show KB context at each turn"
+    },
+    {
+      "id": "T022_ERROR_BOUNDARY_HANDLING",
+      "category": "High",
+      "priority": 14,
+      "title": "Improve Error Boundaries & Recovery",
+      "description": "Add React error boundaries to marketplace and assessment components with graceful fallbacks",
+      "scope": {
+        "frontend": "web/components/ErrorBoundary.tsx - extend",
+        "pages": "marketplace, assessment review, dashboard"
+      },
+      "affected_features": ["App Stability"],
+      "complexity": "Low",
+      "estimated_hours": 2,
+      "dependencies": ["React"],
+      "status": "not-started",
+      "notes": "Catch and display user-friendly error messages instead of blank screens"
+    },
+    {
+      "id": "T023_MARKETPLACE_CACHE_OPTIMIZATION",
+      "category": "Medium",
+      "priority": 15,
+      "title": "Marketplace List Caching & Pagination Optimization",
+      "description": "Implement client-side caching and lazy loading for marketplace packs to improve UX",
+      "scope": {
+        "frontend": "web/lib/marketplace-api.ts - add caching layer",
+        "hooks": "useMarketplacePacks custom hook with stale-while-revalidate"
+      },
+      "affected_features": ["Marketplace Performance"],
+      "complexity": "Low",
+      "estimated_hours": 2,
+      "dependencies": ["SWR or React Query"],
+      "status": "not-started",
+      "notes": "Cache pack list for 5 minutes, refresh on user action"
+    },
+    {
+      "id": "T024_TEACHER_INVITATION_SYSTEM",
+      "category": "Medium",
+      "priority": 16,
+      "title": "Teacher Team Invitation & Sharing",
+      "description": "Allow teachers to invite colleagues and create team knowledge pack sharing groups",
+      "scope": {
+        "backend": "deeptutor/api/routers - new /teams endpoint",
+        "frontend": "web/app/(workspace) - team management UI"
+      },
+      "affected_features": ["Knowledge Pack Sharing", "Collaboration"],
+      "complexity": "High",
+      "estimated_hours": 6,
+      "dependencies": ["User Management", "Access Control"],
+      "status": "not-started",
+      "notes": "Implement team creation, invitations via email/link, access control"
+    },
+    {
+      "id": "T025_ASSESSMENT_DIFFICULTY_ADJUSTMENT",
+      "category": "Medium",
+      "priority": 17,
+      "title": "Assessment Difficulty Adaptive Adjustment",
+      "description": "Adjust question difficulty based on student performance during assessment",
+      "scope": {
+        "backend": "deeptutor/agents/question - add difficulty tracking",
+        "api": "Store difficulty ratings and adjust next question"
+      },
+      "affected_features": ["Question Generation"],
+      "complexity": "High",
+      "estimated_hours": 5,
+      "dependencies": ["Question Analytics"],
+      "status": "not-started",
+      "notes": "Implement CAT-style difficulty adjustment, track performance per difficulty level"
+    },
+    {
+      "id": "T026_MOBILE_RESPONSIVE_MARKETPLACE",
+      "category": "Low",
+      "priority": 18,
+      "title": "Mobile-First Marketplace Responsive Design",
+      "description": "Optimize marketplace pack cards and filters for mobile/tablet viewports",
+      "scope": {
+        "frontend": "web/app/(utility)/marketplace - responsive Tailwind adjustments"
+      },
+      "affected_features": ["Marketplace UX"],
+      "complexity": "Low",
+      "estimated_hours": 1,
+      "dependencies": ["Tailwind CSS"],
+      "status": "not-started",
+      "notes": "Test on phone/tablet, fix filter layout, ensure pagination works on small screens"
+    },
+    {
+      "id": "T027_ANALYTICS_DASHBOARD",
+      "category": "Medium",
+      "priority": 19,
+      "title": "Teacher Analytics Dashboard",
+      "description": "Add comprehensive analytics for teachers: student engagement, assessment trends, common difficulties",
+      "scope": {
+        "frontend": "web/app/(workspace)/dashboard - analytics tab",
+        "backend": "deeptutor/api/routers/dashboard.py - analytics endpoints"
+      },
+      "affected_features": ["Teacher Dashboard"],
+      "complexity": "High",
+      "estimated_hours": 8,
+      "dependencies": ["Analytics Service"],
+      "status": "not-started",
+      "notes": "Charts: student participation over time, question difficulty heatmap, performance distribution"
+    },
+    {
+      "id": "T028_API_RATE_LIMITING",
+      "category": "High",
+      "priority": 20,
+      "title": "API Rate Limiting & Throttling",
+      "description": "Implement rate limiting for marketplace and assessment endpoints to prevent abuse",
+      "scope": {
+        "backend": "deeptutor/api/main.py - add rate limit middleware",
+        "config": "Configure limits per endpoint"
+      },
+      "affected_features": ["API Security"],
+      "complexity": "Medium",
+      "estimated_hours": 2,
+      "dependencies": ["FastAPI Middleware"],
+      "status": "not-started",
+      "notes": "Use sliding window or token bucket algorithm, return 429 Too Many Requests"
+    },
+    {
+      "id": "T029_MARKETPLACE_SEARCH_FULLTEXT",
+      "category": "Medium",
+      "priority": 21,
+      "title": "Full-Text Search for Marketplace Packs",
+      "description": "Implement full-text search across pack name, description, objectives, and content",
+      "scope": {
+        "backend": "deeptutor/api/routers/marketplace.py - full-text search logic",
+        "database": "Add full-text search index if using database"
+      },
+      "affected_features": ["Marketplace Browse"],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": ["Search Service"],
+      "status": "not-started",
+      "notes": "Search in pack metadata and first 3 questions/objectives, case-insensitive match"
+    },
+    {
+      "id": "T030_ASSESSMENT_TIME_TRACKING",
+      "category": "Medium",
+      "priority": 22,
+      "title": "Assessment Time Tracking & Analytics",
+      "description": "Track time spent per question and show time-based analytics in results",
+      "scope": {
+        "backend": "deeptutor/api/routers/question - track time per question",
+        "storage": "Store question_duration in assessment_results"
+      },
+      "affected_features": ["Assessment Review"],
+      "complexity": "Low",
+      "estimated_hours": 2,
+      "dependencies": ["Assessment Schema"],
+      "status": "not-started",
+      "notes": "Display average time per question, identify rush vs. careful answering patterns"
+    },
+    {
+      "id": "T031_TUTOR_FOLLOW_UP_PROMPTS",
+      "category": "Medium",
+      "priority": 23,
+      "title": "Smart Tutor Follow-Up Questions",
+      "description": "Tutor suggests follow-up questions based on student's answer quality to deepen understanding",
+      "scope": {
+        "backend": "deeptutor/agents/tutorbot - add follow-up generation",
+        "api": "Extend tutor response with suggested questions"
+      },
+      "affected_features": ["Student Tutoring"],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": ["LLM Service", "Tutor Agent"],
+      "status": "not-started",
+      "notes": "Generate 1-3 follow-up questions when student answer indicates misunderstanding"
+    },
+    {
+      "id": "T032_KNOWLEDGE_PACK_VERSIONING",
+      "category": "Low",
+      "priority": 24,
+      "title": "Knowledge Pack Versioning System",
+      "description": "Support multiple versions of knowledge packs with change tracking",
+      "scope": {
+        "backend": "deeptutor/knowledge - add versioning support",
+        "database": "Track version history and changelog"
+      },
+      "affected_features": ["Knowledge Pack Management"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["Database Schema"],
+      "status": "not-started",
+      "notes": "Allow teachers to update packs while preserving old versions for existing assessments"
+    },
+    {
+      "id": "T033_LEARNING_PATH_SEQUENCING",
+      "category": "Low",
+      "priority": 25,
+      "title": "Suggested Learning Path Sequencing",
+      "description": "Generate recommended sequence of topics based on prerequisites and learning objectives",
+      "scope": {
+        "backend": "deeptutor/services - new learning_path service",
+        "api": "GET /api/v1/learning-paths/{pack_id}"
+      },
+      "affected_features": ["Student Learning Experience"],
+      "complexity": "High",
+      "estimated_hours": 6,
+      "dependencies": ["Knowledge Graph", "Prerequisite Metadata"],
+      "status": "not-started",
+      "notes": "Extract prerequisites from pack metadata, generate optimal learning sequence"
+    },
+    {
+      "id": "T034_BATCH_ASSESSMENT_IMPORT",
+      "category": "Low",
+      "priority": 26,
+      "title": "Batch Import Multiple Packs",
+      "description": "Allow teachers to select and import multiple packs at once",
+      "scope": {
+        "frontend": "web/app/(utility)/marketplace - add multi-select mode",
+        "api": "POST /api/v1/marketplace/import-batch"
+      },
+      "affected_features": ["Marketplace"],
+      "complexity": "Low",
+      "estimated_hours": 2,
+      "dependencies": ["Import Implementation"],
+      "status": "not-started",
+      "notes": "Add checkbox to pack cards, show selected count, batch import button"
+    },
+    {
+      "id": "T035_OFFLINE_MODE_SUPPORT",
+      "category": "Low",
+      "priority": 27,
+      "title": "Offline Mode for Downloaded Packs",
+      "description": "Cache downloaded packs and enable offline assessment taking",
+      "scope": {
+        "frontend": "Service Worker for offline caching",
+        "storage": "Local IndexedDB for pack content"
+      },
+      "affected_features": ["Marketplace", "Assessment"],
+      "complexity": "High",
+      "estimated_hours": 6,
+      "dependencies": ["Service Worker", "IndexedDB"],
+      "status": "not-started",
+      "notes": "Sync when online, allow working offline for imported packs"
+    }
+  ],
+  "github_issues_template": {
+    "marketplace_import": {
+      "title": "[MVP] Implement Marketplace Pack Import Functionality",
+      "body": "**Priority:** Critical (P1)\\n\\n**Description:**\\nReplace placeholder import logic in Marketplace page. Currently shows success message but doesn't actually copy pack to user workspace.\\n\\n**Acceptance Criteria:**\\n- [ ] Import button triggers actual pack copying\\n- [ ] Pack metadata, documents, and config copied to knowledge_bases\\n- [ ] Success/error feedback shown to user\\n- [ ] Imported pack appears in user's Knowledge Pack list\\n\\n**Implementation:**\\n- Backend: Add POST /api/v1/marketplace/import/{pack_name} endpoint\\n- Frontend: Update handleImportPack function\\n- API Client: Add importMarketplacePack function",
+      "labels": ["marketplace", "mvp", "critical", "backend", "frontend"],
+      "assignee": "auto",
+      "milestone": "MVP Feature Pack 3 Extended"
+    },
+    "assessment_feedback": {
+      "title": "[MVP] Enhance Assessment Review with Detailed Feedback",
+      "body": "**Priority:** Critical (P2)\\n\\n**Description:**\\nAdd detailed analysis breakdown, topic-based performance, and personalized learning recommendations to assessment review page.\\n\\n**Acceptance Criteria:**\\n- [ ] Show performance breakdown by topic\\n- [ ] Display learning recommendations based on incorrect answers\\n- [ ] Add topic mastery visualization\\n- [ ] Suggest next learning steps\\n\\n**Implementation:**\\n- Backend: Create /api/v1/dashboard/assessment-analysis endpoint\\n- Frontend: Extend ProgressIndicator component with analysis section",
+      "labels": ["assessment", "mvp", "critical", "backend", "frontend"],
+      "assignee": "auto",
+      "milestone": "MVP Feature Pack 3 Extended"
+    },
+    "kb_context_badges": {
+      "title": "[MVP] Add KB Context Display in Tutoring Session",
+      "body": "**Priority:** High (P3)\\n\\n**Description:**\\nDisplay active knowledge base context badges in student tutoring session to show learning sources.\\n\\n**Acceptance Criteria:**\\n- [ ] KB badges shown in chat interface\\n- [ ] Clear indication of which pack question comes from\\n- [ ] Consistent styling with rest of UI\\n\\n**Implementation:**\\n- Extract KB context from UnifiedContext\\n- Add visual badges to ChatMessageList",
+      "labels": ["ux", "mvp", "frontend"],
+      "assignee": "auto",
+      "milestone": "MVP Feature Pack 3 Extended"
+    },
+    "vietnamese_prompts": {
+      "title": "[MVP] Add Vietnamese Language Prompts",
+      "body": "**Priority:** High (P10)\\n\\n**Description:**\\nCreate Vietnamese language variants for all LLM prompts to complete i18n support.\\n\\n**Acceptance Criteria:**\\n- [ ] Vietnamese prompts for solve agent\\n- [ ] Vietnamese prompts for question generation\\n- [ ] Vietnamese prompts for tutoring\\n- [ ] Fallback chain works (vi -> en)\\n\\n**Implementation:**\\n- Create deeptutor/agents/*/prompts/vi/ directories\\n- Translate prompt YAML files",
+      "labels": ["i18n", "mvp", "backend"],
+      "assignee": "auto",
+      "milestone": "MVP Feature Pack 3 Extended"
+    }
+  },
+  "risk_mitigation": {
+    "performance_risks": [
+      {
+        "risk": "Marketplace queries become slow with many packs",
+        "mitigation": "Implement database indexing on sharing_status, subject, owner; add pagination",
+        "related_task": "T019, T023"
+      },
+      {
+        "risk": "Large pack imports cause UI freeze",
+        "mitigation": "Implement background import worker with progress notification",
+        "related_task": "T009"
+      }
+    ],
+    "ux_risks": [
+      {
+        "risk": "Users don't understand KB context in tutoring",
+        "mitigation": "Add T011 KB context badges and help tooltip",
+        "related_task": "T011"
+      },
+      {
+        "risk": "Marketplace filters overwhelming on mobile",
+        "mitigation": "Implement collapsible filter panel for mobile, T026",
+        "related_task": "T026"
+      }
+    ],
+    "technical_risks": [
+      {
+        "risk": "API rate limiting not implemented, abuse possible",
+        "mitigation": "Implement T028 rate limiting immediately after initial MVP",
+        "related_task": "T028"
+      },
+      {
+        "risk": "Error handling gaps cause blank pages",
+        "mitigation": "Add error boundaries and user-friendly error messages, T022",
+        "related_task": "T022"
+      }
+    ]
+  },
+  "dependency_graph": {
+    "T009": ["Knowledge Manager API exists"],
+    "T010": ["Assessment Generation API", "Question Analytics"],
+    "T011": ["Chat Context System"],
+    "T012": ["Knowledge Manager API"],
+    "T013": ["Marketplace API", "T009"],
+    "T015": ["T010", "LLM Service"],
+    "T024": ["User Management", "Access Control"],
+    "T027": ["Analytics Service"],
+    "T033": ["Knowledge Graph", "Prerequisite Metadata"],
+    "T035": ["T009 (batch import)", "Service Worker"]
+  },
+  "milestones": {
+    "MVP_PHASE_1": {
+      "title": "Critical Path Tasks (Next 2 weeks)",
+      "tasks": ["T009", "T010", "T011", "T012", "T018", "T022"],
+      "target_date": "2026-05-04"
+    },
+    "MVP_PHASE_2": {
+      "title": "High Priority Features (Weeks 3-4)",
+      "tasks": ["T013", "T014", "T015", "T016", "T017", "T019", "T020", "T021", "T023", "T028"],
+      "target_date": "2026-05-18"
+    },
+    "MVP_PHASE_3": {
+      "title": "Medium Priority & Polish (Weeks 5+)",
+      "tasks": ["T024", "T025", "T026", "T027", "T029", "T030", "T031", "T032", "T033", "T034", "T035"],
+      "target_date": "2026-06-01"
+    }
+  }
+}

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -22,9 +22,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 1,
+      "count": 2,
       "tasks": [
-        "T009_MARKETPLACE_IMPORT_IMPLEMENTATION"
+        "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
+        "T028_API_RATE_LIMITING"
       ]
     },
     "blocked": {
@@ -34,7 +35,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 26,
+      "count": 25,
       "tasks": []
     }
   },
@@ -378,8 +379,8 @@
       "complexity": "Medium",
       "estimated_hours": 2,
       "dependencies": ["FastAPI Middleware"],
-      "status": "not-started",
-      "notes": "Use sliding window or token bucket algorithm, return 429 Too Many Requests"
+      "status": "in-progress",
+      "notes": "In-memory sliding-window middleware added in deeptutor/api/main.py with per-prefix route limits and 429 responses including Retry-After header. Pending production load tuning and persistence strategy."
     },
     {
       "id": "T029_MARKETPLACE_SEARCH_FULLTEXT",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -22,10 +22,11 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 4,
+      "count": 5,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
+        "T011_KB_CONTEXT_BADGES",
         "T022_ERROR_BOUNDARY_HANDLING",
         "T028_API_RATE_LIMITING"
       ]
@@ -37,7 +38,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 23,
+      "count": 22,
       "tasks": []
     }
   },
@@ -92,8 +93,8 @@
       "complexity": "Medium",
       "estimated_hours": 2,
       "dependencies": ["Chat Context System"],
-      "status": "not-started",
-      "notes": "Extract KB context from UnifiedContext and display with visual styling"
+      "status": "in-progress",
+      "notes": "KB context badges added to chat message rendering based on request snapshot knowledgeBases for both user prompts and paired assistant responses. Pending UX review in runtime session."
     },
     {
       "id": "T012_TEACHER_PACK_SHARING_UI",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -22,8 +22,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "T009_MARKETPLACE_IMPORT_IMPLEMENTATION"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -32,7 +34,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 27,
+      "count": 26,
       "tasks": []
     }
   },
@@ -52,8 +54,8 @@
       "complexity": "High",
       "estimated_hours": 4,
       "dependencies": ["Knowledge Pack Manager API"],
-      "status": "not-started",
-      "notes": "Need to copy pack metadata, documents, and configuration to user's knowledge_bases directory"
+      "status": "in-progress",
+      "notes": "Backend import endpoint and frontend API wiring are implemented; copy flow now creates imported KB clone and registers it in kb_config. Pending full integration verification in environment with pytest installed."
     },
     {
       "id": "T010_ASSESSMENT_FEEDBACK_DETAILS",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -22,9 +22,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 3,
+      "count": 4,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
+        "T010_ASSESSMENT_FEEDBACK_DETAILS",
         "T022_ERROR_BOUNDARY_HANDLING",
         "T028_API_RATE_LIMITING"
       ]
@@ -36,7 +37,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 24,
+      "count": 23,
       "tasks": []
     }
   },
@@ -74,8 +75,8 @@
       "complexity": "High",
       "estimated_hours": 6,
       "dependencies": ["Assessment Generation API"],
-      "status": "not-started",
-      "notes": "Need ML/heuristic analysis of question performance by topic, difficulty, and learning standard"
+      "status": "in-progress",
+      "notes": "Implemented dashboard assessment-analysis endpoint with heuristic topic breakdown and recommendations, wired into assessment review UI and added API test coverage. Pending runtime validation in env with pytest installed."
     },
     {
       "id": "T011_KB_CONTEXT_BADGES",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -41,6 +41,8 @@ flowchart TD
   Marketplace --> MarketplaceAPI["/api/v1/marketplace"]
   Marketplace --> MarketplaceUI["/marketplace"]
   Marketplace --> MarketplaceFilters["Search/Subject/Owner Filters"]
+  Marketplace --> MarketplaceImport["POST /api/v1/marketplace/import/{pack_name}"]
+  MarketplaceImport --> ImportedClone["Imported KB clone: <pack>__imported"]
   
   Product --> AssessmentBuilder["Assessment Builder"]
   AssessmentBuilder --> QuizGrounding["Knowledge Pack Grounded Quiz Config"]
@@ -55,8 +57,10 @@ flowchart TD
   AssessmentReview --> ReviewAPI["/api/v1/sessions/{session_id}/assessment-review"]
   AssessmentReview --> ProgressIndicator["ProgressIndicator Component"]
   AssessmentReview --> LearningJourney["LearningJourneySummary Component"]
+  AssessmentReview --> AssessErrorBoundary["Route Error Boundary: /dashboard/assessments/error.tsx"]
   ProgressIndicator --> ScoreViz["Score Progress Bar + Recommendations"]
   LearningJourney --> TopicBadges["Mastered/Recommended Topics"]
+  Marketplace --> MarketErrorBoundary["Route Error Boundary: /marketplace/error.tsx"]
 
   Project --> Localization["Internationalization (i18n)"]
   Localization --> UITranslations["UI Translations"]
@@ -97,6 +101,8 @@ flowchart TD
   PRs --> PRNotes["docs/superpowers/pr-notes"]
   PRs --> CI
   PRs --> Reviews
+  API --> APISecurity["API Security Middleware"]
+  APISecurity --> RateLimit["Rate limiting + 429 Retry-After"]
   MergeGates --> PRs
   MergeGates --> CI
   MergeGates --> Reviews

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -49,6 +49,8 @@ flowchart TD
   
   Product --> StudentTutor["Student Tutor Workspace"]
   StudentTutor --> TutorKBContext["Knowledge Pack Tutoring Context"]
+  StudentTutor --> TutorKBBadges["KB Context Badges in Chat Messages"]
+  TutorKBBadges --> SnapshotKBs["Message requestSnapshot.knowledgeBases"]
   
   Product --> TeacherDashboard["Teacher Dashboard"]
   TeacherDashboard --> DashboardSummary["Session Activity Summary"]

--- a/ai_first/daily/2026-04-20-MVP-AUDIT.md
+++ b/ai_first/daily/2026-04-20-MVP-AUDIT.md
@@ -1,0 +1,238 @@
+# Daily Log — 2026-04-20
+
+**Date:** 2026-04-20  
+**Focus:** MVP Gap Analysis & Task Tracking System  
+**Status:** Complete
+
+---
+
+## Checkpoint: MVP Audit & Issue Identification
+
+### Work Completed
+
+#### 1. Comprehensive MVP Gap Analysis
+- **File**: `ai_first/MVP_GAP_ANALYSIS.md`
+- **Scope**: Systematic audit of Knowledge Marketplace, Student Learning Experience, and Vietnamese i18n implementation
+- **Findings**: 27 actionable issues identified
+  - 8 completed and merged ✓
+  - 0 in-progress
+  - 19 pending (4 critical blockers, 6 high priority)
+- **Categories**: 
+  - 5 incomplete feature implementations
+  - 6 missing backend services
+  - 7 UI/UX improvements
+  - 1 i18n completion
+  - 2 security/performance issues
+  - 6 advanced features
+
+#### 2. JSON Task Registry System
+- **File**: `ai_first/TASK_REGISTRY.json`
+- **Structure**: 35 task objects with metadata
+  - Priority levels (P1-P27)
+  - Effort estimates (hours)
+  - File scopes and ownership
+  - Dependency graphs
+  - Risk mitigation strategies
+  - Milestone definitions (Phase 1-3)
+  - GitHub issue templates for quick creation
+- **Schema**: Includes task_categories (completed, in-progress, blocked, pending), individual task objects, and integration guidance
+
+#### 3. AI-First Operating Prompt Enhancement
+- **File**: `ai_first/AI_OPERATING_PROMPT.md`
+- **Addition**: New "Task Tracking System" section (50+ lines)
+  - Explains task workflow and priority levels
+  - Documents MVP gap analysis to execution flow
+  - AI worker quick start guide
+  - Critical P1 tasks summary table
+  - Integration with existing rules
+- **Purpose**: Makes task registry discoverable and actionable for AI workers
+
+#### 4. Updated Execution Queue
+- **File**: `ai_first/EXECUTION_QUEUE.md`
+- **Updates**: 
+  - Added 2026-04-20 status update section
+  - Documented critical blockers (T009, T010, T018, T028)
+  - Created Phase 1 execution table with 6 tasks
+  - Added resource links to task registry and gap analysis
+  - Updated expected next branch: `pod-a/marketplace-pack-import`
+
+### Key Findings: Critical Blockers (Must Fix Before Contest)
+
+#### 1. T009: Marketplace Import is Placeholder
+- **Issue**: Import button shows fake success, doesn't actually copy pack
+- **Location**: `web/app/(utility)/marketplace/page.tsx:60-75`
+- **Impact**: Marketplace feature doesn't work for contest demo
+- **Fix Time**: 4 hours
+- **Priority**: P1 CRITICAL
+
+**Code Evidence**:
+```tsx
+const handleImportPack = async (packName: string) => {
+  setImporting(packName);
+  try {
+    // Placeholder: In a real scenario, this would copy the pack to the user's workspace
+    // For now, we just show a success message
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setImportSuccess(packName);
+    setTimeout(() => setImportSuccess(null), 3000);
+```
+
+#### 2. T010: Assessment Feedback Incomplete
+- **Issue**: Assessment review shows score but lacks topic breakdown and recommendations
+- **Missing Components**:
+  - Topic-level performance analysis
+  - Mistake pattern identification
+  - Score-based learning path suggestions
+  - Visualization (charts/heatmaps)
+- **Priority**: P2 CRITICAL
+
+#### 3. T018: Vietnamese Prompts Missing
+- **Issue**: UI translated to Vietnamese but LLM responses still English
+- **Missing Files**: `deeptutor/agents/*/prompts/vi/` (not created)
+- **Impact**: Vietnamese students get English responses despite setting language
+- **Priority**: P3 CRITICAL
+
+#### 4. T028: API Rate Limiting Missing
+- **Issue**: API endpoints unprotected against DoS/abuse
+- **Missing**: FastAPI middleware for rate limiting
+- **Priority**: P4 CRITICAL (Security)
+
+### Risk Assessment
+
+| Risk | Severity | Mitigation | Task |
+|------|----------|-----------|------|
+| Marketplace import fake | CRITICAL | Implement real import | T009 |
+| Assessment lacks analysis | HIGH | Add feedback service | T010 |
+| Vietnamese=English responses | HIGH | Translate LLM prompts | T018 |
+| API unprotected | HIGH | Add rate limiter | T028 |
+| App crashes on errors | MEDIUM | Error boundaries | T022 |
+| Mobile UX broken | LOW | Responsive fixes | T026 |
+
+### Completed Phase 1 Assessment
+
+**MVP Feature Pack 3 Status** (from previous work):
+- ✅ Knowledge Pack Marketplace API (list, detail endpoints)
+- ✅ Marketplace UI (browse, filter, pagination)
+- ✅ Student Learning Experience (ProgressIndicator, LearningJourneySummary components)
+- ✅ Assessment Review integration
+- ✅ Vietnamese UI Translation (176 lines of Vietnamese text)
+- ✅ Vietnamese Backend Support (language detection, fallback chains)
+
+**BUT**: Import button is non-functional, feedback is minimal, LLM prompts not translated
+
+### Testing & Verification
+
+**Semantic Search**: Conducted `grep` searches for "placeholder", "TODO", "FIXME", "stub" in marketplace and assessment components
+- Found: Input placeholders (normal), `handleImportPack` placeholder (PROBLEM)
+- No other major blockers in code
+
+**File Review Checklist**:
+- ✅ Verified marketplace import function content
+- ✅ Checked assessment components structure
+- ✅ Confirmed i18n files present but prompts missing
+- ✅ Validated JSON schema consistency
+
+### Next Actions
+
+#### Immediate (This Week)
+1. **Create GitHub Issues** from `TASK_REGISTRY.json` github_issues_template (P1 tasks)
+2. **Start Feature Pod** for T009 Marketplace Import Implementation
+   - Branch: `pod-a/marketplace-pack-import`
+   - Task packet: Create in `docs/superpowers/tasks/2026-04-20-T009-marketplace-import.md`
+   - Estimate: 4 hours
+3. **Parallel Work**:
+   - T018: Create Vietnamese prompts (4h, can start independently)
+   - T022: Add error boundaries (2h, independent)
+   - T028: Implement rate limiting (2h, independent)
+
+#### This Sprint (Next 2 Weeks - Phase 1)
+- [ ] T009: Marketplace Import (4h) - **BLOCKING**
+- [ ] T010: Assessment Feedback Analysis (6h)
+- [ ] T018: Vietnamese LLM Prompts (4h)
+- [ ] T022: Error Boundaries (2h)
+- [ ] T028: Rate Limiting (2h)
+- **Total**: ~20 hours to unblock MVP
+
+#### Sprint 2 (Weeks 3-4 - Phase 2)
+- High-priority features: T012-T023 (32.5 hours)
+- Polish and UX improvements
+
+#### Sprint 3+ (Weeks 5+ - Phase 3)
+- Advanced features: T024-T035 (46 hours)
+
+### Documentation Generated
+
+1. **`ai_first/MVP_GAP_ANALYSIS.md`** (350+ lines)
+   - Executive summary of all 27 issues
+   - Detailed descriptions of each task (ID, priority, hours, scope, risks)
+   - Category breakdown (incomplete features, missing services, UI/UX, i18n, security, advanced)
+   - File-level gaps matrix
+   - Risk assessment matrix
+   - Implementation roadmap (3 phases)
+   - Appendix linking to JSON registry
+
+2. **`ai_first/TASK_REGISTRY.json`** (400+ lines, structured)
+   - 35 task objects with full metadata
+   - Task categories (completed, in-progress, blocked, pending)
+   - Dependency graph (task relationships)
+   - Risk mitigation strategies
+   - 3-phase milestone definitions with target dates
+   - GitHub issue templates for batch creation
+
+3. **`ai_first/AI_OPERATING_PROMPT.md`** (enhanced +50 lines)
+   - New Task Tracking System section
+   - Workflow explanation (discovery → selection → planning → execution → tracking)
+   - AI worker quick start guide
+   - Critical P1 tasks table
+   - Integration points with existing rules
+
+4. **`ai_first/EXECUTION_QUEUE.md`** (updated with MVP audit)
+   - Status update for 2026-04-20
+   - Critical blockers list
+   - Phase 1 execution table
+   - Links to detailed resources
+
+### Validation Steps Completed
+
+- ✅ Read marketplace page code to identify fake import
+- ✅ Confirmed ProgressIndicator has limited recommendations
+- ✅ Verified Vietnamese prompts directory doesn't exist
+- ✅ Checked git status (clean on main, ready for feature branches)
+- ✅ JSON schema validated (consistent structure across 35 tasks)
+- ✅ Markdown links verified (all files exist in workspace)
+
+### Key Insights
+
+1. **MVP is 70% complete**: Core features work, but critical features are placeholders
+2. **Marketplace import is showstopper**: Must fix before demo
+3. **i18n is incomplete**: Vietnamese translation is UI-only, not LLM
+4. **Assessment feedback is minimal**: Lacks pedagogical depth
+5. **No API protection**: Rate limiting needed immediately
+6. **Good foundation for automation**: JSON registry enables automated task creation and tracking
+
+### Handoff Notes
+
+**For Next AI Worker**:
+1. Start with `ai_first/MVP_GAP_ANALYSIS.md` for full context
+2. Pick highest-priority pending task from `ai_first/TASK_REGISTRY.json`
+3. Create GitHub issue using corresponding template
+4. Create task packet from `docs/superpowers/tasks/` template
+5. Create feature branch and implement
+6. Update JSON status as work progresses
+7. Link PR to GitHub issue
+
+**Current Blockers**: None - ready to start Phase 1 implementation immediately
+
+**Success Metrics**:
+- [ ] All P1 tasks started by end of this week
+- [ ] T009 (marketplace import) complete within 4 days
+- [ ] Phase 1 complete by 2026-05-04
+- [ ] All GitHub issues created with acceptance criteria
+
+---
+
+**Status**: ✅ COMPLETE  
+**Time Spent**: Research + documentation creation (~3 hours)  
+**Next Task**: Start T009 Marketplace Import implementation  
+**Expected Completion**: 2026-04-21 (4 hours implementation time)
+

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -1,5 +1,25 @@
 # Daily Log — 2026-04-20
 
+## Operating Policy Update — CI + Review Gate (2026-04-20)
+
+### Updated Rules
+
+1. PR must be created in review flow:
+   - Open as Draft first
+   - Move to Ready for review only after self-review checklist
+2. Merge is strictly blocked unless all required CI checks are green
+
+### Files Updated
+
+- `AGENTS.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+
+### Why this change
+
+- Prevent accidental early merges
+- Make review and CI gates explicit and enforceable in the AI-first workflow
+- Keep docs/runtime/product PR handling consistent under one hard merge policy
+
 ## Status
 
 Kicked off MVP Feature Pack 3 (Marketplace + Student Learning Enhancement + Vietnamese i18n).  

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -20,6 +20,35 @@
 - Make review and CI gates explicit and enforceable in the AI-first workflow
 - Keep docs/runtime/product PR handling consistent under one hard merge policy
 
+## T009 Marketplace Import — Implementation Progress (Autopilot)
+
+### Completed in this cycle
+
+1. Implemented real import API endpoint in `deeptutor/api/routers/marketplace.py`:
+   - `POST /api/v1/marketplace/import/{pack_name}` now validates source pack visibility
+   - Copies KB directory to a new imported clone (`<pack_name>__imported`)
+   - Registers imported KB into `kb_config.json` via manager config save flow
+2. Fixed marketplace API client in `web/lib/marketplace-api.ts`:
+   - Repaired broken function boundaries
+   - Added typed `importMarketplacePack()` call path
+3. Wired UI import action in `web/app/(utility)/marketplace/page.tsx`:
+   - Replaced placeholder delay with real API call
+   - Kept loading/success/error feedback and list refresh
+4. Added targeted API tests scaffold `tests/api/test_marketplace_router.py` for list/import behavior.
+
+### Validation
+
+- Python syntax check passed: `.venv/bin/python -m py_compile deeptutor/api/routers/marketplace.py`
+- Frontend lint passed for touched files:
+  - `web/app/(utility)/marketplace/page.tsx`
+  - `web/lib/marketplace-api.ts`
+- `pytest` could not run in current environment (`No module named pytest`) for new test file execution.
+
+### Status
+
+- Task `T009_MARKETPLACE_IMPORT_IMPLEMENTATION`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
+- Next: run integration validation in environment with pytest installed, then mark T009 completed
+
 ## Status
 
 Kicked off MVP Feature Pack 3 (Marketplace + Student Learning Enhancement + Vietnamese i18n).  

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -119,6 +119,31 @@
 - Task `T010_ASSESSMENT_FEEDBACK_DETAILS`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
 - Next: verify endpoint/UI behavior in CI and refine topic inference logic with richer question metadata
 
+## T047 PR #44 Frontend Build Unblock — Follow-up Fix
+
+### Completed in this cycle
+
+1. Added dedicated task packet for issue `#47`:
+   - `docs/superpowers/tasks/2026-04-20-T047-pr44-frontend-build-vi-types.md`
+2. Aligned settings page UI typing with shared `AppLanguage`:
+   - `web/app/(utility)/settings/page.tsx`
+   - `UiSettings.language`, local state, and persistence helpers now accept `vi`
+3. Fixed the next surfaced TypeScript contract mismatch in dashboard review:
+   - `web/lib/dashboard-api.ts`
+   - `AssessmentSummary` now models optional `estimated_time_spent`
+4. Added PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-20-pr44-frontend-build-vi-types.md`
+
+### Validation
+
+- Frontend build passed in isolated worktree:
+  - `cd web && npm run build`
+
+### Status
+
+- Issue `#47`: implementation complete, ready for draft PR
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because the fix does not change system structure
+
 ## T011 KB Context Badges — Implementation Progress (Autopilot)
 
 ### Completed in this cycle

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -119,6 +119,25 @@
 - Task `T010_ASSESSMENT_FEEDBACK_DETAILS`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
 - Next: verify endpoint/UI behavior in CI and refine topic inference logic with richer question metadata
 
+## T011 KB Context Badges — Implementation Progress (Autopilot)
+
+### Completed in this cycle
+
+1. Added reusable KB chip renderer in chat message list.
+2. User message bubbles now display KB badges from request snapshot (`knowledgeBases`).
+3. Assistant message blocks now also display corresponding KB badges from paired user snapshot.
+4. Added task packet: `docs/superpowers/tasks/2026-04-20-T011-kb-context-badges.md`.
+
+### Validation
+
+- Editor diagnostics clean for modified chat component.
+- Pending manual UI pass in live workspace chat flow.
+
+### Status
+
+- Task `T011_KB_CONTEXT_BADGES`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
+- Next: confirm visual spacing/readability with long KB names and multiple KB selections
+
 ## Status
 
 Kicked off MVP Feature Pack 3 (Marketplace + Student Learning Enhancement + Vietnamese i18n).  

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -49,6 +49,27 @@
 - Task `T009_MARKETPLACE_IMPORT_IMPLEMENTATION`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
 - Next: run integration validation in environment with pytest installed, then mark T009 completed
 
+## T028 API Rate Limiting — Implementation Progress (Autopilot)
+
+### Completed in this cycle
+
+1. Added in-memory HTTP rate-limiting middleware in `deeptutor/api/main.py`.
+2. Implemented per-route-prefix limits:
+   - `/api/v1/marketplace/import` -> 20 requests / 60s
+   - `/api/v1/question` -> 40 requests / 60s
+   - `/api/v1/solve` -> 30 requests / 60s
+   - fallback `/api/v1` -> 120 requests / 60s
+3. Middleware now returns `429 Too Many Requests` with `Retry-After` header.
+
+### Validation
+
+- Python syntax check passed: `.venv/bin/python -m py_compile deeptutor/api/main.py`
+
+### Status
+
+- Task `T028_API_RATE_LIMITING`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
+- Next: tune thresholds with real traffic profile and decide whether to replace in-memory store with shared backend for multi-instance deployment
+
 ## Status
 
 Kicked off MVP Feature Pack 3 (Marketplace + Student Learning Enhancement + Vietnamese i18n).  

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -92,6 +92,33 @@
 - Task `T022_ERROR_BOUNDARY_HANDLING`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
 - Next: add boundaries for notebook/dashboard root segments and unify fallback copy in locale files
 
+## T010 Assessment Feedback Details — Implementation Progress (Autopilot)
+
+### Completed in this cycle
+
+1. Added backend analysis endpoint:
+   - `GET /api/v1/dashboard/assessment-analysis/{session_id}` in `deeptutor/api/routers/dashboard.py`
+2. Added heuristic analytics model:
+   - Topic inference from question text
+   - `performance_by_topic`, `weak_topics`, `strong_topics`, and recommendation list
+3. Wired frontend integration:
+   - Added `AssessmentAnalysis` API types + client in `web/lib/dashboard-api.ts`
+   - Assessment review page now fetches review + analysis together
+   - `ProgressIndicator` now renders topic-level performance cards and recommendation lines
+4. Added API router test coverage:
+   - `tests/api/test_dashboard_router.py` extended with `assessment-analysis` endpoint test
+
+### Validation
+
+- Python syntax check passed: `.venv/bin/python -m py_compile deeptutor/api/routers/dashboard.py`
+- Editor diagnostics show no errors in touched backend/frontend files
+- Note: full pytest run still blocked in current environment where `pytest` is not installed
+
+### Status
+
+- Task `T010_ASSESSMENT_FEEDBACK_DETAILS`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
+- Next: verify endpoint/UI behavior in CI and refine topic inference logic with richer question metadata
+
 ## Status
 
 Kicked off MVP Feature Pack 3 (Marketplace + Student Learning Enhancement + Vietnamese i18n).  

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -144,6 +144,32 @@
 - Issue `#47`: implementation complete, ready for draft PR
 - `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because the fix does not change system structure
 
+## T046 Rate-Limit Bucket Isolation — Follow-up Fix
+
+### Completed in this cycle
+
+1. Added dedicated task packet for issue `#46`:
+   - `docs/superpowers/tasks/2026-04-20-T046-rate-limit-bucket-isolation.md`
+2. Added regression coverage for rate-limit bucket derivation:
+   - `tests/api/test_rate_limit_middleware.py`
+3. Fixed middleware bucket-key generation in:
+   - `deeptutor/api/main.py`
+   - bucket keys now derive from the matched policy prefix instead of the first three path segments
+4. Added PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-20-pr44-rate-limit-bucket-isolation.md`
+
+### Validation
+
+- Backend regression test passed:
+  - `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/api/test_rate_limit_middleware.py -q`
+- Python compile check passed:
+  - `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m py_compile deeptutor/api/main.py`
+
+### Status
+
+- Issue `#46`: implementation complete, ready for draft PR
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because the fix does not change system structure
+
 ## T011 KB Context Badges — Implementation Progress (Autopilot)
 
 ### Completed in this cycle

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -70,6 +70,28 @@
 - Task `T028_API_RATE_LIMITING`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
 - Next: tune thresholds with real traffic profile and decide whether to replace in-memory store with shared backend for multi-instance deployment
 
+## T022 Error Boundary Handling — Implementation Progress (Autopilot)
+
+### Completed in this cycle
+
+1. Added route-level marketplace fallback UI:
+   - `web/app/(utility)/marketplace/error.tsx`
+2. Added route-level assessment fallback UI:
+   - `web/app/(workspace)/dashboard/assessments/error.tsx`
+3. Each boundary now:
+   - Logs route exception in client console for triage
+   - Shows user-facing recovery message
+   - Provides reset button (`reset()`) for retry
+
+### Validation
+
+- ESLint passed on both new route error files.
+
+### Status
+
+- Task `T022_ERROR_BOUNDARY_HANDLING`: moved to `in-progress` in `ai_first/TASK_REGISTRY.json`
+- Next: add boundaries for notebook/dashboard root segments and unify fallback copy in locale files
+
 ## Status
 
 Kicked off MVP Feature Pack 3 (Marketplace + Student Learning Enhancement + Vietnamese i18n).  

--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -163,11 +163,16 @@ _RATE_LIMIT_RULES: tuple[tuple[str, int, int], ...] = (
 _rate_limit_store: dict[str, deque[float]] = defaultdict(deque)
 
 
-def _resolve_rate_limit(path: str) -> tuple[int, int]:
+def _resolve_rate_limit(path: str) -> tuple[str, int, int]:
     for prefix, limit, window_seconds in _RATE_LIMIT_RULES:
         if path.startswith(prefix):
-            return limit, window_seconds
-    return 120, 60
+            return prefix, limit, window_seconds
+    return "/api/v1", 120, 60
+
+
+def _build_rate_limit_bucket_key(client_ip: str, path: str) -> str:
+    policy_prefix, _, _ = _resolve_rate_limit(path)
+    return f"{client_ip}:{policy_prefix}"
 
 
 @app.middleware("http")
@@ -178,10 +183,9 @@ async def api_rate_limit(request: Request, call_next):
     if not path.startswith("/api/"):
         return await call_next(request)
 
-    limit, window_seconds = _resolve_rate_limit(path)
+    _, limit, window_seconds = _resolve_rate_limit(path)
     client_ip = request.client.host if request.client else "unknown"
-    path_bucket = "/".join(path.strip("/").split("/")[:3])
-    key = f"{client_ip}:{path_bucket}"
+    key = _build_rate_limit_bucket_key(client_ip, path)
 
     now = monotonic()
     events = _rate_limit_store[key]

--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -1,10 +1,14 @@
 import logging
+from collections import defaultdict, deque
 from contextlib import asynccontextmanager
 from pathlib import Path
+from time import monotonic
 
 from fastapi import FastAPI
 from fastapi import HTTPException
+from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from deeptutor.logging import get_logger
@@ -148,6 +152,53 @@ app = FastAPI(
 
 # Log only non-200 requests (uvicorn access_log is disabled in run_server.py)
 _access_logger = logging.getLogger("uvicorn.access")
+
+
+_RATE_LIMIT_RULES: tuple[tuple[str, int, int], ...] = (
+    ("/api/v1/marketplace/import", 20, 60),
+    ("/api/v1/question", 40, 60),
+    ("/api/v1/solve", 30, 60),
+    ("/api/v1", 120, 60),
+)
+_rate_limit_store: dict[str, deque[float]] = defaultdict(deque)
+
+
+def _resolve_rate_limit(path: str) -> tuple[int, int]:
+    for prefix, limit, window_seconds in _RATE_LIMIT_RULES:
+        if path.startswith(prefix):
+            return limit, window_seconds
+    return 120, 60
+
+
+@app.middleware("http")
+async def api_rate_limit(request: Request, call_next):
+    path = request.url.path
+
+    # Apply rate limits only to API HTTP routes.
+    if not path.startswith("/api/"):
+        return await call_next(request)
+
+    limit, window_seconds = _resolve_rate_limit(path)
+    client_ip = request.client.host if request.client else "unknown"
+    path_bucket = "/".join(path.strip("/").split("/")[:3])
+    key = f"{client_ip}:{path_bucket}"
+
+    now = monotonic()
+    events = _rate_limit_store[key]
+    cutoff = now - window_seconds
+    while events and events[0] < cutoff:
+        events.popleft()
+
+    if len(events) >= limit:
+        retry_after = max(1, int(window_seconds - (now - events[0])))
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "Too Many Requests"},
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    events.append(now)
+    return await call_next(request)
 
 
 @app.middleware("http")

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -1,5 +1,6 @@
 """Dashboard API backed by the unified SQLite session store."""
 
+import re
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
@@ -7,6 +8,96 @@ from fastapi import APIRouter, HTTPException
 from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
 
 router = APIRouter()
+
+_TOPIC_STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "to",
+    "of",
+    "in",
+    "on",
+    "for",
+    "with",
+    "is",
+    "are",
+    "what",
+    "which",
+    "solve",
+    "find",
+    "calculate",
+    "determine",
+}
+
+
+def _infer_topic_from_question(question: str, fallback: str = "general") -> str:
+    words = re.findall(r"[A-Za-z][A-Za-z0-9'-]{2,}", question.lower())
+    filtered = [w for w in words if w not in _TOPIC_STOPWORDS]
+    if not filtered:
+        return fallback
+    return " ".join(filtered[:2])
+
+
+def _build_assessment_analysis(review: dict[str, Any]) -> dict[str, Any]:
+    results = review.get("results", [])
+    if not isinstance(results, list):
+        results = []
+
+    topic_buckets: dict[str, dict[str, int]] = {}
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        question = str(item.get("question") or "")
+        topic = _infer_topic_from_question(question)
+        bucket = topic_buckets.setdefault(topic, {"total": 0, "correct": 0, "incorrect": 0})
+        bucket["total"] += 1
+        if bool(item.get("is_correct")):
+            bucket["correct"] += 1
+        else:
+            bucket["incorrect"] += 1
+
+    performance_by_topic = []
+    for topic, counts in sorted(topic_buckets.items(), key=lambda kv: (-kv[1]["incorrect"], kv[0])):
+        total = counts["total"]
+        accuracy = round((counts["correct"] / total) * 100) if total else 0
+        performance_by_topic.append(
+            {
+                "topic": topic,
+                "total_questions": total,
+                "correct_count": counts["correct"],
+                "incorrect_count": counts["incorrect"],
+                "accuracy_percent": accuracy,
+            }
+        )
+
+    weak_topics = [row["topic"] for row in performance_by_topic if row["incorrect_count"] > 0][:3]
+    strong_topics = [row["topic"] for row in performance_by_topic if row["accuracy_percent"] >= 80][:3]
+
+    score_percent = int(review.get("summary", {}).get("score_percent", 0))
+    recommendations: list[str] = []
+    if weak_topics:
+        recommendations.append(
+            f"Review these topics first: {', '.join(weak_topics)}."
+        )
+    if score_percent < 75:
+        recommendations.append("Retry a focused quiz on weak topics before moving on.")
+    elif score_percent < 90:
+        recommendations.append("Practice mixed-difficulty questions to improve consistency.")
+    else:
+        recommendations.append("You are ready for advanced questions and extension material.")
+    if strong_topics:
+        recommendations.append(f"Strong areas: {', '.join(strong_topics)}.")
+
+    return {
+        "session_id": review.get("session_id"),
+        "summary": review.get("summary", {}),
+        "performance_by_topic": performance_by_topic,
+        "weak_topics": weak_topics,
+        "strong_topics": strong_topics,
+        "recommendations": recommendations,
+    }
 
 
 def _activity_type(capability: str) -> str:
@@ -137,3 +228,17 @@ async def get_activity_entry(entry_id: str):
             "summary": session.get("compressed_summary", ""),
         },
     }
+
+
+@router.get("/assessment-analysis/{session_id}")
+async def get_assessment_analysis(session_id: str):
+    store = get_sqlite_session_store()
+    session = await store.get_session_with_messages(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Assessment session not found")
+
+    review = extract_assessment_review(session)
+    if review is None:
+        raise HTTPException(status_code=404, detail="Assessment review data not found")
+
+    return _build_assessment_analysis(review)

--- a/deeptutor/api/routers/marketplace.py
+++ b/deeptutor/api/routers/marketplace.py
@@ -1,9 +1,49 @@
 """Marketplace API for discovering and browsing teacher-shared Knowledge Packs."""
 
+from datetime import datetime
+from pathlib import Path
+import shutil
+
 from fastapi import APIRouter, HTTPException, Query
-from deeptutor.knowledge.manager import get_knowledge_manager
+
+from deeptutor.api.routers.knowledge import get_kb_manager
 
 router = APIRouter()
+
+
+def _list_marketplace_candidates() -> list[dict]:
+    """Return shareable KB entries formatted for marketplace responses."""
+    manager = get_kb_manager()
+    kb_names = manager.list_knowledge_bases()
+    items: list[dict] = []
+
+    for name in kb_names:
+        try:
+            info = manager.get_info(name)
+            metadata = info.get("metadata") or {}
+            sharing_status = metadata.get("sharing_status")
+
+            if sharing_status not in {"public", "team"}:
+                continue
+
+            items.append(
+                {
+                    "name": info.get("name", name),
+                    "subject": metadata.get("subject"),
+                    "grade": metadata.get("grade"),
+                    "curriculum": metadata.get("curriculum"),
+                    "learning_objectives": metadata.get("learning_objectives", []),
+                    "owner": metadata.get("owner"),
+                    "sharing_status": sharing_status,
+                    "session_count": info.get("statistics", {}).get("content_lists", 0),
+                    "status": info.get("status", "ready"),
+                    "statistics": info.get("statistics", {}),
+                }
+            )
+        except Exception:
+            continue
+
+    return items
 
 
 @router.get("/list")
@@ -20,65 +60,37 @@ async def list_marketplace_packs(
     Returns knowledge packs with metadata, session counts, and owner info.
     """
     try:
-        manager = get_knowledge_manager()
-        
-        # Get all knowledge bases with metadata
-        all_kbs = await manager.list_knowledge_bases()
-        
-        # Filter by sharing_status
+        all_kbs = _list_marketplace_candidates()
+
         if sharing_status:
-            all_kbs = [
-                kb for kb in all_kbs
-                if kb.get("metadata", {}).get("sharing_status") == sharing_status
-            ]
-        else:
-            # Default: show public and team packs
-            all_kbs = [
-                kb for kb in all_kbs
-                if kb.get("metadata", {}).get("sharing_status") in ["public", "team"]
-            ]
-        
-        # Filter by subject
+            all_kbs = [kb for kb in all_kbs if kb.get("sharing_status") == sharing_status]
+
         if subject:
+            needle = subject.lower()
             all_kbs = [
-                kb for kb in all_kbs
-                if kb.get("metadata", {}).get("subject", "").lower() == subject.lower()
+                kb
+                for kb in all_kbs
+                if (kb.get("subject") or "").lower() == needle
             ]
-        
-        # Filter by owner
+
         if owner:
+            needle = owner.lower()
             all_kbs = [
-                kb for kb in all_kbs
-                if kb.get("metadata", {}).get("owner", "").lower() == owner.lower()
+                kb
+                for kb in all_kbs
+                if (kb.get("owner") or "").lower() == needle
             ]
-        
-        # Apply pagination
+
         total = len(all_kbs)
         packs = all_kbs[offset : offset + limit]
-        
-        # Format response with metadata
-        formatted_packs = []
-        for kb in packs:
-            metadata = kb.get("metadata", {})
-            formatted_packs.append({
-                "name": kb.get("name"),
-                "subject": metadata.get("subject"),
-                "grade": metadata.get("grade"),
-                "curriculum": metadata.get("curriculum"),
-                "learning_objectives": metadata.get("learning_objectives", []),
-                "owner": metadata.get("owner"),
-                "sharing_status": metadata.get("sharing_status"),
-                "session_count": kb.get("session_count", 0),
-                "status": kb.get("status", "ready"),
-            })
-        
+
         return {
             "total": total,
             "offset": offset,
             "limit": limit,
-            "packs": formatted_packs,
+            "packs": packs,
         }
-    
+
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -87,35 +99,105 @@ async def list_marketplace_packs(
 async def get_marketplace_pack(pack_name: str):
     """Get detailed information about a specific marketplace pack."""
     try:
-        manager = get_knowledge_manager()
-        kb = await manager.get_knowledge_base(pack_name)
-        
-        if not kb:
+        match = next((kb for kb in _list_marketplace_candidates() if kb.get("name") == pack_name), None)
+
+        if not match:
             raise HTTPException(status_code=404, detail=f"Knowledge pack '{pack_name}' not found")
-        
-        # Check if pack is shareable (public or team)
-        sharing_status = kb.get("metadata", {}).get("sharing_status")
-        if not sharing_status or sharing_status not in ["public", "team"]:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Knowledge pack '{pack_name}' is not publicly shared"
-            )
-        
-        metadata = kb.get("metadata", {})
+
         return {
-            "name": kb.get("name"),
-            "subject": metadata.get("subject"),
-            "grade": metadata.get("grade"),
-            "curriculum": metadata.get("curriculum"),
-            "learning_objectives": metadata.get("learning_objectives", []),
-            "owner": metadata.get("owner"),
-            "sharing_status": metadata.get("sharing_status"),
-            "session_count": kb.get("session_count", 0),
-            "status": kb.get("status", "ready"),
-            "statistics": kb.get("statistics", {}),
+            "name": match.get("name"),
+            "subject": match.get("subject"),
+            "grade": match.get("grade"),
+            "curriculum": match.get("curriculum"),
+            "learning_objectives": match.get("learning_objectives", []),
+            "owner": match.get("owner"),
+            "sharing_status": match.get("sharing_status"),
+            "session_count": match.get("session_count", 0),
+            "status": match.get("status", "ready"),
+            "statistics": match.get("statistics", {}),
         }
     
     except HTTPException:
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/import/{pack_name}")
+async def import_marketplace_pack(pack_name: str):
+    """
+    Import a marketplace knowledge pack to user's workspace.
+    
+    Copies the pack from the marketplace directory to the user's knowledge_bases.
+    Updates metadata with import_date and imported_from fields.
+    """
+    try:
+        manager = get_kb_manager()
+
+        source_info = None
+        for kb in _list_marketplace_candidates():
+            if kb.get("name") == pack_name:
+                source_info = kb
+                break
+
+        if not source_info:
+            raise HTTPException(status_code=404, detail=f"Knowledge pack '{pack_name}' not found")
+
+        source_path = manager.base_dir / pack_name
+        if not source_path.exists() or not source_path.is_dir():
+            raise HTTPException(status_code=404, detail=f"Knowledge pack directory '{pack_name}' not found")
+
+        imported_name = f"{pack_name}__imported"
+        dest_path = manager.base_dir / imported_name
+
+        if dest_path.exists():
+            return {
+                "success": True,
+                "message": "Pack already available",
+                "pack": {
+                    "name": imported_name,
+                    "subject": source_info.get("subject"),
+                    "grade": source_info.get("grade"),
+                    "owner": source_info.get("owner"),
+                    "import_date": datetime.utcnow().isoformat(),
+                },
+            }
+
+        shutil.copytree(source_path, dest_path)
+
+        import_timestamp = datetime.utcnow().isoformat()
+
+        manager.config = manager._load_config()  # keep manager in sync before updating registry
+        source_cfg = manager.config.get("knowledge_bases", {}).get(pack_name, {})
+        imported_cfg = dict(source_cfg)
+        imported_cfg["path"] = imported_name
+        imported_cfg["description"] = source_cfg.get("description") or f"Imported from {pack_name}"
+        imported_cfg["owner"] = source_cfg.get("owner") or source_info.get("owner")
+        imported_cfg["sharing_status"] = "private"
+        imported_cfg["updated_at"] = import_timestamp
+        imported_cfg["created_at"] = source_cfg.get("created_at") or import_timestamp
+        imported_cfg["imported_from"] = pack_name
+        imported_cfg["import_date"] = import_timestamp
+
+        if "knowledge_bases" not in manager.config:
+            manager.config["knowledge_bases"] = {}
+        manager.config["knowledge_bases"][imported_name] = imported_cfg
+        manager._save_config()
+
+        return {
+            "success": True,
+            "message": f"Knowledge pack '{pack_name}' imported successfully as '{imported_name}'",
+            "pack": {
+                "name": imported_name,
+                "subject": source_info.get("subject"),
+                "grade": source_info.get("grade"),
+                "owner": source_info.get("owner"),
+                "import_date": import_timestamp,
+                "session_count": source_info.get("session_count", 0),
+            },
+        }
+    
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Import failed: {str(e)}")

--- a/docs/superpowers/pr-notes/2026-04-20-autopilot-t009-t028-t022.md
+++ b/docs/superpowers/pr-notes/2026-04-20-autopilot-t009-t028-t022.md
@@ -1,0 +1,93 @@
+# Autopilot Batch - T009 + T028 + T022 Architecture Note
+
+**Branch:** `pod-a/marketplace-pack-import`  
+**Scope:** Marketplace import implementation, API rate limiting, route-level error boundaries  
+**Related Tasks:** `T009_MARKETPLACE_IMPORT_IMPLEMENTATION`, `T028_API_RATE_LIMITING`, `T022_ERROR_BOUNDARY_HANDLING`
+
+## Overview
+
+This batch converts a critical placeholder into a real workflow and adds runtime safety rails:
+
+1. Marketplace import now performs a real filesystem copy and KB registration.
+2. API now enforces lightweight request throttling with `429` and `Retry-After`.
+3. Marketplace and assessment routes now have explicit user-facing recovery boundaries.
+
+## Architecture Impact
+
+```mermaid
+flowchart LR
+  UI[Marketplace UI] --> ImportAPI[POST /api/v1/marketplace/import/{pack_name}]
+  ImportAPI --> KBManager[KnowledgeBaseManager]
+  KBManager --> FS[Copy KB directory]
+  FS --> Clone[Create <pack>__imported]
+  Clone --> Registry[Update kb_config.json]
+
+  API[FastAPI app] --> RL[Rate-limit middleware]
+  RL --> Protected[question / solve / marketplace import]
+  RL --> TooMany[429 + Retry-After]
+
+  MarketplaceRoute[/marketplace] --> MarketError[error.tsx fallback]
+  AssessmentRoute[/dashboard/assessments/*] --> AssessError[error.tsx fallback]
+```
+
+## Detailed Changes
+
+### T009 Marketplace Import
+
+- Backend: `deeptutor/api/routers/marketplace.py`
+  - Added real import endpoint: `POST /api/v1/marketplace/import/{pack_name}`
+  - Validates shareable source pack
+  - Copies source KB directory into imported clone `<pack_name>__imported`
+  - Registers imported clone in `kb_config.json`
+- Frontend client: `web/lib/marketplace-api.ts`
+  - Added/fixed `importMarketplacePack()` typed client
+  - Corrected response function boundaries
+- Frontend UI: `web/app/(utility)/marketplace/page.tsx`
+  - Replaced placeholder delay with real API call
+  - Preserved import loading/success/error states
+  - Refreshes list after import
+- Tests scaffold:
+  - `tests/api/test_marketplace_router.py`
+
+### T028 Rate Limiting
+
+- API core: `deeptutor/api/main.py`
+  - Added in-memory sliding-window middleware for `/api/*`
+  - Route-prefix policies:
+    - `/api/v1/marketplace/import` -> 20 req/60s
+    - `/api/v1/question` -> 40 req/60s
+    - `/api/v1/solve` -> 30 req/60s
+    - fallback `/api/v1` -> 120 req/60s
+  - Breach response: `429 Too Many Requests` with `Retry-After`
+
+### T022 Error Boundaries
+
+- Added route-level boundaries:
+  - `web/app/(utility)/marketplace/error.tsx`
+  - `web/app/(workspace)/dashboard/assessments/error.tsx`
+- Each boundary provides:
+  - Friendly failure message
+  - Retry action (`reset()`)
+  - Console logging for diagnosis
+
+## Data/API Notes
+
+- New import behavior is currently implemented as same-instance clone import (`<pack>__imported`).
+- This keeps MVP flow deterministic without introducing multi-tenant storage assumptions.
+- Rate limiting is in-memory and instance-local (sufficient for single-node MVP).
+
+## Validation
+
+- Passed: `.venv/bin/python -m py_compile deeptutor/api/routers/marketplace.py`
+- Passed: `.venv/bin/python -m py_compile deeptutor/api/main.py`
+- Passed: `npx eslint app/(utility)/marketplace/page.tsx lib/marketplace-api.ts`
+- Passed: `npx eslint app/(utility)/marketplace/error.tsx app/(workspace)/dashboard/assessments/error.tsx`
+- Could not run: `pytest` not installed in current `.venv` (`No module named pytest`)
+
+## System Map Update
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated in this batch:
+  - Added marketplace import flow node
+  - Added imported clone/registry node
+  - Added API security/rate-limit node
+  - Added marketplace and assessment error-boundary nodes

--- a/docs/superpowers/pr-notes/2026-04-20-autopilot-t010-t011.md
+++ b/docs/superpowers/pr-notes/2026-04-20-autopilot-t010-t011.md
@@ -1,0 +1,63 @@
+# Autopilot Increment - T010 + T011 Architecture Note
+
+**Branch:** `pod-a/marketplace-pack-import`  
+**Scope:** Assessment feedback detail analytics and KB context badges in tutoring chat  
+**Related Tasks:** `T010_ASSESSMENT_FEEDBACK_DETAILS`, `T011_KB_CONTEXT_BADGES`
+
+## Overview
+
+This increment improves tutor transparency and post-assessment guidance:
+
+1. Adds topic-level analytics for assessment review sessions.
+2. Surfaces KB grounding context inline in tutoring message flow.
+
+## Architecture Impact
+
+```mermaid
+flowchart LR
+  ReviewUI[/dashboard/assessments/[sessionId]] --> ReviewAPI[/api/v1/sessions/{session_id}/assessment-analysis]
+  ReviewAPI --> SQLite[(chat_history.db)]
+  ReviewAPI --> TopicPerf[Topic performance + recommendations]
+  TopicPerf --> ProgressIndicator[ProgressIndicator topic cards]
+
+  TutorUI[/workspace chat/] --> UserMsg[User message requestSnapshot]
+  UserMsg --> KBs[knowledgeBases[]]
+  KBs --> UserBadges[KB chips in user bubble]
+  KBs --> AssistantBadges[KB chips in paired assistant block]
+```
+
+## Detailed Changes
+
+### T010 Assessment Feedback Details
+
+- Backend: `deeptutor/api/routers/dashboard.py`
+  - Added `GET /assessment-analysis/{session_id}`
+  - Topic extraction and performance aggregation from stored assessment review
+- Frontend client: `web/lib/dashboard-api.ts`
+  - Added typed `AssessmentAnalysis` + `TopicPerformance`
+  - Added `getAssessmentAnalysis()`
+- Frontend route/components:
+  - `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+    - Parallel fetch of review + analysis
+  - `web/components/assessment/ProgressIndicator.tsx`
+    - Render per-topic progress and recommendations
+
+### T011 KB Context Badges
+
+- Frontend chat rendering: `web/components/chat/home/ChatMessages.tsx`
+  - Added reusable KB chip renderer
+  - User message bubble now shows `requestSnapshot.knowledgeBases`
+  - Assistant block now mirrors KB context from paired user snapshot
+- Task packet: `docs/superpowers/tasks/2026-04-20-T011-kb-context-badges.md`
+
+## Validation
+
+- Passed: editor diagnostics (`get_errors`) on modified files
+- Passed: `npx eslint components/chat/home/ChatMessages.tsx` (warnings only, no errors)
+- Prior limitation remains: local `.venv` missing `pytest`
+
+## System Map Update
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated with:
+  - `KB Context Badges in Chat Messages`
+  - `Message requestSnapshot.knowledgeBases`

--- a/docs/superpowers/pr-notes/2026-04-20-pr44-frontend-build-vi-types.md
+++ b/docs/superpowers/pr-notes/2026-04-20-pr44-frontend-build-vi-types.md
@@ -1,0 +1,35 @@
+# PR Note: PR #44 Frontend Build Unblock for Vietnamese UI Types
+
+## Summary
+
+This follow-up isolates the frontend compile blockers discovered while reviewing PR #44.
+
+- Aligns the settings page UI preference types with the shared `AppLanguage` union that already includes `vi`
+- Extends the dashboard assessment summary type so the assessment review page can safely reference the optional `estimated_time_spent` field
+- Leaves backend contracts unchanged
+
+## Architecture
+
+```mermaid
+flowchart LR
+  SettingsPage["Settings page"] --> AppLanguage["AppLanguage (en | zh | vi)"]
+  AppLanguage --> UISettings["UI settings payload"]
+  UISettings --> SettingsAPI["PUT /api/v1/settings/ui"]
+
+  AssessmentReview["Assessment review page"] --> AssessmentSummary["AssessmentSummary type"]
+  AssessmentSummary --> LearningJourney["LearningJourneySummary optional time field"]
+```
+
+## Files
+
+- `web/app/(utility)/settings/page.tsx`
+- `web/lib/dashboard-api.ts`
+
+## Validation
+
+- `cd web && npm run build`
+
+## System Map
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
+- Reason: this PR only aligns frontend typing/build contracts and does not change system structure

--- a/docs/superpowers/pr-notes/2026-04-20-pr44-rate-limit-bucket-isolation.md
+++ b/docs/superpowers/pr-notes/2026-04-20-pr44-rate-limit-bucket-isolation.md
@@ -1,0 +1,35 @@
+# PR Note: Rate-Limit Bucket Isolation for PR #44 Middleware
+
+## Summary
+
+This follow-up fixes the rate-limit key derivation added in PR #44.
+
+- adds a dedicated bucket-key helper derived from the matched policy prefix
+- updates the middleware to use that helper instead of truncating to the first three path segments
+- adds regression coverage for marketplace import/list separation and stable keys within the same policy
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Request["HTTP request path"] --> Resolve["_resolve_rate_limit(path)"]
+  Resolve --> Policy["matched policy prefix"]
+  Policy --> Bucket["_build_rate_limit_bucket_key(client_ip, path)"]
+  Bucket --> Store["in-memory counter store"]
+  Store --> Limit["429 + Retry-After when threshold exceeded"]
+```
+
+## Files
+
+- `deeptutor/api/main.py`
+- `tests/api/test_rate_limit_middleware.py`
+
+## Validation
+
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/api/test_rate_limit_middleware.py -q`
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m py_compile deeptutor/api/main.py`
+
+## System Map
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
+- Reason: this PR only fixes internal middleware keying and does not change system structure

--- a/docs/superpowers/tasks/2026-04-20-T009-marketplace-import.md
+++ b/docs/superpowers/tasks/2026-04-20-T009-marketplace-import.md
@@ -1,0 +1,353 @@
+# Task Packet: T009 Marketplace Pack Import Implementation
+
+**Date:** 2026-04-20  
+**Feature Pod:** pod-a/marketplace-pack-import  
+**Priority:** P1 CRITICAL  
+**Status:** Planning → Implementation  
+**Effort:** 4 hours estimated  
+
+---
+
+## Overview
+
+Replace placeholder marketplace pack import with real implementation that copies knowledge packs to user workspace.
+
+**Current State:** Import button shows success message but doesn't actually import pack  
+**Target State:** Clicking import copies pack metadata and documents to user's knowledge_bases directory
+
+---
+
+## Problem Statement
+
+Users can browse marketplace packs but import button is non-functional:
+- Shows fake success after 1-second delay
+- Doesn't copy pack files to workspace
+- Makes marketplace feature appear to work during demo but fails in real use
+- **Blocks contest demo** - judges can't actually import packs
+
+### Evidence
+
+**File:** `web/app/(utility)/marketplace/page.tsx` lines 60-75
+```tsx
+const handleImportPack = async (packName: string) => {
+  setImporting(packName);
+  try {
+    // Placeholder: In a real scenario, this would copy the pack to the user's workspace
+    // For now, we just show a success message
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setImportSuccess(packName);
+    setTimeout(() => setImportSuccess(null), 3000);
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] **API Endpoint Created**: `POST /api/v1/marketplace/import/{pack_name}`
+  - Validates pack exists in marketplace
+  - Copies pack to user's knowledge_bases directory
+  - Returns success/error with proper HTTP status
+  - Handles edge cases (pack already imported, permission denied, disk full)
+
+- [ ] **Frontend Integration**: Replace placeholder in `handleImportPack`
+  - Call new API endpoint with pack name
+  - Show proper loading indicator during import
+  - Handle errors with user-friendly messages
+  - Show success confirmation
+  - Refresh pack list or navigate to imported pack
+
+- [ ] **API Client Function**: Add `importMarketplacePack()` to `web/lib/marketplace-api.ts`
+  - Takes pack name as parameter
+  - Makes POST request with error handling
+  - Returns response with imported pack details
+
+- [ ] **Testing**: Verify end-to-end import flow
+  - Browse marketplace
+  - Click import button
+  - See loading state
+  - Confirm import completes
+  - Check imported pack appears in Knowledge Pack list
+  - Verify pack documents are accessible in workspace
+
+---
+
+## Files to Modify
+
+### Backend
+| File | Work | Lines |
+|------|------|-------|
+| `deeptutor/api/routers/marketplace.py` | Add import endpoint | ~30-40 lines |
+| `deeptutor/api/main.py` | Verify marketplace router mounted | ~2 lines verify |
+| `deeptutor/services/knowledge/pack_manager.py` | Add copy/import logic | ~50-60 lines |
+
+### Frontend
+| File | Work | Lines |
+|------|------|-------|
+| `web/app/(utility)/marketplace/page.tsx` | Implement real import handler | ~15-20 lines |
+| `web/lib/marketplace-api.ts` | Add API client function | ~10-15 lines |
+
+### No Changes
+- Tests (existing placeholder test structure sufficient for now)
+- Database schema (use existing pack metadata structure)
+- i18n (use existing marketplace translations)
+
+---
+
+## Implementation Breakdown
+
+### Step 1: Backend API Endpoint (90 min)
+
+**File:** `deeptutor/api/routers/marketplace.py`
+
+Create endpoint:
+```python
+@router.post("/import/{pack_name}")
+async def import_marketplace_pack(
+    pack_name: str,
+    request: Request,
+) -> dict:
+    """Import marketplace pack to user's workspace."""
+    # 1. Get user context from session
+    # 2. Verify pack exists in marketplace
+    # 3. Check pack is shareable (sharing_status != "private")
+    # 4. Call pack_manager.import_pack(pack_name, user_id)
+    # 5. Return success with imported pack metadata
+```
+
+**Logic:**
+1. Validate pack_name exists in marketplace metadata
+2. Check pack sharing_status is "public" or "team" (not "private")
+3. Get destination path: `knowledge_bases/{user_id}/{pack_name}/`
+4. Copy pack directory with all contents (metadata.yaml + documents)
+5. Update pack metadata with import timestamp, imported_from: "marketplace"
+6. Return import confirmation
+
+**Error Handling:**
+- Pack not found → 404
+- Pack private → 403 Forbidden
+- Pack already imported → 409 Conflict or just re-import
+- Disk space issue → 507 Insufficient Storage
+- Permission denied → 403
+
+### Step 2: Backend Service Layer (60 min)
+
+**File:** `deeptutor/services/knowledge/pack_manager.py`
+
+Add method:
+```python
+async def import_pack(
+    self,
+    pack_name: str,
+    user_id: str,
+    source: str = "marketplace",
+) -> PackMetadata:
+    """Copy pack from marketplace to user workspace."""
+    # 1. Get marketplace pack path
+    # 2. Validate permissions
+    # 3. Create destination directory
+    # 4. Copy all files (shutil.copytree)
+    # 5. Update metadata with import info
+    # 6. Register pack in user's knowledge base index
+    # 7. Return updated metadata
+```
+
+**Details:**
+- Source: Get from marketplace directory or cache
+- Destination: `data/knowledge_bases/{user_id}/{pack_name}`
+- Copy with `shutil.copytree(src, dst, dirs_exist_ok=False)` to prevent overwrite
+- Update metadata JSON with: `imported_from: "marketplace"`, `import_date: now()`
+- Return PackMetadata object
+
+### Step 3: Frontend API Client (30 min)
+
+**File:** `web/lib/marketplace-api.ts`
+
+Add function:
+```typescript
+export async function importMarketplacePack(
+  packName: string,
+): Promise<{ success: boolean; pack: MarketplacePack }> {
+  const response = await fetch(
+    apiUrl(`/api/v1/marketplace/import/${packName}`),
+    { method: "POST" }
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to import: ${response.statusText}`);
+  }
+  return response.json();
+}
+```
+
+**Details:**
+- POST to `/api/v1/marketplace/import/{pack_name}`
+- Handle errors: throw readable error messages
+- Return imported pack data or null on failure
+- No request body needed (pack name in URL)
+
+### Step 4: Frontend Component (30 min)
+
+**File:** `web/app/(utility)/marketplace/page.tsx`
+
+Replace `handleImportPack` function:
+```typescript
+const handleImportPack = async (packName: string) => {
+  setImporting(packName);
+  try {
+    const result = await importMarketplacePack(packName);
+    setImportSuccess(packName);
+    setTimeout(() => setImportSuccess(null), 3000);
+    
+    // Refresh pack list to show import status
+    loadPacks();
+  } catch (err) {
+    setError(
+      err instanceof Error ? err.message : "Failed to import pack"
+    );
+  } finally {
+    setImporting(null);
+  }
+};
+```
+
+**Details:**
+- Call real API endpoint instead of fake delay
+- Handle response/errors appropriately
+- Refresh marketplace list after successful import (shows updated session count)
+- Show error message if import fails
+- Keep loading state visual during import
+
+---
+
+## Testing Checklist
+
+### Manual Testing (Local)
+- [ ] Start backend and frontend locally
+- [ ] Navigate to marketplace
+- [ ] Click import button on any pack
+- [ ] See loading indicator while importing
+- [ ] See success message on completion
+- [ ] Navigate to Knowledge Pack list
+- [ ] Verify imported pack appears in list
+- [ ] Verify pack documents are accessible
+- [ ] Try importing same pack again (should handle gracefully)
+- [ ] Test error cases:
+  - [ ] Simulate API error → see error message
+  - [ ] Try importing while offline → see error
+  - [ ] Import pack with special characters → verify handling
+
+### Integration Testing (if time permits)
+- [ ] Verify imported pack can be used in assessment generation
+- [ ] Check import metadata is correctly recorded
+- [ ] Verify import count increments on marketplace (optional)
+
+---
+
+## Dependencies & Prerequisites
+
+**Backend:**
+- Marketplace pack directory structure exists and is readable
+- Knowledge base manager can write to user workspace directory
+- User session/authentication available in request context
+
+**Frontend:**
+- Marketplace API client library (marketplace-api.ts) exists
+- API base URL correctly configured
+
+**No Blockers:** All dependencies satisfied in current codebase
+
+---
+
+## Architecture Changes
+
+**New Endpoint:**
+```
+POST /api/v1/marketplace/import/{pack_name}
+├── Validate pack exists & is shareable
+├── Copy to user workspace
+└── Return imported pack metadata
+```
+
+**File Flow:**
+```
+marketplace/{pack_name}/
+├── metadata.yaml
+├── documents/
+│   └── *.pdf
+└── assessments/
+    └── config.yaml
+
+Copy to:
+knowledge_bases/{user_id}/{pack_name}/
+├── metadata.yaml (+ imported_from, import_date)
+├── documents/
+└── assessments/
+```
+
+**No database schema changes** - use existing pack metadata structure
+
+---
+
+## Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|-----------|
+| Import fails silently | High | Poor UX | Add detailed error messages |
+| Pack already exists | Medium | Conflict | Handle with 409 or overwrite option |
+| Disk space issue | Low | Failure | Add disk check, return 507 |
+| Slow copy performance | Low | UX lag | Show progress indicator |
+
+---
+
+## Success Criteria
+
+✅ **Definition of Done:**
+1. API endpoint created and tested locally
+2. Import actually copies pack files to workspace
+3. Frontend calls real endpoint instead of fake
+4. Error handling shows user-friendly messages
+5. Imported pack accessible in Knowledge Pack list
+6. PR includes architecture note with Mermaid diagram
+7. Daily log updated with completion status
+
+---
+
+## Effort Estimate
+
+| Component | Time | Est. |
+|-----------|------|------|
+| Backend API endpoint | 90 min | ✓ |
+| Backend service layer | 60 min | ✓ |
+| Frontend API client | 30 min | ✓ |
+| Frontend component update | 30 min | ✓ |
+| Testing & validation | 20 min | ✓ |
+| **Total** | **230 min** | **~4 hours** |
+
+---
+
+## Next Steps
+
+1. ✅ Read and approve this task packet
+2. → Implement backend API endpoint (Step 1)
+3. → Implement backend service (Step 2)
+4. → Implement frontend client (Step 3)
+5. → Update frontend component (Step 4)
+6. → Manual testing
+7. → Create PR with architecture note
+8. → Update `ai_first/TASK_REGISTRY.json` status → "completed"
+9. → Start T010 (Assessment Feedback Analysis)
+
+---
+
+## Reference Files
+
+- **Audit Report:** `ai_first/MVP_GAP_ANALYSIS.md` (lines describing T009)
+- **Task Registry:** `ai_first/TASK_REGISTRY.json` (T009 object)
+- **Current Implementation:** `web/app/(utility)/marketplace/page.tsx` (lines 60-75)
+- **API File:** `deeptutor/api/routers/marketplace.py`
+- **API Client:** `web/lib/marketplace-api.ts`
+
+---
+
+**Created:** 2026-04-20  
+**Status:** Ready for Implementation  
+**Assigned Pod:** pod-a/marketplace-pack-import

--- a/docs/superpowers/tasks/2026-04-20-T010-assessment-feedback-details.md
+++ b/docs/superpowers/tasks/2026-04-20-T010-assessment-feedback-details.md
@@ -1,0 +1,41 @@
+# Task Packet: T010 Assessment Feedback Details
+
+Date: 2026-04-20  
+Branch: pod-a/marketplace-pack-import  
+Priority: Critical (P2)
+
+## Goal
+
+Enhance assessment review with detailed analysis breakdown, topic-level performance, and actionable recommendations.
+
+## Scope
+
+- Backend: `deeptutor/api/routers/dashboard.py`
+  - Add endpoint: `GET /api/v1/dashboard/assessment-analysis/{session_id}`
+  - Produce heuristic topic breakdown from question review data
+- Frontend API client: `web/lib/dashboard-api.ts`
+  - Add `AssessmentAnalysis` types and `getAssessmentAnalysis()`
+- Frontend UI:
+  - `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+  - `web/components/assessment/ProgressIndicator.tsx`
+  - Render topic performance + recommendation lines under recommendations panel
+- Tests:
+  - `tests/api/test_dashboard_router.py`
+
+## Acceptance Criteria
+
+- Endpoint returns:
+  - `summary`
+  - `performance_by_topic`
+  - `weak_topics`
+  - `strong_topics`
+  - `recommendations`
+- Assessment review page fetches analysis and renders it.
+- Existing assessment review flow remains functional.
+- Backend syntax and frontend lint checks pass in local environment.
+
+## Validation Notes
+
+- Python compile check: `.venv/bin/python -m py_compile deeptutor/api/routers/dashboard.py`
+- Frontend lint check: `npx eslint` on touched files
+- API test coverage extended in `tests/api/test_dashboard_router.py`

--- a/docs/superpowers/tasks/2026-04-20-T011-kb-context-badges.md
+++ b/docs/superpowers/tasks/2026-04-20-T011-kb-context-badges.md
@@ -1,0 +1,29 @@
+# Task Packet: T011 KB Context Badges
+
+Date: 2026-04-20  
+Branch: pod-a/marketplace-pack-import  
+Priority: Critical (P3)
+
+## Goal
+
+Display active knowledge base context during tutoring so users know which sources are grounding each exchange.
+
+## Scope
+
+- Frontend chat rendering:
+  - `web/components/chat/home/ChatMessages.tsx`
+- Show KB badges from request snapshot in both:
+  - user message bubble
+  - paired assistant response block
+
+## Acceptance Criteria
+
+- If a request contains `knowledgeBases`, the chat UI shows KB chips.
+- Chips appear for user messages and nearby assistant messages.
+- No rendering change for messages without KB context.
+- Existing message actions/retry flow stay intact.
+
+## Validation
+
+- Frontend lint passes for modified chat component.
+- Manual UI check in workspace chat route.

--- a/docs/superpowers/tasks/2026-04-20-T046-rate-limit-bucket-isolation.md
+++ b/docs/superpowers/tasks/2026-04-20-T046-rate-limit-bucket-isolation.md
@@ -1,0 +1,61 @@
+# Feature Pod Task: Rate-Limit Bucket Isolation for PR #44 Middleware
+
+Owner: Codex
+Branch: `fix/pr44-rate-limit-bucket-isolation`
+GitHub Issue: `#46`
+
+## Goal
+
+Correct the HTTP rate-limit middleware so counters are isolated by the matched policy instead of colliding across different marketplace routes.
+
+## User-visible outcome
+
+- Bursts of marketplace import requests do not incorrectly throttle marketplace list/detail reads.
+- Route-specific rate-limit rules behave as documented.
+
+## Owned files/modules
+
+- `deeptutor/api/main.py`
+- `tests/api/test_rate_limit_middleware.py`
+- `docs/superpowers/tasks/2026-04-20-T046-rate-limit-bucket-isolation.md`
+- `docs/superpowers/pr-notes/2026-04-20-pr44-rate-limit-bucket-isolation.md`
+- `ai_first/daily/2026-04-20.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Unrelated frontend files
+
+## API/data contract
+
+- Keep existing `429` response shape and `Retry-After` header behavior
+- Preserve declared limits while changing only how the bucket key is derived/stored
+
+## Acceptance criteria
+
+- Requests matching different policies do not share the same counter bucket unless intended
+- Marketplace import and marketplace list can no longer collide through a shared key
+- Regression coverage proves the intended bucket split
+- Relevant backend validation passes
+
+## Required tests
+
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/api/test_rate_limit_middleware.py -q`
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m py_compile deeptutor/api/main.py`
+
+## Manual verification
+
+- Verify the computed key/policy for `/api/v1/marketplace/import/...` differs from `/api/v1/marketplace/list`
+- Confirm fallback `/api/v1` policy still works for unrelated routes
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+- Expected: no system-map update unless the middleware architecture changes materially.
+
+## Handoff notes
+
+- This branch is based on `fix/pr44-frontend-build-vi-types` so it can merge after the CI-unblock PR in the PR #44 follow-up stack.
+- Keep the PR narrowly scoped to bucket isolation and regression coverage.

--- a/docs/superpowers/tasks/2026-04-20-T047-pr44-frontend-build-vi-types.md
+++ b/docs/superpowers/tasks/2026-04-20-T047-pr44-frontend-build-vi-types.md
@@ -1,0 +1,63 @@
+# Feature Pod Task: PR #44 Frontend Build Unblock for Vietnamese UI Types
+
+Owner: Codex
+Branch: `fix/pr44-frontend-build-vi-types`
+GitHub Issue: `#47`
+
+## Goal
+
+Unblock PR #44 by fixing the settings UI type mismatch so the frontend build accepts Vietnamese (`vi`) language preferences consistently.
+
+## User-visible outcome
+
+- Settings page can persist theme and language when the selected language is `vi`.
+- Frontend CI for the affected branch no longer fails on the TypeScript compile error.
+
+## Owned files/modules
+
+- `web/app/(utility)/settings/page.tsx`
+- Related shared frontend language helper/type files only if the fix requires them
+- `web/lib/dashboard-api.ts`
+- `docs/superpowers/tasks/2026-04-20-T047-pr44-frontend-build-vi-types.md`
+- `docs/superpowers/pr-notes/2026-04-20-pr44-frontend-build-vi-types.md`
+- `ai_first/daily/2026-04-20.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Unrelated marketplace, dashboard, and backend files
+
+## API/data contract
+
+- No API shape changes
+- Keep `/api/v1/settings/ui` payload compatible, only align frontend types with the already-supported `vi` option
+- Keep `AssessmentSummary.estimated_time_spent` optional to match the current assessment-review flow
+
+## Acceptance criteria
+
+- `persistUi()` accepts the full supported language union used by the settings page
+- Any local helper that writes/persists UI language accepts `vi`
+- Assessment review typing no longer blocks the build on optional `estimated_time_spent`
+- `cd web && npm run build` passes from a clean checkout on the fix branch
+- Diff stays limited to the UI preference/build blocker
+
+## Required tests
+
+- `cd web && npm run build`
+
+## Manual verification
+
+- Open settings UI and inspect the language/theme persistence path for `vi`
+- Confirm no new type errors are introduced in the settings and assessment review routes
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+- Expected: no system-map update unless architecture changed beyond typing alignment.
+
+## Handoff notes
+
+- Base this task from the branch used to validate PR #44 so the fix can be merged back into that PR flow cleanly.
+- Keep the PR narrowly scoped to the frontend build blockers only.

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -143,3 +143,38 @@ async def test_dashboard_overview_includes_assessment_summary(
     assert assessment_row["review_ref"] == "dashboard/assessments/quiz-session"
     assert assessment_row["assessment_summary"]["score_percent"] == 100
     assert assessment_row["assessment_summary"]["total_questions"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dashboard_assessment_analysis_returns_topic_breakdown(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="analysis-session",
+        capability="deep_question",
+        message="Generate a quiz on algebra",
+        knowledge_bases=["algebra-pack"],
+    )
+    await store.add_message(
+        "analysis-session",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve algebra equation x + 2 = 5 -> Answered: 3 (Correct)\n"
+        "2. [q2] Q: Solve algebra equation 2x = 10 -> Answered: 3 (Incorrect, correct: 5)\n"
+        "Score: 1/2 (50%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/assessment-analysis/analysis-session")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["session_id"] == "analysis-session"
+    assert payload["summary"]["score_percent"] == 50
+    assert len(payload["performance_by_topic"]) >= 1
+    assert "recommendations" in payload
+    assert len(payload["recommendations"]) >= 1

--- a/tests/api/test_marketplace_router.py
+++ b/tests/api/test_marketplace_router.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from deeptutor.api.routers import marketplace
+
+
+class _FakeKBManager:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+        self.config = {
+            "knowledge_bases": {
+                "shared-pack": {
+                    "path": "shared-pack",
+                    "description": "Shared pack",
+                    "sharing_status": "public",
+                    "subject": "Math",
+                    "owner": "Teacher A",
+                    "created_at": "2026-04-20T00:00:00",
+                    "updated_at": "2026-04-20T00:00:00",
+                },
+                "private-pack": {
+                    "path": "private-pack",
+                    "description": "Private pack",
+                    "sharing_status": "private",
+                    "subject": "Math",
+                    "owner": "Teacher B",
+                },
+            }
+        }
+
+    def list_knowledge_bases(self) -> list[str]:
+        return list(self.config.get("knowledge_bases", {}).keys())
+
+    def get_info(self, name: str) -> dict:
+        kb = self.config["knowledge_bases"][name]
+        return {
+            "name": name,
+            "is_default": False,
+            "status": "ready",
+            "statistics": {"content_lists": 3},
+            "metadata": {
+                "subject": kb.get("subject"),
+                "grade": kb.get("grade"),
+                "curriculum": kb.get("curriculum"),
+                "learning_objectives": kb.get("learning_objectives", []),
+                "owner": kb.get("owner"),
+                "sharing_status": kb.get("sharing_status"),
+            },
+        }
+
+    def _load_config(self) -> dict:
+        return self.config
+
+    def _save_config(self) -> None:
+        return
+
+
+def _build_app(monkeypatch, tmp_path: Path) -> TestClient:
+    (tmp_path / "shared-pack").mkdir(parents=True)
+    (tmp_path / "shared-pack" / "raw").mkdir(parents=True)
+    (tmp_path / "shared-pack" / "rag_storage").mkdir(parents=True)
+
+    manager = _FakeKBManager(tmp_path)
+    monkeypatch.setattr("deeptutor.api.routers.marketplace.get_kb_manager", lambda: manager)
+
+    app = FastAPI()
+    app.include_router(marketplace.router, prefix="/api/v1/marketplace")
+    return TestClient(app)
+
+
+def test_marketplace_list_only_returns_shareable_packs(monkeypatch, tmp_path: Path) -> None:
+    client = _build_app(monkeypatch, tmp_path)
+
+    response = client.get("/api/v1/marketplace/list")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["packs"][0]["name"] == "shared-pack"
+    assert payload["packs"][0]["sharing_status"] == "public"
+
+
+def test_marketplace_import_copies_pack_and_registers_new_entry(monkeypatch, tmp_path: Path) -> None:
+    client = _build_app(monkeypatch, tmp_path)
+
+    response = client.post("/api/v1/marketplace/import/shared-pack")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["pack"]["name"] == "shared-pack__imported"
+
+    imported_path = tmp_path / "shared-pack__imported"
+    assert imported_path.exists()
+    assert (imported_path / "raw").exists()
+    assert (imported_path / "rag_storage").exists()

--- a/tests/api/test_rate_limit_middleware.py
+++ b/tests/api/test_rate_limit_middleware.py
@@ -1,0 +1,29 @@
+from deeptutor.api import main
+
+
+def test_rate_limit_bucket_key_uses_matched_policy_prefix() -> None:
+    import_key = main._build_rate_limit_bucket_key(
+        client_ip="127.0.0.1",
+        path="/api/v1/marketplace/import/shared-pack",
+    )
+    list_key = main._build_rate_limit_bucket_key(
+        client_ip="127.0.0.1",
+        path="/api/v1/marketplace/list",
+    )
+
+    assert import_key != list_key
+    assert import_key.endswith("/api/v1/marketplace/import")
+    assert list_key.endswith("/api/v1")
+
+
+def test_rate_limit_bucket_key_is_stable_within_a_policy_prefix() -> None:
+    first = main._build_rate_limit_bucket_key(
+        client_ip="127.0.0.1",
+        path="/api/v1/question",
+    )
+    second = main._build_rate_limit_bucket_key(
+        client_ip="127.0.0.1",
+        path="/api/v1/question/stream",
+    )
+
+    assert first == second

--- a/web/app/(utility)/marketplace/error.tsx
+++ b/web/app/(utility)/marketplace/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+export default function MarketplaceError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    // Keep route-level exceptions visible in browser console for quick triage.
+    console.error("Marketplace route error:", error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-[50vh] w-full max-w-[860px] flex-col items-center justify-center gap-4 px-6 py-10 text-center">
+      <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+        {t("Knowledge Marketplace")}
+      </p>
+      <h1 className="text-[24px] font-semibold text-[var(--foreground)]">{t("Something went wrong")}</h1>
+      <p className="max-w-[560px] text-[14px] text-[var(--muted-foreground)]">
+        {t("We could not load the marketplace right now. Please try again.")}
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md bg-[var(--primary)] px-4 py-2 text-[13px] font-medium text-[var(--primary-foreground)]"
+      >
+        {t("Try again")}
+      </button>
+    </main>
+  );
+}

--- a/web/app/(utility)/marketplace/page.tsx
+++ b/web/app/(utility)/marketplace/page.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { BookOpen, Download, Filter, Loader2, Search } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   listMarketplacePacks,
+  importMarketplacePack,
   type MarketplaceListResponse,
   type MarketplacePack,
 } from "@/lib/marketplace-api";
-import { updateKnowledgeBaseConfig } from "@/lib/knowledge-api";
 
 export default function MarketplacePage() {
   const { t } = useTranslation();
@@ -32,7 +32,7 @@ export default function MarketplacePage() {
   const [importing, setImporting] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
 
-  const loadPacks = async () => {
+  const loadPacks = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -51,20 +51,19 @@ export default function MarketplacePage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [filterOwner, filterSubject, limit, offset, sharingStatus]);
 
   useEffect(() => {
     loadPacks();
-  }, [offset, sharingStatus, filterSubject, filterOwner]);
+  }, [loadPacks]);
 
   const handleImportPack = async (packName: string) => {
     setImporting(packName);
     try {
-      // Placeholder: In a real scenario, this would copy the pack to the user's workspace
-      // For now, we just show a success message
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await importMarketplacePack(packName);
       setImportSuccess(packName);
       setTimeout(() => setImportSuccess(null), 3000);
+      await loadPacks();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to import pack");
     } finally {

--- a/web/app/(utility)/settings/page.tsx
+++ b/web/app/(utility)/settings/page.tsx
@@ -23,7 +23,7 @@ import {
 
 import { useTranslation } from "react-i18next";
 
-import { writeStoredLanguage } from "@/context/AppShellContext";
+import { writeStoredLanguage, type AppLanguage } from "@/context/AppShellContext";
 import { apiUrl } from "@/lib/api";
 import { setTheme as applyThemePreference } from "@/lib/theme";
 
@@ -67,7 +67,7 @@ type Catalog = {
 
 type UiSettings = {
   theme: "light" | "dark";
-  language: "en" | "zh";
+  language: AppLanguage;
 };
 
 type ProviderOption = { value: string; label: string; base_url?: string };
@@ -368,7 +368,7 @@ function SettingsPageContent() {
 
   const [status, setStatus] = useState<SystemStatus | null>(null);
   const [theme, setTheme] = useState<"light" | "dark">("light");
-  const [language, setLanguage] = useState<"en" | "zh" | "vi">("en");
+  const [language, setLanguage] = useState<AppLanguage>("en");
   const [catalog, setCatalog] = useState<Catalog>(defaultCatalog());
   const [draft, setDraft] = useState<Catalog>(defaultCatalog());
   const [activeService, setActiveService] = useState<ServiceName>("llm");
@@ -460,7 +460,7 @@ function SettingsPageContent() {
 
   // -- UI preference helpers ----------------------------------------------
 
-  const persistUi = async (nextTheme: "light" | "dark", nextLanguage: "en" | "zh") => {
+  const persistUi = async (nextTheme: "light" | "dark", nextLanguage: AppLanguage) => {
     await fetch(apiUrl("/api/v1/settings/ui"), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -474,7 +474,7 @@ function SettingsPageContent() {
     await persistUi(nextTheme, language);
   };
 
-  const updateLanguage = async (nextLanguage: "en" | "zh") => {
+  const updateLanguage = async (nextLanguage: AppLanguage) => {
     setLanguage(nextLanguage);
     writeStoredLanguage(nextLanguage);
     await persistUi(theme, nextLanguage);

--- a/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
+++ b/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
@@ -5,7 +5,12 @@ import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ArrowLeft, CheckCircle2, Loader2, XCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { getAssessmentReview, type AssessmentReview } from "@/lib/dashboard-api";
+import {
+  getAssessmentAnalysis,
+  getAssessmentReview,
+  type AssessmentAnalysis,
+  type AssessmentReview,
+} from "@/lib/dashboard-api";
 import { ProgressIndicator } from "@/components/assessment/ProgressIndicator";
 import { LearningJourneySummary } from "@/components/assessment/LearningJourneySummary";
 
@@ -24,16 +29,18 @@ export default function AssessmentReviewPage() {
   const { t } = useTranslation();
   const { sessionId } = useParams<{ sessionId: string }>();
   const [review, setReview] = useState<AssessmentReview | null>(null);
+  const [analysis, setAnalysis] = useState<AssessmentAnalysis | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    getAssessmentReview(sessionId)
-      .then((data) => {
+    Promise.all([getAssessmentReview(sessionId), getAssessmentAnalysis(sessionId)])
+      .then(([reviewData, analysisData]) => {
         if (!cancelled) {
-          setReview(data);
+          setReview(reviewData);
+          setAnalysis(analysisData);
           setError(null);
         }
       })
@@ -118,6 +125,7 @@ export default function AssessmentReviewPage() {
           incorrectCount={review.summary.incorrect_count}
           scorePercent={review.summary.score_percent}
           knowledgeBases={review.knowledge_bases}
+          analysis={analysis}
         />
 
         <LearningJourneySummary

--- a/web/app/(workspace)/dashboard/assessments/error.tsx
+++ b/web/app/(workspace)/dashboard/assessments/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+export default function AssessmentError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    console.error("Assessment route error:", error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-[50vh] w-full max-w-[860px] flex-col items-center justify-center gap-4 px-6 py-10 text-center">
+      <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+        {t("Assessment")}
+      </p>
+      <h1 className="text-[24px] font-semibold text-[var(--foreground)]">{t("Something went wrong")}</h1>
+      <p className="max-w-[560px] text-[14px] text-[var(--muted-foreground)]">
+        {t("We could not load this assessment session. Please retry.")}
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md bg-[var(--primary)] px-4 py-2 text-[13px] font-medium text-[var(--primary-foreground)]"
+      >
+        {t("Try again")}
+      </button>
+    </main>
+  );
+}

--- a/web/components/assessment/ProgressIndicator.tsx
+++ b/web/components/assessment/ProgressIndicator.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ChevronDown, TrendingUp } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { AssessmentAnalysis } from "@/lib/dashboard-api";
 
 export interface ProgressIndicatorProps {
   totalQuestions: number;
@@ -10,6 +11,7 @@ export interface ProgressIndicatorProps {
   incorrectCount: number;
   scorePercent: number;
   knowledgeBases: string[];
+  analysis?: AssessmentAnalysis | null;
 }
 
 export function ProgressIndicator({
@@ -18,6 +20,7 @@ export function ProgressIndicator({
   incorrectCount,
   scorePercent,
   knowledgeBases,
+  analysis,
 }: ProgressIndicatorProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
@@ -141,6 +144,31 @@ export function ProgressIndicator({
 
       {expanded && (
         <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 space-y-3">
+          {analysis && analysis.performance_by_topic.length > 0 && (
+            <div className="rounded-md border border-[var(--border)] p-3">
+              <p className="text-[12px] font-semibold text-[var(--foreground)] mb-2">
+                {t("Performance by topic")}
+              </p>
+              <div className="space-y-2">
+                {analysis.performance_by_topic.slice(0, 4).map((topic) => (
+                  <div key={topic.topic} className="rounded-md bg-[var(--muted)] px-3 py-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-[12px] font-medium text-[var(--foreground)]">
+                        {topic.topic}
+                      </span>
+                      <span className="text-[11px] text-[var(--muted-foreground)]">
+                        {topic.accuracy_percent}%
+                      </span>
+                    </div>
+                    <p className="mt-1 text-[11px] text-[var(--muted-foreground)]">
+                      {t("Correct")}: {topic.correct_count} / {topic.total_questions}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {scorePercent < 75 && (
             <div className="p-3 rounded-md bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-800">
               <p className="text-[12px] font-medium text-yellow-900 dark:text-yellow-300">
@@ -195,6 +223,9 @@ export function ProgressIndicator({
               <li>{t("Review your incorrect answers")}</li>
               <li>{t("Study related concepts in the knowledge bases")}</li>
               <li>{t("Take another assessment to track improvement")}</li>
+              {analysis?.recommendations?.slice(0, 2).map((item) => (
+                <li key={item}>{item}</li>
+              ))}
             </ul>
           </div>
         </div>

--- a/web/components/chat/home/ChatMessages.tsx
+++ b/web/components/chat/home/ChatMessages.tsx
@@ -58,6 +58,29 @@ interface NotebookReferenceGroup {
   count: number;
 }
 
+function KnowledgeBaseChips({
+  knowledgeBases,
+  align = "left",
+}: {
+  knowledgeBases: string[];
+  align?: "left" | "right";
+}) {
+  if (!knowledgeBases.length) return null;
+  return (
+    <div className={`mb-2 flex flex-wrap gap-1.5 ${align === "right" ? "justify-end" : "justify-start"}`}>
+      {knowledgeBases.map((kb) => (
+        <span
+          key={kb}
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--background)]/60 px-2 py-1 text-[11px] font-medium text-[var(--muted-foreground)]"
+        >
+          <BookOpen size={11} strokeWidth={1.8} />
+          {kb}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 function getModeBadgeLabel(capability?: string | null) {
   if (!capability || capability === "chat") return "Chat";
   if (capability === "deep_solve") return "Deep Solve";
@@ -347,6 +370,10 @@ export function ChatMessageList({
                   </div>
                 )}
                 <div className="rounded-2xl bg-[var(--secondary)] px-4 py-2.5 text-[14px] leading-relaxed text-[var(--foreground)] shadow-sm">
+                  <KnowledgeBaseChips
+                    knowledgeBases={msg.requestSnapshot?.knowledgeBases ?? []}
+                    align="right"
+                  />
                   {(() => {
                     const snap = msg.requestSnapshot;
                     const hasNotebook = Boolean(snap?.notebookReferences?.length);
@@ -426,6 +453,9 @@ export function ChatMessageList({
 
         return (
           <div key={`${msg.role}-${i}`} className="w-full">
+            <KnowledgeBaseChips
+              knowledgeBases={pairedUserMessage?.requestSnapshot?.knowledgeBases ?? []}
+            />
             <AssistantMessage
               msg={msg}
               isStreaming={isStreaming && i === messages.length - 1}

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -5,6 +5,7 @@ export interface AssessmentSummary {
   correct_count: number;
   incorrect_count: number;
   score_percent: number;
+  estimated_time_spent?: number;
 }
 
 export interface AssessmentReviewResult {

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -25,6 +25,23 @@ export interface AssessmentReview {
   results: AssessmentReviewResult[];
 }
 
+export interface TopicPerformance {
+  topic: string;
+  total_questions: number;
+  correct_count: number;
+  incorrect_count: number;
+  accuracy_percent: number;
+}
+
+export interface AssessmentAnalysis {
+  session_id: string;
+  summary: AssessmentSummary;
+  performance_by_topic: TopicPerformance[];
+  weak_topics: string[];
+  strong_topics: string[];
+  recommendations: string[];
+}
+
 export interface DashboardActivity {
   id: string;
   type: "assessment" | "tutoring" | string;
@@ -76,4 +93,11 @@ export async function getAssessmentReview(sessionId: string): Promise<Assessment
     cache: "no-store",
   });
   return expectJson<AssessmentReview>(response);
+}
+
+export async function getAssessmentAnalysis(sessionId: string): Promise<AssessmentAnalysis> {
+  const response = await fetch(apiUrl(`/api/v1/dashboard/assessment-analysis/${sessionId}`), {
+    cache: "no-store",
+  });
+  return expectJson<AssessmentAnalysis>(response);
 }

--- a/web/lib/marketplace-api.ts
+++ b/web/lib/marketplace-api.ts
@@ -69,3 +69,41 @@ export async function getMarketplacePack(packName: string): Promise<MarketplaceP
 
   return response.json();
 }
+
+
+export interface ImportPackResult {
+  success: boolean;
+  message: string;
+  pack: {
+    name: string;
+    subject?: string;
+    grade?: string;
+    owner?: string;
+    import_date: string;
+    session_count?: number;
+  };
+}
+
+export async function importMarketplacePack(
+  packName: string,
+): Promise<ImportPackResult> {
+  const response = await fetch(
+    apiUrl(`/api/v1/marketplace/import/${encodeURIComponent(packName)}`),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    try {
+      const error = JSON.parse(errorBody);
+      throw new Error(error.detail || `Failed to import pack: ${response.status}`);
+    } catch {
+      throw new Error(`Failed to import pack: ${response.status} ${response.statusText}`);
+    }
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
# Autopilot Batch - T009 + T028 + T022 Architecture Note

**Branch:** `pod-a/marketplace-pack-import`  
**Scope:** Marketplace import implementation, API rate limiting, route-level error boundaries  
**Related Tasks:** `T009_MARKETPLACE_IMPORT_IMPLEMENTATION`, `T028_API_RATE_LIMITING`, `T022_ERROR_BOUNDARY_HANDLING`

## Overview

This batch converts a critical placeholder into a real workflow and adds runtime safety rails:

1. Marketplace import now performs a real filesystem copy and KB registration.
2. API now enforces lightweight request throttling with `429` and `Retry-After`.
3. Marketplace and assessment routes now have explicit user-facing recovery boundaries.

## Architecture Impact

```mermaid
flowchart LR
  UI[Marketplace UI] --> ImportAPI[POST /api/v1/marketplace/import/{pack_name}]
  ImportAPI --> KBManager[KnowledgeBaseManager]
  KBManager --> FS[Copy KB directory]
  FS --> Clone[Create <pack>__imported]
  Clone --> Registry[Update kb_config.json]

  API[FastAPI app] --> RL[Rate-limit middleware]
  RL --> Protected[question / solve / marketplace import]
  RL --> TooMany[429 + Retry-After]

  MarketplaceRoute[/marketplace] --> MarketError[error.tsx fallback]
  AssessmentRoute[/dashboard/assessments/*] --> AssessError[error.tsx fallback]
```

## Detailed Changes

### T009 Marketplace Import

- Backend: `deeptutor/api/routers/marketplace.py`
  - Added real import endpoint: `POST /api/v1/marketplace/import/{pack_name}`
  - Validates shareable source pack
  - Copies source KB directory into imported clone `<pack_name>__imported`
  - Registers imported clone in `kb_config.json`
- Frontend client: `web/lib/marketplace-api.ts`
  - Added/fixed `importMarketplacePack()` typed client
  - Corrected response function boundaries
- Frontend UI: `web/app/(utility)/marketplace/page.tsx`
  - Replaced placeholder delay with real API call
  - Preserved import loading/success/error states
  - Refreshes list after import
- Tests scaffold:
  - `tests/api/test_marketplace_router.py`

### T028 Rate Limiting

- API core: `deeptutor/api/main.py`
  - Added in-memory sliding-window middleware for `/api/*`
  - Route-prefix policies:
    - `/api/v1/marketplace/import` -> 20 req/60s
    - `/api/v1/question` -> 40 req/60s
    - `/api/v1/solve` -> 30 req/60s
    - fallback `/api/v1` -> 120 req/60s
  - Breach response: `429 Too Many Requests` with `Retry-After`

### T022 Error Boundaries

- Added route-level boundaries:
  - `web/app/(utility)/marketplace/error.tsx`
  - `web/app/(workspace)/dashboard/assessments/error.tsx`
- Each boundary provides:
  - Friendly failure message
  - Retry action (`reset()`)
  - Console logging for diagnosis

## Data/API Notes

- New import behavior is currently implemented as same-instance clone import (`<pack>__imported`).
- This keeps MVP flow deterministic without introducing multi-tenant storage assumptions.
- Rate limiting is in-memory and instance-local (sufficient for single-node MVP).

## Validation

- Passed: `.venv/bin/python -m py_compile deeptutor/api/routers/marketplace.py`
- Passed: `.venv/bin/python -m py_compile deeptutor/api/main.py`
- Passed: `npx eslint app/(utility)/marketplace/page.tsx lib/marketplace-api.ts`
- Passed: `npx eslint app/(utility)/marketplace/error.tsx app/(workspace)/dashboard/assessments/error.tsx`
- Could not run: `pytest` not installed in current `.venv` (`No module named pytest`)

## System Map Update

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated in this batch:
  - Added marketplace import flow node
  - Added imported clone/registry node
  - Added API security/rate-limit node
  - Added marketplace and assessment error-boundary nodes
