### PR TITLE
fix: isolate rate-limit buckets by policy

### DIFF
--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -144,6 +144,32 @@
 - Issue `#47`: implementation complete, ready for draft PR
 - `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because the fix does not change system structure
 
+## T046 Rate-Limit Bucket Isolation — Follow-up Fix
+
+### Completed in this cycle
+
+1. Added dedicated task packet for issue `#46`:
+   - `docs/superpowers/tasks/2026-04-20-T046-rate-limit-bucket-isolation.md`
+2. Added regression coverage for rate-limit bucket derivation:
+   - `tests/api/test_rate_limit_middleware.py`
+3. Fixed middleware bucket-key generation in:
+   - `deeptutor/api/main.py`
+   - bucket keys now derive from the matched policy prefix instead of the first three path segments
+4. Added PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-20-pr44-rate-limit-bucket-isolation.md`
+
+### Validation
+
+- Backend regression test passed:
+  - `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/api/test_rate_limit_middleware.py -q`
+- Python compile check passed:
+  - `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m py_compile deeptutor/api/main.py`
+
+### Status
+
+- Issue `#46`: implementation complete, ready for draft PR
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because the fix does not change system structure
+
 ## T011 KB Context Badges — Implementation Progress (Autopilot)
 
 ### Completed in this cycle

--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -163,11 +163,16 @@ _RATE_LIMIT_RULES: tuple[tuple[str, int, int], ...] = (
 _rate_limit_store: dict[str, deque[float]] = defaultdict(deque)
 
 
-def _resolve_rate_limit(path: str) -> tuple[int, int]:
+def _resolve_rate_limit(path: str) -> tuple[str, int, int]:
     for prefix, limit, window_seconds in _RATE_LIMIT_RULES:
         if path.startswith(prefix):
-            return limit, window_seconds
-    return 120, 60
+            return prefix, limit, window_seconds
+    return "/api/v1", 120, 60
+
+
+def _build_rate_limit_bucket_key(client_ip: str, path: str) -> str:
+    policy_prefix, _, _ = _resolve_rate_limit(path)
+    return f"{client_ip}:{policy_prefix}"
 
 
 @app.middleware("http")
@@ -178,10 +183,9 @@ async def api_rate_limit(request: Request, call_next):
     if not path.startswith("/api/"):
         return await call_next(request)
 
-    limit, window_seconds = _resolve_rate_limit(path)
+    _, limit, window_seconds = _resolve_rate_limit(path)
     client_ip = request.client.host if request.client else "unknown"
-    path_bucket = "/".join(path.strip("/").split("/")[:3])
-    key = f"{client_ip}:{path_bucket}"
+    key = _build_rate_limit_bucket_key(client_ip, path)
 
     now = monotonic()
     events = _rate_limit_store[key]

--- a/docs/superpowers/pr-notes/2026-04-20-pr44-rate-limit-bucket-isolation.md
+++ b/docs/superpowers/pr-notes/2026-04-20-pr44-rate-limit-bucket-isolation.md
@@ -1,0 +1,35 @@
+# PR Note: Rate-Limit Bucket Isolation for PR #44 Middleware
+
+## Summary
+
+This follow-up fixes the rate-limit key derivation added in PR #44.
+
+- adds a dedicated bucket-key helper derived from the matched policy prefix
+- updates the middleware to use that helper instead of truncating to the first three path segments
+- adds regression coverage for marketplace import/list separation and stable keys within the same policy
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Request["HTTP request path"] --> Resolve["_resolve_rate_limit(path)"]
+  Resolve --> Policy["matched policy prefix"]
+  Policy --> Bucket["_build_rate_limit_bucket_key(client_ip, path)"]
+  Bucket --> Store["in-memory counter store"]
+  Store --> Limit["429 + Retry-After when threshold exceeded"]
+```
+
+## Files
+
+- `deeptutor/api/main.py`
+- `tests/api/test_rate_limit_middleware.py`
+
+## Validation
+
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/api/test_rate_limit_middleware.py -q`
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m py_compile deeptutor/api/main.py`
+
+## System Map
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
+- Reason: this PR only fixes internal middleware keying and does not change system structure

--- a/docs/superpowers/tasks/2026-04-20-T046-rate-limit-bucket-isolation.md
+++ b/docs/superpowers/tasks/2026-04-20-T046-rate-limit-bucket-isolation.md
@@ -1,0 +1,61 @@
+# Feature Pod Task: Rate-Limit Bucket Isolation for PR #44 Middleware
+
+Owner: Codex
+Branch: `fix/pr44-rate-limit-bucket-isolation`
+GitHub Issue: `#46`
+
+## Goal
+
+Correct the HTTP rate-limit middleware so counters are isolated by the matched policy instead of colliding across different marketplace routes.
+
+## User-visible outcome
+
+- Bursts of marketplace import requests do not incorrectly throttle marketplace list/detail reads.
+- Route-specific rate-limit rules behave as documented.
+
+## Owned files/modules
+
+- `deeptutor/api/main.py`
+- `tests/api/test_rate_limit_middleware.py`
+- `docs/superpowers/tasks/2026-04-20-T046-rate-limit-bucket-isolation.md`
+- `docs/superpowers/pr-notes/2026-04-20-pr44-rate-limit-bucket-isolation.md`
+- `ai_first/daily/2026-04-20.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Unrelated frontend files
+
+## API/data contract
+
+- Keep existing `429` response shape and `Retry-After` header behavior
+- Preserve declared limits while changing only how the bucket key is derived/stored
+
+## Acceptance criteria
+
+- Requests matching different policies do not share the same counter bucket unless intended
+- Marketplace import and marketplace list can no longer collide through a shared key
+- Regression coverage proves the intended bucket split
+- Relevant backend validation passes
+
+## Required tests
+
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/api/test_rate_limit_middleware.py -q`
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m py_compile deeptutor/api/main.py`
+
+## Manual verification
+
+- Verify the computed key/policy for `/api/v1/marketplace/import/...` differs from `/api/v1/marketplace/list`
+- Confirm fallback `/api/v1` policy still works for unrelated routes
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+- Expected: no system-map update unless the middleware architecture changes materially.
+
+## Handoff notes
+
+- This branch is based on `fix/pr44-frontend-build-vi-types` so it can merge after the CI-unblock PR in the PR #44 follow-up stack.
+- Keep the PR narrowly scoped to bucket isolation and regression coverage.

--- a/tests/api/test_rate_limit_middleware.py
+++ b/tests/api/test_rate_limit_middleware.py
@@ -1,0 +1,29 @@
+from deeptutor.api import main
+
+
+def test_rate_limit_bucket_key_uses_matched_policy_prefix() -> None:
+    import_key = main._build_rate_limit_bucket_key(
+        client_ip="127.0.0.1",
+        path="/api/v1/marketplace/import/shared-pack",
+    )
+    list_key = main._build_rate_limit_bucket_key(
+        client_ip="127.0.0.1",
+        path="/api/v1/marketplace/list",
+    )
+
+    assert import_key != list_key
+    assert import_key.endswith("/api/v1/marketplace/import")
+    assert list_key.endswith("/api/v1")
+
+
+def test_rate_limit_bucket_key_is_stable_within_a_policy_prefix() -> None:
+    first = main._build_rate_limit_bucket_key(
+        client_ip="127.0.0.1",
+        path="/api/v1/question",
+    )
+    second = main._build_rate_limit_bucket_key(
+        client_ip="127.0.0.1",
+        path="/api/v1/question/stream",
+    )
+
+    assert first == second


### PR DESCRIPTION
## What changed
- added `_build_rate_limit_bucket_key()` so the middleware keys counters by the matched policy prefix
- updated the rate-limit middleware to use the matched policy bucket instead of truncating to the first three path segments
- added regression coverage for marketplace import/list bucket separation and stable keys within one policy
- added the task packet and PR note required by the AI operating workflow

## Why
The PR #44 rate-limit middleware declared route-specific policies, but `/api/v1/marketplace/import/...` and `/api/v1/marketplace/list` still shared the same counter bucket. That made stricter import traffic able to throttle unrelated marketplace reads.

## Validation
- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/api/test_rate_limit_middleware.py -q`
- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m py_compile deeptutor/api/main.py`

## Impact
- keeps the existing `429` response and `Retry-After` header
- no `MAIN_SYSTEM_MAP` update required
- stacked on top of `fix/pr44-frontend-build-vi-types`

Closes #46
