### PR TITLE
[MVP] Student Progress Tracking Dashboard

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, `T012 Teacher Knowledge Pack Sharing UI` was verified as already implemented on `main`, and the active short task is `T013 Marketplace Pack Preview Modal`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace preview is now merged into `main`, and the active short task is `T014 Student Progress Tracking Dashboard`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T013`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T014`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace preview is now merged into `main`, and the active short task is `T014 Student Progress Tracking Dashboard`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace preview is now merged into `main`, and Draft PR `#54` is active for `T014 Student Progress Tracking Dashboard`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T014`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T014` via Draft PR `#54`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -1,6 +1,6 @@
 # Execution Queue
 
-Last updated: 2026-04-20
+Last updated: 2026-04-21
 
 This is the compact status board for humans and AI workers.  
 The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
@@ -15,20 +15,22 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 - Active issue: `#53 [MVP] Student Progress Tracking Dashboard`
 - Active branch: `pod-a/t014-student-progress-dashboard`
+- Active PR: `#54 [MVP] Student Progress Tracking Dashboard` (Draft)
 - Active task packet: `docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md`
 - Focus set: `T014` (student-facing progress dashboard)
 
 ## Next recommended task
 
-Implement `T014` on `pod-a/t014-student-progress-dashboard`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Monitor CI for `#54`, fix any failing checks on `pod-a/t014-student-progress-dashboard`, then merge to `main` once all required checks are green.
 
-## Status Update (2026-04-20)
+## Status Update (2026-04-21)
 
 **Queue Advance**:
 1. `#52` merged to `main` after all required CI checks passed
 2. Completed registry tasks were reconciled to match what is already merged on `main`
 3. Next pending registry task selected in strict order: `T014 Student Progress Tracking Dashboard`
 4. Issue `#53` created and task packet added for the new execution lane
+5. Draft PR `#54` opened with validation complete and architecture note attached
 
 ## AI-owned blockers
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#44 feat: complete autopilot batch for marketplace import, API throttling, route resilience, assessment insights, and KB context badges`
-- Follow-up fix PRs `#48` and `#49` were merged first, then folded into `#44`, and all required CI checks passed before merge.
-- Core MVP path in `main` now includes marketplace import, assessment insights, KB context badges, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#52 feat: add marketplace pack preview`
+- `#52` added compact preview-before-import flow for marketplace packs and passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import and preview, assessment insights, KB context badges, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#51 [MVP] Marketplace Pack Preview Modal`
-- Active branch: `pod-a/t013-marketplace-pack-preview`
-- Active task packet: `docs/superpowers/tasks/2026-04-20-T013-marketplace-pack-preview.md`
-- Focus set: `T013` (preview modal for marketplace packs)
+- Active issue: `#53 [MVP] Student Progress Tracking Dashboard`
+- Active branch: `pod-a/t014-student-progress-dashboard`
+- Active task packet: `docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md`
+- Focus set: `T014` (student-facing progress dashboard)
 
 ## Next recommended task
 
-Implement `T013` on `pod-a/t013-marketplace-pack-preview`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T014` on `pod-a/t014-student-progress-dashboard`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-20)
 
 **Queue Advance**:
-1. `#44` merged to `main` after `Backend`, `Frontend`, `Docs`, and `Summary` checks passed
-2. `T012` was verified as already implemented on `main` and reclassified to completed
-3. Next pending registry task selected in strict order: `T013 Marketplace Pack Preview Modal`
-4. Issue `#51` created and task packet added for the new execution lane
+1. `#52` merged to `main` after all required CI checks passed
+2. Completed registry tasks were reconciled to match what is already merged on `main`
+3. Next pending registry task selected in strict order: `T014 Student Progress Tracking Dashboard`
+4. Issue `#53` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -55,7 +55,8 @@ Implement `T013` on `pod-a/t013-marketplace-pack-preview`, then open a Draft PR 
 | T010: Assessment Feedback | Completed | 6 | YES | Done |
 | T011: KB Context Badges | Completed | 2 | NO | Done |
 | T012: Teacher Sharing UI | Completed | 3 | NO | Verified |
-| T013: Marketplace Preview | In Progress | 3 | NO | Now |
+| T013: Marketplace Preview | Completed | 3 | NO | Done |
+| T014: Student Progress Dashboard | In Progress | 5 | NO | Now |
 | T018: Vietnamese Prompts | Not Started | 4 | YES | Parallel |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -58,8 +58,8 @@
       "complexity": "High",
       "estimated_hours": 4,
       "dependencies": ["Knowledge Pack Manager API"],
-      "status": "in-progress",
-      "notes": "Backend import endpoint and frontend API wiring are implemented; copy flow now creates imported KB clone and registers it in kb_config. Pending full integration verification in environment with pytest installed."
+      "status": "completed",
+      "notes": "Merged to main through PR #44 with follow-up fixes #48 and #49. Import flow clones marketplace packs into imported KBs and registers them in kb_config."
     },
     {
       "id": "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -76,8 +76,8 @@
       "complexity": "High",
       "estimated_hours": 6,
       "dependencies": ["Assessment Generation API"],
-      "status": "in-progress",
-      "notes": "Implemented dashboard assessment-analysis endpoint with heuristic topic breakdown and recommendations, wired into assessment review UI and added API test coverage. Pending runtime validation in env with pytest installed."
+      "status": "completed",
+      "notes": "Merged to main through PR #44. Assessment review now includes backend analysis, topic signals, and richer frontend progress summaries."
     },
     {
       "id": "T011_KB_CONTEXT_BADGES",
@@ -93,8 +93,8 @@
       "complexity": "Medium",
       "estimated_hours": 2,
       "dependencies": ["Chat Context System"],
-      "status": "in-progress",
-      "notes": "KB context badges added to chat message rendering based on request snapshot knowledgeBases for both user prompts and paired assistant responses. Pending UX review in runtime session."
+      "status": "completed",
+      "notes": "Merged to main through PR #44. KB context badges render in chat from request snapshot knowledgeBases."
     },
     {
       "id": "T012_TEACHER_PACK_SHARING_UI",
@@ -127,8 +127,8 @@
       "complexity": "Medium",
       "estimated_hours": 3,
       "dependencies": ["Marketplace API"],
-      "status": "in-progress",
-      "notes": "Issue #51 opened and task packet created at docs/superpowers/tasks/2026-04-20-T013-marketplace-pack-preview.md. Next step: implement a compact preview endpoint and marketplace modal flow."
+      "status": "completed",
+      "notes": "Merged to main through PR #52. Marketplace now supports compact preview before import."
     },
     {
       "id": "T014_STUDENT_PROGRESS_DASHBOARD",
@@ -144,8 +144,8 @@
       "complexity": "High",
       "estimated_hours": 5,
       "dependencies": ["Assessment Analytics"],
-      "status": "not-started",
-      "notes": "Show progress over time, topic mastery chart, recent assessments, learning streak"
+      "status": "in-progress",
+      "notes": "Issue #53 opened and task packet created at docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md. Active branch: pod-a/t014-student-progress-dashboard."
     },
     {
       "id": "T015_ASSESSMENT_RECOMMENDATIONS",
@@ -281,8 +281,8 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["React"],
-      "status": "in-progress",
-      "notes": "Route-level error boundaries added for marketplace and assessment pages. Pending extension to additional high-traffic routes and UX copy parity across locales."
+      "status": "completed",
+      "notes": "Merged to main through PR #44. Marketplace and assessment review routes now have explicit error boundaries."
     },
     {
       "id": "T023_MARKETPLACE_CACHE_OPTIMIZATION",
@@ -382,8 +382,8 @@
       "complexity": "Medium",
       "estimated_hours": 2,
       "dependencies": ["FastAPI Middleware"],
-      "status": "in-progress",
-      "notes": "In-memory sliding-window middleware added in deeptutor/api/main.py with per-prefix route limits and 429 responses including Retry-After header. Pending production load tuning and persistence strategy."
+      "status": "completed",
+      "notes": "Merged to main through PR #44 and follow-up PR #49. API middleware now enforces per-policy rate limits with isolated buckets."
     },
     {
       "id": "T029_MARKETPLACE_SEARCH_FULLTEXT",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -145,7 +145,7 @@
       "estimated_hours": 5,
       "dependencies": ["Assessment Analytics"],
       "status": "in-progress",
-      "notes": "Issue #53 opened and task packet created at docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md. Active branch: pod-a/t014-student-progress-dashboard."
+      "notes": "Issue #53 opened and task packet created at docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md. Active branch: pod-a/t014-student-progress-dashboard. Draft PR #54 is open with backend tests and frontend build passing locally."
     },
     {
       "id": "T015_ASSESSMENT_RECOMMENDATIONS",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -56,7 +56,12 @@ flowchart TD
   
   Product --> TeacherDashboard["Teacher Dashboard"]
   TeacherDashboard --> DashboardSummary["Session Activity Summary"]
+  TeacherDashboard --> StudentDashboard["Student Progress Dashboard"]
   TeacherDashboard --> AssessmentReview["Assessment Review Drill-down"]
+  StudentDashboard --> StudentRoute["/dashboard/student"]
+  StudentDashboard --> StudentProgressAPI["GET /api/v1/dashboard/student-progress"]
+  StudentDashboard --> TrendCards["Streak + average score + recent assessments"]
+  StudentDashboard --> TopicSignals["Focus topics + mastered topics"]
   AssessmentReview --> ReviewRoute["/dashboard/assessments/[sessionId]"]
   AssessmentReview --> ReviewAPI["/api/v1/sessions/{session_id}/assessment-review"]
   AssessmentReview --> ProgressIndicator["ProgressIndicator Component"]

--- a/ai_first/daily/2026-04-20.md
+++ b/ai_first/daily/2026-04-20.md
@@ -235,6 +235,25 @@
 
 - Task `T013_MARKETPLACE_PACK_PREVIEW`: implementation complete, ready for draft PR
 
+## T014 Student Progress Tracking Dashboard — Task Selection
+
+### Completed in this cycle
+
+1. Synced from `main` after PR `#52` merged.
+2. Reconciled stale task states in `ai_first/TASK_REGISTRY.json` for already-merged tasks.
+3. Opened GitHub issue `#53` for `T014 Student Progress Tracking Dashboard`.
+4. Added task packet:
+   - `docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md`
+5. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T014_STUDENT_PROGRESS_DASHBOARD`: moved to `in-progress`
+- Next: implement the smallest useful student-facing dashboard view from existing dashboard session data
+
 ## T011 KB Context Badges — Implementation Progress (Autopilot)
 
 ### Completed in this cycle

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -1,0 +1,35 @@
+# Daily Log — 2026-04-21
+
+## T014 Student Progress Tracking Dashboard — Implementation Progress
+
+### Completed in this cycle
+
+1. Added student progress API aggregation in `deeptutor/api/routers/dashboard.py`:
+   - `GET /api/v1/dashboard/student-progress`
+   - derives learning streak, average score, recent assessments, and topic-level focus/mastery from existing session data
+2. Added regression coverage in `tests/api/test_dashboard_router.py`:
+   - verifies score trend ordering, topic aggregation, knowledge-pack usage, and streak calculation
+3. Added typed frontend integration in `web/lib/dashboard-api.ts`
+4. Added student-facing route:
+   - `web/app/(workspace)/dashboard/student/page.tsx`
+   - handles loading, error, and empty states
+5. Updated teacher dashboard entry point in:
+   - `web/app/(workspace)/dashboard/page.tsx`
+   - adds direct navigation to the student dashboard
+6. Updated system map and PR architecture note:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+   - `docs/superpowers/pr-notes/2026-04-21-student-progress-dashboard.md`
+
+### Validation
+
+- Backend dashboard tests passed:
+  - `python3 -m pytest tests/api/test_dashboard_router.py -q`
+- Python compile check passed:
+  - `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+- Frontend production build passed in the feature worktree:
+  - `cd web && npm run build`
+
+### Status
+
+- Task `T014_STUDENT_PROGRESS_DASHBOARD`: implementation complete on branch `pod-a/t014-student-progress-dashboard`
+- Next: commit, push, open Draft PR linked to issue `#53`, then monitor CI and merge per AI-first policy

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -1,5 +1,6 @@
 """Dashboard API backed by the unified SQLite session store."""
 
+from datetime import datetime, timezone
 import re
 from typing import Any
 
@@ -108,6 +109,15 @@ def _activity_type(capability: str) -> str:
     return capability.replace("deep_", "")
 
 
+def _timestamp_to_day(value: float | int | None) -> int | None:
+    if not value:
+        return None
+    timestamp = float(value)
+    if timestamp > 10_000_000_000:
+        timestamp /= 1000
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).date().toordinal()
+
+
 def _session_knowledge_bases(session: dict[str, Any]) -> list[str]:
     preferences = session.get("preferences")
     if not isinstance(preferences, dict):
@@ -153,6 +163,66 @@ async def _activity_with_review(
     detail = await store.get_session_with_messages(str(session.get("session_id") or session.get("id")))
     review = extract_assessment_review(detail) if detail else None
     return _activity_from_session(session, review)
+
+
+def _summarize_topic_mastery(
+    assessment_rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    topic_totals: dict[str, dict[str, int]] = {}
+
+    for activity in assessment_rows:
+        for row in _build_assessment_analysis(
+            {
+                "session_id": activity.get("session_id"),
+                "summary": activity.get("summary") or {},
+                "results": activity.get("assessment_results") or [],
+            }
+        )["performance_by_topic"]:
+            bucket = topic_totals.setdefault(
+                row["topic"],
+                {"topic": row["topic"], "total_questions": 0, "correct_count": 0, "incorrect_count": 0},
+            )
+            bucket["total_questions"] += row["total_questions"]
+            bucket["correct_count"] += row["correct_count"]
+            bucket["incorrect_count"] += row["incorrect_count"]
+
+    topic_rows = []
+    for row in topic_totals.values():
+        total = row["total_questions"]
+        row["accuracy_percent"] = round((row["correct_count"] / total) * 100) if total else 0
+        topic_rows.append(row)
+
+    focus_topics = sorted(
+        [row for row in topic_rows if row["incorrect_count"] > 0],
+        key=lambda row: (-row["incorrect_count"], row["accuracy_percent"], row["topic"]),
+    )[:5]
+    mastered_topics = sorted(
+        [row for row in topic_rows if row["accuracy_percent"] >= 80],
+        key=lambda row: (-row["accuracy_percent"], row["topic"]),
+    )[:5]
+    return focus_topics, mastered_topics
+
+
+def _learning_streak_days(activities: list[dict[str, Any]]) -> int:
+    days = []
+    seen_days: set[int] = set()
+    for activity in sorted(activities, key=lambda row: row.get("timestamp", 0), reverse=True):
+        day = _timestamp_to_day(activity.get("timestamp"))
+        if day is None or day in seen_days:
+            continue
+        seen_days.add(day)
+        days.append(day)
+
+    if not days:
+        return 0
+
+    streak = 1
+    for previous, current in zip(days, days[1:]):
+        if previous - current == 1:
+            streak += 1
+            continue
+        break
+    return streak
 
 
 @router.get("/recent")
@@ -201,6 +271,77 @@ async def get_dashboard_overview(limit: int = 50):
             )
         ],
         "recent_activity": activities[:limit],
+    }
+
+
+@router.get("/student-progress")
+async def get_student_progress(limit: int = 50):
+    store = get_sqlite_session_store()
+    sessions = await store.list_sessions(limit=limit, offset=0)
+    activities = [await _activity_with_review(store, session) for session in sessions]
+
+    assessment_rows = [
+        {
+            "session_id": activity["id"],
+            "title": activity["title"],
+            "timestamp": activity["timestamp"],
+            "knowledge_bases": activity["knowledge_bases"],
+            "summary": activity["assessment_summary"],
+            "review_ref": activity["review_ref"],
+            "assessment_results": activity.get("assessment_summary") and (
+                extract_assessment_review(await store.get_session_with_messages(activity["id"])) or {}
+            ).get("results", []),
+        }
+        for activity in activities
+        if activity["type"] == "assessment" and activity.get("assessment_summary")
+    ]
+
+    focus_topics, mastered_topics = _summarize_topic_mastery(assessment_rows)
+    unique_knowledge_packs = sorted(
+        {
+            kb_name
+            for activity in activities
+            for kb_name in activity.get("knowledge_bases", [])
+        }
+    )
+    average_score_percent = round(
+        sum(int(row["summary"]["score_percent"]) for row in assessment_rows) / len(assessment_rows)
+    ) if assessment_rows else 0
+
+    score_trend = [
+        {
+            "session_id": row["session_id"],
+            "score_percent": int(row["summary"]["score_percent"]),
+            "timestamp": row["timestamp"],
+        }
+        for row in sorted(assessment_rows, key=lambda row: row["timestamp"])
+    ]
+    recent_assessments = [
+        {
+            "session_id": row["session_id"],
+            "title": row["title"],
+            "timestamp": row["timestamp"],
+            "score_percent": int(row["summary"]["score_percent"]),
+            "correct_count": int(row["summary"]["correct_count"]),
+            "total_questions": int(row["summary"]["total_questions"]),
+            "knowledge_bases": row["knowledge_bases"],
+            "review_ref": row["review_ref"],
+        }
+        for row in sorted(assessment_rows, key=lambda row: row["timestamp"], reverse=True)[:5]
+    ]
+
+    return {
+        "totals": {
+            "assessments_completed": len(assessment_rows),
+            "tutoring_sessions": sum(1 for activity in activities if activity["type"] == "tutoring"),
+            "knowledge_packs_used": len(unique_knowledge_packs),
+            "average_score_percent": average_score_percent,
+            "streak_days": _learning_streak_days(activities),
+        },
+        "focus_topics": focus_topics,
+        "mastered_topics": mastered_topics,
+        "score_trend": score_trend,
+        "recent_assessments": recent_assessments,
     }
 
 

--- a/docs/superpowers/pr-notes/2026-04-21-student-progress-dashboard.md
+++ b/docs/superpowers/pr-notes/2026-04-21-student-progress-dashboard.md
@@ -1,0 +1,62 @@
+# PR Architecture Note: Student Progress Dashboard
+
+## Summary
+
+Adds a student-facing dashboard route that summarizes assessment performance, recent progress, and topic signals from the existing unified session store.
+
+## Scope
+
+- `GET /api/v1/dashboard/student-progress`
+- `web/app/(workspace)/dashboard/student/page.tsx`
+- shared dashboard API typings and client fetch
+- dashboard router regression coverage
+- teacher dashboard link to the new student route
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Student["Student"]
+  StudentPage["/dashboard/student"]
+  DashboardClient["web/lib/dashboard-api.ts"]
+  StudentProgressAPI["GET /api/v1/dashboard/student-progress"]
+  SessionStore["SQLite Session Store"]
+  AssessmentReview["Assessment Review Parser"]
+  Summary["Streak + scores + topic signals"]
+
+  Student --> StudentPage
+  StudentPage --> DashboardClient
+  DashboardClient --> StudentProgressAPI
+  StudentProgressAPI --> SessionStore
+  StudentProgressAPI --> AssessmentReview
+  SessionStore --> Summary
+  AssessmentReview --> Summary
+  Summary --> StudentPage
+```
+
+## Architecture Impact
+
+This change extends the existing dashboard route family instead of introducing a second analytics service or persistence layer. Student progress is derived deterministically from existing sessions and assessment review messages.
+
+## Data/API Changes
+
+- Adds `GET /api/v1/dashboard/student-progress`
+- Returns:
+  - `totals`
+  - `focus_topics`
+  - `mastered_topics`
+  - `score_trend`
+  - `recent_assessments`
+
+## Tests
+
+```bash
+python3 -m pytest tests/api/test_dashboard_router.py -q
+python3 -m py_compile deeptutor/api/routers/dashboard.py
+cd web && npm run build
+```
+
+## Main System Map Update
+
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- [ ] Not needed

--- a/docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md
+++ b/docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: Student Progress Tracking Dashboard
+
+Owner: Codex
+Branch: `pod-a/t014-student-progress-dashboard`
+GitHub Issue: `#53`
+
+## Goal
+
+Add a student-facing dashboard view that shows progress across assessments, recent learning activity, and topic or knowledge-pack level signals using existing session data.
+
+## User-visible outcome
+
+- Students can open a dashboard view focused on their own learning progress.
+- The view summarizes recent assessments and tutoring sessions in one place.
+- Students can see at-a-glance progress trends without opening each assessment review separately.
+
+## Owned files/modules
+
+- `web/app/(workspace)/dashboard/`
+- `web/lib/dashboard-api.ts`
+- `deeptutor/api/routers/dashboard.py`
+- `tests/api/test_dashboard_router.py`
+- `docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-20.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Unrelated marketplace, settings, and knowledge-page files
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Prefer extending the current dashboard route family in `deeptutor/api/routers/dashboard.py`
+- Reuse existing recent-activity and assessment-summary data before introducing new storage
+- Keep the first version read-only and deterministic
+
+## Acceptance criteria
+
+- A student-facing dashboard route or section exists under the current dashboard flow.
+- The UI shows recent assessment/tutoring activity with useful progress context.
+- The backend exposes only the minimal additional data needed for the student dashboard.
+- Empty/loading/error states are handled cleanly.
+
+## Required tests
+
+- Targeted backend tests for any new dashboard response shape
+- Frontend build/lint validation for touched dashboard files
+
+## Manual verification
+
+- Open the dashboard student view.
+- Confirm recent progress data renders.
+- Confirm a user with no activity sees a clean empty state.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+
+## Handoff notes
+
+- `T009`, `T010`, `T011`, `T013`, `T022`, and `T028` are now merged and should be treated as completed.
+- Start from existing dashboard session summaries and assessment review data; do not invent a second analytics model unless forced by missing fields.

--- a/docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md
+++ b/docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md
@@ -67,3 +67,13 @@ Add a student-facing dashboard view that shows progress across assessments, rece
 
 - `T009`, `T010`, `T011`, `T013`, `T022`, and `T028` are now merged and should be treated as completed.
 - Start from existing dashboard session summaries and assessment review data; do not invent a second analytics model unless forced by missing fields.
+- Implemented on branch `pod-a/t014-student-progress-dashboard` with:
+  - `GET /api/v1/dashboard/student-progress`
+  - `web/app/(workspace)/dashboard/student/page.tsx`
+  - direct teacher-dashboard link into the student progress view
+- Validation completed:
+  - `python3 -m pytest tests/api/test_dashboard_router.py -q`
+  - `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+  - `cd web && npm run build`
+- PR note prepared:
+  - `docs/superpowers/pr-notes/2026-04-21-student-progress-dashboard.md`

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 try:
@@ -45,6 +47,23 @@ async def _seed_session(
     turn = await store.create_turn(session_id, capability=capability)
     await store.add_message(session_id, "user", message, capability=capability)
     await store.update_turn_status(turn["id"], status)
+
+
+def _set_session_timestamp(store: SQLiteSessionStore, session_id: str, timestamp: float) -> None:
+    with sqlite3.connect(store.db_path) as conn:
+        conn.execute(
+            "UPDATE sessions SET created_at = ?, updated_at = ? WHERE id = ?",
+            (timestamp, timestamp, session_id),
+        )
+        conn.execute(
+            "UPDATE turns SET created_at = ?, updated_at = ?, finished_at = ? WHERE session_id = ?",
+            (timestamp, timestamp, timestamp, session_id),
+        )
+        conn.execute(
+            "UPDATE messages SET created_at = ? WHERE session_id = ?",
+            (timestamp, session_id),
+        )
+        conn.commit()
 
 
 @pytest.mark.asyncio
@@ -178,3 +197,79 @@ async def test_dashboard_assessment_analysis_returns_topic_breakdown(
     assert len(payload["performance_by_topic"]) >= 1
     assert "recommendations" in payload
     assert len(payload["recommendations"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_student_progress_summarizes_scores_topics_and_streak(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="assessment-recent",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "assessment-recent",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions addition 1/2 + 1/4 -> Answered: 3/4 (Correct)\n"
+        "2. [q2] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4)\n"
+        "Score: 1/2 (50%)",
+        capability="deep_question",
+    )
+    _set_session_timestamp(store, "assessment-recent", 1_710_000_000)
+
+    await _seed_session(
+        store,
+        session_id="assessment-older",
+        capability="deep_question",
+        message="Generate a quiz on algebra",
+        knowledge_bases=["algebra-pack"],
+    )
+    await store.add_message(
+        "assessment-older",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve algebra equation x + 2 = 5 -> Answered: 3 (Correct)\n"
+        "2. [q2] Q: Solve algebra equation 2x = 10 -> Answered: 5 (Correct)\n"
+        "Score: 2/2 (100%)",
+        capability="deep_question",
+    )
+    _set_session_timestamp(store, "assessment-older", 1_709_913_600)
+
+    await _seed_session(
+        store,
+        session_id="tutor-recent",
+        capability="chat",
+        message="Help me review fractions mistakes",
+        knowledge_bases=["fractions-pack"],
+    )
+    _set_session_timestamp(store, "tutor-recent", 1_709_827_200)
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/student-progress")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["totals"] == {
+        "assessments_completed": 2,
+        "tutoring_sessions": 1,
+        "knowledge_packs_used": 2,
+        "average_score_percent": 75,
+        "streak_days": 3,
+    }
+    assert payload["focus_topics"][0]["topic"] == "fractions subtraction"
+    assert payload["focus_topics"][0]["incorrect_count"] == 1
+    assert payload["mastered_topics"][0]["topic"] == "algebra equation"
+    assert payload["score_trend"] == [
+        {"session_id": "assessment-older", "score_percent": 100, "timestamp": 1_709_913_600},
+        {"session_id": "assessment-recent", "score_percent": 50, "timestamp": 1_710_000_000},
+    ]
+    assert [row["session_id"] for row in payload["recent_assessments"]] == [
+        "assessment-recent",
+        "assessment-older",
+    ]

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Activity, BookOpen, CheckCircle2, Loader2, PenLine, Users } from "lucide-react";
+import { Activity, ArrowRight, BookOpen, CheckCircle2, Loader2, PenLine, Users } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   getDashboardOverview,
@@ -84,16 +84,25 @@ export default function DashboardPage() {
   return (
     <main className="h-full overflow-y-auto bg-[var(--background)]">
       <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-6 px-6 py-8">
-        <header>
-          <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
-            {t("Teacher Dashboard")}
-          </p>
-          <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
-            {t("Class activity")}
-          </h1>
-          <p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
-            {t("Review recent assessments, tutoring sessions, and Knowledge Pack usage.")}
-          </p>
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+              {t("Teacher Dashboard")}
+            </p>
+            <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
+              {t("Class activity")}
+            </h1>
+            <p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
+              {t("Review recent assessments, tutoring sessions, and Knowledge Pack usage.")}
+            </p>
+          </div>
+          <Link
+            href="/dashboard/student"
+            className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--card)] px-4 py-2 text-[13px] font-medium text-[var(--foreground)] transition hover:border-[var(--foreground)]"
+          >
+            {t("Open student progress")}
+            <ArrowRight size={15} />
+          </Link>
         </header>
 
         {error && (
@@ -142,12 +151,12 @@ export default function DashboardPage() {
                       ? `/${activity.review_ref}`
                       : null;
                   return (
-                    <div
+                    <article
                       key={activity.id}
                       className="border-b border-[var(--border)] bg-[var(--card)] px-4 py-3 last:border-b-0"
                     >
-                      <div className="flex flex-wrap items-center justify-between gap-2">
-                        <div>
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
                           {reviewHref ? (
                             <Link
                               href={reviewHref}
@@ -160,37 +169,37 @@ export default function DashboardPage() {
                               {activity.title || t("Untitled session")}
                             </div>
                           )}
-                        <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
-                          {t(activityLabel(activity))} - {activity.status} -{" "}
-                          {formatTime(activity.timestamp)}
+                          <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
+                            {t(activityLabel(activity))} - {activity.status} -{" "}
+                            {formatTime(activity.timestamp)}
+                          </div>
+                          {activity.assessment_summary && (
+                            <div className="mt-2 text-[12px] text-[var(--muted-foreground)]">
+                              {t("Score")}: {activity.assessment_summary.score_percent}% -{" "}
+                              {activity.assessment_summary.correct_count}/
+                              {activity.assessment_summary.total_questions}
+                            </div>
+                          )}
+                          {activity.summary && (
+                            <p className="mt-2 line-clamp-2 text-[13px] leading-5 text-[var(--muted-foreground)]">
+                              {activity.summary}
+                            </p>
+                          )}
                         </div>
-                        {activity.assessment_summary && (
-                          <div className="mt-2 text-[12px] text-[var(--muted-foreground)]">
-                            {t("Score")}: {activity.assessment_summary.score_percent}% -{" "}
-                            {activity.assessment_summary.correct_count}/
-                            {activity.assessment_summary.total_questions}
+                        {activity.knowledge_bases.length > 0 && (
+                          <div className="flex flex-wrap justify-end gap-1">
+                            {activity.knowledge_bases.map((kb) => (
+                              <span
+                                key={`${activity.id}-${kb}`}
+                                className="rounded-md bg-[var(--muted)] px-2 py-1 text-[11px] text-[var(--muted-foreground)]"
+                              >
+                                {kb}
+                              </span>
+                            ))}
                           </div>
                         )}
                       </div>
-                      {activity.knowledge_bases.length > 0 && (
-                        <div className="flex flex-wrap gap-1">
-                          {activity.knowledge_bases.map((kb) => (
-                            <span
-                              key={`${activity.id}-${kb}`}
-                              className="rounded-md bg-[var(--muted)] px-2 py-1 text-[11px] text-[var(--muted-foreground)]"
-                            >
-                              {kb}
-                            </span>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                      {activity.summary && (
-                        <p className="mt-2 line-clamp-2 text-[13px] leading-5 text-[var(--muted-foreground)]">
-                          {activity.summary}
-                        </p>
-                      )}
-                    </div>
+                    </article>
                   );
                 })
               ) : (

--- a/web/app/(workspace)/dashboard/student/page.tsx
+++ b/web/app/(workspace)/dashboard/student/page.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, ArrowRight, BookOpen, Flame, LineChart, Loader2, Target } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  getStudentProgress,
+  type StudentProgressAssessment,
+  type StudentProgressOverview,
+  type StudentProgressTopic,
+} from "@/lib/dashboard-api";
+
+function formatTime(value: number): string {
+  if (!value) return "";
+  const timestamp = value < 10_000_000_000 ? value * 1000 : value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
+function scoreTone(value: number): string {
+  if (value >= 85) return "text-emerald-600";
+  if (value >= 70) return "text-amber-600";
+  return "text-rose-600";
+}
+
+function TopicList({
+  title,
+  icon: Icon,
+  rows,
+  emptyLabel,
+}: {
+  title: string;
+  icon: typeof Target;
+  rows: StudentProgressTopic[];
+  emptyLabel: string;
+}) {
+  return (
+    <section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="flex items-center gap-2">
+        <Icon size={16} className="text-[var(--muted-foreground)]" />
+        <h2 className="text-[16px] font-semibold text-[var(--foreground)]">{title}</h2>
+      </div>
+      {rows.length > 0 ? (
+        <div className="mt-4 space-y-3">
+          {rows.map((row) => (
+            <div
+              key={row.topic}
+              className="rounded-2xl bg-[var(--muted)]/60 px-4 py-3"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[13px] font-medium text-[var(--foreground)]">{row.topic}</span>
+                <span className={`text-[13px] font-semibold ${scoreTone(row.accuracy_percent)}`}>
+                  {row.accuracy_percent}%
+                </span>
+              </div>
+              <div className="mt-2 text-[12px] text-[var(--muted-foreground)]">
+                {row.correct_count}/{row.total_questions} correct
+                {row.incorrect_count > 0 ? ` • ${row.incorrect_count} to revisit` : ""}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-4 rounded-2xl bg-[var(--muted)]/50 px-4 py-6 text-center text-[13px] text-[var(--muted-foreground)]">
+          {emptyLabel}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AssessmentList({
+  rows,
+  emptyLabel,
+  t,
+}: {
+  rows: StudentProgressAssessment[];
+  emptyLabel: string;
+  t: (value: string) => string;
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-[28px] border border-dashed border-[var(--border)] bg-[var(--card)] px-5 py-8 text-center text-[13px] text-[var(--muted-foreground)]">
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.map((row) => {
+        const href = row.review_ref ? `/${row.review_ref}` : null;
+        return (
+          <article
+            key={row.session_id}
+            className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] px-5 py-4"
+          >
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div className="min-w-0">
+                {href ? (
+                  <Link
+                    href={href}
+                    className="text-[15px] font-semibold text-[var(--foreground)] underline-offset-4 hover:underline"
+                  >
+                    {row.title || t("Untitled assessment")}
+                  </Link>
+                ) : (
+                  <div className="text-[15px] font-semibold text-[var(--foreground)]">
+                    {row.title || t("Untitled assessment")}
+                  </div>
+                )}
+                <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
+                  {formatTime(row.timestamp)}
+                </div>
+                {row.knowledge_bases.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-1">
+                    {row.knowledge_bases.map((kb) => (
+                      <span
+                        key={`${row.session_id}-${kb}`}
+                        className="rounded-full bg-[var(--muted)] px-2.5 py-1 text-[11px] text-[var(--muted-foreground)]"
+                      >
+                        {kb}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="rounded-2xl bg-[var(--muted)]/70 px-4 py-3 text-right">
+                <div className={`text-[24px] font-semibold ${scoreTone(row.score_percent)}`}>
+                  {row.score_percent}%
+                </div>
+                <div className="text-[12px] text-[var(--muted-foreground)]">
+                  {row.correct_count}/{row.total_questions} {t("correct")}
+                </div>
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function StudentDashboardPage() {
+  const { t } = useTranslation();
+  const [overview, setOverview] = useState<StudentProgressOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getStudentProgress()
+      .then((data) => {
+        if (!cancelled) {
+          setOverview(data);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const totals = overview?.totals;
+  const statCards = useMemo(
+    () => [
+      {
+        label: t("Learning streak"),
+        value: totals?.streak_days ?? 0,
+        suffix: t("days"),
+        icon: Flame,
+      },
+      {
+        label: t("Average score"),
+        value: totals?.average_score_percent ?? 0,
+        suffix: "%",
+        icon: LineChart,
+      },
+      {
+        label: t("Assessments"),
+        value: totals?.assessments_completed ?? 0,
+        suffix: "",
+        icon: ArrowRight,
+      },
+      {
+        label: t("Knowledge Packs"),
+        value: totals?.knowledge_packs_used ?? 0,
+        suffix: "",
+        icon: BookOpen,
+      },
+    ],
+    [t, totals],
+  );
+
+  return (
+    <main className="min-h-full bg-[radial-gradient(circle_at_top_left,_rgba(247,208,96,0.18),_transparent_32%),linear-gradient(180deg,_var(--background),_color-mix(in_oklab,_var(--background)_78%,_white))]">
+      <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-6 px-6 py-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center gap-2 text-[13px] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+          >
+            <ArrowLeft size={15} />
+            {t("Back to teacher dashboard")}
+          </Link>
+          <span className="rounded-full border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-[12px] font-medium text-[var(--muted-foreground)]">
+            {t("Student Dashboard")}
+          </span>
+        </div>
+
+        <section className="rounded-[32px] border border-[var(--border)] bg-[var(--card)]/90 px-6 py-6 shadow-sm">
+          <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-[var(--muted-foreground)]">
+            {t("Learning progress")}
+          </p>
+          <div className="mt-3 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h1 className="text-[30px] font-semibold tracking-tight text-[var(--foreground)]">
+                {t("See the full learning arc, not just the latest quiz")}
+              </h1>
+              <p className="mt-2 max-w-[720px] text-[14px] leading-6 text-[var(--muted-foreground)]">
+                {t("Track recent assessments, revisit weak topics, and spot where the student is building confidence.")}
+              </p>
+            </div>
+            {loading && (
+              <div className="inline-flex items-center gap-2 text-[13px] text-[var(--muted-foreground)]">
+                <Loader2 size={14} className="animate-spin" />
+                {t("Loading progress")}
+              </div>
+            )}
+          </div>
+        </section>
+
+        {error && (
+          <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+            {t("Failed to load student progress")}: {error}
+          </div>
+        )}
+
+        <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {statCards.map((card) => (
+            <div
+              key={card.label}
+              className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] px-5 py-4"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[12px] font-medium text-[var(--muted-foreground)]">
+                  {card.label}
+                </span>
+                <card.icon size={16} className="text-[var(--muted-foreground)]" />
+              </div>
+              <div className="mt-4 flex items-end gap-2">
+                <span className="text-[30px] font-semibold text-[var(--foreground)]">
+                  {loading ? "-" : card.value}
+                </span>
+                {card.suffix && (
+                  <span className="pb-1 text-[13px] text-[var(--muted-foreground)]">
+                    {card.suffix}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-[1.3fr_0.7fr]">
+          <div>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-[18px] font-semibold text-[var(--foreground)]">
+                {t("Recent assessments")}
+              </h2>
+              {overview?.score_trend && overview.score_trend.length > 1 && (
+                <span className="text-[12px] text-[var(--muted-foreground)]">
+                  {t("Trend")}: {overview.score_trend[0].score_percent}% {"->"}{" "}
+                  {overview.score_trend[overview.score_trend.length - 1].score_percent}%
+                </span>
+              )}
+            </div>
+            <AssessmentList
+              rows={overview?.recent_assessments ?? []}
+              emptyLabel={t("No assessments yet. Generate a quiz to begin tracking progress.")}
+              t={t}
+            />
+          </div>
+
+          <div className="space-y-6">
+            <TopicList
+              title={t("Focus next")}
+              icon={Target}
+              rows={overview?.focus_topics ?? []}
+              emptyLabel={t("No weak topics detected yet.")}
+            />
+            <TopicList
+              title={t("Mastered topics")}
+              icon={LineChart}
+              rows={overview?.mastered_topics ?? []}
+              emptyLabel={t("Mastered topics will appear after completed assessments.")}
+            />
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -75,6 +75,45 @@ export interface DashboardOverview {
   recent_activity: DashboardActivity[];
 }
 
+export interface StudentProgressTopic {
+  topic: string;
+  total_questions: number;
+  correct_count: number;
+  incorrect_count: number;
+  accuracy_percent: number;
+}
+
+export interface StudentProgressAssessment {
+  session_id: string;
+  title: string;
+  timestamp: number;
+  score_percent: number;
+  correct_count: number;
+  total_questions: number;
+  knowledge_bases: string[];
+  review_ref?: string | null;
+}
+
+export interface StudentProgressPoint {
+  session_id: string;
+  score_percent: number;
+  timestamp: number;
+}
+
+export interface StudentProgressOverview {
+  totals: {
+    assessments_completed: number;
+    tutoring_sessions: number;
+    knowledge_packs_used: number;
+    average_score_percent: number;
+    streak_days: number;
+  };
+  focus_topics: StudentProgressTopic[];
+  mastered_topics: StudentProgressTopic[];
+  score_trend: StudentProgressPoint[];
+  recent_assessments: StudentProgressAssessment[];
+}
+
 async function expectJson<T>(response: Response): Promise<T> {
   if (!response.ok) {
     throw new Error(`Request failed: ${response.status}`);
@@ -101,4 +140,11 @@ export async function getAssessmentAnalysis(sessionId: string): Promise<Assessme
     cache: "no-store",
   });
   return expectJson<AssessmentAnalysis>(response);
+}
+
+export async function getStudentProgress(limit = 50): Promise<StudentProgressOverview> {
+  const response = await fetch(apiUrl(`/api/v1/dashboard/student-progress?limit=${limit}`), {
+    cache: "no-store",
+  });
+  return expectJson<StudentProgressOverview>(response);
 }


### PR DESCRIPTION
## Summary
- add a student-facing dashboard at `/dashboard/student`
- add `GET /api/v1/dashboard/student-progress` backed by existing session and assessment review data
- surface focus/mastery topics, score trend, streak, and recent assessments without adding a new storage layer

Closes #53

## Validation
- `python3 -m pytest tests/api/test_dashboard_router.py -q`
- `python3 -m py_compile deeptutor/api/routers/dashboard.py`
- `cd web && npm run build`

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-21-student-progress-dashboard.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated
