### PR TITLE
[MVP] AI-Powered Assessment Recommendations

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, student progress dashboard is now merged into `main` through PR `#54`, and the active short task is `T015 AI-Powered Assessment Recommendations`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, student progress dashboard is now merged into `main` through PR `#54`, and Draft PR `#56` is active for `T015 AI-Powered Assessment Recommendations`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T015`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T015` via Draft PR `#56`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace preview is now merged into `main`, and Draft PR `#54` is active for `T014 Student Progress Tracking Dashboard`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, student progress dashboard is now merged into `main` through PR `#54`, and the active short task is `T015 AI-Powered Assessment Recommendations`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T014` via Draft PR `#54`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T015`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -15,12 +15,13 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 - Active issue: `#55 [MVP] AI-Powered Assessment Recommendations`
 - Active branch: `pod-a/t015-assessment-recommendations`
+- Active PR: `#56 [MVP] AI-Powered Assessment Recommendations` (Draft)
 - Active task packet: `docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md`
 - Focus set: `T015` (assessment recommendations)
 
 ## Next recommended task
 
-Implement `T015` on `pod-a/t015-assessment-recommendations`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Monitor CI for `#56`, fix any failing checks on `pod-a/t015-assessment-recommendations`, then merge to `main` once all required checks are green.
 
 ## Status Update (2026-04-21)
 
@@ -29,6 +30,7 @@ Implement `T015` on `pod-a/t015-assessment-recommendations`, then open a Draft P
 2. Issue `#53` auto-closed with the merge
 3. Next pending registry task selected in strict order: `T015 AI-Powered Assessment Recommendations`
 4. Issue `#55` created and task packet added for the new execution lane
+5. Draft PR `#56` opened with validation complete and architecture note attached
 
 ## AI-owned blockers
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,30 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#52 feat: add marketplace pack preview`
-- `#52` added compact preview-before-import flow for marketplace packs and passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import and preview, assessment insights, KB context badges, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#54 [MVP] Student Progress Tracking Dashboard`
+- `#54` added `/dashboard/student` and `GET /api/v1/dashboard/student-progress`, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import and preview, assessment insights, KB context badges, student progress dashboard, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#53 [MVP] Student Progress Tracking Dashboard`
-- Active branch: `pod-a/t014-student-progress-dashboard`
-- Active PR: `#54 [MVP] Student Progress Tracking Dashboard` (Draft)
-- Active task packet: `docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md`
-- Focus set: `T014` (student-facing progress dashboard)
+- Active issue: `#55 [MVP] AI-Powered Assessment Recommendations`
+- Active branch: `pod-a/t015-assessment-recommendations`
+- Active task packet: `docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md`
+- Focus set: `T015` (assessment recommendations)
 
 ## Next recommended task
 
-Monitor CI for `#54`, fix any failing checks on `pod-a/t014-student-progress-dashboard`, then merge to `main` once all required checks are green.
+Implement `T015` on `pod-a/t015-assessment-recommendations`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#52` merged to `main` after all required CI checks passed
-2. Completed registry tasks were reconciled to match what is already merged on `main`
-3. Next pending registry task selected in strict order: `T014 Student Progress Tracking Dashboard`
-4. Issue `#53` created and task packet added for the new execution lane
-5. Draft PR `#54` opened with validation complete and architecture note attached
+1. `#54` merged to `main` after all required CI checks passed
+2. Issue `#53` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T015 AI-Powered Assessment Recommendations`
+4. Issue `#55` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -58,7 +56,8 @@ Monitor CI for `#54`, fix any failing checks on `pod-a/t014-student-progress-das
 | T011: KB Context Badges | Completed | 2 | NO | Done |
 | T012: Teacher Sharing UI | Completed | 3 | NO | Verified |
 | T013: Marketplace Preview | Completed | 3 | NO | Done |
-| T014: Student Progress Dashboard | In Progress | 5 | NO | Now |
+| T014: Student Progress Dashboard | Completed | 5 | NO | Done |
+| T015: Assessment Recommendations | In Progress | 6 | NO | Now |
 | T018: Vietnamese Prompts | Not Started | 4 | YES | Parallel |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -144,8 +144,8 @@
       "complexity": "High",
       "estimated_hours": 5,
       "dependencies": ["Assessment Analytics"],
-      "status": "in-progress",
-      "notes": "Issue #53 opened and task packet created at docs/superpowers/tasks/2026-04-20-T014-student-progress-dashboard.md. Active branch: pod-a/t014-student-progress-dashboard. Draft PR #54 is open with backend tests and frontend build passing locally."
+      "status": "completed",
+      "notes": "Merged to main through PR #54. Student dashboard now exposes /dashboard/student and GET /api/v1/dashboard/student-progress."
     },
     {
       "id": "T015_ASSESSMENT_RECOMMENDATIONS",
@@ -161,8 +161,8 @@
       "complexity": "High",
       "estimated_hours": 6,
       "dependencies": ["LLM Service", "Assessment Analytics"],
-      "status": "not-started",
-      "notes": "Analyze performance data and suggest next topics to study or practice"
+      "status": "in-progress",
+      "notes": "Issue #55 opened and task packet created at docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md. Active branch: pod-a/t015-assessment-recommendations."
     },
     {
       "id": "T016_MARKETPLACE_RATINGS",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -162,7 +162,7 @@
       "estimated_hours": 6,
       "dependencies": ["LLM Service", "Assessment Analytics"],
       "status": "in-progress",
-      "notes": "Issue #55 opened and task packet created at docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md. Active branch: pod-a/t015-assessment-recommendations."
+      "notes": "Issue #55 opened and task packet created at docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md. Active branch: pod-a/t015-assessment-recommendations. Draft PR #56 is open with targeted API tests and compile checks passing locally."
     },
     {
       "id": "T016_MARKETPLACE_RATINGS",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -48,6 +48,9 @@ flowchart TD
   
   Product --> AssessmentBuilder["Assessment Builder"]
   AssessmentBuilder --> QuizGrounding["Knowledge Pack Grounded Quiz Config"]
+  AssessmentBuilder --> AssessmentRecommendAPI["POST /api/v1/assessment/recommend"]
+  AssessmentRecommendAPI --> RecommendEngine["Assessment Recommendation Engine"]
+  RecommendEngine --> AssessmentSignals["Weak topics + score trend + KB context"]
   
   Product --> StudentTutor["Student Tutor Workspace"]
   StudentTutor --> TutorKBContext["Knowledge Pack Tutoring Context"]

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -63,3 +63,34 @@
 
 - Task `T015_ASSESSMENT_RECOMMENDATIONS`: moved to `in-progress`
 - Next: inspect existing assessment analytics and start implementation on `pod-a/t015-assessment-recommendations`
+
+## T015 AI-Powered Assessment Recommendations — Implementation Progress
+
+### Completed in this cycle
+
+1. Added shared assessment analysis helpers:
+   - `deeptutor/services/assessment/analysis.py`
+2. Added deterministic recommendation engine:
+   - `deeptutor/services/assessment/recommendation_engine.py`
+3. Added recommendation API route:
+   - `deeptutor/api/routers/assessment.py`
+   - `POST /api/v1/assessment/recommend`
+4. Wired the new router into `deeptutor/api/main.py`
+5. Updated dashboard analysis code to use the shared assessment analysis helper
+6. Added targeted API regression coverage:
+   - `tests/api/test_assessment_router.py`
+7. Added architecture note and updated system map:
+   - `docs/superpowers/pr-notes/2026-04-21-assessment-recommendations.md`
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+### Validation
+
+- Targeted API tests passed:
+  - `python3 -m pytest tests/api/test_dashboard_router.py tests/api/test_assessment_router.py -q`
+- Python compile checks passed:
+  - `python3 -m py_compile deeptutor/api/routers/assessment.py deeptutor/api/routers/dashboard.py deeptutor/api/main.py deeptutor/services/assessment/analysis.py deeptutor/services/assessment/recommendation_engine.py`
+
+### Status
+
+- Task `T015_ASSESSMENT_RECOMMENDATIONS`: implementation complete on branch `pod-a/t015-assessment-recommendations`
+- Next: commit, push, open Draft PR linked to issue `#55`, then monitor CI and merge per AI-first policy

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -33,3 +33,33 @@
 
 - Task `T014_STUDENT_PROGRESS_DASHBOARD`: implementation complete on branch `pod-a/t014-student-progress-dashboard`
 - Next: commit, push, open Draft PR linked to issue `#53`, then monitor CI and merge per AI-first policy
+
+## T014 Student Progress Tracking Dashboard — Merge Complete
+
+### Completed in this cycle
+
+1. Draft PR `#54` was opened, validated by CI, moved to Ready, and merged to `main`.
+2. Issue `#53` closed with the merge.
+3. Local `main` was fast-forwarded to include the merged student dashboard lane.
+
+### Status
+
+- Task `T014_STUDENT_PROGRESS_DASHBOARD`: moved to `completed`
+
+## T015 AI-Powered Assessment Recommendations — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T014` merged.
+2. Opened GitHub issue `#55` for `T015 AI-Powered Assessment Recommendations`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T015_ASSESSMENT_RECOMMENDATIONS`: moved to `in-progress`
+- Next: inspect existing assessment analytics and start implementation on `pod-a/t015-assessment-recommendations`

--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -252,6 +252,7 @@ app.mount(
 # Import routers only after runtime settings are initialized.
 # Some router modules load YAML settings at import time.
 from deeptutor.api.routers import (
+    assessment,
     agent_config,
     chat,
     co_writer,
@@ -275,6 +276,7 @@ from deeptutor.api.routers import (
 # Include routers
 app.include_router(solve.router, prefix="/api/v1", tags=["solve"])
 app.include_router(chat.router, prefix="/api/v1", tags=["chat"])
+app.include_router(assessment.router, prefix="/api/v1/assessment", tags=["assessment"])
 app.include_router(question.router, prefix="/api/v1/question", tags=["question"])
 app.include_router(knowledge.router, prefix="/api/v1/knowledge", tags=["knowledge"])
 app.include_router(marketplace.router, prefix="/api/v1/marketplace", tags=["marketplace"])

--- a/deeptutor/api/routers/assessment.py
+++ b/deeptutor/api/routers/assessment.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from deeptutor.services.assessment import recommend_next_assessment
+from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
+
+router = APIRouter()
+
+
+class AssessmentRecommendationRequest(BaseModel):
+    session_id: str | None = None
+    limit: int = Field(default=20, ge=1, le=100)
+
+
+async def _collect_assessment_rows(
+    *,
+    session_id: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    store = get_sqlite_session_store()
+    sessions = await store.list_sessions(limit=limit, offset=0)
+    rows: list[dict[str, Any]] = []
+
+    for session in sessions:
+        capability = str(session.get("capability") or "chat")
+        if capability != "deep_question":
+            continue
+        detail = await store.get_session_with_messages(str(session.get("session_id") or session.get("id")))
+        if detail is None:
+            continue
+        review = extract_assessment_review(detail)
+        if review is None:
+            continue
+        rows.append(
+            {
+                "session_id": review["session_id"],
+                "timestamp": review["timestamp"],
+                "summary": review["summary"],
+                "knowledge_bases": review["knowledge_bases"],
+                "assessment_results": review["results"],
+            }
+        )
+
+    if session_id is not None:
+        rows.sort(key=lambda row: row["session_id"] != session_id)
+
+    return rows
+
+
+@router.post("/recommend")
+async def recommend_assessment(payload: AssessmentRecommendationRequest):
+    rows = await _collect_assessment_rows(session_id=payload.session_id, limit=payload.limit)
+    return recommend_next_assessment(rows, preferred_session_id=payload.session_id)

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -1,104 +1,14 @@
 """Dashboard API backed by the unified SQLite session store."""
 
 from datetime import datetime, timezone
-import re
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
+from deeptutor.services.assessment import build_assessment_analysis
 from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
 
 router = APIRouter()
-
-_TOPIC_STOPWORDS = {
-    "the",
-    "a",
-    "an",
-    "and",
-    "or",
-    "to",
-    "of",
-    "in",
-    "on",
-    "for",
-    "with",
-    "is",
-    "are",
-    "what",
-    "which",
-    "solve",
-    "find",
-    "calculate",
-    "determine",
-}
-
-
-def _infer_topic_from_question(question: str, fallback: str = "general") -> str:
-    words = re.findall(r"[A-Za-z][A-Za-z0-9'-]{2,}", question.lower())
-    filtered = [w for w in words if w not in _TOPIC_STOPWORDS]
-    if not filtered:
-        return fallback
-    return " ".join(filtered[:2])
-
-
-def _build_assessment_analysis(review: dict[str, Any]) -> dict[str, Any]:
-    results = review.get("results", [])
-    if not isinstance(results, list):
-        results = []
-
-    topic_buckets: dict[str, dict[str, int]] = {}
-    for item in results:
-        if not isinstance(item, dict):
-            continue
-        question = str(item.get("question") or "")
-        topic = _infer_topic_from_question(question)
-        bucket = topic_buckets.setdefault(topic, {"total": 0, "correct": 0, "incorrect": 0})
-        bucket["total"] += 1
-        if bool(item.get("is_correct")):
-            bucket["correct"] += 1
-        else:
-            bucket["incorrect"] += 1
-
-    performance_by_topic = []
-    for topic, counts in sorted(topic_buckets.items(), key=lambda kv: (-kv[1]["incorrect"], kv[0])):
-        total = counts["total"]
-        accuracy = round((counts["correct"] / total) * 100) if total else 0
-        performance_by_topic.append(
-            {
-                "topic": topic,
-                "total_questions": total,
-                "correct_count": counts["correct"],
-                "incorrect_count": counts["incorrect"],
-                "accuracy_percent": accuracy,
-            }
-        )
-
-    weak_topics = [row["topic"] for row in performance_by_topic if row["incorrect_count"] > 0][:3]
-    strong_topics = [row["topic"] for row in performance_by_topic if row["accuracy_percent"] >= 80][:3]
-
-    score_percent = int(review.get("summary", {}).get("score_percent", 0))
-    recommendations: list[str] = []
-    if weak_topics:
-        recommendations.append(
-            f"Review these topics first: {', '.join(weak_topics)}."
-        )
-    if score_percent < 75:
-        recommendations.append("Retry a focused quiz on weak topics before moving on.")
-    elif score_percent < 90:
-        recommendations.append("Practice mixed-difficulty questions to improve consistency.")
-    else:
-        recommendations.append("You are ready for advanced questions and extension material.")
-    if strong_topics:
-        recommendations.append(f"Strong areas: {', '.join(strong_topics)}.")
-
-    return {
-        "session_id": review.get("session_id"),
-        "summary": review.get("summary", {}),
-        "performance_by_topic": performance_by_topic,
-        "weak_topics": weak_topics,
-        "strong_topics": strong_topics,
-        "recommendations": recommendations,
-    }
 
 
 def _activity_type(capability: str) -> str:
@@ -171,7 +81,7 @@ def _summarize_topic_mastery(
     topic_totals: dict[str, dict[str, int]] = {}
 
     for activity in assessment_rows:
-        for row in _build_assessment_analysis(
+        for row in build_assessment_analysis(
             {
                 "session_id": activity.get("session_id"),
                 "summary": activity.get("summary") or {},
@@ -382,4 +292,4 @@ async def get_assessment_analysis(session_id: str):
     if review is None:
         raise HTTPException(status_code=404, detail="Assessment review data not found")
 
-    return _build_assessment_analysis(review)
+    return build_assessment_analysis(review)

--- a/deeptutor/services/assessment/__init__.py
+++ b/deeptutor/services/assessment/__init__.py
@@ -1,0 +1,4 @@
+from .analysis import build_assessment_analysis
+from .recommendation_engine import recommend_next_assessment
+
+__all__ = ["build_assessment_analysis", "recommend_next_assessment"]

--- a/deeptutor/services/assessment/analysis.py
+++ b/deeptutor/services/assessment/analysis.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_TOPIC_STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "to",
+    "of",
+    "in",
+    "on",
+    "for",
+    "with",
+    "is",
+    "are",
+    "what",
+    "which",
+    "solve",
+    "find",
+    "calculate",
+    "determine",
+}
+
+
+def infer_topic_from_question(question: str, fallback: str = "general") -> str:
+    words = re.findall(r"[A-Za-z][A-Za-z0-9'-]{2,}", question.lower())
+    filtered = [w for w in words if w not in _TOPIC_STOPWORDS]
+    if not filtered:
+        return fallback
+    return " ".join(filtered[:2])
+
+
+def build_assessment_analysis(review: dict[str, Any]) -> dict[str, Any]:
+    results = review.get("results", [])
+    if not isinstance(results, list):
+        results = []
+
+    topic_buckets: dict[str, dict[str, int]] = {}
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        question = str(item.get("question") or "")
+        topic = infer_topic_from_question(question)
+        bucket = topic_buckets.setdefault(topic, {"total": 0, "correct": 0, "incorrect": 0})
+        bucket["total"] += 1
+        if bool(item.get("is_correct")):
+            bucket["correct"] += 1
+        else:
+            bucket["incorrect"] += 1
+
+    performance_by_topic = []
+    for topic, counts in sorted(topic_buckets.items(), key=lambda kv: (-kv[1]["incorrect"], kv[0])):
+        total = counts["total"]
+        accuracy = round((counts["correct"] / total) * 100) if total else 0
+        performance_by_topic.append(
+            {
+                "topic": topic,
+                "total_questions": total,
+                "correct_count": counts["correct"],
+                "incorrect_count": counts["incorrect"],
+                "accuracy_percent": accuracy,
+            }
+        )
+
+    weak_topics = [row["topic"] for row in performance_by_topic if row["incorrect_count"] > 0][:3]
+    strong_topics = [row["topic"] for row in performance_by_topic if row["accuracy_percent"] >= 80][:3]
+
+    score_percent = int(review.get("summary", {}).get("score_percent", 0))
+    recommendations: list[str] = []
+    if weak_topics:
+        recommendations.append(f"Review these topics first: {', '.join(weak_topics)}.")
+    if score_percent < 75:
+        recommendations.append("Retry a focused quiz on weak topics before moving on.")
+    elif score_percent < 90:
+        recommendations.append("Practice mixed-difficulty questions to improve consistency.")
+    else:
+        recommendations.append("You are ready for advanced questions and extension material.")
+    if strong_topics:
+        recommendations.append(f"Strong areas: {', '.join(strong_topics)}.")
+
+    return {
+        "session_id": review.get("session_id"),
+        "summary": review.get("summary", {}),
+        "performance_by_topic": performance_by_topic,
+        "weak_topics": weak_topics,
+        "strong_topics": strong_topics,
+        "recommendations": recommendations,
+    }

--- a/deeptutor/services/assessment/recommendation_engine.py
+++ b/deeptutor/services/assessment/recommendation_engine.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from deeptutor.services.assessment.analysis import build_assessment_analysis
+
+
+def _unique_kbs(rows: list[dict[str, Any]]) -> list[str]:
+    return sorted({kb for row in rows for kb in row.get("knowledge_bases", [])})
+
+
+def recommend_next_assessment(
+    assessment_rows: list[dict[str, Any]],
+    *,
+    preferred_session_id: str | None = None,
+) -> dict[str, Any]:
+    if not assessment_rows:
+        return {
+            "status": "insufficient-data",
+            "recommended_topic": None,
+            "suggested_action": "complete-assessment",
+            "recommended_knowledge_bases": [],
+            "source_session_ids": [],
+            "reason": "Complete at least one assessment to unlock recommendations.",
+            "history_summary": {
+                "assessments_considered": 0,
+                "average_score_percent": 0,
+                "weak_topics": [],
+                "strong_topics": [],
+            },
+        }
+
+    ordered_rows = sorted(assessment_rows, key=lambda row: row.get("timestamp", 0), reverse=True)
+    if preferred_session_id:
+        ordered_rows.sort(key=lambda row: row.get("session_id") != preferred_session_id)
+
+    topic_stats: dict[str, dict[str, Any]] = {}
+    weak_topic_hits: Counter[str] = Counter()
+    strong_topic_hits: Counter[str] = Counter()
+    average_score_percent = round(
+        sum(int(row.get("summary", {}).get("score_percent", 0)) for row in ordered_rows) / len(ordered_rows)
+    )
+
+    for row in ordered_rows:
+        analysis = build_assessment_analysis(
+            {
+                "session_id": row.get("session_id"),
+                "summary": row.get("summary") or {},
+                "results": row.get("assessment_results") or [],
+            }
+        )
+        for topic_row in analysis["performance_by_topic"]:
+            topic = topic_row["topic"]
+            current = topic_stats.setdefault(
+                topic,
+                {
+                    "topic": topic,
+                    "incorrect_count": 0,
+                    "correct_count": 0,
+                    "total_questions": 0,
+                    "accuracy_percent": 0,
+                    "knowledge_bases": set(),
+                },
+            )
+            current["incorrect_count"] += topic_row["incorrect_count"]
+            current["correct_count"] += topic_row["correct_count"]
+            current["total_questions"] += topic_row["total_questions"]
+            current["knowledge_bases"].update(row.get("knowledge_bases", []))
+            total = current["total_questions"]
+            current["accuracy_percent"] = round((current["correct_count"] / total) * 100) if total else 0
+
+        weak_topic_hits.update(analysis["weak_topics"])
+        strong_topic_hits.update(analysis["strong_topics"])
+
+    weak_topic = None
+    if topic_stats:
+        weak_candidates = [row for row in topic_stats.values() if row["incorrect_count"] > 0]
+        if weak_candidates:
+            weak_topic = sorted(
+                weak_candidates,
+                key=lambda row: (-row["incorrect_count"], row["accuracy_percent"], row["topic"]),
+            )[0]
+
+    strong_topic = None
+    if topic_stats:
+        strong_candidates = [row for row in topic_stats.values() if row["accuracy_percent"] >= 80]
+        if strong_candidates:
+            strong_topic = sorted(
+                strong_candidates,
+                key=lambda row: (-row["accuracy_percent"], row["topic"]),
+            )[0]
+
+    if weak_topic is not None:
+        return {
+            "status": "ready",
+            "recommended_topic": weak_topic["topic"],
+            "suggested_action": "retry-focused-quiz" if average_score_percent < 75 else "mixed-practice",
+            "recommended_knowledge_bases": sorted(weak_topic["knowledge_bases"]),
+            "source_session_ids": [str(row["session_id"]) for row in ordered_rows],
+            "reason": (
+                f"Recent assessments show the most missed questions in {weak_topic['topic']}, "
+                f"so the next assessment should revisit that area first."
+            ),
+            "history_summary": {
+                "assessments_considered": len(ordered_rows),
+                "average_score_percent": average_score_percent,
+                "weak_topics": [topic for topic, _count in weak_topic_hits.most_common(3)],
+                "strong_topics": [topic for topic, _count in strong_topic_hits.most_common(3)],
+            },
+        }
+
+    if strong_topic is not None:
+        return {
+            "status": "ready",
+            "recommended_topic": strong_topic["topic"],
+            "suggested_action": "advance-challenge",
+            "recommended_knowledge_bases": sorted(strong_topic["knowledge_bases"]),
+            "source_session_ids": [str(row["session_id"]) for row in ordered_rows],
+            "reason": (
+                f"Recent assessments are consistently strong in {strong_topic['topic']}, "
+                f"so the next assessment can increase difficulty."
+            ),
+            "history_summary": {
+                "assessments_considered": len(ordered_rows),
+                "average_score_percent": average_score_percent,
+                "weak_topics": [topic for topic, _count in weak_topic_hits.most_common(3)],
+                "strong_topics": [topic for topic, _count in strong_topic_hits.most_common(3)],
+            },
+        }
+
+    return {
+        "status": "ready",
+        "recommended_topic": "general review",
+        "suggested_action": "skill-check",
+        "recommended_knowledge_bases": _unique_kbs(ordered_rows),
+        "source_session_ids": [str(row["session_id"]) for row in ordered_rows],
+        "reason": "Recent assessments do not show a clear weak topic, so a balanced review quiz is the safest next step.",
+        "history_summary": {
+            "assessments_considered": len(ordered_rows),
+            "average_score_percent": average_score_percent,
+            "weak_topics": [topic for topic, _count in weak_topic_hits.most_common(3)],
+            "strong_topics": [topic for topic, _count in strong_topic_hits.most_common(3)],
+        },
+    }

--- a/docs/superpowers/pr-notes/2026-04-21-assessment-recommendations.md
+++ b/docs/superpowers/pr-notes/2026-04-21-assessment-recommendations.md
@@ -1,0 +1,66 @@
+# PR Architecture Note: Assessment Recommendations
+
+## Summary
+
+Adds a deterministic assessment recommendation API that suggests the next focus topic from existing assessment review history.
+
+## Scope
+
+- `deeptutor/services/assessment/analysis.py`
+- `deeptutor/services/assessment/recommendation_engine.py`
+- `deeptutor/api/routers/assessment.py`
+- dashboard analysis refactor to use the shared assessment analysis helper
+- targeted API regression coverage
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Client["Student/Teacher Client"]
+  RecommendAPI["POST /api/v1/assessment/recommend"]
+  SessionStore["SQLite Session Store"]
+  ReviewParser["Assessment Review Parser"]
+  Analysis["Shared Assessment Analysis"]
+  Engine["Recommendation Engine"]
+  Output["Recommended Topic + Action + Reason"]
+
+  Client --> RecommendAPI
+  RecommendAPI --> SessionStore
+  RecommendAPI --> ReviewParser
+  ReviewParser --> Analysis
+  Analysis --> Engine
+  SessionStore --> Engine
+  Engine --> Output
+  Output --> Client
+```
+
+## Architecture Impact
+
+This change introduces a small assessment service layer for reusable analysis and next-assessment recommendation logic. The first version stays deterministic and reuses existing session/review data instead of adding a new analytics store or LLM dependency.
+
+## Data/API Changes
+
+- Adds `POST /api/v1/assessment/recommend`
+- Request body:
+  - `session_id` optional
+  - `limit` optional
+- Response includes:
+  - `status`
+  - `recommended_topic`
+  - `suggested_action`
+  - `recommended_knowledge_bases`
+  - `source_session_ids`
+  - `reason`
+  - `history_summary`
+
+## Tests
+
+```bash
+python3 -m pytest tests/api/test_dashboard_router.py tests/api/test_assessment_router.py -q
+python3 -m py_compile deeptutor/api/routers/assessment.py deeptutor/api/routers/dashboard.py deeptutor/api/main.py deeptutor/services/assessment/analysis.py deeptutor/services/assessment/recommendation_engine.py
+```
+
+## Main System Map Update
+
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- [ ] Not needed

--- a/docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md
+++ b/docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md
@@ -67,3 +67,12 @@ Generate the next recommended assessment focus for a student based on recent ass
 
 - `T014` is merged to `main` through PR `#54`.
 - Start from the existing dashboard assessment analysis and review parsing before introducing any new recommendation logic.
+- Implemented on branch `pod-a/t015-assessment-recommendations` with:
+  - `POST /api/v1/assessment/recommend`
+  - shared analysis helper in `deeptutor/services/assessment/analysis.py`
+  - deterministic recommendation engine in `deeptutor/services/assessment/recommendation_engine.py`
+- Validation completed:
+  - `python3 -m pytest tests/api/test_dashboard_router.py tests/api/test_assessment_router.py -q`
+  - `python3 -m py_compile deeptutor/api/routers/assessment.py deeptutor/api/routers/dashboard.py deeptutor/api/main.py deeptutor/services/assessment/analysis.py deeptutor/services/assessment/recommendation_engine.py`
+- PR note prepared:
+  - `docs/superpowers/pr-notes/2026-04-21-assessment-recommendations.md`

--- a/docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md
+++ b/docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: AI-Powered Assessment Recommendations
+
+Owner: Codex
+Branch: `pod-a/t015-assessment-recommendations`
+GitHub Issue: `#55`
+
+## Goal
+
+Generate the next recommended assessment focus for a student based on recent assessment performance and known weak topics.
+
+## User-visible outcome
+
+- A student or teacher can request the next suggested assessment focus instead of guessing the next topic manually.
+- Recommendations are grounded in existing assessment analytics, not a second independent scoring model.
+- The first version stays deterministic unless the current architecture clearly requires an LLM call.
+
+## Owned files/modules
+
+- `deeptutor/services/assessment/`
+- `deeptutor/api/routers/`
+- `tests/api/`
+- `tests/services/`
+- `docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-21.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Unrelated marketplace, settings, and dashboard UI files unless the task packet is updated first
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Prefer a small recommendation service under `deeptutor/services/assessment/`
+- Reuse existing assessment review and dashboard analytics signals before adding new persistence
+- Expose only the minimal API surface required for recommendation consumption
+
+## Acceptance criteria
+
+- The system can derive at least one next assessment recommendation from existing performance data.
+- Recommendations explain the suggested focus topic or reason.
+- Empty state is handled cleanly when there is not enough history.
+- Backend behavior is covered by targeted tests.
+
+## Required tests
+
+- Targeted service and/or API tests for recommendation behavior
+- Python compile or equivalent validation for touched backend files
+
+## Manual verification
+
+- Trigger recommendation generation with at least one weak-topic assessment history
+- Confirm the recommendation points to an appropriate next topic or practice direction
+- Confirm a user with no meaningful history gets a clean fallback response
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+
+## Handoff notes
+
+- `T014` is merged to `main` through PR `#54`.
+- Start from the existing dashboard assessment analysis and review parsing before introducing any new recommendation logic.

--- a/tests/api/test_assessment_router.py
+++ b/tests/api/test_assessment_router.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - optional dependency in lightweight envs
+    FastAPI = None
+    TestClient = None
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+pytestmark = pytest.mark.skipif(FastAPI is None or TestClient is None, reason="fastapi not installed")
+
+
+def _build_app(store: SQLiteSessionStore, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from deeptutor.api.routers import assessment
+
+    app = FastAPI()
+    app.include_router(assessment.router, prefix="/api/v1/assessment")
+    monkeypatch.setattr(assessment, "get_sqlite_session_store", lambda: store)
+    return app
+
+
+async def _seed_session(
+    store: SQLiteSessionStore,
+    *,
+    session_id: str,
+    capability: str,
+    message: str,
+    knowledge_bases: list[str],
+    status: str = "completed",
+) -> None:
+    await store.create_session(session_id=session_id)
+    await store.update_session_preferences(
+        session_id,
+        {
+            "capability": capability,
+            "tools": ["rag"] if knowledge_bases else [],
+            "knowledge_bases": knowledge_bases,
+            "language": "en",
+        },
+    )
+    turn = await store.create_turn(session_id, capability=capability)
+    await store.add_message(session_id, "user", message, capability=capability)
+    await store.update_turn_status(turn["id"], status)
+
+
+def _set_session_timestamp(store: SQLiteSessionStore, session_id: str, timestamp: float) -> None:
+    with sqlite3.connect(store.db_path) as conn:
+        conn.execute(
+            "UPDATE sessions SET created_at = ?, updated_at = ? WHERE id = ?",
+            (timestamp, timestamp, session_id),
+        )
+        conn.execute(
+            "UPDATE turns SET created_at = ?, updated_at = ?, finished_at = ? WHERE session_id = ?",
+            (timestamp, timestamp, timestamp, session_id),
+        )
+        conn.execute(
+            "UPDATE messages SET created_at = ? WHERE session_id = ?",
+            (timestamp, session_id),
+        )
+        conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_assessment_recommend_returns_targeted_next_topic(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="assessment-recent",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "assessment-recent",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4)\n"
+        "2. [q2] Q: Solve fractions subtraction 5/6 - 1/3 -> Answered: 1/2 (Incorrect, correct: 1/2)\n"
+        "Score: 0/2 (0%)",
+        capability="deep_question",
+    )
+    _set_session_timestamp(store, "assessment-recent", 1_710_000_000)
+
+    await _seed_session(
+        store,
+        session_id="assessment-older",
+        capability="deep_question",
+        message="Generate a quiz on algebra",
+        knowledge_bases=["algebra-pack"],
+    )
+    await store.add_message(
+        "assessment-older",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve algebra equation x + 2 = 5 -> Answered: 3 (Correct)\n"
+        "2. [q2] Q: Solve algebra equation 2x = 10 -> Answered: 5 (Correct)\n"
+        "Score: 2/2 (100%)",
+        capability="deep_question",
+    )
+    _set_session_timestamp(store, "assessment-older", 1_709_913_600)
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.post(
+            "/api/v1/assessment/recommend",
+            json={"session_id": "assessment-recent", "limit": 10},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ready"
+    assert payload["recommended_topic"] == "fractions subtraction"
+    assert payload["suggested_action"] == "retry-focused-quiz"
+    assert payload["recommended_knowledge_bases"] == ["fractions-pack"]
+    assert payload["source_session_ids"] == ["assessment-recent", "assessment-older"]
+    assert payload["history_summary"]["assessments_considered"] == 2
+    assert payload["history_summary"]["average_score_percent"] == 50
+    assert "fractions subtraction" in payload["reason"]
+
+
+@pytest.mark.asyncio
+async def test_assessment_recommend_returns_clean_empty_state_without_reviews(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="chat-only",
+        capability="chat",
+        message="Help me study geometry",
+        knowledge_bases=["geometry-pack"],
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.post("/api/v1/assessment/recommend", json={})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "insufficient-data"
+    assert payload["recommended_topic"] is None
+    assert payload["suggested_action"] == "complete-assessment"
+    assert payload["history_summary"]["assessments_considered"] == 0


### PR DESCRIPTION
## Summary
- add a deterministic recommendation engine for the next assessment focus
- add `POST /api/v1/assessment/recommend` using existing session and assessment review data
- refactor dashboard topic analysis into a shared assessment service helper

Closes #55

## Validation
- `python3 -m pytest tests/api/test_dashboard_router.py tests/api/test_assessment_router.py -q`
- `python3 -m py_compile deeptutor/api/routers/assessment.py deeptutor/api/routers/dashboard.py deeptutor/api/main.py deeptutor/services/assessment/analysis.py deeptutor/services/assessment/recommendation_engine.py`

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-21-assessment-recommendations.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated
