### PR TITLE
[MVP] Add Pack Ratings & Reviews System

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, assessment recommendations are now merged into `main` through PR `#56`, and the active short task is `T016 Add Pack Ratings & Reviews System`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, assessment recommendations are now merged into `main` through PR `#56`, and Draft PR `#58` is active for `T016 Add Pack Ratings & Reviews System`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T016`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T016` via Draft PR `#58`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, student progress dashboard is now merged into `main` through PR `#54`, and Draft PR `#56` is active for `T015 AI-Powered Assessment Recommendations`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, assessment recommendations are now merged into `main` through PR `#56`, and the active short task is `T016 Add Pack Ratings & Reviews System`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T015` via Draft PR `#56`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T016`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,30 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#54 [MVP] Student Progress Tracking Dashboard`
-- `#54` added `/dashboard/student` and `GET /api/v1/dashboard/student-progress`, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import and preview, assessment insights, KB context badges, student progress dashboard, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#56 [MVP] AI-Powered Assessment Recommendations`
+- `#56` added `POST /api/v1/assessment/recommend`, shared assessment analysis helpers, and deterministic next-assessment recommendation flow, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import and preview, assessment insights, recommendation flow, KB context badges, student progress dashboard, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#55 [MVP] AI-Powered Assessment Recommendations`
-- Active branch: `pod-a/t015-assessment-recommendations`
-- Active PR: `#56 [MVP] AI-Powered Assessment Recommendations` (Draft)
-- Active task packet: `docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md`
-- Focus set: `T015` (assessment recommendations)
+- Active issue: `#57 [MVP] Add Pack Ratings & Reviews System`
+- Active branch: `pod-a/t016-marketplace-ratings`
+- Active task packet: `docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md`
+- Focus set: `T016` (marketplace ratings)
 
 ## Next recommended task
 
-Monitor CI for `#56`, fix any failing checks on `pod-a/t015-assessment-recommendations`, then merge to `main` once all required checks are green.
+Implement `T016` on `pod-a/t016-marketplace-ratings`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#54` merged to `main` after all required CI checks passed
-2. Issue `#53` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T015 AI-Powered Assessment Recommendations`
-4. Issue `#55` created and task packet added for the new execution lane
-5. Draft PR `#56` opened with validation complete and architecture note attached
+1. `#56` merged to `main` after all required CI checks passed
+2. Issue `#55` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T016 Add Pack Ratings & Reviews System`
+4. Issue `#57` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -59,7 +57,8 @@ Monitor CI for `#56`, fix any failing checks on `pod-a/t015-assessment-recommend
 | T012: Teacher Sharing UI | Completed | 3 | NO | Verified |
 | T013: Marketplace Preview | Completed | 3 | NO | Done |
 | T014: Student Progress Dashboard | Completed | 5 | NO | Done |
-| T015: Assessment Recommendations | In Progress | 6 | NO | Now |
+| T015: Assessment Recommendations | Completed | 6 | NO | Done |
+| T016: Marketplace Ratings | In Progress | 4 | NO | Now |
 | T018: Vietnamese Prompts | Not Started | 4 | YES | Parallel |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -15,12 +15,13 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 - Active issue: `#57 [MVP] Add Pack Ratings & Reviews System`
 - Active branch: `pod-a/t016-marketplace-ratings`
+- Active PR: `#58 [MVP] Add Pack Ratings & Reviews System` (Draft)
 - Active task packet: `docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md`
 - Focus set: `T016` (marketplace ratings)
 
 ## Next recommended task
 
-Implement `T016` on `pod-a/t016-marketplace-ratings`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Monitor CI for `#58`, fix any failing checks on `pod-a/t016-marketplace-ratings`, then merge to `main` once all required checks are green.
 
 ## Status Update (2026-04-21)
 
@@ -29,6 +30,7 @@ Implement `T016` on `pod-a/t016-marketplace-ratings`, then open a Draft PR with 
 2. Issue `#55` auto-closed with the merge
 3. Next pending registry task selected in strict order: `T016 Add Pack Ratings & Reviews System`
 4. Issue `#57` created and task packet added for the new execution lane
+5. Draft PR `#58` opened with validation complete and architecture note attached
 
 ## AI-owned blockers
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -180,7 +180,7 @@
       "estimated_hours": 4,
       "dependencies": ["Database Schema"],
       "status": "in-progress",
-      "notes": "Issue #57 opened and task packet created at docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md. Active branch: pod-a/t016-marketplace-ratings."
+      "notes": "Issue #57 opened and task packet created at docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md. Active branch: pod-a/t016-marketplace-ratings. Draft PR #58 is open with backend tests and frontend build passing locally."
     },
     {
       "id": "T017_ASSESSMENT_HISTORY_FILTERING",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -161,8 +161,8 @@
       "complexity": "High",
       "estimated_hours": 6,
       "dependencies": ["LLM Service", "Assessment Analytics"],
-      "status": "in-progress",
-      "notes": "Issue #55 opened and task packet created at docs/superpowers/tasks/2026-04-21-T015-assessment-recommendations.md. Active branch: pod-a/t015-assessment-recommendations. Draft PR #56 is open with targeted API tests and compile checks passing locally."
+      "status": "completed",
+      "notes": "Merged to main through PR #56. Assessment recommendation API now exposes POST /api/v1/assessment/recommend with deterministic next-topic suggestions."
     },
     {
       "id": "T016_MARKETPLACE_RATINGS",
@@ -179,8 +179,8 @@
       "complexity": "Medium",
       "estimated_hours": 4,
       "dependencies": ["Database Schema"],
-      "status": "not-started",
-      "notes": "5-star rating system with optional comments, show average rating in pack cards"
+      "status": "in-progress",
+      "notes": "Issue #57 opened and task packet created at docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md. Active branch: pod-a/t016-marketplace-ratings."
     },
     {
       "id": "T017_ASSESSMENT_HISTORY_FILTERING",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -43,7 +43,10 @@ flowchart TD
   Marketplace --> MarketplaceFilters["Search/Subject/Owner Filters"]
   Marketplace --> MarketplacePreview["GET /api/v1/marketplace/{pack_name}/preview"]
   MarketplacePreview --> PreviewModal["Preview modal: metadata + sample documents"]
+  MarketplacePreview --> PackRatings["Average rating + recent reviews"]
   Marketplace --> MarketplaceImport["POST /api/v1/marketplace/import/{pack_name}"]
+  Marketplace --> MarketplaceReviewAPI["POST /api/v1/marketplace/{pack_name}/reviews"]
+  MarketplaceReviewAPI --> ReviewStorage["KB config: marketplace_reviews metadata"]
   MarketplaceImport --> ImportedClone["Imported KB clone: <pack>__imported"]
   
   Product --> AssessmentBuilder["Assessment Builder"]

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -124,3 +124,37 @@
 
 - Task `T016_MARKETPLACE_RATINGS`: moved to `in-progress`
 - Next: inspect marketplace data/storage and start implementation on `pod-a/t016-marketplace-ratings`
+
+## T016 Add Pack Ratings & Reviews System — Implementation Progress
+
+### Completed in this cycle
+
+1. Extended marketplace API in `deeptutor/api/routers/marketplace.py`:
+   - rating summary added to list/detail/preview payloads
+   - new `POST /api/v1/marketplace/{pack_name}/reviews`
+2. Used lightweight metadata storage:
+   - `marketplace_reviews` list inside pack config metadata
+3. Added backend regression coverage:
+   - `tests/api/test_marketplace_router.py`
+4. Added frontend API client support:
+   - `web/lib/marketplace-api.ts`
+5. Updated marketplace UI:
+   - pack cards now show average rating/review count
+   - preview modal now shows recent reviews and a review submission form
+6. Updated system map and PR note:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+   - `docs/superpowers/pr-notes/2026-04-21-marketplace-ratings.md`
+
+### Validation
+
+- Marketplace API tests passed:
+  - `python3 -m pytest tests/api/test_marketplace_router.py -q`
+- Python compile check passed:
+  - `python3 -m py_compile deeptutor/api/routers/marketplace.py`
+- Frontend production build passed:
+  - `cd web && npm run build`
+
+### Status
+
+- Task `T016_MARKETPLACE_RATINGS`: implementation complete on branch `pod-a/t016-marketplace-ratings`
+- Next: commit, push, open Draft PR linked to issue `#57`, then monitor CI and merge per AI-first policy

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -94,3 +94,33 @@
 
 - Task `T015_ASSESSMENT_RECOMMENDATIONS`: implementation complete on branch `pod-a/t015-assessment-recommendations`
 - Next: commit, push, open Draft PR linked to issue `#55`, then monitor CI and merge per AI-first policy
+
+## T015 AI-Powered Assessment Recommendations — Merge Complete
+
+### Completed in this cycle
+
+1. Draft PR `#56` was opened, validated by CI, moved to Ready, and merged to `main`.
+2. Issue `#55` closed with the merge.
+3. Local `main` was fast-forwarded to include the merged recommendation lane.
+
+### Status
+
+- Task `T015_ASSESSMENT_RECOMMENDATIONS`: moved to `completed`
+
+## T016 Add Pack Ratings & Reviews System — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T015` merged.
+2. Opened GitHub issue `#57` for `T016 Add Pack Ratings & Reviews System`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T016_MARKETPLACE_RATINGS`: moved to `in-progress`
+- Next: inspect marketplace data/storage and start implementation on `pod-a/t016-marketplace-ratings`

--- a/deeptutor/api/routers/marketplace.py
+++ b/deeptutor/api/routers/marketplace.py
@@ -3,12 +3,40 @@
 from datetime import datetime
 from pathlib import Path
 import shutil
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from deeptutor.api.routers.knowledge import get_kb_manager
 
 router = APIRouter()
+
+
+class MarketplaceReviewRequest(BaseModel):
+    reviewer: str = Field(min_length=1, max_length=80)
+    rating: int = Field(ge=1, le=5)
+    comment: str | None = Field(default=None, max_length=400)
+
+
+def _pack_reviews(source_cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_reviews = source_cfg.get("marketplace_reviews", [])
+    if not isinstance(raw_reviews, list):
+        return []
+    reviews = [review for review in raw_reviews if isinstance(review, dict)]
+    return sorted(
+        reviews,
+        key=lambda review: str(review.get("created_at") or ""),
+        reverse=True,
+    )
+
+
+def _rating_summary(source_cfg: dict[str, Any]) -> dict[str, float | int]:
+    reviews = _pack_reviews(source_cfg)
+    if not reviews:
+        return {"average_rating": 0.0, "review_count": 0}
+    average = round(sum(int(review.get("rating") or 0) for review in reviews) / len(reviews), 1)
+    return {"average_rating": average, "review_count": len(reviews)}
 
 
 def _list_marketplace_candidates() -> list[dict]:
@@ -22,6 +50,7 @@ def _list_marketplace_candidates() -> list[dict]:
             info = manager.get_info(name)
             metadata = info.get("metadata") or {}
             sharing_status = metadata.get("sharing_status")
+            source_cfg = manager.config.get("knowledge_bases", {}).get(name, {})
 
             if sharing_status not in {"public", "team"}:
                 continue
@@ -38,6 +67,7 @@ def _list_marketplace_candidates() -> list[dict]:
                     "session_count": info.get("statistics", {}).get("content_lists", 0),
                     "status": info.get("status", "ready"),
                     "statistics": info.get("statistics", {}),
+                    "rating_summary": _rating_summary(source_cfg),
                 }
             )
         except Exception:
@@ -119,7 +149,9 @@ async def list_marketplace_packs(
 async def get_marketplace_pack(pack_name: str):
     """Get detailed information about a specific marketplace pack."""
     try:
+        manager = get_kb_manager()
         match = _get_marketplace_match(pack_name)
+        source_cfg = manager.config.get("knowledge_bases", {}).get(pack_name, {})
 
         return {
             "name": match.get("name"),
@@ -132,6 +164,8 @@ async def get_marketplace_pack(pack_name: str):
             "session_count": match.get("session_count", 0),
             "status": match.get("status", "ready"),
             "statistics": match.get("statistics", {}),
+            "rating_summary": _rating_summary(source_cfg),
+            "recent_reviews": _pack_reviews(source_cfg)[:5],
         }
     
     except HTTPException:
@@ -165,6 +199,41 @@ async def preview_marketplace_pack(pack_name: str):
             "session_count": match.get("session_count", 0),
             "document_count": document_count,
             "sample_documents": sample_documents,
+            "rating_summary": _rating_summary(source_cfg),
+            "recent_reviews": _pack_reviews(source_cfg)[:5],
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/{pack_name}/reviews")
+async def submit_marketplace_review(pack_name: str, payload: MarketplaceReviewRequest):
+    try:
+        manager = get_kb_manager()
+        _get_marketplace_match(pack_name)
+
+        source_cfg = manager.config.get("knowledge_bases", {}).get(pack_name)
+        if not isinstance(source_cfg, dict):
+            raise HTTPException(status_code=404, detail=f"Knowledge pack '{pack_name}' not found")
+
+        review = {
+            "reviewer": payload.reviewer.strip(),
+            "rating": payload.rating,
+            "comment": (payload.comment or "").strip(),
+            "created_at": datetime.utcnow().isoformat(),
+        }
+        reviews = _pack_reviews(source_cfg)
+        reviews.insert(0, review)
+        source_cfg["marketplace_reviews"] = reviews[:50]
+        source_cfg["updated_at"] = datetime.utcnow().isoformat()
+        manager._save_config()
+
+        return {
+            "success": True,
+            "review": review,
+            "rating_summary": _rating_summary(source_cfg),
         }
     except HTTPException:
         raise

--- a/docs/superpowers/pr-notes/2026-04-21-marketplace-ratings.md
+++ b/docs/superpowers/pr-notes/2026-04-21-marketplace-ratings.md
@@ -1,0 +1,57 @@
+# PR Architecture Note: Marketplace Ratings & Reviews
+
+## Summary
+
+Adds lightweight ratings and short reviews for marketplace knowledge packs using existing pack metadata storage.
+
+## Scope
+
+- marketplace router review submission endpoint
+- marketplace list/preview rating summary payloads
+- marketplace frontend rating display and review form
+- targeted marketplace API regression coverage
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  User["Teacher/Student"]
+  MarketplaceUI["Marketplace Page + Preview Modal"]
+  MarketAPI["Marketplace API"]
+  ReviewEndpoint["POST /api/v1/marketplace/{pack}/reviews"]
+  PreviewEndpoint["GET /api/v1/marketplace/{pack}/preview"]
+  Config["KB Config Metadata"]
+  Summary["Average rating + recent reviews"]
+
+  User --> MarketplaceUI
+  MarketplaceUI --> MarketAPI
+  MarketAPI --> ReviewEndpoint
+  MarketAPI --> PreviewEndpoint
+  ReviewEndpoint --> Config
+  PreviewEndpoint --> Config
+  Config --> Summary
+  Summary --> MarketplaceUI
+```
+
+## Architecture Impact
+
+The first version stores ratings as lightweight `marketplace_reviews` metadata on each shared knowledge pack. This keeps the change inside the existing marketplace/config flow without introducing a new database table yet.
+
+## Data/API Changes
+
+- Extends marketplace list/detail/preview responses with `rating_summary`
+- Extends preview/detail responses with `recent_reviews`
+- Adds `POST /api/v1/marketplace/{pack_name}/reviews`
+
+## Tests
+
+```bash
+python3 -m pytest tests/api/test_marketplace_router.py -q
+python3 -m py_compile deeptutor/api/routers/marketplace.py
+cd web && npm run build
+```
+
+## Main System Map Update
+
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- [ ] Not needed

--- a/docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md
+++ b/docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: Add Pack Ratings & Reviews System
+
+Owner: Codex
+Branch: `pod-a/t016-marketplace-ratings`
+GitHub Issue: `#57`
+
+## Goal
+
+Allow users to rate marketplace knowledge packs and leave short review comments that appear in marketplace listing details.
+
+## User-visible outcome
+
+- Marketplace packs show an average rating and review count.
+- Users can submit a 1-5 star rating with an optional short review comment.
+- The first version keeps storage simple and local to the existing app data model.
+
+## Owned files/modules
+
+- `web/app/(utility)/marketplace/`
+- `web/lib/marketplace-api.ts`
+- `deeptutor/api/routers/marketplace.py`
+- `tests/api/test_marketplace_router.py`
+- `docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-21.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Unrelated dashboard, tutor, settings, and notebook files
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Extend the marketplace router instead of creating a parallel marketplace service surface
+- Keep the first storage model lightweight and deterministic
+- Expose only the minimal rating/review payload needed by the marketplace UI
+
+## Acceptance criteria
+
+- Packs expose rating summary data in marketplace responses.
+- Users can submit a rating and optional review comment through the API.
+- Marketplace UI surfaces average rating and review count cleanly.
+- Empty state is handled when a pack has no reviews yet.
+
+## Required tests
+
+- Targeted backend API tests for rating submission and rating summary retrieval
+- Frontend build or equivalent validation for touched marketplace UI files
+
+## Manual verification
+
+- Submit a review for a pack from the marketplace UI
+- Confirm rating summary updates after submission
+- Confirm a never-reviewed pack shows a clean unrated state
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+
+## Handoff notes
+
+- `T015` is merged to `main` through PR `#56`.
+- Start from the existing marketplace list/preview/import flow before adding new storage or UI state.

--- a/docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md
+++ b/docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md
@@ -67,3 +67,13 @@ Allow users to rate marketplace knowledge packs and leave short review comments 
 
 - `T015` is merged to `main` through PR `#56`.
 - Start from the existing marketplace list/preview/import flow before adding new storage or UI state.
+- Implemented on branch `pod-a/t016-marketplace-ratings` with:
+  - `POST /api/v1/marketplace/{pack_name}/reviews`
+  - rating summary in marketplace list/preview payloads
+  - marketplace review display and submission flow in preview modal
+- Validation completed:
+  - `python3 -m pytest tests/api/test_marketplace_router.py -q`
+  - `python3 -m py_compile deeptutor/api/routers/marketplace.py`
+  - `cd web && npm run build`
+- PR note prepared:
+  - `docs/superpowers/pr-notes/2026-04-21-marketplace-ratings.md`

--- a/tests/api/test_marketplace_router.py
+++ b/tests/api/test_marketplace_router.py
@@ -22,6 +22,14 @@ class _FakeKBManager:
                     "curriculum": "National",
                     "learning_objectives": ["Linear equations", "Word problems"],
                     "owner": "Teacher A",
+                    "marketplace_reviews": [
+                        {
+                            "reviewer": "Teacher B",
+                            "rating": 4,
+                            "comment": "Useful pacing for revision week.",
+                            "created_at": "2026-04-18T10:00:00",
+                        }
+                    ],
                     "created_at": "2026-04-20T00:00:00",
                     "updated_at": "2026-04-20T00:00:00",
                 },
@@ -119,3 +127,36 @@ def test_marketplace_preview_returns_compact_pack_summary(monkeypatch, tmp_path:
     assert payload["document_count"] == 4
     assert payload["sample_documents"] == ["lesson-1.md", "lesson-2.md", "lesson-3.md"]
     assert payload["learning_objectives"] == ["Linear equations", "Word problems"]
+    assert payload["rating_summary"] == {"average_rating": 4.0, "review_count": 1}
+    assert payload["recent_reviews"][0]["comment"] == "Useful pacing for revision week."
+
+
+def test_marketplace_list_includes_rating_summary(monkeypatch, tmp_path: Path) -> None:
+    client = _build_app(monkeypatch, tmp_path)
+
+    response = client.get("/api/v1/marketplace/list")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["packs"][0]["rating_summary"] == {"average_rating": 4.0, "review_count": 1}
+
+
+def test_marketplace_review_submission_updates_pack_summary(monkeypatch, tmp_path: Path) -> None:
+    client = _build_app(monkeypatch, tmp_path)
+
+    response = client.post(
+        "/api/v1/marketplace/shared-pack/reviews",
+        json={"reviewer": "Teacher C", "rating": 5, "comment": "Great question progression."},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["rating_summary"] == {"average_rating": 4.5, "review_count": 2}
+    assert payload["review"]["reviewer"] == "Teacher C"
+    assert payload["review"]["rating"] == 5
+
+    preview_response = client.get("/api/v1/marketplace/shared-pack/preview")
+    preview_payload = preview_response.json()
+    assert preview_payload["rating_summary"] == {"average_rating": 4.5, "review_count": 2}
+    assert preview_payload["recent_reviews"][0]["comment"] == "Great question progression."

--- a/web/app/(utility)/marketplace/page.tsx
+++ b/web/app/(utility)/marketplace/page.tsx
@@ -1,17 +1,27 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import Link from "next/link";
-import { BookOpen, Download, Eye, Filter, Loader2, Search, X } from "lucide-react";
+import { BookOpen, Download, Eye, Filter, Loader2, Star, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   getMarketplacePackPreview,
   listMarketplacePacks,
   importMarketplacePack,
+  submitMarketplaceReview,
   type MarketplaceListResponse,
   type MarketplacePack,
   type MarketplacePackPreview,
 } from "@/lib/marketplace-api";
+
+function renderStars(value: number) {
+  return Array.from({ length: 5 }, (_, index) => (
+    <Star
+      key={index}
+      size={13}
+      className={index < Math.round(value) ? "fill-amber-400 text-amber-400" : "text-slate-300"}
+    />
+  ));
+}
 
 export default function MarketplacePage() {
   const { t } = useTranslation();
@@ -36,6 +46,10 @@ export default function MarketplacePage() {
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewPack, setPreviewPack] = useState<MarketplacePackPreview | null>(null);
+  const [reviewerName, setReviewerName] = useState("");
+  const [reviewRating, setReviewRating] = useState(5);
+  const [reviewComment, setReviewComment] = useState("");
+  const [submittingReview, setSubmittingReview] = useState(false);
 
   const loadPacks = useCallback(async () => {
     setLoading(true);
@@ -88,6 +102,35 @@ export default function MarketplacePage() {
       setPreviewOpen(false);
     } finally {
       setPreviewLoading(false);
+    }
+  };
+
+  const handleSubmitReview = async () => {
+    if (!previewPack) return;
+    setSubmittingReview(true);
+    try {
+      const result = await submitMarketplaceReview(previewPack.name, {
+        reviewer: reviewerName.trim() || "Anonymous",
+        rating: reviewRating,
+        comment: reviewComment.trim() || undefined,
+      });
+      setPreviewPack((current) =>
+        current
+          ? {
+              ...current,
+              rating_summary: result.rating_summary,
+              recent_reviews: [result.review, ...current.recent_reviews].slice(0, 5),
+            }
+          : current,
+      );
+      setReviewerName("");
+      setReviewRating(5);
+      setReviewComment("");
+      await loadPacks();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to submit review");
+    } finally {
+      setSubmittingReview(false);
     }
   };
 
@@ -263,6 +306,16 @@ export default function MarketplacePage() {
                     <p className="text-[12px] text-[var(--muted-foreground)]">
                       <span className="font-medium">{t("Sessions")}:</span> {pack.session_count || 0}
                     </p>
+                    <div className="flex items-center gap-2 text-[12px] text-[var(--muted-foreground)]">
+                      <div className="flex items-center gap-0.5">
+                        {renderStars(pack.rating_summary?.average_rating || 0)}
+                      </div>
+                      <span>
+                        {pack.rating_summary?.review_count
+                          ? `${pack.rating_summary.average_rating.toFixed(1)} • ${pack.rating_summary.review_count} ${t("reviews")}`
+                          : t("Unrated")}
+                      </span>
+                    </div>
                   </div>
 
                   {/* Learning Objectives */}
@@ -407,6 +460,21 @@ export default function MarketplacePage() {
                         {previewPack.session_count || 0}
                       </p>
                     </div>
+                    <div className="rounded-lg bg-[var(--background)] p-3 md:col-span-3">
+                      <p className="text-[11px] font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+                        {t("Rating")}
+                      </p>
+                      <div className="mt-2 flex items-center gap-2">
+                        <div className="flex items-center gap-0.5">
+                          {renderStars(previewPack.rating_summary?.average_rating || 0)}
+                        </div>
+                        <p className="text-[13px] font-medium text-[var(--foreground)]">
+                          {previewPack.rating_summary?.review_count
+                            ? `${previewPack.rating_summary.average_rating.toFixed(1)} • ${previewPack.rating_summary.review_count} ${t("reviews")}`
+                            : t("No reviews yet")}
+                        </p>
+                      </div>
+                    </div>
                   </div>
 
                   {previewPack.learning_objectives && previewPack.learning_objectives.length > 0 && (
@@ -442,6 +510,92 @@ export default function MarketplacePage() {
                         {t("No preview documents available")}
                       </p>
                     )}
+                  </div>
+
+                  <div className="grid gap-4 rounded-xl border border-[var(--border)] bg-[var(--background)] p-4">
+                    <div>
+                      <p className="text-[12px] font-semibold text-[var(--foreground)]">
+                        {t("Ratings & Reviews")}
+                      </p>
+                      {previewPack.recent_reviews.length > 0 ? (
+                        <div className="mt-3 space-y-2">
+                          {previewPack.recent_reviews.map((review) => (
+                            <div
+                              key={`${review.reviewer}-${review.created_at}`}
+                              className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-3"
+                            >
+                              <div className="flex items-center justify-between gap-3">
+                                <span className="text-[13px] font-medium text-[var(--foreground)]">
+                                  {review.reviewer}
+                                </span>
+                                <div className="flex items-center gap-0.5">
+                                  {renderStars(review.rating)}
+                                </div>
+                              </div>
+                              {review.comment && (
+                                <p className="mt-2 text-[13px] leading-6 text-[var(--muted-foreground)]">
+                                  {review.comment}
+                                </p>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="mt-2 text-[13px] text-[var(--muted-foreground)]">
+                          {t("No reviews yet. Be the first to rate this pack.")}
+                        </p>
+                      )}
+                    </div>
+
+                    <div className="grid gap-3 rounded-lg border border-dashed border-[var(--border)] bg-[var(--card)] p-3">
+                      <p className="text-[12px] font-semibold text-[var(--foreground)]">
+                        {t("Add your review")}
+                      </p>
+                      <input
+                        type="text"
+                        placeholder={t("Your name")}
+                        value={reviewerName}
+                        onChange={(e) => setReviewerName(e.target.value)}
+                        className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px]"
+                      />
+                      <div>
+                        <label className="mb-1 block text-[12px] font-medium text-[var(--foreground)]">
+                          {t("Rating")}
+                        </label>
+                        <select
+                          value={reviewRating}
+                          onChange={(e) => setReviewRating(Number(e.target.value))}
+                          className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px]"
+                        >
+                          {[5, 4, 3, 2, 1].map((value) => (
+                            <option key={value} value={value}>
+                              {value} / 5
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <textarea
+                        placeholder={t("What worked well about this pack?")}
+                        value={reviewComment}
+                        onChange={(e) => setReviewComment(e.target.value)}
+                        rows={3}
+                        className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px]"
+                      />
+                      <button
+                        onClick={handleSubmitReview}
+                        disabled={submittingReview || !previewPack}
+                        className="inline-flex items-center justify-center gap-2 rounded-md bg-[var(--primary)] px-3 py-2 text-[12px] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:opacity-50"
+                      >
+                        {submittingReview ? (
+                          <>
+                            <Loader2 size={13} className="animate-spin" />
+                            {t("Saving review")}
+                          </>
+                        ) : (
+                          t("Submit review")
+                        )}
+                      </button>
+                    </div>
                   </div>
                 </>
               ) : null}

--- a/web/lib/marketplace-api.ts
+++ b/web/lib/marketplace-api.ts
@@ -9,6 +9,18 @@ export interface MarketplacePackMetadata {
   sharing_status?: "private" | "team" | "public" | null;
 }
 
+export interface MarketplaceRatingSummary {
+  average_rating: number;
+  review_count: number;
+}
+
+export interface MarketplaceReview {
+  reviewer: string;
+  rating: number;
+  comment?: string | null;
+  created_at: string;
+}
+
 export interface MarketplacePack {
   name: string;
   subject?: string | null;
@@ -19,12 +31,14 @@ export interface MarketplacePack {
   sharing_status?: "public" | "team" | null;
   session_count?: number;
   status?: string;
+  rating_summary?: MarketplaceRatingSummary;
 }
 
 export interface MarketplacePackPreview extends MarketplacePack {
   description?: string | null;
   document_count: number;
   sample_documents: string[];
+  recent_reviews: MarketplaceReview[];
 }
 
 export interface MarketplaceListResponse {
@@ -107,6 +121,18 @@ export interface ImportPackResult {
   };
 }
 
+export interface SubmitMarketplaceReviewRequest {
+  reviewer: string;
+  rating: number;
+  comment?: string;
+}
+
+export interface SubmitMarketplaceReviewResult {
+  success: boolean;
+  review: MarketplaceReview;
+  rating_summary: MarketplaceRatingSummary;
+}
+
 export async function importMarketplacePack(
   packName: string,
 ): Promise<ImportPackResult> {
@@ -125,6 +151,32 @@ export async function importMarketplacePack(
       throw new Error(error.detail || `Failed to import pack: ${response.status}`);
     } catch {
       throw new Error(`Failed to import pack: ${response.status} ${response.statusText}`);
+    }
+  }
+
+  return response.json();
+}
+
+export async function submitMarketplaceReview(
+  packName: string,
+  payload: SubmitMarketplaceReviewRequest,
+): Promise<SubmitMarketplaceReviewResult> {
+  const response = await fetch(
+    apiUrl(`/api/v1/marketplace/${encodeURIComponent(packName)}/reviews`),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    try {
+      const error = JSON.parse(errorBody);
+      throw new Error(error.detail || `Failed to submit review: ${response.status}`);
+    } catch {
+      throw new Error(`Failed to submit review: ${response.status} ${response.statusText}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- add lightweight ratings and short reviews for marketplace packs
- add `POST /api/v1/marketplace/{pack_name}/reviews`
- show rating summary on marketplace cards and preview modal

Closes #57

## Validation
- `python3 -m pytest tests/api/test_marketplace_router.py -q`
- `python3 -m py_compile deeptutor/api/routers/marketplace.py`
- `cd web && npm run build`

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-21-marketplace-ratings.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated
