### PR TITLE
[MVP] Assessment History Filtering & Search

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, assessment recommendations are now merged into `main` through PR `#56`, and Draft PR `#58` is active for `T016 Add Pack Ratings & Reviews System`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace ratings are now merged into `main` through PR `#58`, and the active short task is `T017 Assessment History Filtering & Search`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T016` via Draft PR `#58`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T017`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace ratings are now merged into `main` through PR `#58`, and the active short task is `T017 Assessment History Filtering & Search`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace ratings are now merged into `main` through PR `#58`, and Draft PR `#60` is active for `T017 Assessment History Filtering & Search`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T017`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T017` via Draft PR `#60`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -15,12 +15,13 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 - Active issue: `#59 [MVP] Assessment History Filtering & Search`
 - Active branch: `pod-a/t017-dashboard-filtering`
+- Active PR: `#60 [MVP] Assessment History Filtering & Search` (Draft)
 - Active task packet: `docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md`
 - Focus set: `T017` (dashboard filtering)
 
 ## Next recommended task
 
-Implement `T017` on `pod-a/t017-dashboard-filtering`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Monitor CI for `#60`, fix any failing checks on `pod-a/t017-dashboard-filtering`, then merge to `main` once all required checks are green.
 
 ## Status Update (2026-04-21)
 
@@ -29,6 +30,7 @@ Implement `T017` on `pod-a/t017-dashboard-filtering`, then open a Draft PR with 
 2. Issue `#57` auto-closed with the merge
 3. Next pending registry task selected in strict order: `T017 Assessment History Filtering & Search`
 4. Issue `#59` created and task packet added for the new execution lane
+5. Draft PR `#60` opened with validation complete and architecture note attached
 
 ## AI-owned blockers
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,30 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#56 [MVP] AI-Powered Assessment Recommendations`
-- `#56` added `POST /api/v1/assessment/recommend`, shared assessment analysis helpers, and deterministic next-assessment recommendation flow, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import and preview, assessment insights, recommendation flow, KB context badges, student progress dashboard, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#58 [MVP] Add Pack Ratings & Reviews System`
+- `#58` added lightweight marketplace ratings and review submission, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, and ratings, assessment insights, recommendation flow, KB context badges, student progress dashboard, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#57 [MVP] Add Pack Ratings & Reviews System`
-- Active branch: `pod-a/t016-marketplace-ratings`
-- Active PR: `#58 [MVP] Add Pack Ratings & Reviews System` (Draft)
-- Active task packet: `docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md`
-- Focus set: `T016` (marketplace ratings)
+- Active issue: `#59 [MVP] Assessment History Filtering & Search`
+- Active branch: `pod-a/t017-dashboard-filtering`
+- Active task packet: `docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md`
+- Focus set: `T017` (dashboard filtering)
 
 ## Next recommended task
 
-Monitor CI for `#58`, fix any failing checks on `pod-a/t016-marketplace-ratings`, then merge to `main` once all required checks are green.
+Implement `T017` on `pod-a/t017-dashboard-filtering`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#56` merged to `main` after all required CI checks passed
-2. Issue `#55` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T016 Add Pack Ratings & Reviews System`
-4. Issue `#57` created and task packet added for the new execution lane
-5. Draft PR `#58` opened with validation complete and architecture note attached
+1. `#58` merged to `main` after all required CI checks passed
+2. Issue `#57` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T017 Assessment History Filtering & Search`
+4. Issue `#59` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -60,7 +58,8 @@ Monitor CI for `#58`, fix any failing checks on `pod-a/t016-marketplace-ratings`
 | T013: Marketplace Preview | Completed | 3 | NO | Done |
 | T014: Student Progress Dashboard | Completed | 5 | NO | Done |
 | T015: Assessment Recommendations | Completed | 6 | NO | Done |
-| T016: Marketplace Ratings | In Progress | 4 | NO | Now |
+| T016: Marketplace Ratings | Completed | 4 | NO | Done |
+| T017: Dashboard Filtering | In Progress | 2 | NO | Now |
 | T018: Vietnamese Prompts | Not Started | 4 | YES | Parallel |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -197,7 +197,7 @@
       "estimated_hours": 2,
       "dependencies": ["Dashboard API"],
       "status": "in-progress",
-      "notes": "Issue #59 opened and task packet created at docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md. Active branch: pod-a/t017-dashboard-filtering."
+      "notes": "Issue #59 opened and task packet created at docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md. Active branch: pod-a/t017-dashboard-filtering. Draft PR #60 is open with dashboard API tests and frontend build passing locally."
     },
     {
       "id": "T018_VIETNAMESE_PROMPT_VARIANTS",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -179,8 +179,8 @@
       "complexity": "Medium",
       "estimated_hours": 4,
       "dependencies": ["Database Schema"],
-      "status": "in-progress",
-      "notes": "Issue #57 opened and task packet created at docs/superpowers/tasks/2026-04-21-T016-marketplace-ratings.md. Active branch: pod-a/t016-marketplace-ratings. Draft PR #58 is open with backend tests and frontend build passing locally."
+      "status": "completed",
+      "notes": "Merged to main through PR #58. Marketplace now supports lightweight ratings and review submission."
     },
     {
       "id": "T017_ASSESSMENT_HISTORY_FILTERING",
@@ -196,8 +196,8 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["Dashboard API"],
-      "status": "not-started",
-      "notes": "Reuse existing session query parameters, add UI for common filters"
+      "status": "in-progress",
+      "notes": "Issue #59 opened and task packet created at docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md. Active branch: pod-a/t017-dashboard-filtering."
     },
     {
       "id": "T018_VIETNAMESE_PROMPT_VARIANTS",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -62,6 +62,7 @@ flowchart TD
   
   Product --> TeacherDashboard["Teacher Dashboard"]
   TeacherDashboard --> DashboardSummary["Session Activity Summary"]
+  DashboardSummary --> DashboardFilters["History filters: type + KB + search + min score"]
   TeacherDashboard --> StudentDashboard["Student Progress Dashboard"]
   TeacherDashboard --> AssessmentReview["Assessment Review Drill-down"]
   StudentDashboard --> StudentRoute["/dashboard/student"]

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -188,3 +188,36 @@
 
 - Task `T017_ASSESSMENT_HISTORY_FILTERING`: moved to `in-progress`
 - Next: inspect dashboard API/UI and start implementation on `pod-a/t017-dashboard-filtering`
+
+## T017 Assessment History Filtering & Search — Implementation Progress
+
+### Completed in this cycle
+
+1. Extended dashboard API filtering in `deeptutor/api/routers/dashboard.py`:
+   - `type`
+   - `knowledge_base`
+   - `search`
+   - `min_score`
+2. Added targeted regression coverage in `tests/api/test_dashboard_router.py`
+3. Added dashboard API client filter support in `web/lib/dashboard-api.ts`
+4. Updated teacher dashboard UI in `web/app/(workspace)/dashboard/page.tsx`:
+   - filter panel
+   - filtered empty state
+   - API-backed filter loading instead of client-only narrowing
+5. Updated system map and PR note:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+   - `docs/superpowers/pr-notes/2026-04-21-dashboard-filtering.md`
+
+### Validation
+
+- Dashboard API tests passed:
+  - `python3 -m pytest tests/api/test_dashboard_router.py -q`
+- Python compile check passed:
+  - `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+- Frontend production build passed:
+  - `cd web && npm run build`
+
+### Status
+
+- Task `T017_ASSESSMENT_HISTORY_FILTERING`: implementation complete on branch `pod-a/t017-dashboard-filtering`
+- Next: commit, push, open Draft PR linked to issue `#59`, then monitor CI and merge per AI-first policy

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -158,3 +158,33 @@
 
 - Task `T016_MARKETPLACE_RATINGS`: implementation complete on branch `pod-a/t016-marketplace-ratings`
 - Next: commit, push, open Draft PR linked to issue `#57`, then monitor CI and merge per AI-first policy
+
+## T016 Add Pack Ratings & Reviews System — Merge Complete
+
+### Completed in this cycle
+
+1. Draft PR `#58` was opened, validated by CI, moved to Ready, and merged to `main`.
+2. Issue `#57` closed with the merge.
+3. Local `main` was fast-forwarded to include the merged marketplace rating lane.
+
+### Status
+
+- Task `T016_MARKETPLACE_RATINGS`: moved to `completed`
+
+## T017 Assessment History Filtering & Search — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T016` merged.
+2. Opened GitHub issue `#59` for `T017 Assessment History Filtering & Search`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T017_ASSESSMENT_HISTORY_FILTERING`: moved to `in-progress`
+- Next: inspect dashboard API/UI and start implementation on `pod-a/t017-dashboard-filtering`

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -135,15 +135,62 @@ def _learning_streak_days(activities: list[dict[str, Any]]) -> int:
     return streak
 
 
+def _matches_dashboard_filters(
+    activity: dict[str, Any],
+    *,
+    type: str | None = None,
+    knowledge_base: str | None = None,
+    search: str | None = None,
+    min_score: int | None = None,
+) -> bool:
+    if type is not None and activity.get("type") != type:
+        return False
+
+    if knowledge_base is not None:
+        available = [str(kb).lower() for kb in activity.get("knowledge_bases", [])]
+        if knowledge_base.lower() not in available:
+            return False
+
+    if search:
+        haystack = " ".join(
+            [
+                str(activity.get("title") or ""),
+                str(activity.get("summary") or ""),
+                " ".join(str(kb) for kb in activity.get("knowledge_bases", [])),
+            ]
+        ).lower()
+        if search.lower() not in haystack:
+            return False
+
+    if min_score is not None:
+        summary = activity.get("assessment_summary")
+        if not summary or int(summary.get("score_percent", 0)) < min_score:
+            return False
+
+    return True
+
+
 @router.get("/recent")
-async def get_recent_activities(limit: int = 50, type: str | None = None):
+async def get_recent_activities(
+    limit: int = 50,
+    type: str | None = None,
+    knowledge_base: str | None = None,
+    search: str | None = None,
+    min_score: int | None = None,
+):
     store = get_sqlite_session_store()
     sessions = await store.list_sessions(limit=limit, offset=0)
     activities: list[dict[str, Any]] = []
 
     for session in sessions:
         activity = await _activity_with_review(store, session)
-        if type is not None and activity["type"] != type:
+        if not _matches_dashboard_filters(
+            activity,
+            type=type,
+            knowledge_base=knowledge_base,
+            search=search,
+            min_score=min_score,
+        ):
             continue
         activities.append(activity)
 
@@ -151,10 +198,26 @@ async def get_recent_activities(limit: int = 50, type: str | None = None):
 
 
 @router.get("/overview")
-async def get_dashboard_overview(limit: int = 50):
+async def get_dashboard_overview(
+    limit: int = 50,
+    type: str | None = None,
+    knowledge_base: str | None = None,
+    search: str | None = None,
+    min_score: int | None = None,
+):
     store = get_sqlite_session_store()
     sessions = await store.list_sessions(limit=limit, offset=0)
-    activities = [await _activity_with_review(store, session) for session in sessions]
+    activities = [
+        activity
+        for session in sessions
+        if _matches_dashboard_filters(
+            activity := await _activity_with_review(store, session),
+            type=type,
+            knowledge_base=knowledge_base,
+            search=search,
+            min_score=min_score,
+        )
+    ]
 
     knowledge_pack_counts: dict[str, int] = {}
     status_counts: dict[str, int] = {}

--- a/docs/superpowers/pr-notes/2026-04-21-dashboard-filtering.md
+++ b/docs/superpowers/pr-notes/2026-04-21-dashboard-filtering.md
@@ -1,0 +1,59 @@
+# PR Architecture Note: Dashboard Filtering
+
+## Summary
+
+Adds teacher dashboard filtering for activity type, knowledge pack, search term, and minimum assessment score.
+
+## Scope
+
+- dashboard overview filtering query params
+- dashboard API client support for filters
+- teacher dashboard filter panel UI
+- targeted dashboard API regression coverage
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Teacher["Teacher"]
+  DashboardUI["/dashboard filter panel"]
+  DashboardClient["web/lib/dashboard-api.ts"]
+  OverviewAPI["GET /api/v1/dashboard/overview"]
+  FilterLogic["Dashboard filter matcher"]
+  SessionStore["SQLite Session Store"]
+  ActivityRows["Filtered recent activity + KB summary"]
+
+  Teacher --> DashboardUI
+  DashboardUI --> DashboardClient
+  DashboardClient --> OverviewAPI
+  OverviewAPI --> FilterLogic
+  FilterLogic --> SessionStore
+  SessionStore --> ActivityRows
+  ActivityRows --> DashboardUI
+```
+
+## Architecture Impact
+
+This change keeps filtering inside the existing overview route instead of adding a separate dashboard sessions API. The current dashboard flow remains read-only and deterministic.
+
+## Data/API Changes
+
+- Extends `GET /api/v1/dashboard/overview` with:
+  - `type`
+  - `knowledge_base`
+  - `search`
+  - `min_score`
+- Extends `GET /api/v1/dashboard/recent` with the same filter set for consistency
+
+## Tests
+
+```bash
+python3 -m pytest tests/api/test_dashboard_router.py -q
+python3 -m py_compile deeptutor/api/routers/dashboard.py
+cd web && npm run build
+```
+
+## Main System Map Update
+
+- [x] Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- [ ] Not needed

--- a/docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md
+++ b/docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: Assessment History Filtering & Search
+
+Owner: Codex
+Branch: `pod-a/t017-dashboard-filtering`
+GitHub Issue: `#59`
+
+## Goal
+
+Add filter and search controls to the teacher dashboard so recent assessment history can be narrowed by common signals.
+
+## User-visible outcome
+
+- Teachers can filter dashboard history by assessment/tutoring type, knowledge pack, score range, and search term.
+- The first version stays inside the current dashboard route and API family.
+- Empty state remains clean when filters remove all rows.
+
+## Owned files/modules
+
+- `web/app/(workspace)/dashboard/`
+- `web/lib/dashboard-api.ts`
+- `deeptutor/api/routers/dashboard.py`
+- `tests/api/test_dashboard_router.py`
+- `docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-21.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Unrelated marketplace, settings, and tutor files
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Extend the current dashboard route family
+- Reuse existing recent activity and assessment summary data
+- Keep filters query-param based and deterministic
+
+## Acceptance criteria
+
+- Dashboard history can be narrowed by at least search term, knowledge pack, and score-oriented assessment filter.
+- Backend applies the same filters the UI exposes.
+- Filtered empty/loading/error states render cleanly.
+- Targeted dashboard API tests cover new filtering behavior.
+
+## Required tests
+
+- Targeted backend tests for dashboard filter behavior
+- Frontend build validation for touched dashboard files
+
+## Manual verification
+
+- Open dashboard and apply each filter independently
+- Confirm filtered rows match expected history
+- Confirm no-result state is still readable
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+
+## Handoff notes
+
+- `T016` is merged to `main` through PR `#58`.
+- Start from the existing dashboard overview/history flow before adding new analytics or separate listing endpoints.

--- a/docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md
+++ b/docs/superpowers/tasks/2026-04-21-T017-dashboard-filtering.md
@@ -67,3 +67,13 @@ Add filter and search controls to the teacher dashboard so recent assessment his
 
 - `T016` is merged to `main` through PR `#58`.
 - Start from the existing dashboard overview/history flow before adding new analytics or separate listing endpoints.
+- Implemented on branch `pod-a/t017-dashboard-filtering` with:
+  - dashboard overview filter params
+  - teacher dashboard filter panel
+  - filtered empty state behavior
+- Validation completed:
+  - `python3 -m pytest tests/api/test_dashboard_router.py -q`
+  - `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+  - `cd web && npm run build`
+- PR note prepared:
+  - `docs/superpowers/pr-notes/2026-04-21-dashboard-filtering.md`

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -273,3 +273,63 @@ async def test_student_progress_summarizes_scores_topics_and_streak(
         "assessment-recent",
         "assessment-older",
     ]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_applies_search_kb_type_and_min_score_filters(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="algebra-high",
+        capability="deep_question",
+        message="Generate an algebra assessment",
+        knowledge_bases=["algebra-pack"],
+    )
+    await store.add_message(
+        "algebra-high",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve algebra equation x + 2 = 5 -> Answered: 3 (Correct)\n"
+        "Score: 1/1 (100%)",
+        capability="deep_question",
+    )
+
+    await _seed_session(
+        store,
+        session_id="fractions-low",
+        capability="deep_question",
+        message="Generate a fractions assessment",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "fractions-low",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4)\n"
+        "Score: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    await _seed_session(
+        store,
+        session_id="tutor-fractions",
+        capability="chat",
+        message="Tutor the student on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get(
+            "/api/v1/dashboard/overview?type=assessment&knowledge_base=algebra-pack&search=algebra&min_score=80"
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["totals"]["total_sessions"] == 1
+    assert payload["totals"]["assessments"] == 1
+    assert payload["totals"]["tutoring_sessions"] == 0
+    assert payload["knowledge_packs"] == [{"name": "algebra-pack", "session_count": 1}]
+    assert [row["id"] for row in payload["recent_activity"]] == ["algebra-high"]

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -2,12 +2,13 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Activity, ArrowRight, BookOpen, CheckCircle2, Loader2, PenLine, Users } from "lucide-react";
+import { Activity, ArrowRight, BookOpen, CheckCircle2, Filter, Loader2, PenLine, Search, Users } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   getDashboardOverview,
   type DashboardActivity,
   type DashboardOverview,
+  type DashboardOverviewFilters,
 } from "@/lib/dashboard-api";
 
 function formatTime(value: number): string {
@@ -32,11 +33,25 @@ export default function DashboardPage() {
   const [overview, setOverview] = useState<DashboardOverview | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [activityType, setActivityType] = useState("");
+  const [knowledgeBase, setKnowledgeBase] = useState("");
+  const [minScore, setMinScore] = useState("");
+
+  const filters = useMemo<DashboardOverviewFilters>(
+    () => ({
+      type: activityType || undefined,
+      knowledge_base: knowledgeBase || undefined,
+      search: searchTerm.trim() || undefined,
+      min_score: minScore ? Number(minScore) : undefined,
+    }),
+    [activityType, knowledgeBase, minScore, searchTerm],
+  );
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    getDashboardOverview()
+    getDashboardOverview(50, filters)
       .then((data) => {
         if (!cancelled) {
           setOverview(data);
@@ -52,7 +67,7 @@ export default function DashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [filters]);
 
   const totals = overview?.totals;
   const cards = useMemo(
@@ -80,6 +95,7 @@ export default function DashboardPage() {
     ],
     [t, totals],
   );
+  const activeFilterCount = [searchTerm, activityType, knowledgeBase, minScore].filter(Boolean).length;
 
   return (
     <main className="h-full overflow-y-auto bg-[var(--background)]">
@@ -104,6 +120,88 @@ export default function DashboardPage() {
             <ArrowRight size={15} />
           </Link>
         </header>
+
+        <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--muted-foreground)]">
+              <Filter size={14} />
+              {t("History filters")}
+            </div>
+            {activeFilterCount > 0 && (
+              <button
+                onClick={() => {
+                  setSearchTerm("");
+                  setActivityType("");
+                  setKnowledgeBase("");
+                  setMinScore("");
+                }}
+                className="text-[12px] text-[var(--muted-foreground)] underline-offset-4 hover:text-[var(--foreground)] hover:underline"
+              >
+                {t("Clear filters")}
+              </button>
+            )}
+          </div>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <label className="block">
+              <span className="mb-1 block text-[12px] font-medium text-[var(--foreground)]">
+                {t("Search")}
+              </span>
+              <div className="flex items-center gap-2 rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2">
+                <Search size={14} className="text-[var(--muted-foreground)]" />
+                <input
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  placeholder={t("Search title, summary, KB")}
+                  className="w-full bg-transparent text-[13px] outline-none"
+                />
+              </div>
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-[12px] font-medium text-[var(--foreground)]">
+                {t("Activity type")}
+              </span>
+              <select
+                value={activityType}
+                onChange={(e) => setActivityType(e.target.value)}
+                className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px]"
+              >
+                <option value="">{t("All activity")}</option>
+                <option value="assessment">{t("Assessment")}</option>
+                <option value="tutoring">{t("Tutoring")}</option>
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-[12px] font-medium text-[var(--foreground)]">
+                {t("Knowledge Pack")}
+              </span>
+              <input
+                value={knowledgeBase}
+                onChange={(e) => setKnowledgeBase(e.target.value)}
+                placeholder={t("e.g. algebra-pack")}
+                className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px]"
+              />
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-[12px] font-medium text-[var(--foreground)]">
+                {t("Minimum score")}
+              </span>
+              <select
+                value={minScore}
+                onChange={(e) => setMinScore(e.target.value)}
+                className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px]"
+              >
+                <option value="">{t("Any score")}</option>
+                <option value="50">50%+</option>
+                <option value="70">70%+</option>
+                <option value="80">80%+</option>
+                <option value="90">90%+</option>
+              </select>
+            </label>
+          </div>
+        </section>
 
         {error && (
           <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
@@ -206,7 +304,9 @@ export default function DashboardPage() {
                 <div className="bg-[var(--card)] px-4 py-10 text-center text-[13px] text-[var(--muted-foreground)]">
                   {loading
                     ? t("Loading activity...")
-                    : t("No learning activity yet. Generate an assessment or start a tutoring chat.")}
+                    : activeFilterCount > 0
+                      ? t("No activity matches the current filters.")
+                      : t("No learning activity yet. Generate an assessment or start a tutoring chat.")}
                 </div>
               )}
             </div>
@@ -237,7 +337,9 @@ export default function DashboardPage() {
                 ))
               ) : (
                 <div className="px-4 py-8 text-center text-[13px] text-[var(--muted-foreground)]">
-                  {t("Knowledge Pack activity will appear here.")}
+                  {activeFilterCount > 0
+                    ? t("No Knowledge Pack activity matches the current filters.")
+                    : t("Knowledge Pack activity will appear here.")}
                 </div>
               )}
             </div>

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -75,6 +75,13 @@ export interface DashboardOverview {
   recent_activity: DashboardActivity[];
 }
 
+export interface DashboardOverviewFilters {
+  type?: string;
+  knowledge_base?: string;
+  search?: string;
+  min_score?: number;
+}
+
 export interface StudentProgressTopic {
   topic: string;
   total_questions: number;
@@ -121,8 +128,17 @@ async function expectJson<T>(response: Response): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export async function getDashboardOverview(limit = 50): Promise<DashboardOverview> {
-  const response = await fetch(apiUrl(`/api/v1/dashboard/overview?limit=${limit}`), {
+export async function getDashboardOverview(
+  limit = 50,
+  filters: DashboardOverviewFilters = {},
+): Promise<DashboardOverview> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (filters.type) params.set("type", filters.type);
+  if (filters.knowledge_base) params.set("knowledge_base", filters.knowledge_base);
+  if (filters.search) params.set("search", filters.search);
+  if (typeof filters.min_score === "number") params.set("min_score", String(filters.min_score));
+
+  const response = await fetch(apiUrl(`/api/v1/dashboard/overview?${params.toString()}`), {
     cache: "no-store",
   });
   return expectJson<DashboardOverview>(response);


### PR DESCRIPTION
## Summary
- add teacher dashboard filters for activity type, knowledge pack, search term, and minimum assessment score
- extend dashboard overview filtering query params
- keep filtering inside the existing dashboard overview route

Closes #59

## Validation
- `python3 -m pytest tests/api/test_dashboard_router.py -q`
- `python3 -m py_compile deeptutor/api/routers/dashboard.py`
- `cd web && npm run build`

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-21-dashboard-filtering.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated
