### PR TITLE
[MVP] T019 Marketplace Sorting Options

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, dashboard filtering is now merged into `main` through PR `#60`, and the active short task is `T018 Vietnamese LLM Prompt Variants`.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, Vietnamese prompt coverage is now merged into `main` through PR `#62`, and the active short task is `T019 Marketplace Sorting`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T018`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T019`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,29 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#60 [MVP] Assessment History Filtering & Search`
-- `#60` added API-backed teacher dashboard history filters, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, and ratings, assessment insights, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#62 [MVP] T018 Vietnamese LLM Prompt Variants`
+- `#62` added Vietnamese prompt variants for the MVP agent families, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting prep, assessment insights, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#61 [MVP] Vietnamese LLM Prompt Variants`
-- Active branch: `pod-a/t018-vietnamese-prompts`
-- Active task packet: `docs/superpowers/tasks/2026-04-21-T018-vietnamese-prompts.md`
-- Focus set: `T018` (Vietnamese prompts)
+- Active issue: `#63 [MVP] Marketplace Pack Sorting Options`
+- Active branch: `pod-a/t019-marketplace-sorting`
+- Active task packet: `docs/superpowers/tasks/2026-04-21-T019-marketplace-sorting.md`
+- Focus set: `T019` (Marketplace sorting)
 
 ## Next recommended task
 
-Implement `T018` on `pod-a/t018-vietnamese-prompts`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T019` on `pod-a/t019-marketplace-sorting`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
 1. `#60` merged to `main` after all required CI checks passed
-2. Issue `#59` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T018 Vietnamese LLM Prompt Variants`
-4. Issue `#61` created and task packet added for the new execution lane
+2. `#62` merged to `main` after all required CI checks passed
+3. Issue `#61` auto-closed with the merge
+4. Next pending registry task selected in strict order: `T019 Marketplace Sorting`
+5. Issue `#63` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -60,7 +61,8 @@ Implement `T018` on `pod-a/t018-vietnamese-prompts`, then open a Draft PR with a
 | T015: Assessment Recommendations | Completed | 6 | NO | Done |
 | T016: Marketplace Ratings | Completed | 4 | NO | Done |
 | T017: Dashboard Filtering | Completed | 2 | NO | Done |
-| T018: Vietnamese Prompts | In Progress | 4 | YES | Now |
+| T018: Vietnamese Prompts | Completed | 4 | YES | Done |
+| T019: Marketplace Sorting | In Progress | 1.5 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 8,
+      "count": 18,
       "tasks": [
         "T001_MARKETPLACE_API_LIST",
         "T002_MARKETPLACE_API_DETAIL",
@@ -17,18 +17,24 @@
         "T005_LEARNING_JOURNEY_COMPONENT",
         "T006_ASSESSMENT_REVIEW_INTEGRATION",
         "T007_VIETNAMESE_UI_TRANSLATION",
-        "T008_VIETNAMESE_BACKEND_SUPPORT"
+        "T008_VIETNAMESE_BACKEND_SUPPORT",
+        "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
+        "T010_ASSESSMENT_FEEDBACK_DETAILS",
+        "T011_KB_CONTEXT_BADGES",
+        "T012_TEACHER_PACK_SHARING_UI",
+        "T013_MARKETPLACE_PACK_PREVIEW",
+        "T014_STUDENT_PROGRESS_DASHBOARD",
+        "T015_ASSESSMENT_RECOMMENDATIONS",
+        "T016_MARKETPLACE_RATINGS",
+        "T017_ASSESSMENT_HISTORY_FILTERING",
+        "T018_VIETNAMESE_PROMPT_VARIANTS"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 5,
+      "count": 1,
       "tasks": [
-        "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
-        "T010_ASSESSMENT_FEEDBACK_DETAILS",
-        "T011_KB_CONTEXT_BADGES",
-        "T022_ERROR_BOUNDARY_HANDLING",
-        "T028_API_RATE_LIMITING"
+        "T019_MARKETPLACE_SORTING"
       ]
     },
     "blocked": {
@@ -38,7 +44,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 22,
+      "count": 16,
       "tasks": []
     }
   },
@@ -213,8 +219,8 @@
       "complexity": "Medium",
       "estimated_hours": 4,
       "dependencies": ["i18n System"],
-      "status": "in-progress",
-      "notes": "Issue #61 opened and task packet created at docs/superpowers/tasks/2026-04-21-T018-vietnamese-prompts.md. Active branch: pod-a/t018-vietnamese-prompts."
+      "status": "completed",
+      "notes": "Merged to main through PR #62. Added Vietnamese prompt variants for the MVP prompt families and prompt-manager regression coverage."
     },
     {
       "id": "T019_MARKETPLACE_SORTING",
@@ -230,8 +236,8 @@
       "complexity": "Low",
       "estimated_hours": 1.5,
       "dependencies": ["Marketplace API"],
-      "status": "not-started",
-      "notes": "Implement server-side sorting, maintain download_count and rating metadata"
+      "status": "in-progress",
+      "notes": "Issue #63 opened and task packet created at docs/superpowers/tasks/2026-04-21-T019-marketplace-sorting.md. Active branch: pod-a/t019-marketplace-sorting."
     },
     {
       "id": "T020_ASSESSMENT_EXPORT_PDF",

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -278,3 +278,42 @@
 
 - Task `T018_VIETNAMESE_PROMPT_VARIANTS`: implementation complete on branch `pod-a/t018-vietnamese-prompts`
 - Next: commit, push, open Draft PR linked to issue `#61`, then monitor CI and merge per AI-first policy
+
+## T018 Vietnamese LLM Prompt Variants — Merge Complete
+
+### Completed in this cycle
+
+1. Draft PR `#62` was opened, validated by CI, moved to Ready, and merged to `main`.
+2. Issue `#61` closed with the merge.
+3. Local `main` was fast-forwarded to include the merged Vietnamese prompt lane.
+
+### Status
+
+- Task `T018_VIETNAMESE_PROMPT_VARIANTS`: moved to `completed`
+
+## T019 Marketplace Sorting Options — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T018` merged.
+2. Opened GitHub issue `#63` for `T019 Marketplace Sorting Options`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-21-T019-marketplace-sorting.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+5. Created isolated worktree and branch:
+   - `pod-a/t019-marketplace-sorting`
+   - `.worktrees/pod-a-t019-marketplace-sorting`
+
+### Validation
+
+- Baseline marketplace API test did not complete because worktree-local config is missing:
+  - `python3 -m pytest tests/api/test_marketplace_router.py -q`
+  - error: missing `data/user/settings/main.yaml` under the new worktree path during test collection
+
+### Status
+
+- Task `T019_MARKETPLACE_SORTING`: moved to `in-progress`
+- Next: normalize worktree test environment, then implement API-backed marketplace sorting on `pod-a/t019-marketplace-sorting`

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -317,3 +317,36 @@
 
 - Task `T019_MARKETPLACE_SORTING`: moved to `in-progress`
 - Next: normalize worktree test environment, then implement API-backed marketplace sorting on `pod-a/t019-marketplace-sorting`
+
+## T019 Marketplace Sorting Options — Implementation Progress
+
+### Completed in this cycle
+
+1. Normalized the new worktree runtime setup for local validation:
+   - linked `data/user/settings` from the main checkout so backend tests could resolve runtime config
+   - linked `web/node_modules` from the main checkout so frontend production build could run
+2. Extended marketplace API sorting in `deeptutor/api/routers/marketplace.py`:
+   - added `sort_by` support to `GET /api/v1/marketplace/list`
+   - supported `popularity`, `recent`, `rating`, and `most_objectives`
+   - kept default response shape backward-compatible
+3. Added backend regression coverage in `tests/api/test_marketplace_router.py`
+4. Added typed client support in `web/lib/marketplace-api.ts`
+5. Updated marketplace UI in `web/app/(utility)/marketplace/page.tsx`:
+   - added sort dropdown in the filter bar
+   - moved pack ordering to the API contract instead of relying only on default server order
+6. Added PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-21-t019-marketplace-sorting.md`
+
+### Validation
+
+- Marketplace API tests passed:
+  - `python3 -m pytest tests/api/test_marketplace_router.py -q`
+- Python compile check passed:
+  - `python3 -m py_compile deeptutor/api/routers/marketplace.py`
+- Frontend production build passed:
+  - `cd web && npm run build`
+
+### Status
+
+- Task `T019_MARKETPLACE_SORTING`: implementation complete on branch `pod-a/t019-marketplace-sorting`
+- Next: commit, push, open Draft PR linked to issue `#63`, then monitor CI and merge per AI-first policy

--- a/deeptutor/api/routers/marketplace.py
+++ b/deeptutor/api/routers/marketplace.py
@@ -67,11 +67,56 @@ def _list_marketplace_candidates() -> list[dict]:
                     "session_count": info.get("statistics", {}).get("content_lists", 0),
                     "status": info.get("status", "ready"),
                     "statistics": info.get("statistics", {}),
+                    "created_at": source_cfg.get("created_at"),
+                    "updated_at": source_cfg.get("updated_at"),
                     "rating_summary": _rating_summary(source_cfg),
                 }
             )
         except Exception:
             continue
+
+    return items
+
+
+def _sort_marketplace_candidates(items: list[dict], sort_by: str | None) -> list[dict]:
+    if sort_by == "popularity":
+        return sorted(
+            items,
+            key=lambda kb: (
+                -(kb.get("rating_summary", {}).get("review_count") or 0),
+                -(kb.get("session_count") or 0),
+                str(kb.get("name") or ""),
+            ),
+        )
+
+    if sort_by == "rating":
+        return sorted(
+            items,
+            key=lambda kb: (
+                -(kb.get("rating_summary", {}).get("average_rating") or 0.0),
+                -(kb.get("rating_summary", {}).get("review_count") or 0),
+                str(kb.get("name") or ""),
+            ),
+        )
+
+    if sort_by == "most_objectives":
+        return sorted(
+            items,
+            key=lambda kb: (
+                -len(kb.get("learning_objectives") or []),
+                str(kb.get("name") or ""),
+            ),
+        )
+
+    if sort_by == "recent":
+        return sorted(
+            items,
+            key=lambda kb: (
+                str(kb.get("updated_at") or kb.get("created_at") or ""),
+                str(kb.get("name") or ""),
+            ),
+            reverse=True,
+        )
 
     return items
 
@@ -101,6 +146,10 @@ async def list_marketplace_packs(
     sharing_status: str | None = Query(None, description="Filter by sharing_status: public, team, or None for all"),
     subject: str | None = Query(None, description="Filter by subject"),
     owner: str | None = Query(None, description="Filter by owner"),
+    sort_by: str | None = Query(
+        None,
+        description="Sort packs by popularity, recent, rating, or most_objectives",
+    ),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
@@ -130,6 +179,8 @@ async def list_marketplace_packs(
                 for kb in all_kbs
                 if (kb.get("owner") or "").lower() == needle
             ]
+
+        all_kbs = _sort_marketplace_candidates(all_kbs, sort_by)
 
         total = len(all_kbs)
         packs = all_kbs[offset : offset + limit]

--- a/docs/superpowers/pr-notes/2026-04-21-t019-marketplace-sorting.md
+++ b/docs/superpowers/pr-notes/2026-04-21-t019-marketplace-sorting.md
@@ -1,0 +1,31 @@
+# PR Note — T019 Marketplace Sorting Options
+
+## Summary
+
+- Added API-backed `sort_by` support to marketplace list responses.
+- Wired marketplace UI sorting to the server contract with a dedicated dropdown.
+- Added regression coverage for popularity, recency, rating, and objective-count ordering.
+
+## Architecture Impact
+
+- No route topology or data model changed.
+- `GET /api/v1/marketplace/list` now accepts an additional query parameter without breaking existing callers.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because the change only extends an existing marketplace list flow.
+
+```mermaid
+flowchart LR
+  UI[Marketplace Sort Dropdown] --> Client[listMarketplacePacks sort_by]
+  Client --> API[GET /api/v1/marketplace/list]
+  API --> Sorter[Marketplace sort selector]
+  Sorter --> Response[Ordered pack list]
+```
+
+## Validation
+
+- `python3 -m pytest tests/api/test_marketplace_router.py -q`
+- `python3 -m py_compile deeptutor/api/routers/marketplace.py`
+- `cd web && npm run build`
+
+## Risks
+
+- Current popularity sorting uses review count first, then session count as a secondary signal because the existing payload does not yet expose a separate download/import counter.

--- a/docs/superpowers/tasks/2026-04-21-T019-marketplace-sorting.md
+++ b/docs/superpowers/tasks/2026-04-21-T019-marketplace-sorting.md
@@ -1,0 +1,72 @@
+# Feature Pod Task: Marketplace Sorting Options
+
+Owner: Codex
+Branch: `pod-a/t019-marketplace-sorting`
+GitHub Issue: `#63`
+
+## Goal
+
+Add marketplace sorting options so users can reorder packs by popularity, recency, rating, and objective count.
+
+## User-visible outcome
+
+- Marketplace users can choose a sort mode from the UI.
+- Sorting is applied by the API, not only client-side reshuffling.
+- Existing default ordering remains stable when no explicit sort is selected.
+
+## Owned files/modules
+
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/lib/marketplace-api.ts`
+- `deeptutor/api/routers/marketplace.py`
+- `tests/api/test_marketplace_router.py`
+- `docs/superpowers/tasks/2026-04-21-T019-marketplace-sorting.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-21.md`
+
+## Do-not-touch files/modules
+
+- Assessment, dashboard, tutor, and settings files
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Extend `GET /api/v1/marketplace/list` with a `sort_by` query parameter.
+- Support at least:
+  - `popularity`
+  - `recent`
+  - `rating`
+  - `most_objectives`
+- Keep payload shape backward-compatible.
+
+## Acceptance criteria
+
+- Users can select sort options from the marketplace UI.
+- API-backed sorting returns packs in the expected order for each supported mode.
+- Default marketplace behavior remains backward-compatible when `sort_by` is omitted.
+
+## Required tests
+
+- API regression coverage for supported `sort_by` values
+- Relevant frontend validation if client wiring changes need build verification
+
+## Manual verification
+
+- Open marketplace page
+- Switch between sort modes
+- Confirm card ordering changes accordingly
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T018` merged to `main` through PR `#62`.
+- Baseline worktree marketplace test currently errors at collection because this worktree lacks `data/user/settings/main.yaml`; treat that as environment setup debt, not a `T019` regression.

--- a/docs/superpowers/tasks/2026-04-21-T019-marketplace-sorting.md
+++ b/docs/superpowers/tasks/2026-04-21-T019-marketplace-sorting.md
@@ -70,3 +70,9 @@ Add marketplace sorting options so users can reorder packs by popularity, recenc
 
 - `T018` merged to `main` through PR `#62`.
 - Baseline worktree marketplace test currently errors at collection because this worktree lacks `data/user/settings/main.yaml`; treat that as environment setup debt, not a `T019` regression.
+- Worktree-local runtime settings were normalized with a local symlink so baseline tests and frontend build could run in this lane.
+- Implemented API-backed `sort_by` support and wired marketplace UI sorting to it.
+- Validation:
+  - `python3 -m pytest tests/api/test_marketplace_router.py -q`
+  - `python3 -m py_compile deeptutor/api/routers/marketplace.py`
+  - `cd web && npm run build`

--- a/tests/api/test_marketplace_router.py
+++ b/tests/api/test_marketplace_router.py
@@ -160,3 +160,52 @@ def test_marketplace_review_submission_updates_pack_summary(monkeypatch, tmp_pat
     preview_payload = preview_response.json()
     assert preview_payload["rating_summary"] == {"average_rating": 4.5, "review_count": 2}
     assert preview_payload["recent_reviews"][0]["comment"] == "Great question progression."
+
+
+def test_marketplace_list_supports_sorting_modes(monkeypatch, tmp_path: Path) -> None:
+    client = _build_app(monkeypatch, tmp_path)
+
+    second_pack = tmp_path / "second-pack"
+    (second_pack / "raw").mkdir(parents=True)
+    (second_pack / "rag_storage").mkdir(parents=True)
+    (second_pack / "raw" / "lesson-a.md").write_text("Lesson A", encoding="utf-8")
+
+    manager = marketplace.get_kb_manager()
+    manager.config["knowledge_bases"]["second-pack"] = {
+        "path": "second-pack",
+        "description": "Second pack",
+        "sharing_status": "public",
+        "subject": "Science",
+        "grade": "7",
+        "curriculum": "National",
+        "learning_objectives": ["Cells"],
+        "owner": "Teacher Z",
+        "marketplace_reviews": [
+            {
+                "reviewer": "Teacher D",
+                "rating": 5,
+                "comment": "Excellent structure.",
+                "created_at": "2026-04-20T10:00:00",
+            },
+            {
+                "reviewer": "Teacher E",
+                "rating": 5,
+                "comment": "High quality examples.",
+                "created_at": "2026-04-20T11:00:00",
+            },
+        ],
+        "created_at": "2026-04-21T00:00:00",
+        "updated_at": "2026-04-21T00:00:00",
+    }
+
+    popularity = client.get("/api/v1/marketplace/list?sort_by=popularity").json()["packs"]
+    assert [pack["name"] for pack in popularity] == ["second-pack", "shared-pack"]
+
+    rating = client.get("/api/v1/marketplace/list?sort_by=rating").json()["packs"]
+    assert [pack["name"] for pack in rating] == ["second-pack", "shared-pack"]
+
+    most_objectives = client.get("/api/v1/marketplace/list?sort_by=most_objectives").json()["packs"]
+    assert [pack["name"] for pack in most_objectives] == ["shared-pack", "second-pack"]
+
+    recent = client.get("/api/v1/marketplace/list?sort_by=recent").json()["packs"]
+    assert [pack["name"] for pack in recent] == ["second-pack", "shared-pack"]

--- a/web/app/(utility)/marketplace/page.tsx
+++ b/web/app/(utility)/marketplace/page.tsx
@@ -11,6 +11,7 @@ import {
   type MarketplaceListResponse,
   type MarketplacePack,
   type MarketplacePackPreview,
+  type MarketplaceSortBy,
 } from "@/lib/marketplace-api";
 
 function renderStars(value: number) {
@@ -34,6 +35,7 @@ export default function MarketplacePage() {
   const [filterSubject, setFilterSubject] = useState("");
   const [filterOwner, setFilterOwner] = useState("");
   const [sharingStatus, setSharingStatus] = useState<"public" | "team" | undefined>(undefined);
+  const [sortBy, setSortBy] = useState<MarketplaceSortBy>("popularity");
 
   // Pagination
   const [offset, setOffset] = useState(0);
@@ -55,13 +57,14 @@ export default function MarketplacePage() {
     setLoading(true);
     setError(null);
     try {
-      const response: MarketplaceListResponse = await listMarketplacePacks(
-        sharingStatus,
-        filterSubject || undefined,
-        filterOwner || undefined,
-        limit,
-        offset,
-      );
+        const response: MarketplaceListResponse = await listMarketplacePacks(
+          sharingStatus,
+          filterSubject || undefined,
+          filterOwner || undefined,
+          sortBy,
+          limit,
+          offset,
+        );
       setPacks(response.packs);
       setTotal(response.total);
     } catch (err) {
@@ -70,7 +73,7 @@ export default function MarketplacePage() {
     } finally {
       setLoading(false);
     }
-  }, [filterOwner, filterSubject, limit, offset, sharingStatus]);
+  }, [filterOwner, filterSubject, limit, offset, sharingStatus, sortBy]);
 
   useEffect(() => {
     loadPacks();
@@ -167,7 +170,7 @@ export default function MarketplacePage() {
             {t("Filters")}
           </div>
 
-          <div className="grid gap-3 md:grid-cols-4">
+          <div className="grid gap-3 md:grid-cols-5">
             <div>
               <label className="block text-[12px] font-medium text-[var(--foreground)] mb-1">
                 {t("Search")}
@@ -223,6 +226,22 @@ export default function MarketplacePage() {
                 <option value="">{t("All")}</option>
                 <option value="public">{t("Public")}</option>
                 <option value="team">{t("Team")}</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-[12px] font-medium text-[var(--foreground)]">
+                {t("Sort By")}
+              </label>
+              <select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as MarketplaceSortBy)}
+                className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px]"
+              >
+                <option value="popularity">{t("Popularity")}</option>
+                <option value="recent">{t("Most Recent")}</option>
+                <option value="rating">{t("Top Rated")}</option>
+                <option value="most_objectives">{t("Most Objectives")}</option>
               </select>
             </div>
           </div>

--- a/web/lib/marketplace-api.ts
+++ b/web/lib/marketplace-api.ts
@@ -48,10 +48,17 @@ export interface MarketplaceListResponse {
   packs: MarketplacePack[];
 }
 
+export type MarketplaceSortBy =
+  | "popularity"
+  | "recent"
+  | "rating"
+  | "most_objectives";
+
 export async function listMarketplacePacks(
   sharingStatus?: string,
   subject?: string,
   owner?: string,
+  sortBy?: MarketplaceSortBy,
   limit = 50,
   offset = 0,
 ): Promise<MarketplaceListResponse> {
@@ -63,6 +70,7 @@ export async function listMarketplacePacks(
   if (sharingStatus) params.append("sharing_status", sharingStatus);
   if (subject) params.append("subject", subject);
   if (owner) params.append("owner", owner);
+  if (sortBy) params.append("sort_by", sortBy);
 
   const response = await fetch(apiUrl(`/api/v1/marketplace/list?${params}`), {
     cache: "no-store",


### PR DESCRIPTION
## Summary

- add API-backed marketplace sorting with `sort_by` support for popularity, recency, rating, and objective count
- wire the marketplace page to the new sorting contract with a dedicated dropdown
- add regression coverage for the supported sort modes

## Validation

- `python3 -m pytest tests/api/test_marketplace_router.py -q`
- `python3 -m py_compile deeptutor/api/routers/marketplace.py`
- `cd web && npm run build`

## Notes

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR only extends an existing marketplace listing flow

Closes #63