### PR TITLE
[MVP] T021 Tutoring Session Replay Feature

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace sorting is now merged into `main` through PR `#64`, and the active short task is `T020 Assessment Results Export to PDF`.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, assessment PDF export, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, assessment PDF export is now merged into `main` through PR `#66`, and the active short task is `T021 Tutoring Session Replay Feature`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -170,7 +170,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T020`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T021`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -57,6 +57,10 @@ Before edits:
 - Treat this file as the control plane for the repo-level AI-first workflow.
 - Treat `ai_first/AI_FIRST_ROADMAP.md` as the readable roadmap for what the AI loop does now and where it should evolve next.
 - Keep instructions short, direct, and executable.
+- Do not stop to ask for permission to continue to the next strict-order task when the autonomous path is clear.
+- After each merge or completed verification pass, automatically open the next issue, task packet, branch, and worktree required by the workflow.
+- Do not pad handoff messages with future-intent filler such as "next I will..." when the work should continue immediately; either continue doing it or report a real blocker.
+- Only ask the human to intervene when a blocker, ambiguity, or high-risk decision cannot be resolved from repo context or existing operating rules.
 - Prefer one source of truth over multiple overlapping instructions.
 - If a newer project status needs to be captured, update this file first and then mirror the shortest useful summary to the compatibility snapshots.
 - When a feature, tool, route, data model, or workflow rule changes, update `ai_first/architecture/MAIN_SYSTEM_MAP.md`.
@@ -74,6 +78,7 @@ After opening or updating a PR, classify it before handing off:
 - If CI fails, fixing CI is the next task. Do not start a new feature until the failing PR is fixed or explicitly deferred.
 - If review blocks the PR, address the review before merging or continuing.
 - After a successful merge, sync from `main`, update the daily log and compact status mirrors when useful, then select the next task.
+- Task selection and lane creation should happen immediately after that sync unless a live blocker takes priority.
 - Select next work in this order: active PR blockers, active task packets, `ai_first/NEXT_ACTIONS.md`, then the long-term MVP goal.
 - If the next product change has no task packet, create or update a task packet before implementation.
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#64 [MVP] T019 Marketplace Sorting Options`
-- `#64` added API-backed marketplace sorting, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, assessment insights, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#66 [MVP] T020 Assessment Results Export to PDF`
+- `#66` added assessment PDF export, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, assessment insights, PDF export, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#65 [MVP] Assessment Results Export to PDF`
-- Active branch: `pod-a/t020-assessment-export-pdf`
-- Active task packet: `docs/superpowers/tasks/2026-04-21-T020-assessment-export-pdf.md`
-- Focus set: `T020` (Assessment export PDF)
+- Active issue: `#67 [MVP] Tutoring Session Replay Feature`
+- Active branch: `pod-a/t021-session-replay`
+- Active task packet: `docs/superpowers/tasks/2026-04-21-T021-session-replay.md`
+- Focus set: `T021` (Session replay)
 
 ## Next recommended task
 
-Implement `T020` on `pod-a/t020-assessment-export-pdf`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T021` on `pod-a/t021-session-replay`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#64` merged to `main` after all required CI checks passed
-2. Issue `#63` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T020 Assessment Results Export to PDF`
-4. Issue `#65` created and task packet added for the new execution lane
+1. `#66` merged to `main` after all required CI checks passed
+2. Issue `#65` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T021 Tutoring Session Replay Feature`
+4. Issue `#67` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -62,7 +62,8 @@ Implement `T020` on `pod-a/t020-assessment-export-pdf`, then open a Draft PR wit
 | T017: Dashboard Filtering | Completed | 2 | NO | Done |
 | T018: Vietnamese Prompts | Completed | 4 | YES | Done |
 | T019: Marketplace Sorting | Completed | 1.5 | NO | Done |
-| T020: Assessment Export PDF | In Progress | 3 | NO | Now |
+| T020: Assessment Export PDF | Completed | 3 | NO | Done |
+| T021: Session Replay | In Progress | 3 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -253,8 +253,8 @@
       "complexity": "Medium",
       "estimated_hours": 3,
       "dependencies": ["PDF Generation Library"],
-      "status": "in-progress",
-      "notes": "Issue #65 opened and task packet created at docs/superpowers/tasks/2026-04-21-T020-assessment-export-pdf.md. Active branch: pod-a/t020-assessment-export-pdf."
+      "status": "completed",
+      "notes": "Merged to main through PR #66. Assessment review pages now support backend-generated PDF export."
     },
     {
       "id": "T021_SESSION_REPLAY",
@@ -270,8 +270,8 @@
       "complexity": "Medium",
       "estimated_hours": 3,
       "dependencies": ["Session Storage"],
-      "status": "not-started",
-      "notes": "Reconstruct conversation flow, show KB context at each turn"
+      "status": "in-progress",
+      "notes": "Issue #67 opened and task packet created at docs/superpowers/tasks/2026-04-21-T021-session-replay.md. Active branch: pod-a/t021-session-replay."
     },
     {
       "id": "T022_ERROR_BOUNDARY_HANDLING",

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -416,3 +416,36 @@
 
 - Task `T020_ASSESSMENT_EXPORT_PDF`: implementation complete on branch `pod-a/t020-assessment-export-pdf`
 - Next: commit, push, open Draft PR linked to issue `#65`, then monitor CI and merge per AI-first policy
+
+## T020 Assessment Results Export to PDF — Merge Complete
+
+### Completed in this cycle
+
+1. Draft PR `#66` was opened, validated by CI, moved to Ready, and merged to `main`.
+2. Issue `#65` closed with the merge.
+3. Local `main` was fast-forwarded to include the merged assessment PDF export lane.
+
+### Status
+
+- Task `T020_ASSESSMENT_EXPORT_PDF`: moved to `completed`
+
+## T021 Tutoring Session Replay Feature — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T020` merged.
+2. Opened GitHub issue `#67` for `T021 Tutoring Session Replay Feature`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-21-T021-session-replay.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+5. Created isolated worktree and branch:
+   - `pod-a/t021-session-replay`
+   - `.worktrees/pod-a-t021-session-replay`
+
+### Status
+
+- Task `T021_SESSION_REPLAY`: moved to `in-progress`
+- Next: inspect current dashboard activity detail/session APIs, then implement tutoring session replay on `pod-a/t021-session-replay`

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -463,3 +463,34 @@
 ### Status
 
 - Repo-level operating prompt now encodes the user's fixed rule for autonomous continuation and handoff wording
+
+## T021 Tutoring Session Replay Feature — Implementation Progress
+
+### Completed in this cycle
+
+1. Extended dashboard activity payloads in `deeptutor/api/routers/dashboard.py`:
+   - tutoring rows now include `replay_ref`
+2. Added backend regression coverage in `tests/api/test_dashboard_router.py`:
+   - verifies tutoring dashboard activity exposes a stable replay link target
+3. Added typed dashboard activity detail client support in `web/lib/dashboard-api.ts`
+4. Updated teacher dashboard in `web/app/(workspace)/dashboard/page.tsx`:
+   - tutoring activity rows now link to replay when available
+5. Added tutoring replay page:
+   - `web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx`
+   - renders ordered session messages with timestamps and role labels
+6. Added PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-21-t021-session-replay.md`
+
+### Validation
+
+- Dashboard API tests passed:
+  - `python3 -m pytest tests/api/test_dashboard_router.py -q`
+- Python compile check passed:
+  - `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+- Frontend production build passed:
+  - `cd web && npm run build`
+
+### Status
+
+- Task `T021_SESSION_REPLAY`: implementation complete on branch `pod-a/t021-session-replay`
+- Next: commit, push, open Draft PR linked to issue `#67`, then monitor CI and merge per AI-first policy

--- a/ai_first/daily/2026-04-21.md
+++ b/ai_first/daily/2026-04-21.md
@@ -449,3 +449,17 @@
 
 - Task `T021_SESSION_REPLAY`: moved to `in-progress`
 - Next: inspect current dashboard activity detail/session APIs, then implement tutoring session replay on `pod-a/t021-session-replay`
+
+## Operating Rule Update — Autonomous Handoff Wording
+
+### Completed in this cycle
+
+1. Updated `ai_first/AI_OPERATING_PROMPT.md` to make the following rule explicit:
+   - do not ask for permission to continue when the next strict-order task is clear
+   - automatically open the next issue, task packet, branch, and worktree after each merge
+   - avoid future-intent filler such as "next I will ..." when the work should continue immediately
+   - only ask the human to intervene for real blockers, ambiguity, or high-risk unresolved decisions
+
+### Status
+
+- Repo-level operating prompt now encodes the user's fixed rule for autonomous continuation and handoff wording

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -45,9 +45,10 @@ def _activity_from_session(
 ) -> dict[str, Any]:
     capability = str(session.get("capability") or "chat")
     knowledge_bases = _session_knowledge_bases(session)
+    activity_type = _activity_type(capability)
     return {
         "id": session.get("session_id"),
-        "type": _activity_type(capability),
+        "type": activity_type,
         "capability": capability,
         "title": session.get("title", "Untitled"),
         "timestamp": session.get("updated_at", session.get("created_at", 0)),
@@ -60,6 +61,9 @@ def _activity_from_session(
         "assessment_summary": assessment_review["summary"] if assessment_review else None,
         "review_ref": (
             f"dashboard/assessments/{session.get('session_id')}" if assessment_review else None
+        ),
+        "replay_ref": (
+            f"dashboard/sessions/{session.get('session_id')}" if activity_type == "tutoring" else None
         ),
     }
 

--- a/docs/superpowers/pr-notes/2026-04-21-t021-session-replay.md
+++ b/docs/superpowers/pr-notes/2026-04-21-t021-session-replay.md
@@ -1,0 +1,31 @@
+# PR Note — T021 Tutoring Session Replay Feature
+
+## Summary
+
+- Added tutoring replay links to dashboard activity rows.
+- Added a dedicated dashboard replay page for tutoring sessions that renders the ordered conversation timeline with timestamps.
+- Added regression coverage to ensure tutoring activity payloads expose a stable `replay_ref`.
+
+## Architecture Impact
+
+- No new backend route family was required.
+- The dashboard activity payload now includes `replay_ref` for tutoring sessions, while replay content reuses the existing dashboard activity detail endpoint.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR extends the existing dashboard review flow without changing system boundaries.
+
+```mermaid
+flowchart LR
+  Dashboard[Dashboard activity list] --> ReplayRef[replay_ref]
+  ReplayRef --> ReplayPage[/dashboard/sessions/:sessionId]
+  ReplayPage --> DetailAPI[GET /api/v1/dashboard/:entryId]
+  DetailAPI --> Timeline[Ordered session messages]
+```
+
+## Validation
+
+- `python3 -m pytest tests/api/test_dashboard_router.py -q`
+- `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+- `cd web && npm run build`
+
+## Risks
+
+- Replay currently renders message content as a text-first timeline and does not yet interpret richer event metadata or attachments.

--- a/docs/superpowers/tasks/2026-04-21-T021-session-replay.md
+++ b/docs/superpowers/tasks/2026-04-21-T021-session-replay.md
@@ -1,0 +1,67 @@
+# Feature Pod Task: Tutoring Session Replay Feature
+
+Owner: Codex
+Branch: `pod-a/t021-session-replay`
+GitHub Issue: `#67`
+
+## Goal
+
+Add a replay view for tutoring sessions so teachers can review conversation flow with timestamps and context.
+
+## User-visible outcome
+
+- Teachers can open a tutoring session replay from dashboard data.
+- Replay shows the message timeline in order with timestamps.
+- Existing dashboard and assessment review flows remain unchanged when replay is not used.
+
+## Owned files/modules
+
+- `web/app/(workspace)/dashboard/`
+- `web/lib/dashboard-api.ts`
+- `deeptutor/api/routers/dashboard.py` only if replay-specific API shaping is needed
+- `tests/api/test_dashboard_router.py` if backend changes are required
+- `docs/superpowers/tasks/2026-04-21-T021-session-replay.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-21.md`
+
+## Do-not-touch files/modules
+
+- Marketplace, knowledge, settings, and prompt files
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Prefer reusing existing session/dashboard APIs where possible.
+- If new replay-specific data shaping is needed, keep existing dashboard payloads backward-compatible.
+
+## Acceptance criteria
+
+- Dashboard exposes a way to review tutoring session conversation flow.
+- Replay view shows ordered user/tutor messages with timestamps.
+- Replay remains scoped to teacher review and does not break assessment review routes.
+
+## Required tests
+
+- Backend regression coverage only if API changes are required
+- Frontend build verification after replay UI wiring
+
+## Manual verification
+
+- Open dashboard
+- Select a tutoring session
+- Confirm replay shows the conversation timeline with readable ordering and timestamps
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T020` merged to `main` through PR `#66`.
+- Start by inspecting current dashboard activity detail/session APIs before deciding whether replay needs a new route or only frontend rendering work.

--- a/docs/superpowers/tasks/2026-04-21-T021-session-replay.md
+++ b/docs/superpowers/tasks/2026-04-21-T021-session-replay.md
@@ -65,3 +65,9 @@ Add a replay view for tutoring sessions so teachers can review conversation flow
 
 - `T020` merged to `main` through PR `#66`.
 - Start by inspecting current dashboard activity detail/session APIs before deciding whether replay needs a new route or only frontend rendering work.
+- Reused the existing dashboard activity detail endpoint instead of adding a new replay API.
+- Added tutoring `replay_ref` to dashboard activity payloads and a new replay page route under `/dashboard/sessions/[sessionId]`.
+- Validation:
+  - `python3 -m pytest tests/api/test_dashboard_router.py -q`
+  - `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+  - `cd web && npm run build`

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -337,6 +337,36 @@ async def test_dashboard_overview_applies_search_kb_type_and_min_score_filters(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_recent_tutoring_activity_includes_replay_ref(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="tutor-replay",
+        capability="chat",
+        message="Help me understand photosynthesis",
+        knowledge_bases=["biology-pack"],
+    )
+    await store.add_message(
+        "tutor-replay",
+        "assistant",
+        "Let's break photosynthesis into inputs, process, and outputs.",
+        capability="chat",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/overview")
+
+    assert response.status_code == 200
+    payload = response.json()
+    tutoring_row = next(row for row in payload["recent_activity"] if row["id"] == "tutor-replay")
+    assert tutoring_row["type"] == "tutoring"
+    assert tutoring_row["replay_ref"] == "dashboard/sessions/tutor-replay"
+
+
+@pytest.mark.asyncio
 async def test_dashboard_assessment_export_returns_pdf_report(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -244,10 +244,12 @@ export default function DashboardPage() {
             <div className="overflow-hidden rounded-lg border border-[var(--border)]">
               {(overview?.recent_activity ?? []).length > 0 ? (
                 overview?.recent_activity.map((activity) => {
-                  const reviewHref =
+                  const activityHref =
                     activity.type === "assessment" && activity.review_ref
                       ? `/${activity.review_ref}`
-                      : null;
+                      : activity.type === "tutoring" && activity.replay_ref
+                        ? `/${activity.replay_ref}`
+                        : null;
                   return (
                     <article
                       key={activity.id}
@@ -255,9 +257,9 @@ export default function DashboardPage() {
                     >
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div className="min-w-0 flex-1">
-                          {reviewHref ? (
+                          {activityHref ? (
                             <Link
-                              href={reviewHref}
+                              href={activityHref}
                               className="text-[14px] font-medium text-[var(--foreground)] underline-offset-4 hover:underline"
                             >
                               {activity.title || t("Untitled session")}

--- a/web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx
+++ b/web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, Bot, Loader2, UserRound } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  getDashboardActivityDetail,
+  type DashboardActivityDetail,
+} from "@/lib/dashboard-api";
+
+function formatTime(value: number): string {
+  if (!value) return "";
+  const timestamp = value < 10_000_000_000 ? value * 1000 : value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
+export default function SessionReplayPage() {
+  const { t } = useTranslation();
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const [detail, setDetail] = useState<DashboardActivityDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getDashboardActivityDetail(sessionId)
+      .then((data) => {
+        if (!cancelled) {
+          setDetail(data);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  const replayMessages = useMemo(
+    () =>
+      (detail?.content.messages ?? []).filter((message) =>
+        ["user", "assistant", "system"].includes(message.role),
+      ),
+    [detail],
+  );
+
+  if (loading) {
+    return (
+      <main className="flex h-full items-center justify-center bg-[var(--background)] text-[var(--muted-foreground)]">
+        <Loader2 size={18} className="mr-2 animate-spin" />
+        {t("Loading session replay...")}
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="h-full overflow-y-auto bg-[var(--background)] px-6 py-8">
+        <div className="mx-auto max-w-[900px] rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+          {t("Failed to load tutoring session replay")}: {error}
+        </div>
+      </main>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <main className="h-full overflow-y-auto bg-[var(--background)] px-6 py-8">
+        <div className="mx-auto max-w-[900px] text-sm text-[var(--muted-foreground)]">
+          {t("Session replay not found.")}
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="h-full overflow-y-auto bg-[var(--background)]">
+      <div className="mx-auto flex w-full max-w-[960px] flex-col gap-6 px-6 py-8">
+        <Link
+          href="/dashboard"
+          className="inline-flex w-fit items-center gap-2 text-[13px] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+        >
+          <ArrowLeft size={15} />
+          {t("Back to Dashboard")}
+        </Link>
+
+        <header>
+          <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+            {t("Tutoring Session Replay")}
+          </p>
+          <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
+            {detail.title || t("Untitled session")}
+          </h1>
+          <p className="mt-2 text-[14px] text-[var(--muted-foreground)]">
+            {formatTime(detail.timestamp)} - {detail.content.status}
+          </p>
+          {detail.knowledge_bases.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {detail.knowledge_bases.map((kb) => (
+                <span
+                  key={kb}
+                  className="rounded-md bg-[var(--muted)] px-2 py-1 text-[12px] text-[var(--muted-foreground)]"
+                >
+                  {kb}
+                </span>
+              ))}
+            </div>
+          )}
+        </header>
+
+        <section className="space-y-4">
+          {replayMessages.length > 0 ? (
+            replayMessages.map((message) => {
+              const isUser = message.role === "user";
+              return (
+                <article
+                  key={message.id}
+                  className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--foreground)]">
+                      {isUser ? <UserRound size={16} /> : <Bot size={16} />}
+                      {isUser ? t("Student") : message.role === "assistant" ? t("Tutor") : t("System")}
+                    </div>
+                    <span className="text-[12px] text-[var(--muted-foreground)]">
+                      {formatTime(message.created_at)}
+                    </span>
+                  </div>
+                  <div className="mt-3 whitespace-pre-wrap text-[14px] leading-6 text-[var(--foreground)]">
+                    {message.content}
+                  </div>
+                </article>
+              );
+            })
+          ) : (
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 text-center text-[13px] text-[var(--muted-foreground)]">
+              {t("This tutoring session does not have replayable message content yet.")}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -57,6 +57,32 @@ export interface DashboardActivity {
   knowledge_bases: string[];
   assessment_summary?: AssessmentSummary | null;
   review_ref?: string | null;
+  replay_ref?: string | null;
+}
+
+export interface DashboardActivityDetailMessage {
+  id: number;
+  session_id: string;
+  role: string;
+  content: string;
+  capability: string;
+  created_at: number;
+}
+
+export interface DashboardActivityDetail {
+  id: string;
+  type: "assessment" | "tutoring" | string;
+  capability: string;
+  title: string;
+  timestamp: number;
+  knowledge_bases: string[];
+  assessment_summary?: AssessmentSummary | null;
+  content: {
+    messages: DashboardActivityDetailMessage[];
+    active_turns: Array<Record<string, unknown>>;
+    status: string;
+    summary: string;
+  };
 }
 
 export interface DashboardOverview {
@@ -175,4 +201,11 @@ export async function downloadAssessmentExportPdf(sessionId: string): Promise<Bl
   }
 
   return response.blob();
+}
+
+export async function getDashboardActivityDetail(entryId: string): Promise<DashboardActivityDetail> {
+  const response = await fetch(apiUrl(`/api/v1/dashboard/${entryId}`), {
+    cache: "no-store",
+  });
+  return expectJson<DashboardActivityDetail>(response);
 }


### PR DESCRIPTION
## Summary

- add replay links for tutoring activity in the dashboard
- add a dedicated tutoring replay page that renders the ordered conversation timeline
- add regression coverage for the tutoring replay reference contract

## Validation

- `python3 -m pytest tests/api/test_dashboard_router.py -q`
- `python3 -m py_compile deeptutor/api/routers/dashboard.py`
- `cd web && npm run build`

## Notes

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR extends the existing dashboard review flow only

Closes #67