### PR TITLE
[MVP] T023 Marketplace List Caching & Pagination Optimization

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, assessment PDF export, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, assessment PDF export is now merged into `main` through PR `#66`, and the active short task is `T021 Tutoring Session Replay Feature`.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, tutoring session replay is now merged into `main` through PR `#68`, and the active short task is `T023 Marketplace List Caching & Pagination Optimization`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T021`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T023`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -1,34 +1,34 @@
 # Execution Queue
 
-Last updated: 2026-04-21
+Last updated: 2026-04-23
 
 This is the compact status board for humans and AI workers.  
 The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#66 [MVP] T020 Assessment Results Export to PDF`
-- `#66` added assessment PDF export, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, assessment insights, PDF export, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#68 [MVP] T021 Tutoring Session Replay Feature`
+- `#68` added tutoring replay links and a teacher-facing session replay page, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, assessment insights, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#67 [MVP] Tutoring Session Replay Feature`
-- Active branch: `pod-a/t021-session-replay`
-- Active task packet: `docs/superpowers/tasks/2026-04-21-T021-session-replay.md`
-- Focus set: `T021` (Session replay)
+- Active issue: `#69 [MVP] Marketplace List Caching & Pagination Optimization`
+- Active branch: `pod-a/t023-marketplace-cache-optimization`
+- Active task packet: `docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md`
+- Focus set: `T023` (Marketplace cache optimization)
 
 ## Next recommended task
 
-Implement `T021` on `pod-a/t021-session-replay`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T023` on `pod-a/t023-marketplace-cache-optimization`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#66` merged to `main` after all required CI checks passed
-2. Issue `#65` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T021 Tutoring Session Replay Feature`
-4. Issue `#67` created and task packet added for the new execution lane
+1. `#68` merged to `main` after all required CI checks passed
+2. Issue `#67` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T023 Marketplace List Caching & Pagination Optimization`
+4. Issue `#69` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -63,7 +63,8 @@ Implement `T021` on `pod-a/t021-session-replay`, then open a Draft PR with a Mer
 | T018: Vietnamese Prompts | Completed | 4 | YES | Done |
 | T019: Marketplace Sorting | Completed | 1.5 | NO | Done |
 | T020: Assessment Export PDF | Completed | 3 | NO | Done |
-| T021: Session Replay | In Progress | 3 | NO | Now |
+| T021: Session Replay | Completed | 3 | NO | Done |
+| T023: Cache Optimization | In Progress | 2 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-20T10:00:00Z",
+    "last_updated": "2026-04-23T14:30:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 35
@@ -8,16 +8,8 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 18,
+      "count": 15,
       "tasks": [
-        "T001_MARKETPLACE_API_LIST",
-        "T002_MARKETPLACE_API_DETAIL",
-        "T003_MARKETPLACE_UI_BROWSE",
-        "T004_PROGRESS_INDICATOR_COMPONENT",
-        "T005_LEARNING_JOURNEY_COMPONENT",
-        "T006_ASSESSMENT_REVIEW_INTEGRATION",
-        "T007_VIETNAMESE_UI_TRANSLATION",
-        "T008_VIETNAMESE_BACKEND_SUPPORT",
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
         "T011_KB_CONTEXT_BADGES",
@@ -27,14 +19,19 @@
         "T015_ASSESSMENT_RECOMMENDATIONS",
         "T016_MARKETPLACE_RATINGS",
         "T017_ASSESSMENT_HISTORY_FILTERING",
-        "T018_VIETNAMESE_PROMPT_VARIANTS"
+        "T018_VIETNAMESE_PROMPT_VARIANTS",
+        "T019_MARKETPLACE_SORTING",
+        "T020_ASSESSMENT_EXPORT_PDF",
+        "T021_SESSION_REPLAY",
+        "T022_ERROR_BOUNDARY_HANDLING",
+        "T028_API_RATE_LIMITING"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
       "count": 1,
       "tasks": [
-        "T019_MARKETPLACE_SORTING"
+        "T023_MARKETPLACE_CACHE_OPTIMIZATION"
       ]
     },
     "blocked": {
@@ -44,8 +41,20 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 16,
-      "tasks": []
+      "count": 11,
+      "tasks": [
+        "T024_TEACHER_INVITATION_SYSTEM",
+        "T025_ASSESSMENT_DIFFICULTY_ADJUSTMENT",
+        "T026_MOBILE_RESPONSIVE_MARKETPLACE",
+        "T027_ANALYTICS_DASHBOARD",
+        "T029_MARKETPLACE_SEARCH_FULLTEXT",
+        "T030_ASSESSMENT_TIME_TRACKING",
+        "T031_TUTOR_FOLLOW_UP_PROMPTS",
+        "T032_KNOWLEDGE_PACK_VERSIONING",
+        "T033_LEARNING_PATH_SEQUENCING",
+        "T034_BATCH_ASSESSMENT_IMPORT",
+        "T035_OFFLINE_MODE_SUPPORT"
+      ]
     }
   },
   "tasks": [
@@ -270,8 +279,8 @@
       "complexity": "Medium",
       "estimated_hours": 3,
       "dependencies": ["Session Storage"],
-      "status": "in-progress",
-      "notes": "Issue #67 opened and task packet created at docs/superpowers/tasks/2026-04-21-T021-session-replay.md. Active branch: pod-a/t021-session-replay."
+      "status": "completed",
+      "notes": "Merged to main through PR #68. Teacher dashboard now links tutoring activity to a replay timeline page backed by the existing dashboard detail endpoint."
     },
     {
       "id": "T022_ERROR_BOUNDARY_HANDLING",
@@ -304,8 +313,8 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["SWR or React Query"],
-      "status": "not-started",
-      "notes": "Cache pack list for 5 minutes, refresh on user action"
+      "status": "in-progress",
+      "notes": "Issue #69 opened and task packet created at docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md. Active branch: pod-a/t023-marketplace-cache-optimization."
     },
     {
       "id": "T024_TEACHER_INVITATION_SYSTEM",

--- a/ai_first/daily/2026-04-23.md
+++ b/ai_first/daily/2026-04-23.md
@@ -1,0 +1,55 @@
+# Daily Log — 2026-04-23
+
+## T021 Tutoring Session Replay Feature — Merge Complete
+
+### Completed in this cycle
+
+1. Draft PR `#68` was revalidated, moved to Ready for review, and merged to `main`.
+2. Issue `#67` closed with the merge.
+3. `T021` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T021_SESSION_REPLAY`: moved to `completed`
+
+## T023 Marketplace List Caching & Pagination Optimization — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T021` merged.
+2. Opened GitHub issue `#69` for `T023 Marketplace List Caching & Pagination Optimization`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T023_MARKETPLACE_CACHE_OPTIMIZATION`: moved to `in-progress`
+- Next: implement lightweight marketplace caching and progressive pagination on `pod-a/t023-marketplace-cache-optimization`
+
+## T023 Marketplace List Caching & Pagination Optimization — Implementation Progress
+
+### Completed in this cycle
+
+1. Added a lightweight five-minute cache layer for marketplace list queries in `web/lib/marketplace-api.ts`.
+2. Added cache invalidation after marketplace import and review submission so user actions refresh subsequent list reads.
+3. Updated `web/app/(utility)/marketplace/page.tsx` to:
+   - hydrate the first page from cache when available
+   - refresh stale cache entries in the background
+   - switch from previous/next replacement pagination to progressive load-more behavior
+   - add an explicit refresh control for the current query
+4. Added the required PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-23-t023-marketplace-cache-optimization.md`
+
+### Validation
+
+- Frontend production build passed:
+  - `cd web && npm ci && npm run build`
+
+### Status
+
+- Task `T023_MARKETPLACE_CACHE_OPTIMIZATION`: implementation complete on branch `pod-a/t023-marketplace-cache-optimization`
+- Next: commit, push, open Draft PR linked to issue `#69`, then monitor CI and merge per AI-first policy

--- a/docs/superpowers/pr-notes/2026-04-23-t023-marketplace-cache-optimization.md
+++ b/docs/superpowers/pr-notes/2026-04-23-t023-marketplace-cache-optimization.md
@@ -1,0 +1,32 @@
+# PR Note — T023 Marketplace List Caching & Pagination Optimization
+
+## Summary
+
+- Added a lightweight client-side cache for marketplace list queries with a five-minute TTL.
+- Updated the marketplace page to reuse cached first-page results and refresh them in the background when stale.
+- Replaced previous/next replacement pagination with progressive load-more behavior so already visible cards stay on screen.
+
+## Architecture Impact
+
+- No backend route changes were required.
+- Marketplace list state now flows through a small cache layer in `web/lib/marketplace-api.ts`.
+- The marketplace page reuses cached query responses, explicitly refreshes on demand, and appends subsequent pages without replacing earlier results.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR improves an existing marketplace browse flow without changing system boundaries.
+
+```mermaid
+flowchart LR
+  Query[Marketplace filters + sort] --> Cache[Client list cache]
+  Cache -->|fresh hit| Grid[Marketplace grid]
+  Cache -->|stale or miss| ListAPI[GET /api/v1/marketplace/list]
+  ListAPI --> Cache
+  Grid --> LoadMore[Load more action]
+  LoadMore --> ListAPI
+```
+
+## Validation
+
+- `cd web && npm ci && npm run build`
+
+## Risks
+
+- Search remains a client-side filter over the currently loaded cards, so search results still depend on how many pages have been loaded for the active query.

--- a/docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md
+++ b/docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: Marketplace List Caching & Pagination Optimization
+
+Owner: Codex
+Branch: `pod-a/t023-marketplace-cache-optimization`
+GitHub Issue: `#69`
+
+## Goal
+
+Improve marketplace browsing performance by caching list responses on the client and reducing disruptive full-list reloads during pagination.
+
+## User-visible outcome
+
+- Marketplace browsing reuses recent list results instead of refetching identical queries on every revisit.
+- Marketplace list supports progressive loading for additional packs without replacing already visible results.
+- Existing marketplace filters, sorting, preview, rating, and import flows continue to work.
+
+## Owned files/modules
+
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/lib/marketplace-api.ts`
+- `docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-23.md`
+
+## Do-not-touch files/modules
+
+- Dashboard, tutor, assessment, and settings files
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+- Backend marketplace router unless frontend changes prove an API contract gap
+
+## API/data contract
+
+- Reuse the existing `GET /api/v1/marketplace/list` endpoint.
+- Keep current list response shape backward-compatible.
+- Implement cache and stale refresh behavior on the client without requiring new server dependencies.
+
+## Acceptance criteria
+
+- Marketplace list avoids unnecessary refetches for repeated list queries during a short browsing session.
+- Marketplace users can progressively load additional packs while preserving already rendered results.
+- Existing filters and sorting keep returning the correct list contents.
+
+## Required tests
+
+- Frontend production build verification
+- Any targeted automated coverage added for cache helpers, if introduced
+
+## Manual verification
+
+- Open marketplace and confirm first page loads normally
+- Change sorting or filters and confirm list updates correctly
+- Revisit a recent query and confirm cached results appear without a visible full reset
+- Load more packs and confirm earlier cards remain visible
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T021` merged to `main` through PR `#68`.
+- Start by inspecting `web/lib/marketplace-api.ts` and `web/app/(utility)/marketplace/page.tsx`; the current flow refetches each page with `cache: "no-store"` and replaces the visible list on pagination.
+- Prefer a lightweight in-repo cache over adding a new dependency for this task size.

--- a/web/app/(utility)/marketplace/page.tsx
+++ b/web/app/(utility)/marketplace/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { BookOpen, Download, Eye, Filter, Loader2, Star, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
+  getCachedMarketplacePacks,
   getMarketplacePackPreview,
+  invalidateMarketplaceListCache,
+  isMarketplacePacksCacheStale,
   listMarketplacePacks,
   importMarketplacePack,
   submitMarketplaceReview,
-  type MarketplaceListResponse,
   type MarketplacePack,
   type MarketplacePackPreview,
   type MarketplaceSortBy,
@@ -28,6 +30,8 @@ export default function MarketplacePage() {
   const { t } = useTranslation();
   const [packs, setPacks] = useState<MarketplacePack[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Filters
@@ -38,7 +42,6 @@ export default function MarketplacePage() {
   const [sortBy, setSortBy] = useState<MarketplaceSortBy>("popularity");
 
   // Pagination
-  const [offset, setOffset] = useState(0);
   const [total, setTotal] = useState(0);
   const limit = 20;
 
@@ -53,31 +56,139 @@ export default function MarketplacePage() {
   const [reviewComment, setReviewComment] = useState("");
   const [submittingReview, setSubmittingReview] = useState(false);
 
-  const loadPacks = useCallback(async () => {
-    setLoading(true);
+  const subjectFilter = filterSubject.trim() || undefined;
+  const ownerFilter = filterOwner.trim() || undefined;
+
+  const queryState = useMemo(
+    () => ({
+      sharingStatus,
+      subjectFilter,
+      ownerFilter,
+      sortBy,
+      limit,
+    }),
+    [limit, ownerFilter, sharingStatus, sortBy, subjectFilter],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const cachedFirstPage = getCachedMarketplacePacks(
+      queryState.sharingStatus,
+      queryState.subjectFilter,
+      queryState.ownerFilter,
+      queryState.sortBy,
+      queryState.limit,
+      0,
+    );
+    const needsRefresh = isMarketplacePacksCacheStale(
+      queryState.sharingStatus,
+      queryState.subjectFilter,
+      queryState.ownerFilter,
+      queryState.sortBy,
+      queryState.limit,
+      0,
+    );
+
+    if (cachedFirstPage) {
+      setPacks(cachedFirstPage.packs);
+      setTotal(cachedFirstPage.total);
+      setLoading(false);
+      setRefreshing(needsRefresh);
+      setError(null);
+    } else {
+      setPacks([]);
+      setTotal(0);
+      setLoading(true);
+      setRefreshing(false);
+      setError(null);
+    }
+
+    if (!cachedFirstPage || needsRefresh) {
+      listMarketplacePacks(
+        queryState.sharingStatus,
+        queryState.subjectFilter,
+        queryState.ownerFilter,
+        queryState.sortBy,
+        queryState.limit,
+        0,
+        { forceRefresh: needsRefresh },
+      )
+        .then((response) => {
+          if (cancelled) return;
+          setPacks(response.packs);
+          setTotal(response.total);
+          setError(null);
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          setError(err instanceof Error ? err.message : "Failed to load marketplace");
+          if (!cachedFirstPage) {
+            setPacks([]);
+            setTotal(0);
+          }
+        })
+        .finally(() => {
+          if (cancelled) return;
+          setLoading(false);
+          setRefreshing(false);
+        });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [queryState]);
+
+  const refreshCurrentQuery = async (forceRefresh = true) => {
+    setRefreshing(true);
     setError(null);
     try {
-        const response: MarketplaceListResponse = await listMarketplacePacks(
-          sharingStatus,
-          filterSubject || undefined,
-          filterOwner || undefined,
-          sortBy,
-          limit,
-          offset,
-        );
+      const response = await listMarketplacePacks(
+        queryState.sharingStatus,
+        queryState.subjectFilter,
+        queryState.ownerFilter,
+        queryState.sortBy,
+        queryState.limit,
+        0,
+        { forceRefresh },
+      );
       setPacks(response.packs);
       setTotal(response.total);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load marketplace");
-      setPacks([]);
     } finally {
+      setRefreshing(false);
       setLoading(false);
     }
-  }, [filterOwner, filterSubject, limit, offset, sharingStatus, sortBy]);
+  };
 
-  useEffect(() => {
-    loadPacks();
-  }, [loadPacks]);
+  const handleLoadMore = async () => {
+    if (loadingMore || packs.length >= total) return;
+    setLoadingMore(true);
+    setError(null);
+    try {
+      const response = await listMarketplacePacks(
+        queryState.sharingStatus,
+        queryState.subjectFilter,
+        queryState.ownerFilter,
+        queryState.sortBy,
+        queryState.limit,
+        packs.length,
+      );
+      setPacks((current) => [
+        ...current,
+        ...response.packs.filter(
+          (candidate) => !current.some((existing) => existing.name === candidate.name),
+        ),
+      ]);
+      setTotal(response.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load more packs");
+    } finally {
+      setLoadingMore(false);
+    }
+  };
 
   const handleImportPack = async (packName: string) => {
     setImporting(packName);
@@ -85,7 +196,7 @@ export default function MarketplacePage() {
       await importMarketplacePack(packName);
       setImportSuccess(packName);
       setTimeout(() => setImportSuccess(null), 3000);
-      await loadPacks();
+      await refreshCurrentQuery(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to import pack");
     } finally {
@@ -129,7 +240,7 @@ export default function MarketplacePage() {
       setReviewerName("");
       setReviewRating(5);
       setReviewComment("");
-      await loadPacks();
+      await refreshCurrentQuery(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to submit review");
     } finally {
@@ -260,12 +371,25 @@ export default function MarketplacePage() {
             <span className="text-[13px] text-[var(--muted-foreground)]">
               {t("Showing")} {filteredPacks.length} {t("of")} {total} {t("packs")}
             </span>
-            {loading && (
-              <span className="flex items-center gap-2 text-[12px] text-[var(--muted-foreground)]">
-                <Loader2 size={13} className="animate-spin" />
-                {t("Loading")}
-              </span>
-            )}
+            <div className="flex items-center gap-3">
+              {refreshing && !loading && (
+                <span className="flex items-center gap-2 text-[12px] text-[var(--muted-foreground)]">
+                  <Loader2 size={13} className="animate-spin" />
+                  {t("Refreshing")}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  invalidateMarketplaceListCache();
+                  void refreshCurrentQuery(true);
+                }}
+                disabled={refreshing || loading}
+                className="rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[12px] text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] disabled:opacity-50"
+              >
+                {t("Refresh")}
+              </button>
+            </div>
           </div>
 
           {loading ? (
@@ -393,25 +517,25 @@ export default function MarketplacePage() {
         </div>
 
         {/* Pagination */}
-        {total > limit && (
-          <div className="flex items-center justify-center gap-2">
+        {total > packs.length && (
+          <div className="flex flex-col items-center justify-center gap-3">
+            <p className="text-[12px] text-[var(--muted-foreground)]">
+              {packs.length} / {total} {t("packs loaded")}
+            </p>
             <button
-              onClick={() => setOffset(Math.max(0, offset - limit))}
-              disabled={offset === 0}
-              className="rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[12px] disabled:opacity-50"
+              type="button"
+              onClick={() => void handleLoadMore()}
+              disabled={loadingMore}
+              className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] bg-[var(--card)] px-4 py-2 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] disabled:opacity-50"
             >
-              {t("Previous")}
-            </button>
-            <span className="text-[12px] text-[var(--muted-foreground)]">
-              {t("Page")} {Math.floor(offset / limit) + 1} {t("of")}{" "}
-              {Math.ceil(total / limit)}
-            </span>
-            <button
-              onClick={() => setOffset(offset + limit)}
-              disabled={offset + limit >= total}
-              className="rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[12px] disabled:opacity-50"
-            >
-              {t("Next")}
+              {loadingMore ? (
+                <>
+                  <Loader2 size={13} className="animate-spin" />
+                  {t("Loading more")}
+                </>
+              ) : (
+                t("Load more")
+              )}
             </button>
           </div>
         )}

--- a/web/lib/marketplace-api.ts
+++ b/web/lib/marketplace-api.ts
@@ -54,6 +54,83 @@ export type MarketplaceSortBy =
   | "rating"
   | "most_objectives";
 
+export interface MarketplaceListFetchOptions {
+  forceRefresh?: boolean;
+}
+
+interface MarketplaceListCacheEntry {
+  data?: MarketplaceListResponse;
+  updatedAt: number;
+  promise?: Promise<MarketplaceListResponse>;
+}
+
+const MARKETPLACE_LIST_CACHE_TTL_MS = 5 * 60 * 1000;
+const marketplaceListCache = new Map<string, MarketplaceListCacheEntry>();
+
+function buildMarketplaceListCacheKey(
+  sharingStatus?: string,
+  subject?: string,
+  owner?: string,
+  sortBy?: MarketplaceSortBy,
+  limit = 50,
+  offset = 0,
+): string {
+  return JSON.stringify({
+    sharingStatus: sharingStatus || "",
+    subject: subject || "",
+    owner: owner || "",
+    sortBy: sortBy || "",
+    limit,
+    offset,
+  });
+}
+
+function isMarketplaceListCacheFresh(entry?: MarketplaceListCacheEntry): boolean {
+  return Boolean(entry?.data && Date.now() - entry.updatedAt < MARKETPLACE_LIST_CACHE_TTL_MS);
+}
+
+export function getCachedMarketplacePacks(
+  sharingStatus?: string,
+  subject?: string,
+  owner?: string,
+  sortBy?: MarketplaceSortBy,
+  limit = 50,
+  offset = 0,
+): MarketplaceListResponse | null {
+  const cacheKey = buildMarketplaceListCacheKey(
+    sharingStatus,
+    subject,
+    owner,
+    sortBy,
+    limit,
+    offset,
+  );
+  return marketplaceListCache.get(cacheKey)?.data ?? null;
+}
+
+export function isMarketplacePacksCacheStale(
+  sharingStatus?: string,
+  subject?: string,
+  owner?: string,
+  sortBy?: MarketplaceSortBy,
+  limit = 50,
+  offset = 0,
+): boolean {
+  const cacheKey = buildMarketplaceListCacheKey(
+    sharingStatus,
+    subject,
+    owner,
+    sortBy,
+    limit,
+    offset,
+  );
+  return !isMarketplaceListCacheFresh(marketplaceListCache.get(cacheKey));
+}
+
+export function invalidateMarketplaceListCache(): void {
+  marketplaceListCache.clear();
+}
+
 export async function listMarketplacePacks(
   sharingStatus?: string,
   subject?: string,
@@ -61,7 +138,27 @@ export async function listMarketplacePacks(
   sortBy?: MarketplaceSortBy,
   limit = 50,
   offset = 0,
+  options: MarketplaceListFetchOptions = {},
 ): Promise<MarketplaceListResponse> {
+  const cacheKey = buildMarketplaceListCacheKey(
+    sharingStatus,
+    subject,
+    owner,
+    sortBy,
+    limit,
+    offset,
+  );
+  const existingEntry = marketplaceListCache.get(cacheKey);
+
+  if (!options.forceRefresh) {
+    if (isMarketplaceListCacheFresh(existingEntry)) {
+      return existingEntry!.data!;
+    }
+    if (existingEntry?.promise) {
+      return existingEntry.promise;
+    }
+  }
+
   const params = new URLSearchParams({
     limit: limit.toString(),
     offset: offset.toString(),
@@ -72,15 +169,35 @@ export async function listMarketplacePacks(
   if (owner) params.append("owner", owner);
   if (sortBy) params.append("sort_by", sortBy);
 
-  const response = await fetch(apiUrl(`/api/v1/marketplace/list?${params}`), {
+  const request = fetch(apiUrl(`/api/v1/marketplace/list?${params}`), {
     cache: "no-store",
+  }).then(async (response) => {
+    if (!response.ok) {
+      throw new Error(`Failed to fetch marketplace packs: ${response.status}`);
+    }
+
+    const data = (await response.json()) as MarketplaceListResponse;
+    marketplaceListCache.set(cacheKey, {
+      data,
+      updatedAt: Date.now(),
+    });
+    return data;
+  }).catch((error) => {
+    if (existingEntry?.data) {
+      marketplaceListCache.set(cacheKey, existingEntry);
+    } else {
+      marketplaceListCache.delete(cacheKey);
+    }
+    throw error;
   });
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch marketplace packs: ${response.status}`);
-  }
+  marketplaceListCache.set(cacheKey, {
+    data: existingEntry?.data,
+    updatedAt: existingEntry?.updatedAt ?? 0,
+    promise: request,
+  });
 
-  return response.json();
+  return request;
 }
 
 export async function getMarketplacePack(packName: string): Promise<MarketplacePack> {
@@ -162,7 +279,9 @@ export async function importMarketplacePack(
     }
   }
 
-  return response.json();
+  const result = await response.json();
+  invalidateMarketplaceListCache();
+  return result;
 }
 
 export async function submitMarketplaceReview(
@@ -188,5 +307,7 @@ export async function submitMarketplaceReview(
     }
   }
 
-  return response.json();
+  const result = await response.json();
+  invalidateMarketplaceListCache();
+  return result;
 }


### PR DESCRIPTION
## Summary

- add a lightweight client-side cache for marketplace list queries with a five-minute TTL
- reuse cached marketplace results on the page and refresh stale queries in the background
- replace previous/next replacement pagination with progressive load-more behavior that preserves visible cards

## Validation

- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `cd web && npm ci && npm run build`

## Notes

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR improves an existing marketplace browsing flow without changing system boundaries
- architecture note: `docs/superpowers/pr-notes/2026-04-23-t023-marketplace-cache-optimization.md`

Closes #69
