### PR TITLE
[MVP] T024 Teacher Team Invitation & Sharing

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, tutoring session replay is now merged into `main` through PR `#68`, and the active short task is `T023 Marketplace List Caching & Pagination Optimization`.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace caching is now merged into `main` through PR `#70`, and the active short task is `T024 Teacher Team Invitation & Sharing`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T023`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T024`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#68 [MVP] T021 Tutoring Session Replay Feature`
-- `#68` added tutoring replay links and a teacher-facing session replay page, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, assessment insights, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#70 [MVP] T023 Marketplace List Caching & Pagination Optimization`
+- `#70` added marketplace list caching and progressive load-more browsing, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, assessment insights, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#69 [MVP] Marketplace List Caching & Pagination Optimization`
-- Active branch: `pod-a/t023-marketplace-cache-optimization`
-- Active task packet: `docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md`
-- Focus set: `T023` (Marketplace cache optimization)
+- Active issue: `#71 [MVP] Teacher Team Invitation & Sharing`
+- Active branch: `pod-a/t024-teacher-invitation-sharing`
+- Active task packet: `docs/superpowers/tasks/2026-04-23-T024-teacher-invitation-sharing.md`
+- Focus set: `T024` (Teacher invitation and sharing)
 
 ## Next recommended task
 
-Implement `T023` on `pod-a/t023-marketplace-cache-optimization`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T024` on `pod-a/t024-teacher-invitation-sharing`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#68` merged to `main` after all required CI checks passed
-2. Issue `#67` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T023 Marketplace List Caching & Pagination Optimization`
-4. Issue `#69` created and task packet added for the new execution lane
+1. `#70` merged to `main` after all required CI checks passed
+2. Issue `#69` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T024 Teacher Team Invitation & Sharing`
+4. Issue `#71` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -64,7 +64,8 @@ Implement `T023` on `pod-a/t023-marketplace-cache-optimization`, then open a Dra
 | T019: Marketplace Sorting | Completed | 1.5 | NO | Done |
 | T020: Assessment Export PDF | Completed | 3 | NO | Done |
 | T021: Session Replay | Completed | 3 | NO | Done |
-| T023: Cache Optimization | In Progress | 2 | NO | Now |
+| T023: Cache Optimization | Completed | 2 | NO | Done |
+| T024: Team Sharing | In Progress | 6 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -313,8 +313,8 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["SWR or React Query"],
-      "status": "in-progress",
-      "notes": "Issue #69 opened and task packet created at docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md. Active branch: pod-a/t023-marketplace-cache-optimization."
+      "status": "completed",
+      "notes": "Merged to main through PR #70. Marketplace browsing now reuses cached list responses and progressive load-more pagination."
     },
     {
       "id": "T024_TEACHER_INVITATION_SYSTEM",
@@ -330,8 +330,8 @@
       "complexity": "High",
       "estimated_hours": 6,
       "dependencies": ["User Management", "Access Control"],
-      "status": "not-started",
-      "notes": "Implement team creation, invitations via email/link, access control"
+      "status": "in-progress",
+      "notes": "Issue #71 opened and task packet created at docs/superpowers/tasks/2026-04-23-T024-teacher-invitation-sharing.md. Active branch: pod-a/t024-teacher-invitation-sharing."
     },
     {
       "id": "T025_ASSESSMENT_DIFFICULTY_ADJUSTMENT",

--- a/ai_first/daily/2026-04-23.md
+++ b/ai_first/daily/2026-04-23.md
@@ -1,25 +1,25 @@
 # Daily Log — 2026-04-23
 
-## T021 Tutoring Session Replay Feature — Merge Complete
+## T023 Marketplace List Caching & Pagination Optimization — Merge Complete
 
 ### Completed in this cycle
 
-1. Draft PR `#68` was revalidated, moved to Ready for review, and merged to `main`.
-2. Issue `#67` closed with the merge.
-3. `T021` status was advanced to `completed` in the task tracking flow.
+1. Draft PR `#70` was validated by CI, moved to Ready for review, and merged to `main`.
+2. Issue `#69` closed with the merge.
+3. `T023` status was advanced to `completed` in the task tracking flow.
 
 ### Status
 
-- Task `T021_SESSION_REPLAY`: moved to `completed`
+- Task `T023_MARKETPLACE_CACHE_OPTIMIZATION`: moved to `completed`
 
-## T023 Marketplace List Caching & Pagination Optimization — Task Selection
+## T024 Teacher Team Invitation & Sharing — Task Selection
 
 ### Completed in this cycle
 
-1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T021` merged.
-2. Opened GitHub issue `#69` for `T023 Marketplace List Caching & Pagination Optimization`.
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T023` merged.
+2. Opened GitHub issue `#71` for `T024 Teacher Team Invitation & Sharing`.
 3. Added task packet:
-   - `docs/superpowers/tasks/2026-04-23-T023-marketplace-cache-optimization.md`
+   - `docs/superpowers/tasks/2026-04-23-T024-teacher-invitation-sharing.md`
 4. Updated task tracking mirrors:
    - `ai_first/TASK_REGISTRY.json`
    - `ai_first/EXECUTION_QUEUE.md`
@@ -27,29 +27,36 @@
 
 ### Status
 
-- Task `T023_MARKETPLACE_CACHE_OPTIMIZATION`: moved to `in-progress`
-- Next: implement lightweight marketplace caching and progressive pagination on `pod-a/t023-marketplace-cache-optimization`
+- Task `T024_TEACHER_INVITATION_SYSTEM`: moved to `in-progress`
+- Next: implement an MVP collaboration metadata flow for team members and pending invites on `pod-a/t024-teacher-invitation-sharing`
 
-## T023 Marketplace List Caching & Pagination Optimization — Implementation Progress
+## T024 Teacher Team Invitation & Sharing — Implementation Progress
 
 ### Completed in this cycle
 
-1. Added a lightweight five-minute cache layer for marketplace list queries in `web/lib/marketplace-api.ts`.
-2. Added cache invalidation after marketplace import and review submission so user actions refresh subsequent list reads.
-3. Updated `web/app/(utility)/marketplace/page.tsx` to:
-   - hydrate the first page from cache when available
-   - refresh stale cache entries in the background
-   - switch from previous/next replacement pagination to progressive load-more behavior
-   - add an explicit refresh control for the current query
+1. Extended teacher-pack metadata in:
+   - `deeptutor/api/routers/knowledge.py`
+   - `deeptutor/knowledge/manager.py`
+   - `web/lib/knowledge-api.ts`
+   to support `team_members` and `pending_invites`
+2. Updated `web/app/(utility)/knowledge/page.tsx` so teachers can:
+   - add team members and invite emails while creating a team-shared pack
+   - edit those values from the existing knowledge-pack metadata form
+   - see collaborator and pending-invite summaries in the knowledge-pack card
+3. Added regression coverage in:
+   - `tests/api/test_knowledge_router.py`
+   - `tests/knowledge/test_kb_metadata_normalization.py`
 4. Added the required PR architecture note:
-   - `docs/superpowers/pr-notes/2026-04-23-t023-marketplace-cache-optimization.md`
+   - `docs/superpowers/pr-notes/2026-04-23-t024-teacher-invitation-sharing.md`
 
 ### Validation
 
+- Knowledge metadata tests passed:
+  - `python3 -m pytest tests/api/test_knowledge_router.py tests/knowledge/test_kb_metadata_normalization.py -q`
 - Frontend production build passed:
   - `cd web && npm ci && npm run build`
 
 ### Status
 
-- Task `T023_MARKETPLACE_CACHE_OPTIMIZATION`: implementation complete on branch `pod-a/t023-marketplace-cache-optimization`
-- Next: commit, push, open Draft PR linked to issue `#69`, then monitor CI and merge per AI-first policy
+- Task `T024_TEACHER_INVITATION_SYSTEM`: implementation complete on branch `pod-a/t024-teacher-invitation-sharing`
+- Next: commit, push, open Draft PR linked to issue `#71`, then monitor CI and merge per AI-first policy

--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -51,6 +51,7 @@ router = APIRouter()
 BYTES_PER_GB = 1024**3
 BYTES_PER_MB = 1024**2
 ALLOWED_SHARING_STATUSES = {"private", "team", "public"}
+LIST_METADATA_FIELDS = {"learning_objectives", "team_members", "pending_invites"}
 
 
 def format_bytes_human_readable(size_bytes: int) -> str:
@@ -207,25 +208,28 @@ def _normalize_teacher_pack_config(config: dict) -> dict:
         value = value.strip()
         normalized[field] = value or None
 
-    if "learning_objectives" in normalized:
-        objectives = normalized["learning_objectives"]
-        if objectives is None:
-            pass
-        elif isinstance(objectives, str):
-            cleaned = [item.strip() for item in objectives.splitlines() if item.strip()]
-            normalized["learning_objectives"] = cleaned or None
-        elif isinstance(objectives, list):
-            if not all(isinstance(item, str) for item in objectives):
+    for field in LIST_METADATA_FIELDS:
+        if field not in normalized:
+            continue
+
+        values = normalized[field]
+        if values is None:
+            continue
+        if isinstance(values, str):
+            cleaned = [item.strip() for item in values.splitlines() if item.strip()]
+            normalized[field] = cleaned or None
+        elif isinstance(values, list):
+            if not all(isinstance(item, str) for item in values):
                 raise HTTPException(
                     status_code=400,
-                    detail="'learning_objectives' must be a list of strings",
+                    detail=f"'{field}' must be a list of strings",
                 )
-            cleaned = [item.strip() for item in objectives if item.strip()]
-            normalized["learning_objectives"] = cleaned or None
+            cleaned = [item.strip() for item in values if item.strip()]
+            normalized[field] = cleaned or None
         else:
             raise HTTPException(
                 status_code=400,
-                detail="'learning_objectives' must be a string or list of strings",
+                detail=f"'{field}' must be a string or list of strings",
             )
 
     if "sharing_status" in normalized:

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -28,6 +28,8 @@ PACK_METADATA_FIELDS = (
     "learning_objectives",
     "owner",
     "sharing_status",
+    "team_members",
+    "pending_invites",
 )
 
 
@@ -36,6 +38,12 @@ def _normalize_teacher_pack_field(field: str, value):
         return None
 
     if field == "learning_objectives":
+        if isinstance(value, list):
+            cleaned = [item.strip() for item in value if isinstance(item, str) and item.strip()]
+            return cleaned or None
+        return None
+
+    if field in {"team_members", "pending_invites"}:
         if isinstance(value, list):
             cleaned = [item.strip() for item in value if isinstance(item, str) and item.strip()]
             return cleaned or None

--- a/docs/superpowers/pr-notes/2026-04-23-t024-teacher-invitation-sharing.md
+++ b/docs/superpowers/pr-notes/2026-04-23-t024-teacher-invitation-sharing.md
@@ -1,0 +1,31 @@
+# PR Note — T024 Teacher Team Invitation & Sharing
+
+## Summary
+
+- Extended teacher-pack metadata to store team members and pending invite emails.
+- Updated the knowledge base create/edit UI to manage collaboration details when a pack uses team sharing.
+- Added regression coverage for knowledge metadata normalization and persistence of the new collaboration fields.
+
+## Architecture Impact
+
+- No new route family was added in this slice.
+- Collaboration state now rides on the existing knowledge-base config metadata contract.
+- The knowledge page remains the teacher-side control surface for pack ownership, sharing status, collaborator roster, and pending invites.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR extends the current knowledge-pack management flow without introducing a new subsystem boundary.
+
+```mermaid
+flowchart LR
+  KnowledgeUI[Knowledge page create/edit form] --> MetadataPayload[Teacher pack metadata]
+  MetadataPayload --> KnowledgeAPI[PUT /api/v1/knowledge/:kb/config]
+  KnowledgeAPI --> ConfigStore[kb config + metadata normalization]
+  ConfigStore --> KnowledgeUI
+```
+
+## Validation
+
+- `python3 -m pytest tests/api/test_knowledge_router.py tests/knowledge/test_kb_metadata_normalization.py -q`
+- `cd web && npm ci && npm run build`
+
+## Risks
+
+- Pending invite emails are stored as metadata only in this slice; outbound invitation delivery and access enforcement still need a later collaboration/auth pass.

--- a/docs/superpowers/tasks/2026-04-23-T024-teacher-invitation-sharing.md
+++ b/docs/superpowers/tasks/2026-04-23-T024-teacher-invitation-sharing.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: Teacher Team Invitation & Sharing
+
+Owner: Codex
+Branch: `pod-a/t024-teacher-invitation-sharing`
+GitHub Issue: `#71`
+
+## Goal
+
+Add an MVP team-sharing workflow so teachers can record collaborators and pending invitations for a knowledge pack from the existing teacher workspace.
+
+## User-visible outcome
+
+- Teachers can add team members and pending invite emails while creating or editing a knowledge pack.
+- Team-sharing details are visible in the knowledge pack management UI.
+- Existing private/team/public sharing controls remain intact.
+
+## Owned files/modules
+
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/lib/knowledge-api.ts`
+- `deeptutor/api/routers/knowledge.py`
+- `tests/api/test_knowledge_router.py`
+- `docs/superpowers/tasks/2026-04-23-T024-teacher-invitation-sharing.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-23.md`
+
+## Do-not-touch files/modules
+
+- Marketplace, dashboard, tutor, and settings files
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Extend the existing knowledge-base config metadata contract instead of introducing a new backend route family in this slice.
+- Keep current knowledge-base config updates backward-compatible.
+- Treat team members and pending invites as metadata lists stored with the teacher pack config.
+
+## Acceptance criteria
+
+- Teachers can record collaborator names and invite emails for a team-shared knowledge pack.
+- Knowledge pack details clearly display current collaborators and pending invitations.
+- Existing sharing status flows continue to work with the new metadata fields.
+
+## Required tests
+
+- Knowledge router regression coverage for the new metadata fields
+- Frontend production build verification
+
+## Manual verification
+
+- Create or edit a knowledge pack with sharing status `team`
+- Add team members and invitation emails
+- Save the pack and confirm the values persist in the UI
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T023` merged to `main` through PR `#70`.
+- Start from the existing teacher-pack metadata flow in `web/app/(utility)/knowledge/page.tsx` and `deeptutor/api/routers/knowledge.py`.
+- Keep this slice lightweight: model collaboration state first, not outbound email delivery or full access-control enforcement.

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -256,6 +256,8 @@ def test_update_config_persists_teacher_pack_metadata(monkeypatch, tmp_path: Pat
         "learning_objectives": ["Quadratic equations", "Graph reading"],
         "owner": "teacher-a",
         "sharing_status": "private",
+        "team_members": ["teacher-a", "teacher-b"],
+        "pending_invites": ["invite@example.com"],
     }
 
     monkeypatch.setattr(config_module, "get_kb_config_service", lambda: fake_service)
@@ -271,6 +273,8 @@ def test_update_config_persists_teacher_pack_metadata(monkeypatch, tmp_path: Pat
     assert body["config"]["learning_objectives"] == ["Quadratic equations", "Graph reading"]
     assert body["config"]["owner"] == "teacher-a"
     assert body["config"]["sharing_status"] == "private"
+    assert body["config"]["team_members"] == ["teacher-a", "teacher-b"]
+    assert body["config"]["pending_invites"] == ["invite@example.com"]
 
 
 def test_get_knowledge_base_details_exposes_teacher_pack_metadata(
@@ -296,6 +300,8 @@ def test_get_knowledge_base_details_exposes_teacher_pack_metadata(
                 "learning_objectives": ["Quadratic equations", "Graph reading"],
                 "owner": "teacher-a",
                 "sharing_status": "private",
+                "team_members": ["teacher-a", "teacher-b"],
+                "pending_invites": ["invite@example.com"],
                 "status": "ready",
             }
         }
@@ -315,6 +321,8 @@ def test_get_knowledge_base_details_exposes_teacher_pack_metadata(
     assert metadata["learning_objectives"] == ["Quadratic equations", "Graph reading"]
     assert metadata["owner"] == "teacher-a"
     assert metadata["sharing_status"] == "private"
+    assert metadata["team_members"] == ["teacher-a", "teacher-b"]
+    assert metadata["pending_invites"] == ["invite@example.com"]
 
 
 def test_list_knowledge_bases_includes_teacher_pack_metadata(monkeypatch, tmp_path: Path) -> None:
@@ -338,6 +346,8 @@ def test_list_knowledge_bases_includes_teacher_pack_metadata(monkeypatch, tmp_pa
                     "learning_objectives": ["Quadratic equations"],
                     "owner": "teacher-a",
                     "sharing_status": "private",
+                    "team_members": ["teacher-a", "teacher-b"],
+                    "pending_invites": ["invite@example.com"],
                 },
             }
 
@@ -353,6 +363,8 @@ def test_list_knowledge_bases_includes_teacher_pack_metadata(monkeypatch, tmp_pa
     assert payload[0]["metadata"]["subject"] == "Math"
     assert payload[0]["metadata"]["grade"] == "10"
     assert payload[0]["metadata"]["owner"] == "teacher-a"
+    assert payload[0]["metadata"]["team_members"] == ["teacher-a", "teacher-b"]
+    assert payload[0]["metadata"]["pending_invites"] == ["invite@example.com"]
 
 
 def test_update_config_rejects_invalid_sharing_status(monkeypatch, tmp_path: Path) -> None:
@@ -406,6 +418,8 @@ def test_update_config_normalizes_learning_objectives(monkeypatch, tmp_path: Pat
     payload = {
         "learning_objectives": ["  Quadratic equations  ", "", "  ", "Graph reading"],
         "owner": " teacher-a ",
+        "team_members": [" teacher-a ", " ", "teacher-b "],
+        "pending_invites": [" invite@example.com ", "", "reviewer@example.com "],
     }
 
     with TestClient(_build_app(knowledge_module)) as client:
@@ -415,3 +429,5 @@ def test_update_config_normalizes_learning_objectives(monkeypatch, tmp_path: Pat
     config = response.json()["config"]
     assert config["learning_objectives"] == ["Quadratic equations", "Graph reading"]
     assert config["owner"] == "teacher-a"
+    assert config["team_members"] == ["teacher-a", "teacher-b"]
+    assert config["pending_invites"] == ["invite@example.com", "reviewer@example.com"]

--- a/tests/knowledge/test_kb_metadata_normalization.py
+++ b/tests/knowledge/test_kb_metadata_normalization.py
@@ -21,6 +21,8 @@ def test_get_info_normalizes_teacher_pack_metadata(tmp_path) -> None:
                 "learning_objectives": ["  Quadratic equations  ", "", "Graph reading"],
                 "owner": "  teacher-a  ",
                 "sharing_status": "  private  ",
+                "team_members": [" teacher-a ", "", " teacher-b "],
+                "pending_invites": [" invite1@example.com ", " ", "invite2@example.com"],
                 "status": "ready",
             }
         }
@@ -36,3 +38,5 @@ def test_get_info_normalizes_teacher_pack_metadata(tmp_path) -> None:
     assert metadata["learning_objectives"] == ["Quadratic equations", "Graph reading"]
     assert metadata["owner"] == "teacher-a"
     assert metadata["sharing_status"] == "private"
+    assert metadata["team_members"] == ["teacher-a", "teacher-b"]
+    assert metadata["pending_invites"] == ["invite1@example.com", "invite2@example.com"]

--- a/web/app/(utility)/knowledge/page.tsx
+++ b/web/app/(utility)/knowledge/page.tsx
@@ -136,7 +136,16 @@ const parseLearningObjectives = (value: string): string[] =>
     .map((item) => item.trim())
     .filter(Boolean);
 
+const parseMultilineList = (value: string): string[] =>
+  value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
 const formatLearningObjectives = (value?: string[] | null): string =>
+  Array.isArray(value) ? value.join("\n") : "";
+
+const formatMultilineList = (value?: string[] | null): string =>
   Array.isArray(value) ? value.join("\n") : "";
 
 const normalizeSharingStatus = (value: string): "private" | "team" | "public" | null => {
@@ -154,9 +163,13 @@ const buildTeacherPackMetadata = (input: {
   learningObjectives: string;
   owner: string;
   sharingStatus: string;
+  teamMembers: string;
+  pendingInvites: string;
 }): TeacherPackMetadata | null => {
   const metadata: TeacherPackMetadata = {};
   const learningObjectives = parseLearningObjectives(input.learningObjectives);
+  const teamMembers = parseMultilineList(input.teamMembers);
+  const pendingInvites = parseMultilineList(input.pendingInvites);
 
   if (input.subject.trim()) metadata.subject = input.subject.trim();
   if (input.grade.trim()) metadata.grade = input.grade.trim();
@@ -165,6 +178,10 @@ const buildTeacherPackMetadata = (input: {
   if (input.owner.trim()) metadata.owner = input.owner.trim();
   const sharingStatus = normalizeSharingStatus(input.sharingStatus);
   if (sharingStatus) metadata.sharing_status = sharingStatus;
+  if (sharingStatus === "team") {
+    if (teamMembers.length) metadata.team_members = teamMembers;
+    if (pendingInvites.length) metadata.pending_invites = pendingInvites;
+  }
 
   return Object.keys(metadata).length ? metadata : null;
 };
@@ -190,6 +207,8 @@ export default function KnowledgePage() {
   const [newKbLearningObjectives, setNewKbLearningObjectives] = useState("");
   const [newKbOwner, setNewKbOwner] = useState("");
   const [newKbSharingStatus, setNewKbSharingStatus] = useState<"private" | "team" | "public">("private");
+  const [newKbTeamMembers, setNewKbTeamMembers] = useState("");
+  const [newKbPendingInvites, setNewKbPendingInvites] = useState("");
   const [editingKbName, setEditingKbName] = useState<string | null>(null);
   const [editKbSubject, setEditKbSubject] = useState("");
   const [editKbGrade, setEditKbGrade] = useState("");
@@ -197,6 +216,8 @@ export default function KnowledgePage() {
   const [editKbLearningObjectives, setEditKbLearningObjectives] = useState("");
   const [editKbOwner, setEditKbOwner] = useState("");
   const [editKbSharingStatus, setEditKbSharingStatus] = useState<"private" | "team" | "public">("private");
+  const [editKbTeamMembers, setEditKbTeamMembers] = useState("");
+  const [editKbPendingInvites, setEditKbPendingInvites] = useState("");
   const [savingKbMetadata, setSavingKbMetadata] = useState(false);
   const [editKbError, setEditKbError] = useState<string | null>(null);
   const [uploadTarget, setUploadTarget] = useState("");
@@ -437,6 +458,8 @@ export default function KnowledgePage() {
       learningObjectives: newKbLearningObjectives,
       owner: newKbOwner,
       sharingStatus: newKbSharingStatus,
+      teamMembers: newKbTeamMembers,
+      pendingInvites: newKbPendingInvites,
     });
     setCreating(true);
     try {
@@ -495,6 +518,8 @@ export default function KnowledgePage() {
       setNewKbLearningObjectives("");
       setNewKbOwner("");
       setNewKbSharingStatus("private");
+      setNewKbTeamMembers("");
+      setNewKbPendingInvites("");
       if (createFileRef.current) createFileRef.current.value = "";
       await loadAll();
 
@@ -592,6 +617,8 @@ export default function KnowledgePage() {
     setEditKbCurriculum(kb.metadata?.curriculum ?? "");
     setEditKbLearningObjectives(formatLearningObjectives(kb.metadata?.learning_objectives));
     setEditKbOwner(kb.metadata?.owner ?? "");
+    setEditKbTeamMembers(formatMultilineList(kb.metadata?.team_members));
+    setEditKbPendingInvites(formatMultilineList(kb.metadata?.pending_invites));
     const sharingStatus = kb.metadata?.sharing_status;
     if (sharingStatus === "private" || sharingStatus === "team" || sharingStatus === "public") {
       setEditKbSharingStatus(sharingStatus);
@@ -610,6 +637,8 @@ export default function KnowledgePage() {
     if (!editingKbName) return;
 
     const learningObjectives = parseLearningObjectives(editKbLearningObjectives);
+    const teamMembers = parseMultilineList(editKbTeamMembers);
+    const pendingInvites = parseMultilineList(editKbPendingInvites);
     const payload: TeacherPackMetadata = {
       subject: editKbSubject.trim() || null,
       grade: editKbGrade.trim() || null,
@@ -617,6 +646,9 @@ export default function KnowledgePage() {
       learning_objectives: learningObjectives.length ? learningObjectives : null,
       owner: editKbOwner.trim() || null,
       sharing_status: editKbSharingStatus,
+      team_members: editKbSharingStatus === "team" && teamMembers.length ? teamMembers : null,
+      pending_invites:
+        editKbSharingStatus === "team" && pendingInvites.length ? pendingInvites : null,
     };
 
     setSavingKbMetadata(true);
@@ -844,6 +876,25 @@ export default function KnowledgePage() {
                       <option value="public">{t("Public")}</option>
                     </select>
                   </div>
+
+                  {newKbSharingStatus === "team" && (
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <textarea
+                        value={newKbTeamMembers}
+                        onChange={(event) => setNewKbTeamMembers(event.target.value)}
+                        placeholder={t("Team members (one per line)")}
+                        rows={4}
+                        className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                      />
+                      <textarea
+                        value={newKbPendingInvites}
+                        onChange={(event) => setNewKbPendingInvites(event.target.value)}
+                        placeholder={t("Invite emails (one per line)")}
+                        rows={4}
+                        className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                      />
+                    </div>
+                  )}
 
                   <select
                     value={selectedProvider}
@@ -1139,6 +1190,16 @@ export default function KnowledgePage() {
                               {t("Learning objectives")}: {kb.metadata.learning_objectives.join(", ")}
                             </div>
                           ) : null}
+                          {kb.metadata?.team_members?.length ? (
+                            <div className="mt-2 text-[11px] text-[var(--muted-foreground)]">
+                              {t("Team members")}: {kb.metadata.team_members.join(", ")}
+                            </div>
+                          ) : null}
+                          {kb.metadata?.pending_invites?.length ? (
+                            <div className="mt-1 text-[11px] text-[var(--muted-foreground)]">
+                              {t("Pending invites")}: {kb.metadata.pending_invites.join(", ")}
+                            </div>
+                          ) : null}
                         </div>
 
                         <div className="flex items-center gap-1.5">
@@ -1236,6 +1297,25 @@ export default function KnowledgePage() {
                               <option value="public">{t("Public")}</option>
                             </select>
                           </div>
+
+                          {editKbSharingStatus === "team" && (
+                            <div className="grid gap-2 md:grid-cols-2">
+                              <textarea
+                                value={editKbTeamMembers}
+                                onChange={(event) => setEditKbTeamMembers(event.target.value)}
+                                placeholder={t("Team members (one per line)")}
+                                rows={4}
+                                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                              />
+                              <textarea
+                                value={editKbPendingInvites}
+                                onChange={(event) => setEditKbPendingInvites(event.target.value)}
+                                placeholder={t("Invite emails (one per line)")}
+                                rows={4}
+                                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
+                              />
+                            </div>
+                          )}
 
                           {editKbError && (
                             <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">

--- a/web/lib/knowledge-api.ts
+++ b/web/lib/knowledge-api.ts
@@ -10,6 +10,8 @@ export interface TeacherPackMetadata {
   learning_objectives?: string[] | null;
   owner?: string | null;
   sharing_status?: "private" | "team" | "public" | null;
+  team_members?: string[] | null;
+  pending_invites?: string[] | null;
 }
 
 export interface KnowledgeBaseSummary {


### PR DESCRIPTION
## Summary

- extend teacher-pack metadata with team members and pending invite emails
- update the knowledge page create/edit flows to manage collaboration details for team-shared packs
- add regression coverage for metadata normalization and persistence of the new collaboration fields

## Validation

- `python3 -m pytest tests/api/test_knowledge_router.py tests/knowledge/test_kb_metadata_normalization.py -q`
- `cd web && npm ci && npm run build`

## Notes

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this extends the existing knowledge-pack management flow without changing system boundaries
- architecture note: `docs/superpowers/pr-notes/2026-04-23-t024-teacher-invitation-sharing.md`

Closes #71
