### PR TITLE
[MVP] T025 Adaptive Difficulty Selection

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace caching is now merged into `main` through PR `#70`, and the active short task is `T024 Teacher Team Invitation & Sharing`.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, teacher invitation sharing is now merged into `main` through PR `#72`, and the active short task is `T025 Assessment Difficulty Adaptive Adjustment`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T024`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T025`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#70 [MVP] T023 Marketplace List Caching & Pagination Optimization`
-- `#70` added marketplace list caching and progressive load-more browsing, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, assessment insights, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, and API rate limiting in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#72 [MVP] T024 Teacher Team Invitation & Sharing`
+- `#72` added collaborator and pending-invite metadata to the teacher knowledge-pack flow, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, assessment insights, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#71 [MVP] Teacher Team Invitation & Sharing`
-- Active branch: `pod-a/t024-teacher-invitation-sharing`
-- Active task packet: `docs/superpowers/tasks/2026-04-23-T024-teacher-invitation-sharing.md`
-- Focus set: `T024` (Teacher invitation and sharing)
+- Active issue: `#73 [MVP] Assessment Difficulty Adaptive Adjustment`
+- Active branch: `pod-a/t025-adaptive-difficulty`
+- Active task packet: `docs/superpowers/tasks/2026-04-23-T025-adaptive-difficulty.md`
+- Focus set: `T025` (Adaptive difficulty)
 
 ## Next recommended task
 
-Implement `T024` on `pod-a/t024-teacher-invitation-sharing`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T025` on `pod-a/t025-adaptive-difficulty`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#70` merged to `main` after all required CI checks passed
-2. Issue `#69` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T024 Teacher Team Invitation & Sharing`
-4. Issue `#71` created and task packet added for the new execution lane
+1. `#72` merged to `main` after all required CI checks passed
+2. Issue `#71` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T025 Assessment Difficulty Adaptive Adjustment`
+4. Issue `#73` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -65,7 +65,8 @@ Implement `T024` on `pod-a/t024-teacher-invitation-sharing`, then open a Draft P
 | T020: Assessment Export PDF | Completed | 3 | NO | Done |
 | T021: Session Replay | Completed | 3 | NO | Done |
 | T023: Cache Optimization | Completed | 2 | NO | Done |
-| T024: Team Sharing | In Progress | 6 | NO | Now |
+| T024: Team Sharing | Completed | 6 | NO | Done |
+| T025: Adaptive Difficulty | In Progress | 5 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -347,8 +347,8 @@
       "complexity": "High",
       "estimated_hours": 5,
       "dependencies": ["Question Analytics"],
-      "status": "not-started",
-      "notes": "Implement CAT-style difficulty adjustment, track performance per difficulty level"
+      "status": "in-progress",
+      "notes": "Issue #73 opened and task packet created at docs/superpowers/tasks/2026-04-23-T025-adaptive-difficulty.md. Active branch: pod-a/t025-adaptive-difficulty. MVP slice: infer auto difficulty from recent quiz performance context before template generation."
     },
     {
       "id": "T026_MOBILE_RESPONSIVE_MARKETPLACE",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -1,6 +1,6 @@
 # Main System Map
 
-Last updated: 2026-04-20
+Last updated: 2026-04-23
 
 This is the required top-level Mermaid map for the project. Any PR that adds, removes, or materially changes product features, capabilities, tools, routers, routes, data models, or AI-first workflow must update this map.
 
@@ -51,9 +51,12 @@ flowchart TD
   
   Product --> AssessmentBuilder["Assessment Builder"]
   AssessmentBuilder --> QuizGrounding["Knowledge Pack Grounded Quiz Config"]
+  AssessmentBuilder --> AdaptiveDifficulty["Adaptive Difficulty from Recent Quiz Performance"]
   AssessmentBuilder --> AssessmentRecommendAPI["POST /api/v1/assessment/recommend"]
   AssessmentRecommendAPI --> RecommendEngine["Assessment Recommendation Engine"]
   RecommendEngine --> AssessmentSignals["Weak topics + score trend + KB context"]
+  AdaptiveDifficulty --> QuizHistory["[Quiz Performance] session context"]
+  AdaptiveDifficulty --> DeepQuestion
   
   Product --> StudentTutor["Student Tutor Workspace"]
   StudentTutor --> TutorKBContext["Knowledge Pack Tutoring Context"]

--- a/ai_first/daily/2026-04-23.md
+++ b/ai_first/daily/2026-04-23.md
@@ -60,3 +60,59 @@
 
 - Task `T024_TEACHER_INVITATION_SYSTEM`: implementation complete on branch `pod-a/t024-teacher-invitation-sharing`
 - Next: commit, push, open Draft PR linked to issue `#71`, then monitor CI and merge per AI-first policy
+
+## T024 Teacher Team Invitation & Sharing — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#72` passed required CI and merged to `main`.
+2. Issue `#71` closed with the merge.
+3. `T024` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T024_TEACHER_INVITATION_SYSTEM`: moved to `completed`
+
+## T025 Assessment Difficulty Adaptive Adjustment — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T024` merged.
+2. Opened GitHub issue `#73` for `T025 Assessment Difficulty Adaptive Adjustment`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-23-T025-adaptive-difficulty.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T025_ASSESSMENT_DIFFICULTY_ADJUSTMENT`: moved to `in-progress`
+- Next: add failing coordinator tests for auto difficulty inference, then implement the smallest backend-only adaptive selection slice
+
+## T025 Assessment Difficulty Adaptive Adjustment — Implementation Progress
+
+### Completed in this cycle
+
+1. Added coordinator-side adaptive difficulty selection in:
+   - `deeptutor/agents/question/coordinator.py`
+   by parsing the latest `[Quiz Performance]` score from session context when request difficulty is blank or `auto`
+2. Preserved explicit difficulty overrides so manual `easy`, `medium`, or `hard` requests bypass the adaptive path
+3. Recorded the selected difficulty decision in `summary.trace.adaptive_difficulty`
+4. Added regression coverage in:
+   - `tests/agents/question/test_coordinator.py`
+5. Updated the top-level architecture map:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+6. Added the required PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-23-t025-adaptive-difficulty.md`
+
+### Validation
+
+- Question pipeline tests passed:
+  - `python3 -m pytest tests/agents/question/test_generator.py tests/agents/question/test_coordinator.py -q`
+
+### Status
+
+- Task `T025_ASSESSMENT_DIFFICULTY_ADJUSTMENT`: implementation complete on branch `pod-a/t025-adaptive-difficulty`
+- Next: run final verification, commit, push, open Draft PR linked to issue `#73`, then monitor CI and merge per AI-first policy

--- a/deeptutor/agents/question/coordinator.py
+++ b/deeptutor/agents/question/coordinator.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from datetime import datetime
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 from deeptutor.agents.question.agents.generator import Generator
@@ -133,6 +134,12 @@ class AgentCoordinator:
             if normalized_question_type and normalized_question_type != "auto"
             else ""
         )
+        adaptive_difficulty = self._resolve_adaptive_difficulty(
+            requested_difficulty=normalized_difficulty,
+            history_context=history_context,
+        )
+        if adaptive_difficulty.get("selected") and not target_difficulty:
+            target_difficulty = str(adaptive_difficulty["selected"])
 
         batch_number = 0
         while len(templates) < requested:
@@ -218,7 +225,10 @@ class AgentCoordinator:
             requested=requested,
             templates=templates[:requested],
             qa_pairs=qa_pairs,
-            trace={"batches": batch_trace},
+            trace={
+                "batches": batch_trace,
+                "adaptive_difficulty": adaptive_difficulty,
+            },
         )
 
     async def generate_from_exam(
@@ -458,6 +468,49 @@ class AgentCoordinator:
         }
         self._persist_summary(summary)
         return summary
+
+    @staticmethod
+    def _resolve_adaptive_difficulty(
+        requested_difficulty: str,
+        history_context: str,
+    ) -> dict[str, Any]:
+        normalized_difficulty = str(requested_difficulty or "").strip().lower()
+        if normalized_difficulty and normalized_difficulty != "auto":
+            return {
+                "selected": normalized_difficulty,
+                "source": "request",
+            }
+
+        score_percent = AgentCoordinator._extract_recent_quiz_score_percent(history_context)
+        if score_percent is None:
+            return {
+                "selected": "medium",
+                "source": "default",
+            }
+        if score_percent >= 80:
+            selected = "hard"
+        elif score_percent < 50:
+            selected = "easy"
+        else:
+            selected = "medium"
+        return {
+            "selected": selected,
+            "source": "history_context",
+            "score_percent": score_percent,
+        }
+
+    @staticmethod
+    def _extract_recent_quiz_score_percent(history_context: str) -> int | None:
+        text = str(history_context or "").strip()
+        if not text:
+            return None
+        matches = re.findall(r"Score:\s*\d+\s*/\s*\d+\s*\((\d+)%\)", text)
+        if not matches:
+            return None
+        try:
+            return int(matches[-1])
+        except ValueError:
+            return None
 
     def _create_batch_dir(self, prefix: str) -> Path:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/docs/superpowers/pr-notes/2026-04-23-t025-adaptive-difficulty.md
+++ b/docs/superpowers/pr-notes/2026-04-23-t025-adaptive-difficulty.md
@@ -1,0 +1,35 @@
+# PR Note: T025 Adaptive Difficulty
+
+## Summary
+
+This slice adds coordinator-side adaptive difficulty selection for `deep_question` when the request difficulty is blank or `auto`. The coordinator now inspects the most recent `[Quiz Performance]` score in session history, maps it to `easy`, `medium`, or `hard`, and records that decision in the generation summary trace.
+
+## Architecture
+
+```mermaid
+flowchart TD
+  SessionHistory["Session history / [Quiz Performance]"] --> Coordinator["AgentCoordinator.generate_from_topic"]
+  RequestDifficulty["Request difficulty"] --> Coordinator
+  Coordinator --> Decision{"Explicit difficulty set?"}
+  Decision -->|Yes| Explicit["Use requested difficulty"]
+  Decision -->|No| ScoreParse["Parse latest score percent"]
+  ScoreParse --> DifficultyMap["Map score to easy / medium / hard"]
+  Explicit --> IdeaAgent["IdeaAgent target_difficulty"]
+  DifficultyMap --> IdeaAgent
+  IdeaAgent --> Summary["summary.trace.adaptive_difficulty"]
+```
+
+## Files
+
+- `deeptutor/agents/question/coordinator.py`
+- `tests/agents/question/test_coordinator.py`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## Verification
+
+- `python3 -m pytest tests/agents/question/test_generator.py tests/agents/question/test_coordinator.py -q`
+- `python3 -m py_compile deeptutor/agents/question/coordinator.py`
+
+## MAIN_SYSTEM_MAP
+
+Updated: `yes`

--- a/docs/superpowers/tasks/2026-04-23-T025-adaptive-difficulty.md
+++ b/docs/superpowers/tasks/2026-04-23-T025-adaptive-difficulty.md
@@ -1,0 +1,66 @@
+# Feature Pod Task: Assessment Difficulty Adaptive Adjustment
+
+Owner: Codex
+Branch: `pod-a/t025-adaptive-difficulty`
+GitHub Issue: `#73`
+
+## Goal
+
+Add an MVP adaptive difficulty flow for `deep_question` so auto-selected quizzes react to the learner's recent quiz performance instead of always staying static.
+
+## User-visible outcome
+
+- A quiz request with difficulty set to `auto` adjusts toward easier, medium, or harder questions based on recent quiz performance recorded in the same session context.
+- Explicit difficulty requests such as `easy`, `medium`, or `hard` still win and bypass the adaptive logic.
+- Generated quiz summaries record which difficulty was selected and why, so follow-up debugging is possible.
+
+## Owned files/modules
+
+- `deeptutor/agents/question/coordinator.py`
+- `tests/agents/question/test_coordinator.py`
+- `docs/superpowers/tasks/2026-04-23-T025-adaptive-difficulty.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-23.md`
+
+## Do-not-touch files/modules
+
+- Frontend quiz UI and dashboard files in this slice
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Keep the public `deep_question` request contract backward-compatible.
+- Treat adaptive difficulty as a coordinator-side inference when the request difficulty is blank or `auto`.
+- Persist the selected difficulty decision inside the generation summary trace instead of introducing a new storage model in this slice.
+
+## Acceptance criteria
+
+- `generate_from_topic()` derives a difficulty for auto mode from recent `[Quiz Performance]` context.
+- A strong recent score selects a harder difficulty; a weak recent score selects an easier one; mixed performance keeps medium.
+- Explicit request difficulty still overrides any inferred adaptive difficulty.
+- Summary metadata exposes the adaptive difficulty decision for inspection.
+
+## Required tests
+
+- Coordinator unit coverage for adaptive difficulty selection and explicit override behavior
+
+## Manual verification
+
+- Start a quiz session and record quiz results into the same session history
+- Generate a new quiz with difficulty `auto`
+- Confirm the resulting summary trace shows the inferred difficulty level
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T024` merged to `main` through PR `#72`.
+- Keep the first slice backend-only and session-context-driven; do not expand into new frontend controls or a new persistence table unless this MVP slice proves insufficient.

--- a/tests/agents/question/test_coordinator.py
+++ b/tests/agents/question/test_coordinator.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from deeptutor.agents.question.coordinator import AgentCoordinator
+from deeptutor.agents.question.models import QuestionTemplate
+
+
+class _StubIdeaAgent:
+    def __init__(self, captured: dict[str, Any]) -> None:
+        self._captured = captured
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self._captured["idea_process"] = kwargs
+        return {
+            "templates": [
+                QuestionTemplate(
+                    question_id="",
+                    concentration="linear equations",
+                    question_type=kwargs.get("target_question_type") or "written",
+                    difficulty=kwargs.get("target_difficulty") or "medium",
+                )
+            ],
+            "knowledge_context": "recent quiz performance",
+        }
+
+
+@pytest.mark.asyncio
+async def test_generate_from_topic_infers_hard_difficulty_from_recent_quiz_score(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "deeptutor.agents.question.coordinator.load_config_with_main",
+        lambda *_args, **_kwargs: {},
+    )
+    coordinator = AgentCoordinator(output_dir=str(tmp_path))
+    coordinator._create_idea_agent = lambda: _StubIdeaAgent(captured)  # type: ignore[method-assign]
+
+    async def fake_generation_loop(**kwargs: Any) -> list[dict[str, Any]]:
+        captured["generation_loop"] = kwargs
+        return []
+
+    coordinator._generation_loop = fake_generation_loop  # type: ignore[method-assign]
+
+    result = await coordinator.generate_from_topic(
+        user_topic="linear equations",
+        preference="",
+        num_questions=1,
+        difficulty="",
+        question_type="",
+        history_context=(
+            "[Quiz Performance]\n"
+            "1. [q_1] Q: Solve 2x=6 -> Answered: 3 (Correct)\n"
+            "2. [q_2] Q: Solve 3x=12 -> Answered: 4 (Correct)\n"
+            "Score: 2/2 (100%)"
+        ),
+    )
+
+    assert captured["idea_process"]["target_difficulty"] == "hard"
+    assert result["trace"]["adaptive_difficulty"] == {
+        "selected": "hard",
+        "source": "history_context",
+        "score_percent": 100,
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_from_topic_respects_explicit_difficulty_over_history(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "deeptutor.agents.question.coordinator.load_config_with_main",
+        lambda *_args, **_kwargs: {},
+    )
+    coordinator = AgentCoordinator(output_dir=str(tmp_path))
+    coordinator._create_idea_agent = lambda: _StubIdeaAgent(captured)  # type: ignore[method-assign]
+
+    async def fake_generation_loop(**kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    coordinator._generation_loop = fake_generation_loop  # type: ignore[method-assign]
+
+    result = await coordinator.generate_from_topic(
+        user_topic="fractions",
+        preference="",
+        num_questions=1,
+        difficulty="easy",
+        question_type="",
+        history_context=(
+            "[Quiz Performance]\n"
+            "1. [q_1] Q: Simplify 6/8 -> Answered: 3/4 (Correct)\n"
+            "2. [q_2] Q: Simplify 9/12 -> Answered: 3/4 (Correct)\n"
+            "Score: 2/2 (100%)"
+        ),
+    )
+
+    assert captured["idea_process"]["target_difficulty"] == "easy"
+    assert result["trace"]["adaptive_difficulty"] == {
+        "selected": "easy",
+        "source": "request",
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_from_topic_infers_easy_difficulty_from_low_recent_quiz_score(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "deeptutor.agents.question.coordinator.load_config_with_main",
+        lambda *_args, **_kwargs: {},
+    )
+    coordinator = AgentCoordinator(output_dir=str(tmp_path))
+    coordinator._create_idea_agent = lambda: _StubIdeaAgent(captured)  # type: ignore[method-assign]
+
+    async def fake_generation_loop(**kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    coordinator._generation_loop = fake_generation_loop  # type: ignore[method-assign]
+
+    result = await coordinator.generate_from_topic(
+        user_topic="fractions",
+        preference="",
+        num_questions=1,
+        difficulty="",
+        question_type="",
+        history_context=(
+            "[Quiz Performance]\n"
+            "1. [q_1] Q: Simplify 6/8 -> Answered: 6/8 (Incorrect, correct: 3/4)\n"
+            "2. [q_2] Q: Simplify 9/12 -> Answered: 9/12 (Incorrect, correct: 3/4)\n"
+            "Score: 0/2 (0%)"
+        ),
+    )
+
+    assert captured["idea_process"]["target_difficulty"] == "easy"
+    assert result["trace"]["adaptive_difficulty"] == {
+        "selected": "easy",
+        "source": "history_context",
+        "score_percent": 0,
+    }


### PR DESCRIPTION
## Summary
- add coordinator-side adaptive difficulty selection for `deep_question` when request difficulty is blank or `auto`
- parse the latest `[Quiz Performance]` score from session context and map it to `easy`, `medium`, or `hard`
- record the selected difficulty in `summary.trace.adaptive_difficulty` and add coordinator regression coverage

Closes #73

## Testing
- python3 -m pytest tests/agents/question/test_generator.py tests/agents/question/test_coordinator.py -q
- python3 -m py_compile deeptutor/agents/question/coordinator.py

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-23-t025-adaptive-difficulty.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated: yes
