### PR TITLE
[MVP] T027 Teacher Analytics Dashboard

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, assessment adaptive difficulty, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, adaptive difficulty selection is now merged into `main` through PR `#74`, and the active short task is `T026 Mobile-First Marketplace Responsive Design`.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, assessment adaptive difficulty, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, mobile-first marketplace responsiveness is now merged into `main` through PR `#76`, and the active short task is `T027 Teacher Analytics Dashboard`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T026`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T027`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#74 [MVP] T025 Adaptive Difficulty Selection`
-- `#74` added coordinator-side adaptive quiz difficulty selection from recent quiz performance context, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, assessment insights, adaptive difficulty selection, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#76 [MVP] T026 Mobile-First Marketplace Responsive Design`
+- `#76` improved marketplace responsiveness for mobile/tablet browsing without changing the underlying API or cache behavior, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, assessment insights, adaptive difficulty selection, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#75 [MVP] Mobile-First Marketplace Responsive Design`
-- Active branch: `pod-a/t026-marketplace-mobile`
-- Active task packet: `docs/superpowers/tasks/2026-04-23-T026-marketplace-mobile.md`
-- Focus set: `T026` (Marketplace mobile responsive design)
+- Active issue: `#77 [MVP] Teacher Analytics Dashboard`
+- Active branch: `pod-a/t027-analytics-dashboard`
+- Active task packet: `docs/superpowers/tasks/2026-04-23-T027-analytics-dashboard.md`
+- Focus set: `T027` (Teacher analytics dashboard)
 
 ## Next recommended task
 
-Implement `T026` on `pod-a/t026-marketplace-mobile`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T027` on `pod-a/t027-analytics-dashboard`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#74` merged to `main` after all required CI checks passed
-2. Issue `#73` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T026 Mobile-First Marketplace Responsive Design`
-4. Issue `#75` created and task packet added for the new execution lane
+1. `#76` merged to `main` after all required CI checks passed
+2. Issue `#75` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T027 Teacher Analytics Dashboard`
+4. Issue `#77` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -67,7 +67,8 @@ Implement `T026` on `pod-a/t026-marketplace-mobile`, then open a Draft PR with a
 | T023: Cache Optimization | Completed | 2 | NO | Done |
 | T024: Team Sharing | Completed | 6 | NO | Done |
 | T025: Adaptive Difficulty | Completed | 5 | NO | Done |
-| T026: Marketplace Mobile | In Progress | 1 | NO | Now |
+| T026: Marketplace Mobile | Completed | 1 | NO | Done |
+| T027: Analytics Dashboard | In Progress | 8 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -363,8 +363,8 @@
       "complexity": "Low",
       "estimated_hours": 1,
       "dependencies": ["Tailwind CSS"],
-      "status": "in-progress",
-      "notes": "Issue #75 opened and task packet created at docs/superpowers/tasks/2026-04-23-T026-marketplace-mobile.md. Active branch: pod-a/t026-marketplace-mobile."
+      "status": "completed",
+      "notes": "Merged to main through PR #76. Mobile/tablet marketplace layout now has safer filters, card spacing, CTA layout, and preview modal scrolling."
     },
     {
       "id": "T027_ANALYTICS_DASHBOARD",
@@ -380,8 +380,8 @@
       "complexity": "High",
       "estimated_hours": 8,
       "dependencies": ["Analytics Service"],
-      "status": "not-started",
-      "notes": "Charts: student participation over time, question difficulty heatmap, performance distribution"
+      "status": "in-progress",
+      "notes": "Issue #77 opened and task packet created at docs/superpowers/tasks/2026-04-23-T027-analytics-dashboard.md. Active branch: pod-a/t027-analytics-dashboard."
     },
     {
       "id": "T028_API_RATE_LIMITING",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -1,6 +1,6 @@
 # Main System Map
 
-Last updated: 2026-04-23
+Last updated: 2026-04-24
 
 This is the required top-level Mermaid map for the project. Any PR that adds, removes, or materially changes product features, capabilities, tools, routers, routes, data models, or AI-first workflow must update this map.
 
@@ -66,6 +66,10 @@ flowchart TD
   Product --> TeacherDashboard["Teacher Dashboard"]
   TeacherDashboard --> DashboardSummary["Session Activity Summary"]
   DashboardSummary --> DashboardFilters["History filters: type + KB + search + min score"]
+  DashboardSummary --> TeacherAnalytics["Teacher Analytics Signals"]
+  TeacherAnalytics --> EngagementSignals["Engagement: active days + streak + KB usage"]
+  TeacherAnalytics --> AssessmentTrend["Assessment trend: average + latest + delta"]
+  TeacherAnalytics --> DifficultySignals["Learning signals: focus topics + strong areas"]
   TeacherDashboard --> StudentDashboard["Student Progress Dashboard"]
   TeacherDashboard --> AssessmentReview["Assessment Review Drill-down"]
   StudentDashboard --> StudentRoute["/dashboard/student"]

--- a/ai_first/daily/2026-04-23.md
+++ b/ai_first/daily/2026-04-23.md
@@ -170,3 +170,68 @@
 
 - Task `T026_MOBILE_RESPONSIVE_MARKETPLACE`: implementation complete on branch `pod-a/t026-marketplace-mobile`
 - Next: restore any generated build artifacts outside scope, then commit, push, open Draft PR linked to issue `#75`, and monitor CI per AI-first policy
+
+## T026 Mobile-First Marketplace Responsive Design — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#76` passed required CI and merged to `main`.
+2. Issue `#75` closed with the merge.
+3. `T026` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T026_MOBILE_RESPONSIVE_MARKETPLACE`: moved to `completed`
+
+## T027 Teacher Analytics Dashboard — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T026` merged.
+2. Opened GitHub issue `#77` for `T027 Teacher Analytics Dashboard`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-23-T027-analytics-dashboard.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T027_ANALYTICS_DASHBOARD`: moved to `in-progress`
+- Next: inspect the current dashboard overview flow and define the smallest useful analytics slice on `pod-a/t027-analytics-dashboard`
+
+## T027 Teacher Analytics Dashboard — Implementation Progress
+
+### Completed in this cycle
+
+1. Extended `deeptutor/api/routers/dashboard.py` so `/api/v1/dashboard/overview` now returns:
+   - `analytics.engagement`
+   - `analytics.assessment_trend`
+   - `analytics.learning_signals`
+   using the current session history and assessment review parsing only
+2. Updated `web/lib/dashboard-api.ts` with the new overview analytics types
+3. Updated `web/app/(workspace)/dashboard/page.tsx` to render:
+   - engagement cards
+   - assessment trend summary
+   - learning signal badges for weak and strong topics
+4. Added regression coverage in:
+   - `tests/api/test_dashboard_router.py`
+5. Updated the top-level architecture map:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+6. Added the required PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-24-t027-analytics-dashboard.md`
+
+### Validation
+
+- Dashboard router tests passed:
+  - `python3 -m pytest tests/api/test_dashboard_router.py -q`
+- Dashboard router module compiles:
+  - `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+- Frontend production build passed:
+  - `cd web && npm run build`
+
+### Status
+
+- Task `T027_ANALYTICS_DASHBOARD`: implementation complete on branch `pod-a/t027-analytics-dashboard`
+- Next: remove generated build artifacts outside scope, then commit, push, open Draft PR linked to issue `#77`, and monitor CI per AI-first policy

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -118,6 +118,56 @@ def _summarize_topic_mastery(
     return focus_topics, mastered_topics
 
 
+def _build_dashboard_analytics(
+    activities: list[dict[str, Any]],
+    assessment_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    focus_topics, mastered_topics = _summarize_topic_mastery(assessment_rows)
+    unique_knowledge_packs = sorted(
+        {
+            kb_name
+            for activity in activities
+            for kb_name in activity.get("knowledge_bases", [])
+        }
+    )
+    average_score_percent = round(
+        sum(int(row["summary"]["score_percent"]) for row in assessment_rows) / len(assessment_rows)
+    ) if assessment_rows else 0
+    ordered_assessments = sorted(assessment_rows, key=lambda row: row["timestamp"])
+    latest_score_percent = (
+        int(ordered_assessments[-1]["summary"]["score_percent"]) if ordered_assessments else 0
+    )
+    previous_score_percent = (
+        int(ordered_assessments[-2]["summary"]["score_percent"])
+        if len(ordered_assessments) > 1
+        else latest_score_percent
+    )
+
+    return {
+        "engagement": {
+            "active_days": len(
+                {
+                    day
+                    for activity in activities
+                    if (day := _timestamp_to_day(activity.get("timestamp"))) is not None
+                }
+            ),
+            "streak_days": _learning_streak_days(activities),
+            "knowledge_packs_used": len(unique_knowledge_packs),
+        },
+        "assessment_trend": {
+            "assessments_completed": len(assessment_rows),
+            "average_score_percent": average_score_percent,
+            "latest_score_percent": latest_score_percent,
+            "score_delta": latest_score_percent - previous_score_percent,
+        },
+        "learning_signals": {
+            "focus_topics": focus_topics,
+            "mastered_topics": mastered_topics,
+        },
+    }
+
+
 def _learning_streak_days(activities: list[dict[str, Any]]) -> int:
     days = []
     seen_days: set[int] = set()
@@ -286,6 +336,22 @@ async def get_dashboard_overview(
         for kb_name in activity["knowledge_bases"]:
             knowledge_pack_counts[kb_name] = knowledge_pack_counts.get(kb_name, 0) + 1
 
+    assessment_rows = [
+        {
+            "session_id": activity["id"],
+            "title": activity["title"],
+            "timestamp": activity["timestamp"],
+            "knowledge_bases": activity["knowledge_bases"],
+            "summary": activity["assessment_summary"],
+            "review_ref": activity["review_ref"],
+            "assessment_results": activity.get("assessment_summary") and (
+                extract_assessment_review(await store.get_session_with_messages(activity["id"])) or {}
+            ).get("results", []),
+        }
+        for activity in activities
+        if activity["type"] == "assessment" and activity.get("assessment_summary")
+    ]
+
     return {
         "totals": {
             "total_sessions": len(activities),
@@ -302,6 +368,7 @@ async def get_dashboard_overview(
                 key=lambda item: (-item[1], item[0]),
             )
         ],
+        "analytics": _build_dashboard_analytics(activities, assessment_rows),
         "recent_activity": activities[:limit],
     }
 

--- a/docs/superpowers/pr-notes/2026-04-24-t027-analytics-dashboard.md
+++ b/docs/superpowers/pr-notes/2026-04-24-t027-analytics-dashboard.md
@@ -1,0 +1,39 @@
+# PR Note: T027 Teacher Analytics Dashboard
+
+## Summary
+
+This slice extends the existing dashboard overview payload with teacher-facing analytics derived from the current session and assessment-review data. It adds three high-signal sections: engagement, assessment trend, and learning signals, while keeping the existing filters, recent activity list, and student progress route intact.
+
+## Architecture
+
+```mermaid
+flowchart TD
+  Sessions["SQLite sessions + messages"] --> Overview["GET /api/v1/dashboard/overview"]
+  Reviews["Assessment review extraction"] --> Overview
+  Overview --> Engagement["analytics.engagement"]
+  Overview --> Trend["analytics.assessment_trend"]
+  Overview --> Signals["analytics.learning_signals"]
+  Engagement --> DashboardPage["/dashboard page"]
+  Trend --> DashboardPage
+  Signals --> DashboardPage
+  Overview --> Recent["recent_activity"]
+  Overview --> Packs["knowledge_packs"]
+```
+
+## Files
+
+- `deeptutor/api/routers/dashboard.py`
+- `web/lib/dashboard-api.ts`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `tests/api/test_dashboard_router.py`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## Verification
+
+- `python3 -m pytest tests/api/test_dashboard_router.py -q`
+- `python3 -m py_compile deeptutor/api/routers/dashboard.py`
+- `cd web && npm run build`
+
+## MAIN_SYSTEM_MAP
+
+Updated: `yes`

--- a/docs/superpowers/tasks/2026-04-23-T027-analytics-dashboard.md
+++ b/docs/superpowers/tasks/2026-04-23-T027-analytics-dashboard.md
@@ -1,0 +1,67 @@
+# Feature Pod Task: Teacher Analytics Dashboard
+
+Owner: Codex
+Branch: `pod-a/t027-analytics-dashboard`
+GitHub Issue: `#77`
+
+## Goal
+
+Add a higher-signal teacher analytics slice so the dashboard shows more than session lists and basic student progress summaries.
+
+## User-visible outcome
+
+- Teachers can see richer dashboard insights for engagement, assessment trends, and common learning difficulties.
+- The dashboard stays grounded in existing session and assessment-review data instead of introducing a separate analytics store in this slice.
+- Existing dashboard filters and review drill-downs continue to work.
+
+## Owned files/modules
+
+- `web/app/(workspace)/dashboard/page.tsx`
+- `deeptutor/api/routers/dashboard.py`
+- `tests/api/test_dashboard_router.py`
+- `docs/superpowers/tasks/2026-04-23-T027-analytics-dashboard.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-23.md`
+
+## Do-not-touch files/modules
+
+- Marketplace, knowledge, tutor, and settings pages
+- Unrelated API routers
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Prefer extending the existing dashboard overview payload instead of creating a separate dashboard API family in this first slice.
+- Use current session history and assessment review parsing as the source of truth.
+- Keep existing dashboard filters backward-compatible.
+
+## Acceptance criteria
+
+- Dashboard exposes at least one new engagement signal, one assessment trend signal, and one learning-difficulty signal useful to teachers.
+- Backend analytics remain derived from the current session/review data already stored in the app.
+- Existing overview and student progress routes do not regress.
+
+## Required tests
+
+- Dashboard router regression coverage for the new analytics fields
+- Frontend production build verification
+
+## Manual verification
+
+- Open the teacher dashboard with mixed assessment/session history
+- Confirm the new analytics summaries render and stay coherent with the existing filters
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T026` merged to `main` through PR `#76`.
+- Start from the current dashboard overview flow and extend the most useful signals first; avoid building a full charting system in one slice.

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -337,6 +337,77 @@ async def test_dashboard_overview_applies_search_kb_type_and_min_score_filters(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_overview_includes_teacher_analytics_signals(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="assessment-latest",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "assessment-latest",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4)\n"
+        "2. [q2] Q: Solve fractions addition 1/2 + 1/4 -> Answered: 3/4 (Correct)\n"
+        "Score: 1/2 (50%)",
+        capability="deep_question",
+    )
+    _set_session_timestamp(store, "assessment-latest", 1_710_000_000)
+
+    await _seed_session(
+        store,
+        session_id="assessment-older",
+        capability="deep_question",
+        message="Generate a quiz on algebra",
+        knowledge_bases=["algebra-pack"],
+    )
+    await store.add_message(
+        "assessment-older",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve algebra equation x + 2 = 5 -> Answered: 3 (Correct)\n"
+        "2. [q2] Q: Solve algebra equation 2x = 10 -> Answered: 5 (Correct)\n"
+        "Score: 2/2 (100%)",
+        capability="deep_question",
+    )
+    _set_session_timestamp(store, "assessment-older", 1_709_913_600)
+
+    await _seed_session(
+        store,
+        session_id="tutor-recent",
+        capability="chat",
+        message="Tutor the student on fraction mistakes",
+        knowledge_bases=["fractions-pack"],
+    )
+    _set_session_timestamp(store, "tutor-recent", 1_709_827_200)
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/overview")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["analytics"]["engagement"] == {
+        "active_days": 3,
+        "streak_days": 3,
+        "knowledge_packs_used": 2,
+    }
+    assert payload["analytics"]["assessment_trend"] == {
+        "assessments_completed": 2,
+        "average_score_percent": 75,
+        "latest_score_percent": 50,
+        "score_delta": -50,
+    }
+    assert payload["analytics"]["learning_signals"]["focus_topics"][0]["topic"] == "fractions subtraction"
+    assert payload["analytics"]["learning_signals"]["mastered_topics"][0]["topic"] == "algebra equation"
+
+
+@pytest.mark.asyncio
 async def test_dashboard_recent_tutoring_activity_includes_replay_ref(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -28,6 +28,12 @@ function activityLabel(activity: DashboardActivity): string {
   return activity.type.replaceAll("_", " ");
 }
 
+function scoreDeltaTone(value: number): string {
+  if (value > 0) return "text-emerald-600";
+  if (value < 0) return "text-rose-600";
+  return "text-[var(--muted-foreground)]";
+}
+
 export default function DashboardPage() {
   const { t } = useTranslation();
   const [overview, setOverview] = useState<DashboardOverview | null>(null);
@@ -70,6 +76,7 @@ export default function DashboardPage() {
   }, [filters]);
 
   const totals = overview?.totals;
+  const analytics = overview?.analytics;
   const cards = useMemo(
     () => [
       {
@@ -226,6 +233,127 @@ export default function DashboardPage() {
               </div>
             </div>
           ))}
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-3">
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-[16px] font-semibold text-[var(--foreground)]">
+                {t("Engagement")}
+              </h2>
+              <Activity size={16} className="text-[var(--muted-foreground)]" />
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+              <div className="rounded-lg bg-[var(--background)] px-3 py-3">
+                <div className="text-[12px] text-[var(--muted-foreground)]">{t("Active days")}</div>
+                <div className="mt-2 text-[24px] font-semibold text-[var(--foreground)]">
+                  {loading ? "-" : analytics?.engagement.active_days ?? 0}
+                </div>
+              </div>
+              <div className="rounded-lg bg-[var(--background)] px-3 py-3">
+                <div className="text-[12px] text-[var(--muted-foreground)]">{t("Streak")}</div>
+                <div className="mt-2 text-[24px] font-semibold text-[var(--foreground)]">
+                  {loading ? "-" : analytics?.engagement.streak_days ?? 0}
+                </div>
+              </div>
+              <div className="rounded-lg bg-[var(--background)] px-3 py-3">
+                <div className="text-[12px] text-[var(--muted-foreground)]">{t("Knowledge Packs used")}</div>
+                <div className="mt-2 text-[24px] font-semibold text-[var(--foreground)]">
+                  {loading ? "-" : analytics?.engagement.knowledge_packs_used ?? 0}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-[16px] font-semibold text-[var(--foreground)]">
+                {t("Assessment trend")}
+              </h2>
+              <PenLine size={16} className="text-[var(--muted-foreground)]" />
+            </div>
+            <div className="mt-4 space-y-3">
+              <div className="rounded-lg bg-[var(--background)] px-3 py-3">
+                <div className="text-[12px] text-[var(--muted-foreground)]">{t("Average score")}</div>
+                <div className="mt-2 text-[24px] font-semibold text-[var(--foreground)]">
+                  {loading ? "-" : `${analytics?.assessment_trend.average_score_percent ?? 0}%`}
+                </div>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-lg bg-[var(--background)] px-3 py-3">
+                  <div className="text-[12px] text-[var(--muted-foreground)]">{t("Latest score")}</div>
+                  <div className="mt-2 text-[18px] font-semibold text-[var(--foreground)]">
+                    {loading ? "-" : `${analytics?.assessment_trend.latest_score_percent ?? 0}%`}
+                  </div>
+                </div>
+                <div className="rounded-lg bg-[var(--background)] px-3 py-3">
+                  <div className="text-[12px] text-[var(--muted-foreground)]">{t("Score delta")}</div>
+                  <div
+                    className={`mt-2 text-[18px] font-semibold ${scoreDeltaTone(
+                      analytics?.assessment_trend.score_delta ?? 0,
+                    )}`}
+                  >
+                    {loading
+                      ? "-"
+                      : `${(analytics?.assessment_trend.score_delta ?? 0) > 0 ? "+" : ""}${analytics?.assessment_trend.score_delta ?? 0}`}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-[16px] font-semibold text-[var(--foreground)]">
+                {t("Learning signals")}
+              </h2>
+              <BookOpen size={16} className="text-[var(--muted-foreground)]" />
+            </div>
+            <div className="mt-4 grid gap-4">
+              <div>
+                <div className="text-[12px] font-medium text-[var(--muted-foreground)]">
+                  {t("Needs attention")}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {(analytics?.learning_signals.focus_topics ?? []).length > 0 ? (
+                    analytics?.learning_signals.focus_topics.map((topic) => (
+                      <span
+                        key={`focus-${topic.topic}`}
+                        className="rounded-full bg-rose-50 px-3 py-1 text-[12px] text-rose-700"
+                      >
+                        {topic.topic}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-[13px] text-[var(--muted-foreground)]">
+                      {loading ? t("Loading") : t("No weak topics yet")}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div>
+                <div className="text-[12px] font-medium text-[var(--muted-foreground)]">
+                  {t("Strong areas")}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {(analytics?.learning_signals.mastered_topics ?? []).length > 0 ? (
+                    analytics?.learning_signals.mastered_topics.map((topic) => (
+                      <span
+                        key={`mastered-${topic.topic}`}
+                        className="rounded-full bg-emerald-50 px-3 py-1 text-[12px] text-emerald-700"
+                      >
+                        {topic.topic}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-[13px] text-[var(--muted-foreground)]">
+                      {loading ? t("Loading") : t("No strong topics yet")}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section className="grid gap-5 lg:grid-cols-[1fr_320px]">

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -98,6 +98,23 @@ export interface DashboardOverview {
     name: string;
     session_count: number;
   }>;
+  analytics: {
+    engagement: {
+      active_days: number;
+      streak_days: number;
+      knowledge_packs_used: number;
+    };
+    assessment_trend: {
+      assessments_completed: number;
+      average_score_percent: number;
+      latest_score_percent: number;
+      score_delta: number;
+    };
+    learning_signals: {
+      focus_topics: StudentProgressTopic[];
+      mastered_topics: StudentProgressTopic[];
+    };
+  };
   recent_activity: DashboardActivity[];
 }
 


### PR DESCRIPTION
## Summary
- extend `GET /api/v1/dashboard/overview` with teacher-facing analytics for engagement, assessment trend, and learning signals
- render the new analytics sections on `/dashboard` without breaking existing filters, recent activity, or student progress links
- add dashboard router regression coverage and update the system map for the new dashboard analytics layer

Closes #77

## Testing
- python3 -m pytest tests/api/test_dashboard_router.py -q
- python3 -m py_compile deeptutor/api/routers/dashboard.py
- cd web && npm run build

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-24-t027-analytics-dashboard.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated: yes
