### PR TITLE
[MVP] T029 Marketplace Full-Text Search

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, assessment adaptive difficulty, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, mobile-first marketplace responsiveness is now merged into `main` through PR `#76`, and the active short task is `T027 Teacher Analytics Dashboard`.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, teacher analytics is now merged into `main` through PR `#78`, and the active short task is `T029 Marketplace Full-Text Search`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T027`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current next task is `T029`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#76 [MVP] T026 Mobile-First Marketplace Responsive Design`
-- `#76` improved marketplace responsiveness for mobile/tablet browsing without changing the underlying API or cache behavior, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, assessment insights, adaptive difficulty selection, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, teacher dashboard filtering, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#78 [MVP] T027 Teacher Analytics Dashboard`
+- `#78` extended the teacher dashboard with engagement, assessment trend, and learning signal analytics, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, assessment insights, adaptive difficulty selection, teacher analytics, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#77 [MVP] Teacher Analytics Dashboard`
-- Active branch: `pod-a/t027-analytics-dashboard`
-- Active task packet: `docs/superpowers/tasks/2026-04-23-T027-analytics-dashboard.md`
-- Focus set: `T027` (Teacher analytics dashboard)
+- Active issue: `#79 [MVP] Marketplace Full-Text Search`
+- Active branch: `pod-a/t029-marketplace-search`
+- Active task packet: `docs/superpowers/tasks/2026-04-24-T029-marketplace-search.md`
+- Focus set: `T029` (Marketplace search)
 
 ## Next recommended task
 
-Implement `T027` on `pod-a/t027-analytics-dashboard`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T029` on `pod-a/t029-marketplace-search`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-21)
 
 **Queue Advance**:
-1. `#76` merged to `main` after all required CI checks passed
-2. Issue `#75` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T027 Teacher Analytics Dashboard`
-4. Issue `#77` created and task packet added for the new execution lane
+1. `#78` merged to `main` after all required CI checks passed
+2. Issue `#77` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T029 Marketplace Full-Text Search`
+4. Issue `#79` created and task packet added for the new execution lane
 
 ## AI-owned blockers
 
@@ -68,7 +68,8 @@ Implement `T027` on `pod-a/t027-analytics-dashboard`, then open a Draft PR with 
 | T024: Team Sharing | Completed | 6 | NO | Done |
 | T025: Adaptive Difficulty | Completed | 5 | NO | Done |
 | T026: Marketplace Mobile | Completed | 1 | NO | Done |
-| T027: Analytics Dashboard | In Progress | 8 | NO | Now |
+| T027: Analytics Dashboard | Completed | 8 | NO | Done |
+| T029: Marketplace Search | In Progress | 3 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -380,8 +380,8 @@
       "complexity": "High",
       "estimated_hours": 8,
       "dependencies": ["Analytics Service"],
-      "status": "in-progress",
-      "notes": "Issue #77 opened and task packet created at docs/superpowers/tasks/2026-04-23-T027-analytics-dashboard.md. Active branch: pod-a/t027-analytics-dashboard."
+      "status": "completed",
+      "notes": "Merged to main through PR #78. Dashboard overview now includes teacher-facing engagement, assessment trend, and learning signal analytics."
     },
     {
       "id": "T028_API_RATE_LIMITING",
@@ -414,8 +414,8 @@
       "complexity": "Medium",
       "estimated_hours": 3,
       "dependencies": ["Search Service"],
-      "status": "not-started",
-      "notes": "Search in pack metadata and first 3 questions/objectives, case-insensitive match"
+      "status": "in-progress",
+      "notes": "Issue #79 opened and task packet created at docs/superpowers/tasks/2026-04-24-T029-marketplace-search.md. Active branch: pod-a/t029-marketplace-search."
     },
     {
       "id": "T030_ASSESSMENT_TIME_TRACKING",

--- a/ai_first/daily/2026-04-23.md
+++ b/ai_first/daily/2026-04-23.md
@@ -235,3 +235,66 @@
 
 - Task `T027_ANALYTICS_DASHBOARD`: implementation complete on branch `pod-a/t027-analytics-dashboard`
 - Next: remove generated build artifacts outside scope, then commit, push, open Draft PR linked to issue `#77`, and monitor CI per AI-first policy
+
+## T027 Teacher Analytics Dashboard — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#78` passed required CI and merged to `main`.
+2. Issue `#77` closed with the merge.
+3. `T027` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T027_ANALYTICS_DASHBOARD`: moved to `completed`
+
+## T029 Marketplace Full-Text Search — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T027` merged.
+2. Opened GitHub issue `#79` for `T029 Marketplace Full-Text Search`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-24-T029-marketplace-search.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T029_MARKETPLACE_SEARCH_FULLTEXT`: moved to `in-progress`
+- Next: inspect the current marketplace router search behavior and define the smallest useful metadata-driven search expansion on `pod-a/t029-marketplace-search`
+
+## T029 Marketplace Full-Text Search — Implementation Progress
+
+### Completed in this cycle
+
+1. Extended `deeptutor/api/routers/marketplace.py` so `/api/v1/marketplace/list` now accepts `search` and matches across:
+   - name
+   - subject
+   - grade
+   - curriculum
+   - owner
+   - description
+   - learning objectives
+2. Updated `web/lib/marketplace-api.ts` so the marketplace list cache key and request builder include the `search` term
+3. Updated `web/app/(utility)/marketplace/page.tsx` so the current search box uses the backend list query instead of a duplicate client-only filter
+4. Added regression coverage in:
+   - `tests/api/test_marketplace_router.py`
+5. Added the required PR architecture note:
+   - `docs/superpowers/pr-notes/2026-04-24-t029-marketplace-search.md`
+
+### Validation
+
+- Marketplace router tests passed:
+  - `python3 -m pytest tests/api/test_marketplace_router.py -q`
+- Marketplace router module compiles:
+  - `python3 -m py_compile deeptutor/api/routers/marketplace.py`
+- Frontend production build passed:
+  - `cd web && npm run build`
+
+### Status
+
+- Task `T029_MARKETPLACE_SEARCH_FULLTEXT`: implementation complete on branch `pod-a/t029-marketplace-search`
+- Next: remove generated build artifacts outside scope, then commit, push, open Draft PR linked to issue `#79`, and monitor CI per AI-first policy

--- a/deeptutor/api/routers/marketplace.py
+++ b/deeptutor/api/routers/marketplace.py
@@ -63,6 +63,7 @@ def _list_marketplace_candidates() -> list[dict]:
                     "curriculum": metadata.get("curriculum"),
                     "learning_objectives": metadata.get("learning_objectives", []),
                     "owner": metadata.get("owner"),
+                    "description": source_cfg.get("description"),
                     "sharing_status": sharing_status,
                     "session_count": info.get("statistics", {}).get("content_lists", 0),
                     "status": info.get("status", "ready"),
@@ -76,6 +77,24 @@ def _list_marketplace_candidates() -> list[dict]:
             continue
 
     return items
+
+
+def _matches_marketplace_search(pack: dict[str, Any], search: str | None) -> bool:
+    needle = str(search or "").strip().lower()
+    if not needle:
+        return True
+
+    haystack_parts = [
+        str(pack.get("name") or ""),
+        str(pack.get("subject") or ""),
+        str(pack.get("grade") or ""),
+        str(pack.get("curriculum") or ""),
+        str(pack.get("owner") or ""),
+        str(pack.get("description") or ""),
+        " ".join(str(item or "") for item in pack.get("learning_objectives") or []),
+    ]
+    haystack = " ".join(part for part in haystack_parts if part).lower()
+    return needle in haystack
 
 
 def _sort_marketplace_candidates(items: list[dict], sort_by: str | None) -> list[dict]:
@@ -146,6 +165,7 @@ async def list_marketplace_packs(
     sharing_status: str | None = Query(None, description="Filter by sharing_status: public, team, or None for all"),
     subject: str | None = Query(None, description="Filter by subject"),
     owner: str | None = Query(None, description="Filter by owner"),
+    search: str | None = Query(None, description="Case-insensitive metadata search"),
     sort_by: str | None = Query(
         None,
         description="Sort packs by popularity, recent, rating, or most_objectives",
@@ -179,6 +199,9 @@ async def list_marketplace_packs(
                 for kb in all_kbs
                 if (kb.get("owner") or "").lower() == needle
             ]
+
+        if search:
+            all_kbs = [kb for kb in all_kbs if _matches_marketplace_search(kb, search)]
 
         all_kbs = _sort_marketplace_candidates(all_kbs, sort_by)
 

--- a/docs/superpowers/pr-notes/2026-04-24-t029-marketplace-search.md
+++ b/docs/superpowers/pr-notes/2026-04-24-t029-marketplace-search.md
@@ -1,0 +1,35 @@
+# PR Note: T029 Marketplace Full-Text Search
+
+## Summary
+
+This slice upgrades marketplace search from a narrow client-only filter to an API-backed metadata search. The existing list route now accepts a `search` query, matches against compact pack metadata and learning objectives, and the marketplace page passes the current search term through the cached list API so pagination and result counts stay coherent.
+
+## Architecture
+
+```mermaid
+flowchart TD
+  SearchInput["Marketplace search input"] --> Page["/marketplace page"]
+  Page --> APIClient["listMarketplacePacks(search, ...)"]
+  APIClient --> ListRoute["GET /api/v1/marketplace/list"]
+  ListRoute --> SearchMatch["metadata/objectives match"]
+  SearchMatch --> FilteredPacks["filtered marketplace packs"]
+  FilteredPacks --> Page
+  FilteredPacks --> LoadMore["load-more pagination"]
+```
+
+## Files
+
+- `deeptutor/api/routers/marketplace.py`
+- `web/lib/marketplace-api.ts`
+- `web/app/(utility)/marketplace/page.tsx`
+- `tests/api/test_marketplace_router.py`
+
+## Verification
+
+- `python3 -m pytest tests/api/test_marketplace_router.py -q`
+- `python3 -m py_compile deeptutor/api/routers/marketplace.py`
+- `cd web && npm run build`
+
+## MAIN_SYSTEM_MAP
+
+Updated: `no`

--- a/docs/superpowers/tasks/2026-04-24-T029-marketplace-search.md
+++ b/docs/superpowers/tasks/2026-04-24-T029-marketplace-search.md
@@ -1,0 +1,67 @@
+# Feature Pod Task: Marketplace Full-Text Search
+
+Owner: Codex
+Branch: `pod-a/t029-marketplace-search`
+GitHub Issue: `#79`
+
+## Goal
+
+Improve marketplace search so teachers can discover packs through broader metadata and lightweight content signals, not only narrow name matches.
+
+## User-visible outcome
+
+- Marketplace search matches pack name, owner, subject, curriculum, learning objectives, and other compact metadata signals.
+- Search remains compatible with the existing marketplace filters, sorting, cache, and pagination flow.
+- The first slice stays lightweight and does not require a dedicated full-text index.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/marketplace.py`
+- `web/lib/marketplace-api.ts`
+- `web/app/(utility)/marketplace/page.tsx`
+- `tests/api/test_marketplace_router.py`
+- `docs/superpowers/tasks/2026-04-24-T029-marketplace-search.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-24.md` if created, otherwise `ai_first/daily/2026-04-23.md`
+
+## Do-not-touch files/modules
+
+- Dashboard, tutor, knowledge, and settings features
+- Unrelated API routers
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Preserve the current marketplace list API shape.
+- Extend search behavior inside the existing query/filter path instead of creating a new route family.
+- Keep search case-insensitive and deterministic.
+
+## Acceptance criteria
+
+- Marketplace search can match across more than just pack name fragments.
+- Search works against compact metadata such as objectives and curriculum.
+- Existing list sorting/filtering behavior stays intact.
+
+## Required tests
+
+- Marketplace router regression coverage for the expanded search matching
+
+## Manual verification
+
+- Search for terms found only in metadata/objectives and confirm matching packs appear
+- Confirm filters and sort still behave correctly with search applied
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T027` merged to `main` through PR `#78`.
+- Keep the first slice metadata-driven before considering a real full-text index.

--- a/tests/api/test_marketplace_router.py
+++ b/tests/api/test_marketplace_router.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from deeptutor.api.routers import marketplace
 
 
 class _FakeKBManager:
@@ -70,7 +69,11 @@ class _FakeKBManager:
         return
 
 
-def _build_app(monkeypatch, tmp_path: Path) -> TestClient:
+def _build_app(monkeypatch, tmp_path: Path) -> tuple[TestClient, object]:
+    settings_dir = Path.cwd() / "data" / "user" / "settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "main.yaml").write_text("knowledge_base: {}\n", encoding="utf-8")
+
     (tmp_path / "shared-pack").mkdir(parents=True)
     (tmp_path / "shared-pack" / "raw").mkdir(parents=True)
     (tmp_path / "shared-pack" / "rag_storage").mkdir(parents=True)
@@ -80,15 +83,16 @@ def _build_app(monkeypatch, tmp_path: Path) -> TestClient:
     (tmp_path / "shared-pack" / "raw" / "lesson-4.md").write_text("Lesson 4", encoding="utf-8")
 
     manager = _FakeKBManager(tmp_path)
-    monkeypatch.setattr("deeptutor.api.routers.marketplace.get_kb_manager", lambda: manager)
+    marketplace = importlib.import_module("deeptutor.api.routers.marketplace")
+    monkeypatch.setattr(marketplace, "get_kb_manager", lambda: manager)
 
     app = FastAPI()
     app.include_router(marketplace.router, prefix="/api/v1/marketplace")
-    return TestClient(app)
+    return TestClient(app), marketplace
 
 
 def test_marketplace_list_only_returns_shareable_packs(monkeypatch, tmp_path: Path) -> None:
-    client = _build_app(monkeypatch, tmp_path)
+    client, _ = _build_app(monkeypatch, tmp_path)
 
     response = client.get("/api/v1/marketplace/list")
 
@@ -100,7 +104,7 @@ def test_marketplace_list_only_returns_shareable_packs(monkeypatch, tmp_path: Pa
 
 
 def test_marketplace_import_copies_pack_and_registers_new_entry(monkeypatch, tmp_path: Path) -> None:
-    client = _build_app(monkeypatch, tmp_path)
+    client, _ = _build_app(monkeypatch, tmp_path)
 
     response = client.post("/api/v1/marketplace/import/shared-pack")
 
@@ -116,7 +120,7 @@ def test_marketplace_import_copies_pack_and_registers_new_entry(monkeypatch, tmp
 
 
 def test_marketplace_preview_returns_compact_pack_summary(monkeypatch, tmp_path: Path) -> None:
-    client = _build_app(monkeypatch, tmp_path)
+    client, _ = _build_app(monkeypatch, tmp_path)
 
     response = client.get("/api/v1/marketplace/shared-pack/preview")
 
@@ -132,7 +136,7 @@ def test_marketplace_preview_returns_compact_pack_summary(monkeypatch, tmp_path:
 
 
 def test_marketplace_list_includes_rating_summary(monkeypatch, tmp_path: Path) -> None:
-    client = _build_app(monkeypatch, tmp_path)
+    client, _ = _build_app(monkeypatch, tmp_path)
 
     response = client.get("/api/v1/marketplace/list")
 
@@ -142,7 +146,7 @@ def test_marketplace_list_includes_rating_summary(monkeypatch, tmp_path: Path) -
 
 
 def test_marketplace_review_submission_updates_pack_summary(monkeypatch, tmp_path: Path) -> None:
-    client = _build_app(monkeypatch, tmp_path)
+    client, _ = _build_app(monkeypatch, tmp_path)
 
     response = client.post(
         "/api/v1/marketplace/shared-pack/reviews",
@@ -163,7 +167,7 @@ def test_marketplace_review_submission_updates_pack_summary(monkeypatch, tmp_pat
 
 
 def test_marketplace_list_supports_sorting_modes(monkeypatch, tmp_path: Path) -> None:
-    client = _build_app(monkeypatch, tmp_path)
+    client, marketplace = _build_app(monkeypatch, tmp_path)
 
     second_pack = tmp_path / "second-pack"
     (second_pack / "raw").mkdir(parents=True)
@@ -209,3 +213,35 @@ def test_marketplace_list_supports_sorting_modes(monkeypatch, tmp_path: Path) ->
 
     recent = client.get("/api/v1/marketplace/list?sort_by=recent").json()["packs"]
     assert [pack["name"] for pack in recent] == ["second-pack", "shared-pack"]
+
+
+def test_marketplace_list_search_matches_metadata_and_objectives(monkeypatch, tmp_path: Path) -> None:
+    client, marketplace = _build_app(monkeypatch, tmp_path)
+
+    second_pack = tmp_path / "science-pack"
+    (second_pack / "raw").mkdir(parents=True)
+    (second_pack / "rag_storage").mkdir(parents=True)
+    (second_pack / "raw" / "cells.md").write_text("Cells lesson", encoding="utf-8")
+
+    manager = marketplace.get_kb_manager()
+    manager.config["knowledge_bases"]["science-pack"] = {
+        "path": "science-pack",
+        "description": "Microscopy starter pack",
+        "sharing_status": "public",
+        "subject": "Science",
+        "grade": "7",
+        "curriculum": "STEM Explorers",
+        "learning_objectives": ["Cell structure", "Microscope safety"],
+        "owner": "Teacher Z",
+        "created_at": "2026-04-21T00:00:00",
+        "updated_at": "2026-04-21T00:00:00",
+    }
+
+    by_objective = client.get("/api/v1/marketplace/list?search=microscope").json()
+    assert [pack["name"] for pack in by_objective["packs"]] == ["science-pack"]
+
+    by_curriculum = client.get("/api/v1/marketplace/list?search=stem").json()
+    assert [pack["name"] for pack in by_curriculum["packs"]] == ["science-pack"]
+
+    by_owner = client.get("/api/v1/marketplace/list?search=teacher%20a").json()
+    assert [pack["name"] for pack in by_owner["packs"]] == ["shared-pack"]

--- a/web/app/(utility)/marketplace/page.tsx
+++ b/web/app/(utility)/marketplace/page.tsx
@@ -58,22 +58,25 @@ export default function MarketplacePage() {
 
   const subjectFilter = filterSubject.trim() || undefined;
   const ownerFilter = filterOwner.trim() || undefined;
+  const searchFilter = searchTerm.trim() || undefined;
 
   const queryState = useMemo(
     () => ({
+      searchFilter,
       sharingStatus,
       subjectFilter,
       ownerFilter,
       sortBy,
       limit,
     }),
-    [limit, ownerFilter, sharingStatus, sortBy, subjectFilter],
+    [limit, ownerFilter, searchFilter, sharingStatus, sortBy, subjectFilter],
   );
 
   useEffect(() => {
     let cancelled = false;
 
     const cachedFirstPage = getCachedMarketplacePacks(
+      queryState.searchFilter,
       queryState.sharingStatus,
       queryState.subjectFilter,
       queryState.ownerFilter,
@@ -82,6 +85,7 @@ export default function MarketplacePage() {
       0,
     );
     const needsRefresh = isMarketplacePacksCacheStale(
+      queryState.searchFilter,
       queryState.sharingStatus,
       queryState.subjectFilter,
       queryState.ownerFilter,
@@ -106,6 +110,7 @@ export default function MarketplacePage() {
 
     if (!cachedFirstPage || needsRefresh) {
       listMarketplacePacks(
+        queryState.searchFilter,
         queryState.sharingStatus,
         queryState.subjectFilter,
         queryState.ownerFilter,
@@ -145,6 +150,7 @@ export default function MarketplacePage() {
     setError(null);
     try {
       const response = await listMarketplacePacks(
+        queryState.searchFilter,
         queryState.sharingStatus,
         queryState.subjectFilter,
         queryState.ownerFilter,
@@ -169,6 +175,7 @@ export default function MarketplacePage() {
     setError(null);
     try {
       const response = await listMarketplacePacks(
+        queryState.searchFilter,
         queryState.sharingStatus,
         queryState.subjectFilter,
         queryState.ownerFilter,
@@ -247,16 +254,6 @@ export default function MarketplacePage() {
       setSubmittingReview(false);
     }
   };
-
-  const filteredPacks = packs.filter((pack) => {
-    if (!searchTerm) return true;
-    const term = searchTerm.toLowerCase();
-    return (
-      pack.name.toLowerCase().includes(term) ||
-      pack.subject?.toLowerCase().includes(term) ||
-      pack.owner?.toLowerCase().includes(term)
-    );
-  });
 
   return (
     <main className="h-full overflow-y-auto bg-[var(--background)]">
@@ -369,7 +366,7 @@ export default function MarketplacePage() {
         <div>
           <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <span className="text-[13px] text-[var(--muted-foreground)]">
-              {t("Showing")} {filteredPacks.length} {t("of")} {total} {t("packs")}
+              {t("Showing")} {packs.length} {t("of")} {total} {t("packs")}
             </span>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
               {refreshing && !loading && (
@@ -396,7 +393,7 @@ export default function MarketplacePage() {
             <div className="flex justify-center py-12">
               <Loader2 size={24} className="animate-spin text-[var(--muted-foreground)]" />
             </div>
-          ) : filteredPacks.length === 0 ? (
+          ) : packs.length === 0 ? (
             <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-4 py-12 text-center">
               <BookOpen size={32} className="mx-auto mb-3 text-[var(--muted-foreground)]" />
               <p className="text-[14px] font-medium text-[var(--foreground)]">
@@ -408,7 +405,7 @@ export default function MarketplacePage() {
             </div>
           ) : (
             <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              {filteredPacks.map((pack) => (
+              {packs.map((pack) => (
                 <div
                   key={pack.name}
                   className="flex flex-col rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 transition-colors hover:border-[var(--foreground)]/30"

--- a/web/lib/marketplace-api.ts
+++ b/web/lib/marketplace-api.ts
@@ -68,6 +68,7 @@ const MARKETPLACE_LIST_CACHE_TTL_MS = 5 * 60 * 1000;
 const marketplaceListCache = new Map<string, MarketplaceListCacheEntry>();
 
 function buildMarketplaceListCacheKey(
+  search?: string,
   sharingStatus?: string,
   subject?: string,
   owner?: string,
@@ -76,6 +77,7 @@ function buildMarketplaceListCacheKey(
   offset = 0,
 ): string {
   return JSON.stringify({
+    search: search || "",
     sharingStatus: sharingStatus || "",
     subject: subject || "",
     owner: owner || "",
@@ -90,6 +92,7 @@ function isMarketplaceListCacheFresh(entry?: MarketplaceListCacheEntry): boolean
 }
 
 export function getCachedMarketplacePacks(
+  search?: string,
   sharingStatus?: string,
   subject?: string,
   owner?: string,
@@ -98,6 +101,7 @@ export function getCachedMarketplacePacks(
   offset = 0,
 ): MarketplaceListResponse | null {
   const cacheKey = buildMarketplaceListCacheKey(
+    search,
     sharingStatus,
     subject,
     owner,
@@ -109,6 +113,7 @@ export function getCachedMarketplacePacks(
 }
 
 export function isMarketplacePacksCacheStale(
+  search?: string,
   sharingStatus?: string,
   subject?: string,
   owner?: string,
@@ -117,6 +122,7 @@ export function isMarketplacePacksCacheStale(
   offset = 0,
 ): boolean {
   const cacheKey = buildMarketplaceListCacheKey(
+    search,
     sharingStatus,
     subject,
     owner,
@@ -132,6 +138,7 @@ export function invalidateMarketplaceListCache(): void {
 }
 
 export async function listMarketplacePacks(
+  search?: string,
   sharingStatus?: string,
   subject?: string,
   owner?: string,
@@ -141,6 +148,7 @@ export async function listMarketplacePacks(
   options: MarketplaceListFetchOptions = {},
 ): Promise<MarketplaceListResponse> {
   const cacheKey = buildMarketplaceListCacheKey(
+    search,
     sharingStatus,
     subject,
     owner,
@@ -165,6 +173,7 @@ export async function listMarketplacePacks(
   });
 
   if (sharingStatus) params.append("sharing_status", sharingStatus);
+  if (search) params.append("search", search);
   if (subject) params.append("subject", subject);
   if (owner) params.append("owner", owner);
   if (sortBy) params.append("sort_by", sortBy);


### PR DESCRIPTION
## Summary
- extend `/api/v1/marketplace/list` with case-insensitive metadata search across owner, curriculum, description, and learning objectives
- pass the marketplace search box through the cached list API so results, pagination, and counts stay coherent
- add router regression coverage for the expanded search behavior

Closes #79

## Testing
- python3 -m pytest tests/api/test_marketplace_router.py -q
- python3 -m py_compile deeptutor/api/routers/marketplace.py
- cd web && npm run build

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-24-t029-marketplace-search.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated: no
