### PR TITLE
[MVP] T031 Smart Tutor Follow-Up Questions

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, marketplace full-text search is now merged into `main` through PR `#80`, `T030 Assessment Time Tracking & Analytics` is implemented on branch `pod-a/t030-assessment-time`, and issue `#81` now mirrors the active lane.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, `T030 Assessment Time Tracking & Analytics` merged into `main` through PR `#82`, and the active short task is now `T031 Smart Tutor Follow-Up Questions` on branch `pod-a/t031-tutor-follow-ups` with issue `#83`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T030` on `pod-a/t030-assessment-time` and the next strict-order task after merge will be `T031`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T031` on `pod-a/t031-tutor-follow-ups` and the next strict-order task after merge will be `T032`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,30 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#80 [MVP] T029 Marketplace Full-Text Search`
-- `#80` upgraded marketplace search to match broader metadata and objective text through the list API, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment insights, adaptive difficulty selection, teacher analytics, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#82 [MVP] T030 Assessment Time Tracking & Analytics`
+- `#82` added lightweight per-question duration recording and assessment review timing metrics, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#81 [MVP] T030 Assessment Time Tracking & Analytics`
-- Active branch: `pod-a/t030-assessment-time`
-- Active task packet: `docs/superpowers/tasks/2026-04-24-T030-assessment-time.md`
-- Focus set: `T030` (Assessment time tracking)
+- Active issue: `#83 [MVP] T031 Smart Tutor Follow-Up Questions`
+- Active branch: `pod-a/t031-tutor-follow-ups`
+- Active task packet: `docs/superpowers/tasks/2026-04-24-T031-tutor-follow-up-prompts.md`
+- Focus set: `T031` (Tutor follow-up prompts)
 
 ## Next recommended task
 
-Publish the completed `T030` implementation from `pod-a/t030-assessment-time` as a Draft PR, then monitor CI and merge before opening `T031`.
+Implement `T031` on `pod-a/t031-tutor-follow-ups`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-24)
 
 **Queue Advance**:
-1. `#80` merged to `main` after all required CI checks passed
-2. Issue `#79` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T030 Assessment Time Tracking & Analytics`
-4. Task packet and execution lane created immediately
-5. Issue `#81` now mirrors the active `T030` lane after the earlier transient GitHub CLI `503` issue cleared
-6. `T030` implementation and validation are complete locally; the lane is ready for commit/push/Draft PR
+1. `#82` merged to `main` after all required CI checks passed
+2. Issue `#81` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T031 Smart Tutor Follow-Up Questions`
+4. Issue `#83`, branch `pod-a/t031-tutor-follow-ups`, and task packet were created immediately after the merge sync
 
 ## AI-owned blockers
 
@@ -72,7 +70,8 @@ Publish the completed `T030` implementation from `pod-a/t030-assessment-time` as
 | T026: Marketplace Mobile | Completed | 1 | NO | Done |
 | T027: Analytics Dashboard | Completed | 8 | NO | Done |
 | T029: Marketplace Search | Completed | 3 | NO | Done |
-| T030: Assessment Time | In Progress | 2 | NO | Now |
+| T030: Assessment Time | Completed | 2 | NO | Done |
+| T031: Tutor Follow-Up Questions | In Progress | 3 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-24T08:40:00Z",
+    "last_updated": "2026-04-24T15:46:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 35
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 21,
+      "count": 22,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -30,14 +30,15 @@
         "T026_MOBILE_RESPONSIVE_MARKETPLACE",
         "T027_ANALYTICS_DASHBOARD",
         "T028_API_RATE_LIMITING",
-        "T029_MARKETPLACE_SEARCH_FULLTEXT"
+        "T029_MARKETPLACE_SEARCH_FULLTEXT",
+        "T030_ASSESSMENT_TIME_TRACKING"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
       "count": 1,
       "tasks": [
-        "T030_ASSESSMENT_TIME_TRACKING"
+        "T031_TUTOR_FOLLOW_UP_PROMPTS"
       ]
     },
     "blocked": {
@@ -47,9 +48,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 5,
+      "count": 4,
       "tasks": [
-        "T031_TUTOR_FOLLOW_UP_PROMPTS",
         "T032_KNOWLEDGE_PACK_VERSIONING",
         "T033_LEARNING_PATH_SEQUENCING",
         "T034_BATCH_ASSESSMENT_IMPORT",
@@ -431,8 +431,8 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["Assessment Schema"],
-      "status": "in-progress",
-      "notes": "Issue #81 now mirrors the active lane. The branch records optional per-question duration_seconds in quiz results, parses timing from the existing [Quiz Performance] transcript, and surfaces total/average/per-question timing in assessment review without a new storage table."
+      "status": "completed",
+      "notes": "Merged to main through PR #82. Assessment review now records optional per-question duration_seconds inside the existing [Quiz Performance] transcript and surfaces total/average/per-question timing without a new storage table."
     },
     {
       "id": "T031_TUTOR_FOLLOW_UP_PROMPTS",
@@ -448,8 +448,8 @@
       "complexity": "Medium",
       "estimated_hours": 3,
       "dependencies": ["LLM Service", "Tutor Agent"],
-      "status": "not-started",
-      "notes": "Generate 1-3 follow-up questions when student answer indicates misunderstanding"
+      "status": "in-progress",
+      "notes": "Issue #83 mirrors the active lane. Task packet created at docs/superpowers/tasks/2026-04-24-T031-tutor-follow-up-prompts.md. Active branch: pod-a/t031-tutor-follow-ups."
     },
     {
       "id": "T032_KNOWLEDGE_PACK_VERSIONING",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -61,7 +61,9 @@ flowchart TD
   Product --> StudentTutor["Student Tutor Workspace"]
   StudentTutor --> TutorKBContext["Knowledge Pack Tutoring Context"]
   StudentTutor --> TutorKBBadges["KB Context Badges in Chat Messages"]
+  StudentTutor --> TutorFollowups["Optional follow-up questions in tutor replies"]
   TutorKBBadges --> SnapshotKBs["Message requestSnapshot.knowledgeBases"]
+  TutorFollowups --> ChatResponse["Agentic chat final response section: Follow-up questions"]
   
   Product --> TeacherDashboard["Teacher Dashboard"]
   TeacherDashboard --> DashboardSummary["Session Activity Summary"]

--- a/ai_first/daily/2026-04-24.md
+++ b/ai_first/daily/2026-04-24.md
@@ -42,3 +42,65 @@
 
 - Task `T030_ASSESSMENT_TIME_TRACKING`: implementation complete on branch `pod-a/t030-assessment-time`
 - Next: commit, push, open Draft PR linked to issue `#81`, then monitor CI and merge per AI-first policy
+
+## T030 Assessment Time Tracking & Analytics — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#82` passed required CI and merged to `main`.
+2. Issue `#81` closed with the merge.
+3. `T030` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T030_ASSESSMENT_TIME_TRACKING`: moved to `completed`
+
+## T031 Smart Tutor Follow-Up Questions — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T030` merged.
+2. Opened GitHub issue `#83` for `T031`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-24-T031-tutor-follow-up-prompts.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T031_TUTOR_FOLLOW_UP_PROMPTS`: moved to `in-progress`
+- Next: inspect the current tutor response flow and define the smallest useful follow-up-question slice on `pod-a/t031-tutor-follow-ups`
+
+## T031 Smart Tutor Follow-Up Questions — Implementation Progress
+
+### Completed in this cycle
+
+1. Narrowed the active slice to the real tutoring path in:
+   - `deeptutor/agents/chat/agentic_pipeline.py`
+   instead of the non-existent `tutorbot` module from the registry placeholder scope.
+2. Added a lightweight follow-up contract to the final tutor response stage so replies can optionally end with:
+   - `Follow-up questions:`
+   - `1. ...`
+   - `2. ...`
+   - `3. ...`
+3. Parsed that visible response section back into `result.followup_questions` metadata while preserving the existing chat text flow.
+4. Added regression coverage in:
+   - `tests/agents/chat/test_agentic_followup_prompts.py`
+5. Updated the top-level architecture map:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+6. Added the required PR note:
+   - `docs/superpowers/pr-notes/2026-04-24-t031-tutor-follow-up-prompts.md`
+
+### Validation
+
+- Chat pipeline tests passed:
+  - `python3 -m pytest tests/agents/chat/test_agentic_parallel_tools.py tests/agents/chat/test_agentic_followup_prompts.py -q`
+- Chat pipeline module compiles:
+  - `python3 -m py_compile deeptutor/agents/chat/agentic_pipeline.py`
+
+### Status
+
+- Task `T031_TUTOR_FOLLOW_UP_PROMPTS`: implementation complete on branch `pod-a/t031-tutor-follow-ups`
+- Next: commit, push, open Draft PR linked to issue `#83`, then monitor CI and merge per AI-first policy

--- a/deeptutor/agents/chat/agentic_pipeline.py
+++ b/deeptutor/agents/chat/agentic_pipeline.py
@@ -7,6 +7,7 @@ from dataclasses import asdict, dataclass
 import json
 import logging
 import os
+import re
 from typing import Any
 
 import httpx
@@ -42,6 +43,7 @@ CHAT_OPTIONAL_TOOLS = [
 ]
 MAX_PARALLEL_TOOL_CALLS = 8
 MAX_TOOL_RESULT_CHARS = 4000
+FOLLOWUP_LIST_RE = re.compile(r"^\s*(?:[-*]|\d+[.)])\s*(?P<question>.+?)\s*$")
 
 
 @dataclass
@@ -93,11 +95,14 @@ class AgenticChatPipeline:
                 answer_now_context=answer_now_context,
                 stream=stream,
             )
+            final_response, followup_questions = self._extract_followup_questions(final_response)
             result_payload: dict[str, Any] = {
                 "response": final_response,
                 "answer_now": True,
                 "source_trace": trace_meta.get("label", "Answer now"),
             }
+            if followup_questions:
+                result_payload["followup_questions"] = followup_questions
             cs = self._get_cost_summary()
             if cs:
                 result_payload["metadata"] = {"cost_summary": cs}
@@ -127,6 +132,7 @@ class AgenticChatPipeline:
             tool_traces=tool_traces,
             stream=stream,
         )
+        final_response, followup_questions = self._extract_followup_questions(final_response)
 
         all_sources: list[dict[str, Any]] = []
         for trace in tool_traces:
@@ -147,6 +153,8 @@ class AgenticChatPipeline:
             "observation": observation,
             "tool_traces": [asdict(trace) for trace in tool_traces],
         }
+        if followup_questions:
+            result_payload["followup_questions"] = followup_questions
         cs = self._get_cost_summary()
         if cs:
             result_payload["metadata"] = {"cost_summary": cs}
@@ -1269,9 +1277,54 @@ class AgenticChatPipeline:
                 "1. Output only the final user-facing answer.\n"
                 "2. Do not reveal the internal chain, reasoning, or tool orchestration.\n"
                 "3. Naturally integrate evidence or limits surfaced by the tools.\n\n"
+                "4. If the learner still seems confused, partially correct, or unsure, end with a section titled "
+                "'Follow-up questions:' and include 1-3 short numbered questions that help them continue thinking.\n\n"
                 f"Tool context for this turn:\n{tool_list or '- none'}"
             ),
         )
+
+    def _extract_followup_questions(self, response: str) -> tuple[str, list[str]]:
+        text = str(response or "").strip()
+        if not text:
+            return "", []
+
+        headings = {
+            "follow-up questions:",
+            "follow up questions:",
+            "cau hoi tiep theo:",
+            "câu hỏi tiếp theo:",
+            "后续问题:",
+        }
+        lines = text.splitlines()
+        heading_index = -1
+        for index, raw_line in enumerate(lines):
+            normalized = raw_line.strip().lower()
+            if normalized in headings:
+                heading_index = index
+                break
+
+        if heading_index < 0:
+            return text, []
+
+        questions: list[str] = []
+        for raw_line in lines[heading_index + 1 :]:
+            line = raw_line.strip()
+            if not line:
+                if questions:
+                    break
+                continue
+            match = FOLLOWUP_LIST_RE.match(line)
+            if match is None:
+                if questions:
+                    break
+                continue
+            question = match.group("question").strip()
+            if question:
+                questions.append(question)
+            if len(questions) == 3:
+                break
+
+        return text, questions
 
     def _acting_user_prompt(self, context: UnifiedContext, thinking_text: str) -> str:
         return self._text(

--- a/docs/superpowers/pr-notes/2026-04-24-t031-tutor-follow-up-prompts.md
+++ b/docs/superpowers/pr-notes/2026-04-24-t031-tutor-follow-up-prompts.md
@@ -1,0 +1,24 @@
+# T031 Smart Tutor Follow-Up Questions
+
+## Summary
+
+- Added a lightweight tutor follow-up slice to the agentic chat pipeline.
+- The tutor can now end a response with a visible `Follow-up questions:` section containing 1-3 short numbered prompts when the learner still seems unsure.
+- The same section is parsed back into `result.followup_questions` metadata so future UI work can reuse it without changing the chat route now.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  UserTurn["Student tutoring turn"] --> ChatPipeline["AgenticChatPipeline"]
+  ChatPipeline --> FinalResponse["Final response text"]
+  FinalResponse --> FollowupSection["Optional 'Follow-up questions:' section"]
+  FollowupSection --> VisibleReply["Assistant reply content"]
+  FollowupSection --> ResultMetadata["result.followup_questions[]"]
+  VisibleReply --> SessionStore["Assistant message persisted in session history"]
+```
+
+## Notes
+
+- This slice stays backend-only and reuses the current chat response surface.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated for this change.

--- a/docs/superpowers/tasks/2026-04-24-T031-tutor-follow-up-prompts.md
+++ b/docs/superpowers/tasks/2026-04-24-T031-tutor-follow-up-prompts.md
@@ -1,0 +1,68 @@
+# Feature Pod Task: Smart Tutor Follow-Up Questions
+
+Owner: Codex
+Branch: `pod-a/t031-tutor-follow-ups`
+GitHub Issue: `#83`
+
+## Goal
+
+Add a lightweight tutor follow-up slice so the tutoring flow can suggest 1-3 next questions when a student response shows likely misunderstanding.
+
+## User-visible outcome
+
+- Tutor responses can optionally include short follow-up questions that help the learner continue instead of stopping after a single answer.
+- The first slice should stay compatible with the current tutoring chat flow when no follow-up is needed.
+- Follow-up generation should be grounded in the latest learner response and current tutoring context.
+
+## Owned files/modules
+
+- `deeptutor/agents/chat/agentic_pipeline.py`
+- `deeptutor/agents/chat/prompts/en/chat_agent.yaml`
+- `deeptutor/agents/chat/prompts/vi/chat_agent.yaml` if the prompt contract changes
+- `tests/agents/chat/` covering the selected tutor follow-up slice
+- `docs/superpowers/tasks/2026-04-24-T031-tutor-follow-up-prompts.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-24.md`
+
+## Do-not-touch files/modules
+
+- Marketplace, knowledge-pack management, dashboard analytics, and assessment review flows
+- Unrelated API routers and session-history code
+- `deeptutor/core/`
+- `deeptutor/runtime/` unless the task packet is updated first
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Preserve current tutoring behavior when follow-up prompts are absent.
+- Keep the first slice inside the existing assistant response text and optional `result` metadata; do not introduce a new route family.
+- Keep the first slice backend-only unless a contract gap forces a follow-up task.
+
+## Acceptance criteria
+
+- Tutor flow can emit 1-3 follow-up questions when the latest learner answer indicates confusion or partial understanding.
+- Tutor flow remains clean when no follow-up is needed.
+- Regression coverage exists for the chosen generation path.
+
+## Required tests
+
+- Tutor-agent regression coverage for follow-up generation
+- Frontend production build verification only if UI/event typing changes are made
+
+## Manual verification
+
+- Run a tutoring exchange where the student gives an incomplete or incorrect answer
+- Confirm the tutor output includes actionable follow-up questions instead of only a generic reply
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T030` merged to `main` through PR `#82`.
+- Start by reading the current tutor response flow and narrow the owned-file set if the smallest useful slice can stay inside the tutor agent only.

--- a/tests/agents/chat/test_agentic_followup_prompts.py
+++ b/tests/agents/chat/test_agentic_followup_prompts.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from deeptutor.agents.chat.agentic_pipeline import AgenticChatPipeline
+from deeptutor.core.context import UnifiedContext
+from deeptutor.core.stream import StreamEvent
+from deeptutor.core.stream_bus import StreamBus
+
+
+async def _collect_bus_events(bus: StreamBus) -> tuple[list[StreamEvent], asyncio.Task[Any]]:
+    events: list[StreamEvent] = []
+
+    async def _consume() -> None:
+        async for event in bus.subscribe():
+            events.append(event)
+
+    consumer = asyncio.create_task(_consume())
+    await asyncio.sleep(0)
+    return events, consumer  # type: ignore[return-value]
+
+
+def test_extract_followup_questions_parses_visible_section(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "deeptutor.agents.chat.agentic_pipeline.get_llm_config",
+        lambda: SimpleNamespace(
+            binding="openai",
+            model="gpt-test",
+            api_key="k",
+            base_url="u",
+            api_version=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "deeptutor.agents.chat.agentic_pipeline.get_tool_registry",
+        lambda: SimpleNamespace(build_prompt_text=lambda *_args, **_kwargs: "", get_enabled=lambda _selected: []),
+    )
+    pipeline = AgenticChatPipeline(language="en")
+
+    cleaned, questions = pipeline._extract_followup_questions(
+        "The derivative of x^2 is 2x.\n\n"
+        "Follow-up questions:\n"
+        "1. Which power rule applies to x^2?\n"
+        "2. What derivative do you get for x^3?\n"
+        "3. Why is 2x different from x here?"
+    )
+
+    assert cleaned.startswith("The derivative of x^2 is 2x.")
+    assert questions == [
+        "Which power rule applies to x^2?",
+        "What derivative do you get for x^3?",
+        "Why is 2x different from x here?",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_emits_followup_questions_in_result_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "deeptutor.agents.chat.agentic_pipeline.get_llm_config",
+        lambda: SimpleNamespace(
+            binding="openai",
+            model="gpt-test",
+            api_key="k",
+            base_url="u",
+            api_version=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "deeptutor.agents.chat.agentic_pipeline.get_tool_registry",
+        lambda: SimpleNamespace(build_prompt_text=lambda *_args, **_kwargs: "", get_enabled=lambda _selected: []),
+    )
+
+    pipeline = AgenticChatPipeline(language="en")
+    monkeypatch.setattr(pipeline, "_extract_answer_now_context", lambda _context: None)
+
+    async def fake_stage_thinking(*_args, **_kwargs):
+        return ""
+
+    async def fake_stage_acting(*_args, **_kwargs):
+        return []
+
+    async def fake_stage_observing(*_args, **_kwargs):
+        return "Student is still mixing up the power rule."
+
+    async def fake_stage_responding(*_args, **_kwargs):
+        return (
+            "The derivative of x^2 is 2x because the exponent becomes a multiplier and then drops by one.\n\n"
+            "Follow-up questions:\n"
+            "1. What derivative do you get for x^3?\n"
+            "2. Which step turns x^2 into 2x?\n",
+            {"label": "Final response"},
+        )
+
+    monkeypatch.setattr(pipeline, "_stage_thinking", fake_stage_thinking)
+    monkeypatch.setattr(pipeline, "_stage_acting", fake_stage_acting)
+    monkeypatch.setattr(pipeline, "_stage_observing", fake_stage_observing)
+    monkeypatch.setattr(pipeline, "_stage_responding", fake_stage_responding)
+
+    bus = StreamBus()
+    events, consumer = await _collect_bus_events(bus)
+    context = UnifiedContext(
+        session_id="session-1",
+        user_message="I think the derivative of x^2 is x.",
+        enabled_tools=[],
+        language="en",
+        metadata={"turn_id": "turn-1"},
+    )
+
+    await pipeline.run(context, bus)
+    await asyncio.sleep(0)
+    await bus.close()
+    await consumer
+
+    result_event = next(event for event in events if event.type.value == "result")
+    assert result_event.metadata["followup_questions"] == [
+        "What derivative do you get for x^3?",
+        "Which step turns x^2 into 2x?",
+    ]
+    assert "Follow-up questions:" in result_event.metadata["response"]


### PR DESCRIPTION
## Summary
- add optional tutor follow-up prompts to the agentic chat pipeline via a visible `Follow-up questions:` section
- parse the section back into `result.followup_questions` metadata without changing the chat route or UI contract
- update AI-first tracking, task packet, daily log, architecture map, and PR note for T031

## Validation
- `python3 -m pytest tests/agents/chat/test_agentic_parallel_tools.py tests/agents/chat/test_agentic_followup_prompts.py -q`
- `python3 -m py_compile deeptutor/agents/chat/agentic_pipeline.py`
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `git diff --check`

## Notes
- keeps the first slice backend-only by reusing the current assistant response surface
- updates `ai_first/architecture/MAIN_SYSTEM_MAP.md`

Closes #83
