### PR TITLE
[MVP] T032 Knowledge Pack Versioning System

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, `T030 Assessment Time Tracking & Analytics` merged into `main` through PR `#82`, and the active short task is now `T031 Smart Tutor Follow-Up Questions` on branch `pod-a/t031-tutor-follow-ups` with issue `#83`.
+- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, `T031 Smart Tutor Follow-Up Questions` merged into `main` through PR `#84`, and the active short task is now `T032 Knowledge Pack Versioning System` on branch `pod-a/t032-kb-versioning` with issue `#85`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T031` on `pod-a/t031-tutor-follow-ups` and the next strict-order task after merge will be `T032`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T032` on `pod-a/t032-kb-versioning` and the next strict-order task after merge will be `T033`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#82 [MVP] T030 Assessment Time Tracking & Analytics`
-- `#82` added lightweight per-question duration recording and assessment review timing metrics, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#84 [MVP] T031 Smart Tutor Follow-Up Questions`
+- `#84` added lightweight follow-up questions in tutor replies and result metadata, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, tutor follow-up prompts, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#83 [MVP] T031 Smart Tutor Follow-Up Questions`
-- Active branch: `pod-a/t031-tutor-follow-ups`
-- Active task packet: `docs/superpowers/tasks/2026-04-24-T031-tutor-follow-up-prompts.md`
-- Focus set: `T031` (Tutor follow-up prompts)
+- Active issue: `#85 [MVP] T032 Knowledge Pack Versioning`
+- Active branch: `pod-a/t032-kb-versioning`
+- Active task packet: `docs/superpowers/tasks/2026-04-24-T032-knowledge-pack-versioning.md`
+- Focus set: `T032` (Knowledge pack versioning)
 
 ## Next recommended task
 
-Implement `T031` on `pod-a/t031-tutor-follow-ups`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T032` on `pod-a/t032-kb-versioning`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-24)
 
 **Queue Advance**:
-1. `#82` merged to `main` after all required CI checks passed
-2. Issue `#81` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T031 Smart Tutor Follow-Up Questions`
-4. Issue `#83`, branch `pod-a/t031-tutor-follow-ups`, and task packet were created immediately after the merge sync
+1. `#84` merged to `main` after all required CI checks passed
+2. Issue `#83` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T032 Knowledge Pack Versioning System`
+4. Issue `#85`, branch `pod-a/t032-kb-versioning`, and task packet were created immediately after the merge sync
 
 ## AI-owned blockers
 
@@ -71,7 +71,8 @@ Implement `T031` on `pod-a/t031-tutor-follow-ups`, then open a Draft PR with a M
 | T027: Analytics Dashboard | Completed | 8 | NO | Done |
 | T029: Marketplace Search | Completed | 3 | NO | Done |
 | T030: Assessment Time | Completed | 2 | NO | Done |
-| T031: Tutor Follow-Up Questions | In Progress | 3 | NO | Now |
+| T031: Tutor Follow-Up Questions | Completed | 3 | NO | Done |
+| T032: Knowledge Pack Versioning | In Progress | 4 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-24T15:46:00Z",
+    "last_updated": "2026-04-24T15:57:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 35
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 22,
+      "count": 23,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -31,14 +31,15 @@
         "T027_ANALYTICS_DASHBOARD",
         "T028_API_RATE_LIMITING",
         "T029_MARKETPLACE_SEARCH_FULLTEXT",
-        "T030_ASSESSMENT_TIME_TRACKING"
+        "T030_ASSESSMENT_TIME_TRACKING",
+        "T031_TUTOR_FOLLOW_UP_PROMPTS"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
       "count": 1,
       "tasks": [
-        "T031_TUTOR_FOLLOW_UP_PROMPTS"
+        "T032_KNOWLEDGE_PACK_VERSIONING"
       ]
     },
     "blocked": {
@@ -48,9 +49,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 4,
+      "count": 3,
       "tasks": [
-        "T032_KNOWLEDGE_PACK_VERSIONING",
         "T033_LEARNING_PATH_SEQUENCING",
         "T034_BATCH_ASSESSMENT_IMPORT",
         "T035_OFFLINE_MODE_SUPPORT"
@@ -448,8 +448,8 @@
       "complexity": "Medium",
       "estimated_hours": 3,
       "dependencies": ["LLM Service", "Tutor Agent"],
-      "status": "in-progress",
-      "notes": "Issue #83 mirrors the active lane. Task packet created at docs/superpowers/tasks/2026-04-24-T031-tutor-follow-up-prompts.md. Active branch: pod-a/t031-tutor-follow-ups."
+      "status": "completed",
+      "notes": "Merged to main through PR #84. The tutoring chat pipeline can now emit a visible 'Follow-up questions:' section and parse the same section back into result.followup_questions metadata without changing the chat route."
     },
     {
       "id": "T032_KNOWLEDGE_PACK_VERSIONING",
@@ -465,8 +465,8 @@
       "complexity": "Medium",
       "estimated_hours": 4,
       "dependencies": ["Database Schema"],
-      "status": "not-started",
-      "notes": "Allow teachers to update packs while preserving old versions for existing assessments"
+      "status": "in-progress",
+      "notes": "Issue #85 mirrors the active lane. Task packet created at docs/superpowers/tasks/2026-04-24-T032-knowledge-pack-versioning.md. Active branch: pod-a/t032-kb-versioning."
     },
     {
       "id": "T033_LEARNING_PATH_SEQUENCING",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -36,6 +36,7 @@ flowchart TD
   Product --> TeacherWorkspace["Teacher Workspace"]
   Product --> KnowledgePack["Knowledge Pack"]
   KnowledgePack --> KPMetaFlow["Metadata Create/Edit/Update Flow"]
+  KnowledgePack --> KPVersions["Versioned teacher-pack metadata: current_version + version_history"]
   
   Product --> Marketplace["Knowledge Pack Marketplace"]
   Marketplace --> MarketplaceAPI["/api/v1/marketplace"]

--- a/ai_first/daily/2026-04-24.md
+++ b/ai_first/daily/2026-04-24.md
@@ -104,3 +104,65 @@
 
 - Task `T031_TUTOR_FOLLOW_UP_PROMPTS`: implementation complete on branch `pod-a/t031-tutor-follow-ups`
 - Next: commit, push, open Draft PR linked to issue `#83`, then monitor CI and merge per AI-first policy
+
+## T031 Smart Tutor Follow-Up Questions — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#84` passed required CI and merged to `main`.
+2. Issue `#83` closed with the merge.
+3. `T031` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T031_TUTOR_FOLLOW_UP_PROMPTS`: moved to `completed`
+
+## T032 Knowledge Pack Versioning System — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T031` merged.
+2. Opened GitHub issue `#85` for `T032`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-24-T032-knowledge-pack-versioning.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T032_KNOWLEDGE_PACK_VERSIONING`: moved to `in-progress`
+- Next: inspect the current knowledge-pack metadata/update flow and define the smallest useful versioning slice on `pod-a/t032-kb-versioning`
+
+## T032 Knowledge Pack Versioning System — Implementation Progress
+
+### Completed in this cycle
+
+1. Kept the first slice backend-first inside the current knowledge metadata update path:
+   - `deeptutor/api/routers/knowledge.py`
+   - `deeptutor/knowledge/manager.py`
+2. Added lightweight teacher-pack versioning so metadata updates can now record:
+   - `current_version`
+   - `version_history[]`
+   with `version`, `updated_at`, and `changed_fields`
+3. Preserved backward compatibility for older packs that have no version metadata.
+4. Added regression coverage in:
+   - `tests/api/test_knowledge_router.py`
+   - `tests/knowledge/test_kb_metadata_normalization.py`
+5. Updated the top-level architecture map:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+6. Added the required PR note:
+   - `docs/superpowers/pr-notes/2026-04-24-t032-knowledge-pack-versioning.md`
+
+### Validation
+
+- Knowledge router and metadata tests passed:
+  - `python3 -m pytest tests/api/test_knowledge_router.py tests/knowledge/test_kb_metadata_normalization.py -q`
+- Knowledge modules compile:
+  - `python3 -m py_compile deeptutor/api/routers/knowledge.py deeptutor/knowledge/manager.py`
+
+### Status
+
+- Task `T032_KNOWLEDGE_PACK_VERSIONING`: implementation complete on branch `pod-a/t032-kb-versioning`
+- Next: commit, push, open Draft PR linked to issue `#85`, then monitor CI and merge per AI-first policy

--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -52,6 +52,16 @@ BYTES_PER_GB = 1024**3
 BYTES_PER_MB = 1024**2
 ALLOWED_SHARING_STATUSES = {"private", "team", "public"}
 LIST_METADATA_FIELDS = {"learning_objectives", "team_members", "pending_invites"}
+VERSION_METADATA_FIELDS = (
+    "subject",
+    "grade",
+    "curriculum",
+    "learning_objectives",
+    "owner",
+    "sharing_status",
+    "team_members",
+    "pending_invites",
+)
 
 
 def format_bytes_human_readable(size_bytes: int) -> str:
@@ -262,6 +272,48 @@ def _load_kb_entry_or_404(manager: KnowledgeBaseManager, kb_name: str) -> dict:
     if kb_entry is None:
         raise HTTPException(status_code=404, detail=f"Knowledge base '{kb_name}' not found")
     return kb_entry
+
+
+def _build_versioned_teacher_pack_config(
+    current_config: dict,
+    updated_config: dict,
+) -> dict:
+    merged = dict(updated_config)
+    has_prior_pack_metadata = any(
+        current_config.get(field) not in (None, [], "")
+        for field in VERSION_METADATA_FIELDS
+    )
+    changed_fields: list[str] = []
+    for field in VERSION_METADATA_FIELDS:
+        before = current_config.get(field)
+        after = updated_config.get(field, before)
+        if before != after:
+            changed_fields.append(field)
+
+    current_version = current_config.get("current_version")
+    try:
+        normalized_current_version = int(current_version)
+    except (TypeError, ValueError):
+        normalized_current_version = 1 if has_prior_pack_metadata else 0
+
+    if changed_fields:
+        next_version = normalized_current_version + 1 if normalized_current_version > 0 else 1
+        history = list(current_config.get("version_history") or [])
+        history.append(
+            {
+                "version": next_version,
+                "updated_at": datetime.utcnow().isoformat() + "Z",
+                "changed_fields": sorted(changed_fields),
+            }
+        )
+        merged["current_version"] = next_version
+        merged["version_history"] = history
+    elif normalized_current_version > 0:
+        merged["current_version"] = normalized_current_version
+        if current_config.get("version_history"):
+            merged["version_history"] = current_config["version_history"]
+
+    return merged
 
 
 def _assert_kb_writable_or_409(kb_name: str, kb_entry: dict) -> None:
@@ -529,7 +581,9 @@ async def update_kb_config(kb_name: str, config: dict):
             )
 
         service = get_kb_config_service()
-        service.set_kb_config(kb_name, normalized_config)
+        current_config = service.get_kb_config(kb_name)
+        versioned_config = _build_versioned_teacher_pack_config(current_config, normalized_config)
+        service.set_kb_config(kb_name, versioned_config)
         return {"status": "success", "kb_name": kb_name, "config": service.get_kb_config(kb_name)}
     except HTTPException:
         raise

--- a/deeptutor/knowledge/manager.py
+++ b/deeptutor/knowledge/manager.py
@@ -30,12 +30,54 @@ PACK_METADATA_FIELDS = (
     "sharing_status",
     "team_members",
     "pending_invites",
+    "current_version",
+    "version_history",
 )
 
 
 def _normalize_teacher_pack_field(field: str, value):
     if value is None:
         return None
+
+    if field == "current_version":
+        if isinstance(value, bool):
+            return None
+        try:
+            normalized = int(value)
+        except (TypeError, ValueError):
+            return None
+        return normalized if normalized > 0 else None
+
+    if field == "version_history":
+        if not isinstance(value, list):
+            return None
+        cleaned_history = []
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            try:
+                version = int(item.get("version"))
+            except (TypeError, ValueError):
+                continue
+            if version <= 0:
+                continue
+            updated_at = str(item.get("updated_at") or "").strip()
+            changed_fields = item.get("changed_fields")
+            if not isinstance(changed_fields, list):
+                continue
+            normalized_fields = [
+                entry.strip()
+                for entry in changed_fields
+                if isinstance(entry, str) and entry.strip()
+            ]
+            cleaned_entry = {
+                "version": version,
+                "changed_fields": normalized_fields,
+            }
+            if updated_at:
+                cleaned_entry["updated_at"] = updated_at
+            cleaned_history.append(cleaned_entry)
+        return cleaned_history or None
 
     if field == "learning_objectives":
         if isinstance(value, list):

--- a/docs/superpowers/pr-notes/2026-04-24-t032-knowledge-pack-versioning.md
+++ b/docs/superpowers/pr-notes/2026-04-24-t032-knowledge-pack-versioning.md
@@ -1,0 +1,24 @@
+# T032 Knowledge Pack Versioning System
+
+## Summary
+
+- Added a lightweight versioning layer to teacher-pack metadata updates.
+- Knowledge-pack config updates now auto-record `current_version` and append `version_history` entries when teacher-pack metadata actually changes.
+- Existing knowledge packs remain backward-compatible when version metadata is absent.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  TeacherEdit["Teacher updates KB metadata"] --> KnowledgeAPI["PUT /api/v1/knowledge/{kb}/config"]
+  KnowledgeAPI --> DiffLogic["Compare current teacher-pack metadata vs new payload"]
+  DiffLogic --> VersionEntry["Append version_history entry\nversion + updated_at + changed_fields"]
+  VersionEntry --> KBConfig["kb_config.json teacher-pack metadata"]
+  KBConfig --> KnowledgeList["GET /api/v1/knowledge/list"]
+  KBConfig --> KnowledgeDetail["GET /api/v1/knowledge/{kb}"]
+```
+
+## Notes
+
+- This slice stays backend-first and does not require a new knowledge-pack route family.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated for this change.

--- a/docs/superpowers/tasks/2026-04-24-T032-knowledge-pack-versioning.md
+++ b/docs/superpowers/tasks/2026-04-24-T032-knowledge-pack-versioning.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: Knowledge Pack Versioning System
+
+Owner: Codex
+Branch: `pod-a/t032-kb-versioning`
+GitHub Issue: `#85`
+
+## Goal
+
+Add a lightweight versioning slice for knowledge packs so teachers can update pack content without losing visibility into what changed.
+
+## User-visible outcome
+
+- Knowledge packs can preserve a simple version marker or revision history when updated.
+- Existing pack creation, editing, and import flows remain backward-compatible when version history is absent.
+- The first slice should be small enough to avoid schema churn beyond what is required for meaningful change tracking.
+
+## Owned files/modules
+
+- `deeptutor/knowledge/`
+- `deeptutor/api/routers/knowledge.py` only if the existing metadata/update flow needs a small extension
+- `web/app/(utility)/knowledge/` only if the first useful slice needs explicit teacher-facing version visibility
+- `web/lib/knowledge-api.ts` only if API typing changes are required
+- `tests/` covering the selected versioning slice
+- `docs/superpowers/tasks/2026-04-24-T032-knowledge-pack-versioning.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-24.md`
+
+## Do-not-touch files/modules
+
+- Marketplace, dashboard, tutor follow-up, and assessment review flows
+- Unrelated API routers and session history code
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Preserve current knowledge pack behavior when version history does not exist.
+- Prefer extending existing pack metadata/update contracts over introducing a separate versioning route family for this first slice.
+- Keep the first slice compatible with imported marketplace packs and existing teacher-managed packs.
+
+## Acceptance criteria
+
+- Updating a knowledge pack can record at least one useful version/revision marker.
+- Existing pack flows remain clean when no version history exists.
+- Regression coverage exists for the chosen versioning behavior.
+
+## Required tests
+
+- Knowledge-pack regression coverage for the selected versioning path
+- Frontend production build verification only if teacher UI or API typing changes are made
+
+## Manual verification
+
+- Update a knowledge pack twice and confirm the selected version marker/history reflects the change
+- Confirm older packs without version metadata still load and edit cleanly
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T031` merged to `main` through PR `#84`.
+- Start by reading the existing knowledge metadata/update flow and keep the first slice as small as possible before considering any UI work.

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -431,3 +431,84 @@ def test_update_config_normalizes_learning_objectives(monkeypatch, tmp_path: Pat
     assert config["owner"] == "teacher-a"
     assert config["team_members"] == ["teacher-a", "teacher-b"]
     assert config["pending_invites"] == ["invite@example.com", "reviewer@example.com"]
+
+
+def test_update_config_appends_teacher_pack_version_history(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
+
+    class _FakeConfigService:
+        def __init__(self) -> None:
+            self.store = {
+                "demo": {
+                    "rag_provider": "llamaindex",
+                    "subject": "Math",
+                    "grade": "10",
+                    "owner": "teacher-a",
+                }
+            }
+
+        def set_kb_config(self, kb_name: str, config: dict) -> None:
+            current = self.store.get(kb_name, {})
+            current.update(config)
+            self.store[kb_name] = current
+
+        def get_kb_config(self, kb_name: str) -> dict:
+            return dict(self.store.get(kb_name, {}))
+
+    fake_service = _FakeConfigService()
+    config_module = importlib.import_module("deeptutor.services.config")
+    monkeypatch.setattr(config_module, "get_kb_config_service", lambda: fake_service)
+
+    with TestClient(_build_app(knowledge_module)) as client:
+        response = client.put(
+            "/api/v1/knowledge/demo/config",
+            json={
+                "subject": "Advanced Math",
+                "grade": "10",
+                "owner": "teacher-a",
+                "learning_objectives": ["Quadratic equations"],
+            },
+        )
+
+    assert response.status_code == 200
+    config = response.json()["config"]
+    assert config["current_version"] == 2
+    assert len(config["version_history"]) == 1
+    revision = config["version_history"][0]
+    assert revision["version"] == 2
+    assert revision["changed_fields"] == ["learning_objectives", "subject"]
+
+
+def test_update_config_starts_teacher_pack_version_history_at_one(monkeypatch, tmp_path: Path) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
+
+    class _FakeConfigService:
+        def __init__(self) -> None:
+            self.store = {"demo": {"rag_provider": "llamaindex"}}
+
+        def set_kb_config(self, kb_name: str, config: dict) -> None:
+            current = self.store.get(kb_name, {})
+            current.update(config)
+            self.store[kb_name] = current
+
+        def get_kb_config(self, kb_name: str) -> dict:
+            return dict(self.store.get(kb_name, {}))
+
+    fake_service = _FakeConfigService()
+    config_module = importlib.import_module("deeptutor.services.config")
+    monkeypatch.setattr(config_module, "get_kb_config_service", lambda: fake_service)
+
+    with TestClient(_build_app(knowledge_module)) as client:
+        response = client.put(
+            "/api/v1/knowledge/demo/config",
+            json={
+                "subject": "Math",
+                "owner": "teacher-a",
+            },
+        )
+
+    assert response.status_code == 200
+    config = response.json()["config"]
+    assert config["current_version"] == 1
+    assert config["version_history"][0]["version"] == 1
+    assert config["version_history"][0]["changed_fields"] == ["owner", "subject"]

--- a/tests/knowledge/test_kb_metadata_normalization.py
+++ b/tests/knowledge/test_kb_metadata_normalization.py
@@ -40,3 +40,52 @@ def test_get_info_normalizes_teacher_pack_metadata(tmp_path) -> None:
     assert metadata["sharing_status"] == "private"
     assert metadata["team_members"] == ["teacher-a", "teacher-b"]
     assert metadata["pending_invites"] == ["invite1@example.com", "invite2@example.com"]
+
+
+def test_get_info_normalizes_version_history_metadata(tmp_path) -> None:
+    kb_root = tmp_path / "knowledge_bases"
+    kb_dir = kb_root / "demo"
+    (kb_dir / "llamaindex_storage").mkdir(parents=True, exist_ok=True)
+
+    manager = KnowledgeBaseManager(base_dir=str(kb_root))
+    manager.config = {
+        "knowledge_bases": {
+            "demo": {
+                "path": "demo",
+                "description": "Knowledge base: demo",
+                "rag_provider": "llamaindex",
+                "current_version": 3,
+                "version_history": [
+                    {
+                        "version": 2,
+                        "updated_at": "2026-04-24T15:00:00Z",
+                        "changed_fields": [" subject ", "", "learning_objectives"],
+                    },
+                    {
+                        "version": "3",
+                        "updated_at": "2026-04-24T15:30:00Z",
+                        "changed_fields": [" owner "],
+                    },
+                ],
+                "status": "ready",
+            }
+        }
+    }
+    manager._save_config()
+
+    info = manager.get_info("demo")
+    metadata = info["metadata"]
+
+    assert metadata["current_version"] == 3
+    assert metadata["version_history"] == [
+        {
+            "version": 2,
+            "updated_at": "2026-04-24T15:00:00Z",
+            "changed_fields": ["subject", "learning_objectives"],
+        },
+        {
+            "version": 3,
+            "updated_at": "2026-04-24T15:30:00Z",
+            "changed_fields": ["owner"],
+        },
+    ]


### PR DESCRIPTION
## Summary
- add lightweight teacher-pack versioning to the existing knowledge config update flow
- record `current_version` and `version_history` entries when teacher-pack metadata changes
- update AI-first tracking, task packet, daily log, architecture map, and PR note for T032

## Validation
- `python3 -m pytest tests/api/test_knowledge_router.py tests/knowledge/test_kb_metadata_normalization.py -q`
- `python3 -m py_compile deeptutor/api/routers/knowledge.py deeptutor/knowledge/manager.py`
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `git diff --check`

## Notes
- keeps the first slice backend-first and backward-compatible for packs without version metadata
- updates `ai_first/architecture/MAIN_SYSTEM_MAP.md`

Closes #85
