### PR TITLE
[MVP] T034 Batch Import Multiple Packs

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, `T032 Knowledge Pack Versioning System` merged into `main` through PR `#86`, and the active short task is now `T033 Suggested Learning Path Sequencing` on branch `pod-a/t033-learning-paths` with issue `#88`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, `T033 Suggested Learning Path Sequencing` merged into `main` through PR `#89`, and the active short task is now `T034 Batch Import Multiple Packs` on branch `pod-a/t034-batch-import` with issue `#90`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T033` on `pod-a/t033-learning-paths` and the next strict-order task after merge will be `T034`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T034` on `pod-a/t034-batch-import` and the next strict-order task after merge will be `T035`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#86 [MVP] T032 Knowledge Pack Versioning System`
-- `#86` added lightweight `current_version` and `version_history` tracking for teacher-pack metadata updates, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, tutor follow-up prompts, knowledge-pack version metadata, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#89 [MVP] T033 Suggested Learning Path Sequencing`
+- `#89` added a deterministic `suggested_learning_path` sequence to the student progress flow, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, batch-ready marketplace UI groundwork, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, tutor follow-up prompts, knowledge-pack version metadata, student learning-path sequencing, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#88 [MVP] T033 Suggested Learning Path Sequencing`
-- Active branch: `pod-a/t033-learning-paths`
-- Active task packet: `docs/superpowers/tasks/2026-04-24-T033-learning-path-sequencing.md`
-- Focus set: `T033` (Suggested learning path sequencing)
+- Active issue: `#90 [MVP] T034 Batch Import Multiple Packs`
+- Active branch: `pod-a/t034-batch-import`
+- Active task packet: `docs/superpowers/tasks/2026-04-24-T034-batch-import-multiple-packs.md`
+- Focus set: `T034` (Batch import multiple packs)
 
 ## Next recommended task
 
-Implement `T033` on `pod-a/t033-learning-paths`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T034` on `pod-a/t034-batch-import`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-24)
 
 **Queue Advance**:
-1. `#86` merged to `main` after all required CI checks passed
-2. Issue `#85` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T033 Suggested Learning Path Sequencing`
-4. Issue `#88`, branch `pod-a/t033-learning-paths`, and task packet were created immediately after the merge sync
+1. `#89` merged to `main` after all required CI checks passed
+2. Issue `#88` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T034 Batch Import Multiple Packs`
+4. Issue `#90`, branch `pod-a/t034-batch-import`, and task packet were created immediately after the merge sync
 
 ## AI-owned blockers
 
@@ -73,7 +73,8 @@ Implement `T033` on `pod-a/t033-learning-paths`, then open a Draft PR with a Mer
 | T030: Assessment Time | Completed | 2 | NO | Done |
 | T031: Tutor Follow-Up Questions | Completed | 3 | NO | Done |
 | T032: Knowledge Pack Versioning | Completed | 4 | NO | Done |
-| T033: Suggested Learning Path Sequencing | In Progress | 6 | NO | Now |
+| T033: Suggested Learning Path Sequencing | Completed | 6 | NO | Done |
+| T034: Batch Import Multiple Packs | In Progress | 2 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-24T16:45:00Z",
+    "last_updated": "2026-04-24T16:28:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 35
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 24,
+      "count": 25,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -33,14 +33,15 @@
         "T029_MARKETPLACE_SEARCH_FULLTEXT",
         "T030_ASSESSMENT_TIME_TRACKING",
         "T031_TUTOR_FOLLOW_UP_PROMPTS",
-        "T032_KNOWLEDGE_PACK_VERSIONING"
+        "T032_KNOWLEDGE_PACK_VERSIONING",
+        "T033_LEARNING_PATH_SEQUENCING"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
       "count": 1,
       "tasks": [
-        "T033_LEARNING_PATH_SEQUENCING"
+        "T034_BATCH_ASSESSMENT_IMPORT"
       ]
     },
     "blocked": {
@@ -50,9 +51,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 2,
+      "count": 1,
       "tasks": [
-        "T034_BATCH_ASSESSMENT_IMPORT",
         "T035_OFFLINE_MODE_SUPPORT"
       ]
     }
@@ -482,8 +482,8 @@
       "complexity": "High",
       "estimated_hours": 6,
       "dependencies": ["Knowledge Graph", "Prerequisite Metadata"],
-      "status": "in-progress",
-      "notes": "Issue #88 mirrors the active lane. Task packet created at docs/superpowers/tasks/2026-04-24-T033-learning-path-sequencing.md. Active branch: pod-a/t033-learning-paths."
+      "status": "completed",
+      "notes": "Merged to main through PR #89. Student progress now exposes a deterministic suggested_learning_path sequence built from weak topics and knowledge-pack learning objectives."
     },
     {
       "id": "T034_BATCH_ASSESSMENT_IMPORT",
@@ -499,8 +499,8 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["Import Implementation"],
-      "status": "not-started",
-      "notes": "Add checkbox to pack cards, show selected count, batch import button"
+      "status": "in-progress",
+      "notes": "Issue #90 mirrors the active lane. Task packet created at docs/superpowers/tasks/2026-04-24-T034-batch-import-multiple-packs.md. Active branch: pod-a/t034-batch-import."
     },
     {
       "id": "T035_OFFLINE_MODE_SUPPORT",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -46,9 +46,12 @@ flowchart TD
   MarketplacePreview --> PreviewModal["Preview modal: metadata + sample documents"]
   MarketplacePreview --> PackRatings["Average rating + recent reviews"]
   Marketplace --> MarketplaceImport["POST /api/v1/marketplace/import/{pack_name}"]
+  Marketplace --> MarketplaceBatchImport["POST /api/v1/marketplace/import-batch"]
   Marketplace --> MarketplaceReviewAPI["POST /api/v1/marketplace/{pack_name}/reviews"]
   MarketplaceReviewAPI --> ReviewStorage["KB config: marketplace_reviews metadata"]
   MarketplaceImport --> ImportedClone["Imported KB clone: <pack>__imported"]
+  MarketplaceBatchImport --> BatchSelectUI["Multi-select cards + import selected action bar"]
+  MarketplaceBatchImport --> ImportedClone
   
   Product --> AssessmentBuilder["Assessment Builder"]
   AssessmentBuilder --> QuizGrounding["Knowledge Pack Grounded Quiz Config"]

--- a/ai_first/daily/2026-04-24.md
+++ b/ai_first/daily/2026-04-24.md
@@ -234,3 +234,68 @@
 
 - Task `T033_LEARNING_PATH_SEQUENCING`: implementation complete on branch `pod-a/t033-learning-paths`
 - Next: self-review the diff, commit, push, open Draft PR linked to issue `#88`, then monitor CI and merge per AI-first policy
+
+## T033 Suggested Learning Path Sequencing — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#89` passed required CI and merged to `main`.
+2. Issue `#88` closed with the merge.
+3. `T033` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T033_LEARNING_PATH_SEQUENCING`: moved to `completed`
+
+## T034 Batch Import Multiple Packs — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T033` merged.
+2. Opened GitHub issue `#90` for `T034`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-24-T034-batch-import-multiple-packs.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T034_BATCH_ASSESSMENT_IMPORT`: moved to `in-progress`
+- Next: inspect the current marketplace single-pack import flow and define the smallest reusable batch-import slice on `pod-a/t034-batch-import`
+
+## T034 Batch Import Multiple Packs — Implementation Progress
+
+### Completed in this cycle
+
+1. Kept the first slice anchored to the existing marketplace import path:
+   - `deeptutor/api/routers/marketplace.py`
+   - `web/lib/marketplace-api.ts`
+   - `web/app/(utility)/marketplace/page.tsx`
+2. Added `POST /api/v1/marketplace/import-batch` backed by the same single-pack import helper so batch import reuses the current copy-and-register behavior.
+3. Extended the marketplace UI with:
+   - per-card selection checkboxes
+   - a batch action bar for importing selected packs
+   - a per-pack batch result panel
+   while preserving the existing one-click single-pack import button.
+4. Added regression coverage in:
+   - `tests/api/test_marketplace_router.py`
+5. Updated the top-level architecture map:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+6. Added the required PR note:
+   - `docs/superpowers/pr-notes/2026-04-24-t034-batch-import-multiple-packs.md`
+
+### Validation
+
+- Marketplace router tests passed:
+  - `python3 -m pytest tests/api/test_marketplace_router.py -q`
+- Marketplace router module compiles:
+  - `python3 -m py_compile deeptutor/api/routers/marketplace.py`
+- Frontend production build passed after installing workspace dependencies:
+  - `cd web && npm ci && npm run build`
+
+### Status
+
+- Task `T034_BATCH_ASSESSMENT_IMPORT`: implementation complete on branch `pod-a/t034-batch-import`
+- Next: self-review the diff, commit, push, open Draft PR linked to issue `#90`, then monitor CI and merge per AI-first policy

--- a/deeptutor/api/routers/marketplace.py
+++ b/deeptutor/api/routers/marketplace.py
@@ -19,6 +19,10 @@ class MarketplaceReviewRequest(BaseModel):
     comment: str | None = Field(default=None, max_length=400)
 
 
+class MarketplaceBatchImportRequest(BaseModel):
+    pack_names: list[str] = Field(min_length=1, max_length=20)
+
+
 def _pack_reviews(source_cfg: dict[str, Any]) -> list[dict[str, Any]]:
     raw_reviews = source_cfg.get("marketplace_reviews", [])
     if not isinstance(raw_reviews, list):
@@ -158,6 +162,71 @@ def _preview_document_summary(pack_dir: Path) -> tuple[int, list[str]]:
         if path.is_file()
     )
     return len(documents), documents[:3]
+
+
+def _import_marketplace_pack_impl(pack_name: str) -> dict[str, Any]:
+    manager = get_kb_manager()
+
+    source_info = next(
+        (kb for kb in _list_marketplace_candidates() if kb.get("name") == pack_name),
+        None,
+    )
+    if not source_info:
+        raise HTTPException(status_code=404, detail=f"Knowledge pack '{pack_name}' not found")
+
+    source_path = manager.base_dir / pack_name
+    if not source_path.exists() or not source_path.is_dir():
+        raise HTTPException(status_code=404, detail=f"Knowledge pack directory '{pack_name}' not found")
+
+    imported_name = f"{pack_name}__imported"
+    dest_path = manager.base_dir / imported_name
+    import_timestamp = datetime.utcnow().isoformat()
+
+    if dest_path.exists():
+        return {
+            "success": True,
+            "message": "Pack already available",
+            "pack": {
+                "name": imported_name,
+                "subject": source_info.get("subject"),
+                "grade": source_info.get("grade"),
+                "owner": source_info.get("owner"),
+                "import_date": import_timestamp,
+                "session_count": source_info.get("session_count", 0),
+            },
+        }
+
+    shutil.copytree(source_path, dest_path)
+
+    manager.config = manager._load_config()
+    source_cfg = manager.config.get("knowledge_bases", {}).get(pack_name, {})
+    imported_cfg = dict(source_cfg)
+    imported_cfg["path"] = imported_name
+    imported_cfg["description"] = source_cfg.get("description") or f"Imported from {pack_name}"
+    imported_cfg["owner"] = source_cfg.get("owner") or source_info.get("owner")
+    imported_cfg["sharing_status"] = "private"
+    imported_cfg["updated_at"] = import_timestamp
+    imported_cfg["created_at"] = source_cfg.get("created_at") or import_timestamp
+    imported_cfg["imported_from"] = pack_name
+    imported_cfg["import_date"] = import_timestamp
+
+    if "knowledge_bases" not in manager.config:
+        manager.config["knowledge_bases"] = {}
+    manager.config["knowledge_bases"][imported_name] = imported_cfg
+    manager._save_config()
+
+    return {
+        "success": True,
+        "message": f"Knowledge pack '{pack_name}' imported successfully as '{imported_name}'",
+        "pack": {
+            "name": imported_name,
+            "subject": source_info.get("subject"),
+            "grade": source_info.get("grade"),
+            "owner": source_info.get("owner"),
+            "import_date": import_timestamp,
+            "session_count": source_info.get("session_count", 0),
+        },
+    }
 
 
 @router.get("/list")
@@ -324,72 +393,43 @@ async def import_marketplace_pack(pack_name: str):
     Updates metadata with import_date and imported_from fields.
     """
     try:
-        manager = get_kb_manager()
-
-        source_info = None
-        for kb in _list_marketplace_candidates():
-            if kb.get("name") == pack_name:
-                source_info = kb
-                break
-
-        if not source_info:
-            raise HTTPException(status_code=404, detail=f"Knowledge pack '{pack_name}' not found")
-
-        source_path = manager.base_dir / pack_name
-        if not source_path.exists() or not source_path.is_dir():
-            raise HTTPException(status_code=404, detail=f"Knowledge pack directory '{pack_name}' not found")
-
-        imported_name = f"{pack_name}__imported"
-        dest_path = manager.base_dir / imported_name
-
-        if dest_path.exists():
-            return {
-                "success": True,
-                "message": "Pack already available",
-                "pack": {
-                    "name": imported_name,
-                    "subject": source_info.get("subject"),
-                    "grade": source_info.get("grade"),
-                    "owner": source_info.get("owner"),
-                    "import_date": datetime.utcnow().isoformat(),
-                },
-            }
-
-        shutil.copytree(source_path, dest_path)
-
-        import_timestamp = datetime.utcnow().isoformat()
-
-        manager.config = manager._load_config()  # keep manager in sync before updating registry
-        source_cfg = manager.config.get("knowledge_bases", {}).get(pack_name, {})
-        imported_cfg = dict(source_cfg)
-        imported_cfg["path"] = imported_name
-        imported_cfg["description"] = source_cfg.get("description") or f"Imported from {pack_name}"
-        imported_cfg["owner"] = source_cfg.get("owner") or source_info.get("owner")
-        imported_cfg["sharing_status"] = "private"
-        imported_cfg["updated_at"] = import_timestamp
-        imported_cfg["created_at"] = source_cfg.get("created_at") or import_timestamp
-        imported_cfg["imported_from"] = pack_name
-        imported_cfg["import_date"] = import_timestamp
-
-        if "knowledge_bases" not in manager.config:
-            manager.config["knowledge_bases"] = {}
-        manager.config["knowledge_bases"][imported_name] = imported_cfg
-        manager._save_config()
-
-        return {
-            "success": True,
-            "message": f"Knowledge pack '{pack_name}' imported successfully as '{imported_name}'",
-            "pack": {
-                "name": imported_name,
-                "subject": source_info.get("subject"),
-                "grade": source_info.get("grade"),
-                "owner": source_info.get("owner"),
-                "import_date": import_timestamp,
-                "session_count": source_info.get("session_count", 0),
-            },
-        }
-    
+        return _import_marketplace_pack_impl(pack_name)
     except HTTPException:
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Import failed: {str(e)}")
+
+
+@router.post("/import-batch")
+async def import_marketplace_packs_batch(payload: MarketplaceBatchImportRequest):
+    results: list[dict[str, Any]] = []
+
+    for pack_name in payload.pack_names:
+        normalized_name = pack_name.strip()
+        if not normalized_name:
+            continue
+        try:
+            result = _import_marketplace_pack_impl(normalized_name)
+            results.append(
+                {
+                    "source_pack": normalized_name,
+                    **result,
+                }
+            )
+        except HTTPException as exc:
+            results.append(
+                {
+                    "source_pack": normalized_name,
+                    "success": False,
+                    "message": str(exc.detail),
+                    "pack": None,
+                }
+            )
+
+    imported = sum(1 for row in results if row.get("success"))
+    return {
+        "success": imported == len(results),
+        "requested": len(payload.pack_names),
+        "imported": imported,
+        "results": results,
+    }

--- a/docs/superpowers/pr-notes/2026-04-24-t034-batch-import-multiple-packs.md
+++ b/docs/superpowers/pr-notes/2026-04-24-t034-batch-import-multiple-packs.md
@@ -1,0 +1,25 @@
+# T034 Batch Import Multiple Packs
+
+## Summary
+
+- Added a minimal batch-import API for marketplace packs.
+- Reused the existing single-pack import behavior for each selected pack and returned per-pack results.
+- Extended the marketplace UI with multi-select checkboxes, a batch action bar, and result feedback while preserving the single-pack import button.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  MarketplacePage["Marketplace page"] --> SelectedCards["Selected pack names[]"]
+  SelectedCards --> BatchImportClient["importMarketplacePacks()"]
+  BatchImportClient --> BatchImportAPI["POST /api/v1/marketplace/import-batch"]
+  BatchImportAPI --> ImportHelper["Shared single-pack import helper"]
+  ImportHelper --> ImportedKBs["<pack>__imported knowledge bases"]
+  BatchImportAPI --> BatchResults["Per-pack success + message payload"]
+  BatchResults --> ResultPanel["Batch result feedback panel"]
+```
+
+## Notes
+
+- This slice keeps the batch flow deterministic and backend-light by iterating through the same import helper used for one pack.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated for this change.

--- a/docs/superpowers/tasks/2026-04-24-T034-batch-import-multiple-packs.md
+++ b/docs/superpowers/tasks/2026-04-24-T034-batch-import-multiple-packs.md
@@ -1,0 +1,70 @@
+# Feature Pod Task: Batch Import Multiple Packs
+
+Owner: Codex
+Branch: `pod-a/t034-batch-import`
+GitHub Issue: `#90`
+
+## Goal
+
+Add a lightweight batch-import slice so teachers can select multiple marketplace packs and import them in one action without repeating the single-pack flow manually.
+
+## User-visible outcome
+
+- Marketplace cards support multi-select for pack import.
+- Teachers can trigger one batch action and get per-pack success or failure feedback.
+- Existing single-pack import remains available and backward-compatible.
+
+## Owned files/modules
+
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/lib/marketplace-api.ts`
+- `deeptutor/api/routers/marketplace.py` only if the selected slice needs backend batch orchestration
+- `tests/api/test_marketplace_router.py` and any focused frontend-adjacent regression coverage
+- `docs/superpowers/tasks/2026-04-24-T034-batch-import-multiple-packs.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-24.md`
+
+## Do-not-touch files/modules
+
+- Dashboard, tutoring, assessment review, and knowledge-pack versioning flows
+- Unrelated API routers and session persistence code
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Preserve the existing single-pack import behavior.
+- Prefer reusing the current import path and response shape where possible.
+- If a batch endpoint is added, keep the payload small and deterministic: explicit pack list in, per-pack status out.
+
+## Acceptance criteria
+
+- Marketplace UI supports selecting multiple packs and clearing the selection.
+- One user action can import the selected set and report which imports succeeded or failed.
+- Existing single-pack import flow still works.
+- Regression coverage exists for the chosen backend/client batch behavior.
+
+## Required tests
+
+- Marketplace router regression coverage for the selected batch-import slice
+- Frontend production build verification if marketplace UI or client typing changes
+
+## Manual verification
+
+- Select at least two public packs in marketplace
+- Trigger batch import once
+- Confirm imported packs appear in the user workspace and the selection resets or reflects completion cleanly
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T033` merged to `main` through PR `#89`.
+- Start by reading the current single-pack import flow in marketplace UI and API client; keep the first batch slice minimal and reuse the existing import behavior instead of inventing a second import stack.

--- a/tests/api/test_marketplace_router.py
+++ b/tests/api/test_marketplace_router.py
@@ -119,6 +119,44 @@ def test_marketplace_import_copies_pack_and_registers_new_entry(monkeypatch, tmp
     assert (imported_path / "rag_storage").exists()
 
 
+def test_marketplace_batch_import_returns_per_pack_results(monkeypatch, tmp_path: Path) -> None:
+    client, marketplace = _build_app(monkeypatch, tmp_path)
+
+    second_pack = tmp_path / "science-pack"
+    (second_pack / "raw").mkdir(parents=True)
+    (second_pack / "rag_storage").mkdir(parents=True)
+    (second_pack / "raw" / "cells.md").write_text("Cells lesson", encoding="utf-8")
+
+    manager = marketplace.get_kb_manager()
+    manager.config["knowledge_bases"]["science-pack"] = {
+        "path": "science-pack",
+        "description": "Science pack",
+        "sharing_status": "public",
+        "subject": "Science",
+        "grade": "7",
+        "curriculum": "National",
+        "learning_objectives": ["Cells"],
+        "owner": "Teacher Z",
+        "created_at": "2026-04-21T00:00:00",
+        "updated_at": "2026-04-21T00:00:00",
+    }
+
+    response = client.post(
+        "/api/v1/marketplace/import-batch",
+        json={"pack_names": ["shared-pack", "science-pack"]},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["requested"] == 2
+    assert payload["imported"] == 2
+    assert [row["source_pack"] for row in payload["results"]] == ["shared-pack", "science-pack"]
+    assert all(row["success"] is True for row in payload["results"])
+    assert (tmp_path / "shared-pack__imported").exists()
+    assert (tmp_path / "science-pack__imported").exists()
+
+
 def test_marketplace_preview_returns_compact_pack_summary(monkeypatch, tmp_path: Path) -> None:
     client, _ = _build_app(monkeypatch, tmp_path)
 

--- a/web/app/(utility)/marketplace/page.tsx
+++ b/web/app/(utility)/marketplace/page.tsx
@@ -6,11 +6,13 @@ import { useTranslation } from "react-i18next";
 import {
   getCachedMarketplacePacks,
   getMarketplacePackPreview,
+  importMarketplacePacks,
   invalidateMarketplaceListCache,
   isMarketplacePacksCacheStale,
   listMarketplacePacks,
   importMarketplacePack,
   submitMarketplaceReview,
+  type BatchImportPacksResult,
   type MarketplacePack,
   type MarketplacePackPreview,
   type MarketplaceSortBy,
@@ -47,7 +49,10 @@ export default function MarketplacePage() {
 
   // Import state
   const [importing, setImporting] = useState<string | null>(null);
+  const [batchImporting, setBatchImporting] = useState(false);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
+  const [selectedPacks, setSelectedPacks] = useState<string[]>([]);
+  const [batchImportResult, setBatchImportResult] = useState<BatchImportPacksResult | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewPack, setPreviewPack] = useState<MarketplacePackPreview | null>(null);
@@ -199,6 +204,7 @@ export default function MarketplacePage() {
 
   const handleImportPack = async (packName: string) => {
     setImporting(packName);
+    setBatchImportResult(null);
     try {
       await importMarketplacePack(packName);
       setImportSuccess(packName);
@@ -208,6 +214,38 @@ export default function MarketplacePage() {
       setError(err instanceof Error ? err.message : "Failed to import pack");
     } finally {
       setImporting(null);
+    }
+  };
+
+  const togglePackSelection = (packName: string) => {
+    setBatchImportResult(null);
+    setSelectedPacks((current) =>
+      current.includes(packName)
+        ? current.filter((name) => name !== packName)
+        : [...current, packName],
+    );
+  };
+
+  const handleBatchImport = async () => {
+    if (!selectedPacks.length || batchImporting) return;
+    setBatchImporting(true);
+    setBatchImportResult(null);
+    try {
+      const result = await importMarketplacePacks(selectedPacks);
+      setBatchImportResult(result);
+      const successfulPacks = result.results
+        .filter((row) => row.success)
+        .map((row) => row.source_pack);
+      if (successfulPacks.length > 0) {
+        setImportSuccess(successfulPacks[0] ?? null);
+        setTimeout(() => setImportSuccess(null), 3000);
+      }
+      setSelectedPacks(result.results.filter((row) => !row.success).map((row) => row.source_pack));
+      await refreshCurrentQuery(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to import selected packs");
+    } finally {
+      setBatchImporting(false);
     }
   };
 
@@ -369,6 +407,41 @@ export default function MarketplacePage() {
               {t("Showing")} {packs.length} {t("of")} {total} {t("packs")}
             </span>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+              {selectedPacks.length > 0 && (
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <span className="text-[12px] text-[var(--muted-foreground)]">
+                    {selectedPacks.length} {t("selected")}
+                  </span>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setSelectedPacks([])}
+                      disabled={batchImporting}
+                      className="rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[12px] text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] disabled:opacity-50"
+                    >
+                      {t("Clear selection")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void handleBatchImport()}
+                      disabled={batchImporting}
+                      className="inline-flex items-center justify-center gap-2 rounded-md bg-[var(--primary)] px-3 py-2 text-[12px] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:opacity-50"
+                    >
+                      {batchImporting ? (
+                        <>
+                          <Loader2 size={13} className="animate-spin" />
+                          {t("Importing selected")}
+                        </>
+                      ) : (
+                        <>
+                          <Download size={13} />
+                          {t("Import selected")}
+                        </>
+                      )}
+                    </button>
+                  </div>
+                </div>
+              )}
               {refreshing && !loading && (
                 <span className="flex items-center gap-2 text-[12px] text-[var(--muted-foreground)]">
                   <Loader2 size={13} className="animate-spin" />
@@ -412,6 +485,14 @@ export default function MarketplacePage() {
                 >
                   {/* Header */}
                   <div className="mb-3 flex items-start justify-between gap-3">
+                    <label className="mt-0.5 inline-flex items-center">
+                      <input
+                        type="checkbox"
+                        checked={selectedPacks.includes(pack.name)}
+                        onChange={() => togglePackSelection(pack.name)}
+                        className="h-4 w-4 rounded border-[var(--border)]"
+                      />
+                    </label>
                     <div className="flex-1">
                       <h3 className="break-words text-[14px] font-semibold text-[var(--foreground)]">
                         {pack.name}
@@ -489,7 +570,7 @@ export default function MarketplacePage() {
                     </button>
                     <button
                       onClick={() => handleImportPack(pack.name)}
-                      disabled={importing === pack.name || importSuccess === pack.name}
+                      disabled={batchImporting || importing === pack.name || importSuccess === pack.name}
                       className="flex items-center justify-center gap-2 rounded-md bg-[var(--primary)] px-3 py-2 text-[12px] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:opacity-50"
                     >
                       {importing === pack.name ? (
@@ -512,6 +593,27 @@ export default function MarketplacePage() {
             </div>
           )}
         </div>
+
+        {batchImportResult && (
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <div className="text-[13px] font-medium text-[var(--foreground)]">
+              {t("Batch import result")}: {batchImportResult.imported}/{batchImportResult.requested} {t("packs imported")}
+            </div>
+            <div className="mt-3 space-y-2">
+              {batchImportResult.results.map((row) => (
+                <div
+                  key={row.source_pack}
+                  className="flex flex-col gap-1 rounded-md bg-[var(--background)] px-3 py-2 text-[12px] sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <span className="font-medium text-[var(--foreground)]">{row.source_pack}</span>
+                  <span className={row.success ? "text-emerald-600" : "text-rose-600"}>
+                    {row.message}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Pagination */}
         {total > packs.length && (

--- a/web/lib/marketplace-api.ts
+++ b/web/lib/marketplace-api.ts
@@ -255,6 +255,20 @@ export interface ImportPackResult {
   };
 }
 
+export interface BatchImportPackResult {
+  source_pack: string;
+  success: boolean;
+  message: string;
+  pack: ImportPackResult["pack"] | null;
+}
+
+export interface BatchImportPacksResult {
+  success: boolean;
+  requested: number;
+  imported: number;
+  results: BatchImportPackResult[];
+}
+
 export interface SubmitMarketplaceReviewRequest {
   reviewer: string;
   rating: number;
@@ -289,6 +303,33 @@ export async function importMarketplacePack(
   }
 
   const result = await response.json();
+  invalidateMarketplaceListCache();
+  return result;
+}
+
+export async function importMarketplacePacks(
+  packNames: string[],
+): Promise<BatchImportPacksResult> {
+  const response = await fetch(
+    apiUrl("/api/v1/marketplace/import-batch"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pack_names: packNames }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    try {
+      const error = JSON.parse(errorBody);
+      throw new Error(error.detail || `Failed to import packs: ${response.status}`);
+    } catch {
+      throw new Error(`Failed to import packs: ${response.status} ${response.statusText}`);
+    }
+  }
+
+  const result = (await response.json()) as BatchImportPacksResult;
   invalidateMarketplaceListCache();
   return result;
 }


### PR DESCRIPTION
## Summary
- add a batch marketplace import endpoint that reuses the existing single-pack import helper
- extend the marketplace client and UI with multi-select, import-selected action, and per-pack batch feedback
- cover the new batch import contract with marketplace router regression tests

## Validation
- `python3 -m pytest tests/api/test_marketplace_router.py -q`
- `python3 -m py_compile deeptutor/api/routers/marketplace.py`
- `cd web && npm ci && npm run build`

## Notes
- Architecture note: `docs/superpowers/pr-notes/2026-04-24-t034-batch-import-multiple-packs.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
- Closes #90
