### PR TITLE
[MVP] T035 Offline Mode for Downloaded Packs

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -24,8 +24,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Base project: HKUDS/DeepTutor under Apache 2.0
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
-- Latest product status: Knowledge Pack, marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, `T033 Suggested Learning Path Sequencing` merged into `main` through PR `#89`, and the active short task is now `T034 Batch Import Multiple Packs` on branch `pod-a/t034-batch-import` with issue `#90`.
+- Latest product status: Knowledge Pack, marketplace import, batch marketplace import, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, `T034 Batch Import Multiple Packs` merged into `main` through PR `#91`, and the active short task is now `T035 Offline Mode for Downloaded Packs` on branch `pod-a/t035-offline-mode` with issue `#92`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T034` on `pod-a/t034-batch-import` and the next strict-order task after merge will be `T035`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; current active task is `T035` on `pod-a/t035-offline-mode` and there is no remaining pending registry task after it.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#89 [MVP] T033 Suggested Learning Path Sequencing`
-- `#89` added a deterministic `suggested_learning_path` sequence to the student progress flow, then passed all required CI checks before merge.
-- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, batch-ready marketplace UI groundwork, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, tutor follow-up prompts, knowledge-pack version metadata, student learning-path sequencing, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
+- Latest merged PR: `#91 [MVP] T034 Batch Import Multiple Packs`
+- `#91` added batch marketplace import through a shared import helper plus multi-select UI, then passed all required CI checks before merge.
+- Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, batch import, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, tutor follow-up prompts, knowledge-pack version metadata, student learning-path sequencing, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active issue: `#90 [MVP] T034 Batch Import Multiple Packs`
-- Active branch: `pod-a/t034-batch-import`
-- Active task packet: `docs/superpowers/tasks/2026-04-24-T034-batch-import-multiple-packs.md`
-- Focus set: `T034` (Batch import multiple packs)
+- Active issue: `#92 [MVP] T035 Offline Mode for Downloaded Packs`
+- Active branch: `pod-a/t035-offline-mode`
+- Active task packet: `docs/superpowers/tasks/2026-04-24-T035-offline-mode-support.md`
+- Focus set: `T035` (Offline mode for downloaded packs)
 
 ## Next recommended task
 
-Implement `T034` on `pod-a/t034-batch-import`, then open a Draft PR with a Mermaid architecture note and required validation before review.
+Implement `T035` on `pod-a/t035-offline-mode`, then open a Draft PR with a Mermaid architecture note and required validation before review.
 
 ## Status Update (2026-04-24)
 
 **Queue Advance**:
-1. `#89` merged to `main` after all required CI checks passed
-2. Issue `#88` auto-closed with the merge
-3. Next pending registry task selected in strict order: `T034 Batch Import Multiple Packs`
-4. Issue `#90`, branch `pod-a/t034-batch-import`, and task packet were created immediately after the merge sync
+1. `#91` merged to `main` after all required CI checks passed
+2. Issue `#90` auto-closed with the merge
+3. Next pending registry task selected in strict order: `T035 Offline Mode for Downloaded Packs`
+4. Issue `#92`, branch `pod-a/t035-offline-mode`, and task packet were created immediately after the merge sync
 
 ## AI-owned blockers
 
@@ -74,7 +74,8 @@ Implement `T034` on `pod-a/t034-batch-import`, then open a Draft PR with a Merma
 | T031: Tutor Follow-Up Questions | Completed | 3 | NO | Done |
 | T032: Knowledge Pack Versioning | Completed | 4 | NO | Done |
 | T033: Suggested Learning Path Sequencing | Completed | 6 | NO | Done |
-| T034: Batch Import Multiple Packs | In Progress | 2 | NO | Now |
+| T034: Batch Import Multiple Packs | Completed | 2 | NO | Done |
+| T035: Offline Mode for Downloaded Packs | In Progress | 6 | NO | Now |
 | T022: Error Boundaries | Completed | 2 | NO | Done |
 | T028: Rate Limiting | Completed | 2 | YES | Done |
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-24T16:28:00Z",
+    "last_updated": "2026-04-24T16:42:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 35
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 25,
+      "count": 26,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -34,14 +34,15 @@
         "T030_ASSESSMENT_TIME_TRACKING",
         "T031_TUTOR_FOLLOW_UP_PROMPTS",
         "T032_KNOWLEDGE_PACK_VERSIONING",
-        "T033_LEARNING_PATH_SEQUENCING"
+        "T033_LEARNING_PATH_SEQUENCING",
+        "T034_BATCH_ASSESSMENT_IMPORT"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
       "count": 1,
       "tasks": [
-        "T034_BATCH_ASSESSMENT_IMPORT"
+        "T035_OFFLINE_MODE_SUPPORT"
       ]
     },
     "blocked": {
@@ -51,10 +52,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 1,
-      "tasks": [
-        "T035_OFFLINE_MODE_SUPPORT"
-      ]
+      "count": 0,
+      "tasks": []
     }
   },
   "tasks": [
@@ -499,8 +498,8 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["Import Implementation"],
-      "status": "in-progress",
-      "notes": "Issue #90 mirrors the active lane. Task packet created at docs/superpowers/tasks/2026-04-24-T034-batch-import-multiple-packs.md. Active branch: pod-a/t034-batch-import."
+      "status": "completed",
+      "notes": "Merged to main through PR #91. Marketplace now supports batch import through a shared single-pack import helper plus multi-select UI."
     },
     {
       "id": "T035_OFFLINE_MODE_SUPPORT",
@@ -516,8 +515,8 @@
       "complexity": "High",
       "estimated_hours": 6,
       "dependencies": ["Service Worker", "IndexedDB"],
-      "status": "not-started",
-      "notes": "Sync when online, allow working offline for imported packs"
+      "status": "in-progress",
+      "notes": "Issue #92 mirrors the active lane. Task packet created at docs/superpowers/tasks/2026-04-24-T035-offline-mode-support.md. Active branch: pod-a/t035-offline-mode."
     }
   ],
   "github_issues_template": {

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -52,6 +52,7 @@ flowchart TD
   MarketplaceImport --> ImportedClone["Imported KB clone: <pack>__imported"]
   MarketplaceBatchImport --> BatchSelectUI["Multi-select cards + import selected action bar"]
   MarketplaceBatchImport --> ImportedClone
+  ImportedClone --> OfflinePackManifest["Browser offline imported-pack manifest"]
   
   Product --> AssessmentBuilder["Assessment Builder"]
   AssessmentBuilder --> QuizGrounding["Knowledge Pack Grounded Quiz Config"]
@@ -88,6 +89,7 @@ flowchart TD
   PathEngine --> ObjectiveInputs["Knowledge-pack learning_objectives metadata"]
   AssessmentReview --> ReviewRoute["/dashboard/assessments/[sessionId]"]
   AssessmentReview --> ReviewAPI["/api/v1/sessions/{session_id}/assessment-review"]
+  AssessmentReview --> OfflineQuizQueue["Browser offline quiz-result sync queue"]
   AssessmentReview --> ProgressIndicator["ProgressIndicator Component"]
   AssessmentReview --> LearningJourney["LearningJourneySummary Component"]
   AssessmentReview --> TimeMetrics["Timing metrics: total + average + per-question response time"]

--- a/ai_first/daily/2026-04-24.md
+++ b/ai_first/daily/2026-04-24.md
@@ -235,6 +235,63 @@
 - Task `T033_LEARNING_PATH_SEQUENCING`: implementation complete on branch `pod-a/t033-learning-paths`
 - Next: self-review the diff, commit, push, open Draft PR linked to issue `#88`, then monitor CI and merge per AI-first policy
 
+## T034 Batch Import Multiple Packs — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#91` passed required CI and merged to `main`.
+2. Issue `#90` closed with the merge.
+3. `T034` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T034_BATCH_ASSESSMENT_IMPORT`: moved to `completed`
+
+## T035 Offline Mode for Downloaded Packs — Task Selection
+
+### Completed in this cycle
+
+1. Selected the next pending task from `ai_first/TASK_REGISTRY.json` in strict order after `T034` merged.
+2. Opened GitHub issue `#92` for `T035`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-24-T035-offline-mode-support.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T035_OFFLINE_MODE_SUPPORT`: moved to `in-progress`
+- Next: keep the first offline slice browser-local by caching imported-pack manifests and queuing quiz-result sync for reconnect
+
+## T035 Offline Mode for Downloaded Packs — Implementation Progress
+
+### Completed in this cycle
+
+1. Kept the first slice frontend-only and browser-local inside:
+   - `web/lib/marketplace-api.ts`
+   - `web/lib/knowledge-api.ts`
+   - `web/lib/session-api.ts`
+   - `web/components/quiz/QuizViewer.tsx`
+2. Added an imported-pack manifest cache so successful marketplace imports can be surfaced later when `/api/v1/knowledge/list` is unavailable.
+3. Added an offline quiz-result queue so already loaded assessments can finish offline and retry sync on the browser `online` event.
+4. Updated the top-level architecture map:
+   - `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+5. Added the required PR note:
+   - `docs/superpowers/pr-notes/2026-04-24-t035-offline-mode-support.md`
+
+### Validation
+
+- Task registry JSON is valid:
+  - `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- Frontend production build validation pending after final diff check
+
+### Status
+
+- Task `T035_OFFLINE_MODE_SUPPORT`: implementation in progress on branch `pod-a/t035-offline-mode`
+- Next: run final frontend build/verification, then self-review and publish the lane
+
 ## T033 Suggested Learning Path Sequencing — Merge Complete
 
 ### Completed in this cycle

--- a/docs/superpowers/pr-notes/2026-04-24-t035-offline-mode-support.md
+++ b/docs/superpowers/pr-notes/2026-04-24-t035-offline-mode-support.md
@@ -1,0 +1,28 @@
+# T035 Offline Mode for Downloaded Packs
+
+## Summary
+
+- Added a browser-local manifest for imported packs so downloaded packs can still appear when the knowledge-list API is unavailable.
+- Added a browser-local queue for quiz result recording so a loaded assessment can be completed offline and synced later.
+- Kept the first slice frontend-only and reversible without introducing a full service-worker/PWA stack.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  MarketplaceImport["Marketplace import success"] --> OfflinePackCache["offline imported-pack manifest"]
+  OfflinePackCache --> KnowledgeListFallback["listKnowledgeBases() offline fallback"]
+  KnowledgeListFallback --> KBPicker["Workspace KB selector"]
+
+  QuizViewer["QuizViewer completion"] --> QuizResultAPI["recordQuizResults()"]
+  QuizResultAPI --> OnlineWrite["POST /api/v1/sessions/{id}/quiz-results"]
+  QuizResultAPI --> OfflineQueue["offline quiz-result queue"]
+  OfflineQueue --> OnlineEvent["window online event"]
+  OnlineEvent --> FlushQueue["flushQueuedQuizResults()"]
+  FlushQueue --> OnlineWrite
+```
+
+## Notes
+
+- This slice intentionally focuses on imported-pack visibility plus deferred quiz-result sync, not on a full offline generation pipeline.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated for this change.

--- a/docs/superpowers/tasks/2026-04-24-T035-offline-mode-support.md
+++ b/docs/superpowers/tasks/2026-04-24-T035-offline-mode-support.md
@@ -1,0 +1,72 @@
+# Feature Pod Task: Offline Mode for Downloaded Packs
+
+Owner: Codex
+Branch: `pod-a/t035-offline-mode`
+GitHub Issue: `#92`
+
+## Goal
+
+Add a first offline-capable slice so imported packs remain usable when the network drops and quiz completion can queue its result sync until connectivity returns.
+
+## User-visible outcome
+
+- Imported/downloaded packs remain visible from a local browser cache even if the API is unavailable.
+- Users can still finish an already loaded assessment while offline.
+- Quiz result recording retries automatically when the browser comes back online.
+
+## Owned files/modules
+
+- `web/lib/marketplace-api.ts`
+- `web/lib/knowledge-api.ts`
+- `web/lib/session-api.ts`
+- `web/components/quiz/QuizViewer.tsx`
+- `web/app/(workspace)/page.tsx` only if lightweight offline status or fallback handling is needed
+- `docs/superpowers/tasks/2026-04-24-T035-offline-mode-support.md`
+- `docs/superpowers/pr-notes/` for the follow-up PR note
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-24.md`
+
+## Do-not-touch files/modules
+
+- Backend routers and storage schemas unless the selected slice truly needs them
+- Dashboard, tutoring, and knowledge-pack versioning flows
+- `deeptutor/core/`
+- `deeptutor/runtime/`
+- Root license and upstream attribution files
+
+## API/data contract
+
+- Preserve current online behavior for marketplace import, knowledge-base listing, and quiz result recording.
+- Prefer browser-local persistence for the first slice instead of introducing server-side offline state.
+- Keep offline state deterministic and scoped to imported packs plus pending quiz-result sync.
+
+## Acceptance criteria
+
+- Imported packs are cached locally after import and can be surfaced when knowledge-base listing fails offline.
+- Completing a loaded quiz offline does not lose the result payload.
+- Pending offline quiz results retry automatically when the browser is online again.
+- Existing online flows remain unchanged when the network is available.
+
+## Required tests
+
+- Focused frontend-safe validation through production build
+- Targeted regression coverage for any added pure helper behavior when feasible
+
+## Manual verification
+
+- Import at least one marketplace pack while online
+- Simulate offline browser state
+- Confirm the imported pack still appears in the KB selection surface
+- Complete a loaded quiz offline and verify sync occurs after reconnect
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T034` merged to `main` through PR `#91`.
+- Keep the first slice browser-local and reversible; do not try to build a full PWA stack in one pass.

--- a/web/components/quiz/QuizViewer.tsx
+++ b/web/components/quiz/QuizViewer.tsx
@@ -8,7 +8,7 @@ import QuestionFollowupPanel, {
   type FollowupThreadState,
 } from "@/components/quiz/QuestionFollowupPanel";
 import { buildQuizFollowupConfig, type QuizQuestion } from "@/lib/quiz-types";
-import { recordQuizResults } from "@/lib/session-api";
+import { flushQueuedQuizResults, recordQuizResults } from "@/lib/session-api";
 import { shouldAppendEventContent } from "@/lib/stream";
 import { type StartTurnMessage, type StreamEvent, UnifiedWSClient } from "@/lib/unified-ws";
 
@@ -84,6 +84,7 @@ export default function QuizViewer({
   const [idx, setIdx] = useState(0);
   const [answers, setAnswers] = useState<Record<number, AnswerState>>({});
   const [threads, setThreads] = useState<Record<string, FollowupThreadState>>({});
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "queued-offline" | "syncing">("idle");
   const lastReportedSignatureRef = useRef("");
   const threadsRef = useRef<Record<string, FollowupThreadState>>({});
   const threadRunnersRef = useRef<
@@ -309,13 +310,33 @@ export default function QuizViewer({
     const signature = JSON.stringify(submittedResults);
     if (!signature || signature === lastReportedSignatureRef.current) return;
     lastReportedSignatureRef.current = signature;
-    void recordQuizResults(sessionId, submittedResults).catch((error) => {
-      console.error("Failed to record quiz results:", error);
-      if (lastReportedSignatureRef.current === signature) {
-        lastReportedSignatureRef.current = "";
-      }
-    });
+    void recordQuizResults(sessionId, submittedResults)
+      .then((result) => {
+        setSaveStatus(result.queued_offline ? "queued-offline" : "saved");
+      })
+      .catch((error) => {
+        console.error("Failed to record quiz results:", error);
+        if (lastReportedSignatureRef.current === signature) {
+          lastReportedSignatureRef.current = "";
+        }
+      });
   }, [completedCount, sessionId, submittedResults, total]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleOnline = () => {
+      setSaveStatus((current) => (current === "queued-offline" ? "syncing" : current));
+      void flushQueuedQuizResults().then((count) => {
+        if (count > 0) {
+          setSaveStatus("saved");
+        } else {
+          setSaveStatus((current) => (current === "syncing" ? "queued-offline" : current));
+        }
+      });
+    };
+    window.addEventListener("online", handleOnline);
+    return () => window.removeEventListener("online", handleOnline);
+  }, []);
 
   const handleSubmit = () => {
     if (ans.submitted) return;
@@ -389,6 +410,15 @@ export default function QuizViewer({
         <span className="mr-2 text-[11px] font-semibold text-[var(--muted-foreground)]">
           {completedCount}/{total}
         </span>
+        {saveStatus !== "idle" && (
+          <span className="mr-2 rounded-full bg-[var(--muted)] px-2 py-0.5 text-[10px] font-medium text-[var(--muted-foreground)]">
+            {saveStatus === "saved"
+              ? t("Results saved")
+              : saveStatus === "queued-offline"
+                ? t("Saved offline, syncing later")
+                : t("Syncing offline results")}
+          </span>
+        )}
         <div className="flex flex-wrap gap-1">
           {questions.map((question, questionIndex) => {
             const answer = answers[questionIndex];

--- a/web/lib/knowledge-api.ts
+++ b/web/lib/knowledge-api.ts
@@ -1,5 +1,6 @@
 import { apiUrl } from "@/lib/api";
 import { invalidateClientCache, withClientCache } from "@/lib/client-cache";
+import { listOfflineImportedPacks } from "@/lib/offline-pack-cache";
 
 const KNOWLEDGE_CACHE_PREFIX = "knowledge:";
 
@@ -33,15 +34,24 @@ export async function listKnowledgeBases(options?: { force?: boolean }) {
   return withClientCache<KnowledgeBaseSummary[]>(
     `${KNOWLEDGE_CACHE_PREFIX}list`,
     async () => {
-      const response = await fetch(apiUrl("/api/v1/knowledge/list"), {
-        cache: "no-store",
-      });
-      const data = await response.json();
-      return Array.isArray(data)
-        ? data
-        : Array.isArray(data?.knowledge_bases)
-          ? data.knowledge_bases
-          : [];
+      try {
+        const response = await fetch(apiUrl("/api/v1/knowledge/list"), {
+          cache: "no-store",
+        });
+        const data = await response.json();
+        return Array.isArray(data)
+          ? data
+          : Array.isArray(data?.knowledge_bases)
+            ? data.knowledge_bases
+            : [];
+      } catch {
+        return listOfflineImportedPacks().map((pack) => ({
+          name: pack.name,
+          is_default: false,
+          status: "offline-cached",
+          metadata: pack.metadata ?? null,
+        }));
+      }
     },
     {
       force: options?.force,

--- a/web/lib/marketplace-api.ts
+++ b/web/lib/marketplace-api.ts
@@ -1,4 +1,5 @@
 import { apiUrl } from "@/lib/api";
+import { cacheImportedPack } from "@/lib/offline-pack-cache";
 
 export interface MarketplacePackMetadata {
   subject?: string | null;
@@ -303,6 +304,16 @@ export async function importMarketplacePack(
   }
 
   const result = await response.json();
+  cacheImportedPack({
+    name: result.pack.name,
+    imported_at: result.pack.import_date,
+    metadata: {
+      subject: result.pack.subject ?? null,
+      grade: result.pack.grade ?? null,
+      owner: result.pack.owner ?? null,
+      sharing_status: "private",
+    },
+  });
   invalidateMarketplaceListCache();
   return result;
 }
@@ -330,6 +341,20 @@ export async function importMarketplacePacks(
   }
 
   const result = (await response.json()) as BatchImportPacksResult;
+  result.results
+    .filter((row) => row.success && row.pack)
+    .forEach((row) => {
+      cacheImportedPack({
+        name: row.pack!.name,
+        imported_at: row.pack!.import_date,
+        metadata: {
+          subject: row.pack!.subject ?? null,
+          grade: row.pack!.grade ?? null,
+          owner: row.pack!.owner ?? null,
+          sharing_status: "private",
+        },
+      });
+    });
   invalidateMarketplaceListCache();
   return result;
 }

--- a/web/lib/offline-pack-cache.ts
+++ b/web/lib/offline-pack-cache.ts
@@ -1,0 +1,42 @@
+import type { TeacherPackMetadata } from "@/lib/knowledge-api";
+
+const OFFLINE_IMPORTED_PACKS_KEY = "deeptutor:offline-imported-packs";
+
+export interface OfflineImportedPack {
+  name: string;
+  imported_at: string;
+  metadata?: TeacherPackMetadata | null;
+}
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function readOfflineImportedPacks(): OfflineImportedPack[] {
+  if (!canUseStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(OFFLINE_IMPORTED_PACKS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is OfflineImportedPack => Boolean(item && typeof item === "object"))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeOfflineImportedPacks(packs: OfflineImportedPack[]): void {
+  if (!canUseStorage()) return;
+  window.localStorage.setItem(OFFLINE_IMPORTED_PACKS_KEY, JSON.stringify(packs));
+}
+
+export function cacheImportedPack(pack: OfflineImportedPack): void {
+  const existing = readOfflineImportedPacks().filter((item) => item.name !== pack.name);
+  existing.unshift(pack);
+  writeOfflineImportedPacks(existing.slice(0, 100));
+}
+
+export function listOfflineImportedPacks(): OfflineImportedPack[] {
+  return readOfflineImportedPacks();
+}

--- a/web/lib/offline-quiz-sync.ts
+++ b/web/lib/offline-quiz-sync.ts
@@ -1,0 +1,46 @@
+import type { QuizResultItem } from "@/lib/session-api";
+
+const OFFLINE_QUIZ_RESULTS_KEY = "deeptutor:offline-quiz-results";
+
+export interface PendingQuizResultRecord {
+  sessionId: string;
+  answers: QuizResultItem[];
+  savedAt: string;
+}
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function readQueue(): PendingQuizResultRecord[] {
+  if (!canUseStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(OFFLINE_QUIZ_RESULTS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is PendingQuizResultRecord => Boolean(item && typeof item === "object"))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeQueue(queue: PendingQuizResultRecord[]): void {
+  if (!canUseStorage()) return;
+  window.localStorage.setItem(OFFLINE_QUIZ_RESULTS_KEY, JSON.stringify(queue));
+}
+
+export function enqueueOfflineQuizResults(record: PendingQuizResultRecord): void {
+  const queue = readQueue().filter((item) => item.sessionId !== record.sessionId);
+  queue.push(record);
+  writeQueue(queue);
+}
+
+export function getPendingOfflineQuizResults(): PendingQuizResultRecord[] {
+  return readQueue();
+}
+
+export function removePendingOfflineQuizResults(sessionId: string): void {
+  writeQueue(readQueue().filter((item) => item.sessionId !== sessionId));
+}

--- a/web/lib/session-api.ts
+++ b/web/lib/session-api.ts
@@ -1,6 +1,11 @@
 import type { StreamEvent } from "@/lib/unified-ws";
 import { apiUrl } from "@/lib/api";
 import { invalidateClientCache, withClientCache } from "@/lib/client-cache";
+import {
+  enqueueOfflineQuizResults,
+  getPendingOfflineQuizResults,
+  removePendingOfflineQuizResults,
+} from "@/lib/offline-quiz-sync";
 
 export interface SessionMessage {
   id: number;
@@ -79,6 +84,11 @@ export interface QuizResultItem {
   duration_seconds?: number;
 }
 
+export interface RecordQuizResultsStatus {
+  recorded: boolean;
+  queued_offline?: boolean;
+}
+
 async function expectJson<T>(response: Response): Promise<T> {
   if (!response.ok) {
     throw new Error(`Request failed: ${response.status}`);
@@ -136,11 +146,47 @@ export async function deleteSession(sessionId: string): Promise<void> {
 export async function recordQuizResults(
   sessionId: string,
   answers: QuizResultItem[],
-): Promise<void> {
-  const response = await fetch(apiUrl(`/api/v1/sessions/${sessionId}/quiz-results`), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ answers }),
-  });
-  await expectJson<{ recorded: boolean }>(response);
+): Promise<RecordQuizResultsStatus> {
+  try {
+    const response = await fetch(apiUrl(`/api/v1/sessions/${sessionId}/quiz-results`), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ answers }),
+    });
+    await expectJson<{ recorded: boolean }>(response);
+    removePendingOfflineQuizResults(sessionId);
+    return { recorded: true };
+  } catch (error) {
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      enqueueOfflineQuizResults({
+        sessionId,
+        answers,
+        savedAt: new Date().toISOString(),
+      });
+      return { recorded: false, queued_offline: true };
+    }
+    throw error;
+  }
+}
+
+export async function flushQueuedQuizResults(): Promise<number> {
+  const queued = getPendingOfflineQuizResults();
+  let flushed = 0;
+
+  for (const item of queued) {
+    try {
+      const response = await fetch(apiUrl(`/api/v1/sessions/${item.sessionId}/quiz-results`), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answers: item.answers }),
+      });
+      await expectJson<{ recorded: boolean }>(response);
+      removePendingOfflineQuizResults(item.sessionId);
+      flushed += 1;
+    } catch {
+      continue;
+    }
+  }
+
+  return flushed;
 }


### PR DESCRIPTION
## Summary
- add a browser-local imported-pack manifest so downloaded packs can still appear when knowledge listing is unavailable
- add a browser-local offline queue for quiz result recording with retry on reconnect
- keep the first offline slice frontend-only and wire it into the existing marketplace, knowledge, and quiz flows

## Validation
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `cd web && npm ci && npm run build`

## Notes
- Architecture note: `docs/superpowers/pr-notes/2026-04-24-t035-offline-mode-support.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
- Closes #92
