### PR TITLE
[Docs] T036 Contest smoke and evidence refresh

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, batch marketplace import, offline-ready imported-pack fallback, offline quiz-result sync queue, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, the scripted-reset smoke lane has passed against the current local demo dataset, `docs/contest/` carries the latest smoke-backed evidence refresh record, and `T035 Offline Mode for Downloaded Packs` merged into `main` through PR `#93`. The strict-order registry queue is now empty.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `T035 Offline Mode for Downloaded Packs` merged into `main` through PR `#93`, and the current derived short task is `T036 Contest Smoke and Evidence Refresh` on branch `docs/t036-contest-evidence-refresh`. The scripted-reset smoke lane passed again on 2026-04-24 against the current local demo dataset, command-backed contest evidence is refreshed, and screenshot freshness is currently marked `Stale` pending human recapture.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; the strict-order registry queue is currently empty, so derive the next short task from smoke gaps, evidence freshness, or the MVP goal before opening a new lane.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; the strict-order registry queue is currently empty, so derive the next short task from smoke gaps, evidence freshness, or the MVP goal before opening a new lane. The current derived short task is `T036 Contest Smoke and Evidence Refresh`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -13,29 +13,30 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Active queue
 
-- No strict-order registry task is currently active.
-- The last completed task was `T035 Offline Mode for Downloaded Packs`.
-- Next lane should be derived from smoke gaps, evidence freshness, or the MVP goal.
+- Active short task: `T036 Contest Smoke and Evidence Refresh`
+- Branch: `docs/t036-contest-evidence-refresh`
+- Goal: refresh smoke-backed contest validation evidence and mark screenshot freshness honestly after the recent merged UI changes.
 
 ## Next recommended task
 
-Run smoke/evidence freshness checks or derive the next short task from the MVP goal, then open a new task packet and focused branch before implementation.
+Finish `T036` by publishing the smoke/evidence refresh docs lane, then choose whether the next short task should be screenshot recapture or a new MVP/runtime slice.
 
 ## Status Update (2026-04-24)
 
 **Queue Advance**:
 1. `#93` merged to `main` after all required CI checks passed
 2. Issue `#92` auto-closed with the merge
-3. The strict-order registry queue is now empty
-4. Next work should be chosen from smoke gaps, evidence freshness, or newly created MVP tasks
+3. Derived docs short task `T036 Contest Smoke and Evidence Refresh`
+4. Opened issue `#95` and started branch `docs/t036-contest-evidence-refresh`
+5. Re-ran the scripted-reset smoke lane on 2026-04-24
 
 ## AI-owned blockers
 
-- None currently. The scripted-reset smoke lane passed with demo-safe reset output, backend startup through the CLI server path, frontend production build, Knowledge Pack metadata, assessment session evidence, tutor session evidence, and dashboard activity.
+- None currently. The scripted-reset smoke lane passed on 2026-04-24 with demo-safe reset output, backend startup through the CLI server path, frontend production build, Knowledge Pack metadata, assessment session evidence, tutor session evidence, and dashboard activity.
 
 ## Human-review blockers
 
-- None currently. Human review is still required for product direction changes, deployment or credential decisions, and any PR explicitly marked blocked.
+- Screenshot freshness is now `Stale` until a human recapture refreshes the linked UI bundle. This does not block command-backed smoke evidence, but it does block claiming the screenshot bundle is current.
 
 ## Read path
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,14 +1,14 @@
 {
   "metadata": {
-    "last_updated": "2026-04-24T16:42:00Z",
+    "last_updated": "2026-04-24T16:55:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
-    "total_tasks": 35
+    "total_tasks": 36
   },
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 26,
+      "count": 27,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -35,13 +35,16 @@
         "T031_TUTOR_FOLLOW_UP_PROMPTS",
         "T032_KNOWLEDGE_PACK_VERSIONING",
         "T033_LEARNING_PATH_SEQUENCING",
-        "T034_BATCH_ASSESSMENT_IMPORT"
+        "T034_BATCH_ASSESSMENT_IMPORT",
+        "T035_OFFLINE_MODE_SUPPORT"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "T036_CONTEST_EVIDENCE_REFRESH"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -515,6 +518,23 @@
       "dependencies": ["Service Worker", "IndexedDB"],
       "status": "completed",
       "notes": "Merged to main through PR #93. Imported packs now have a browser-local offline manifest fallback and loaded quiz results can queue sync until the browser reconnects."
+    },
+    {
+      "id": "T036_CONTEST_EVIDENCE_REFRESH",
+      "category": "Low",
+      "priority": 28,
+      "title": "Contest Smoke and Evidence Refresh",
+      "description": "Refresh the smoke-backed contest validation record, mark screenshot freshness honestly, and keep AI-first control-plane docs aligned with the derived evidence lane.",
+      "scope": {
+        "docs": "docs/contest/VALIDATION_REPORT.md, docs/contest/EVIDENCE_CHECKLIST.md, docs/superpowers/tasks/, docs/superpowers/pr-notes/",
+        "control_plane": "ai_first/AI_OPERATING_PROMPT.md, ai_first/EXECUTION_QUEUE.md, ai_first/TASK_REGISTRY.json, ai_first/daily/2026-04-24.md"
+      },
+      "affected_features": ["Contest Evidence", "AI-first Control Plane"],
+      "complexity": "Low",
+      "estimated_hours": 2,
+      "dependencies": ["T035 merged to main", "scripts/contest/reset_demo_data.py"],
+      "status": "in-progress",
+      "notes": "Issue #95 opened and task packet created at docs/superpowers/tasks/2026-04-24-T036-contest-evidence-refresh.md. Active branch: docs/t036-contest-evidence-refresh."
     }
   ],
   "github_issues_template": {
@@ -610,7 +630,7 @@
     },
     "MVP_PHASE_3": {
       "title": "Medium Priority & Polish (Weeks 5+)",
-      "tasks": ["T024", "T025", "T026", "T027", "T029", "T030", "T031", "T032", "T033", "T034", "T035"],
+      "tasks": ["T024", "T025", "T026", "T027", "T029", "T030", "T031", "T032", "T033", "T034", "T035", "T036"],
       "target_date": "2026-06-01"
     }
   }

--- a/ai_first/daily/2026-04-24.md
+++ b/ai_first/daily/2026-04-24.md
@@ -306,6 +306,54 @@
 - Task `T035_OFFLINE_MODE_SUPPORT`: moved to `completed`
 - Next: refresh smoke/evidence state or derive the next short task from the MVP goal before opening a new feature lane
 
+## T036 Contest Smoke and Evidence Refresh — Task Selection
+
+### Completed in this cycle
+
+1. Derived the next short task from evidence freshness after the strict-order feature queue became empty.
+2. Opened GitHub issue `#95` for `T036`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-24-T036-contest-evidence-refresh.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T036_CONTEST_EVIDENCE_REFRESH`: moved to `in-progress`
+- Next: run the scripted demo reset plus smoke lane on current `main`, then refresh contest evidence docs with the real results
+
+## T036 Contest Smoke and Evidence Refresh — Smoke Pass and Docs Refresh
+
+### Completed in this cycle
+
+1. Ran the demo-safe reset:
+   - `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
+2. Started the local backend through the repository-root virtual environment:
+   - `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`
+3. Verified command-backed evidence:
+   - `curl -s http://127.0.0.1:8001/api/v1/system/status`
+   - `curl -s http://127.0.0.1:8001/api/v1/knowledge/list`
+   - `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview`
+   - `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent`
+   - `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo`
+   - `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo`
+4. Installed fresh worktree frontend dependencies and passed the production build:
+   - `cd web && npm ci`
+   - `cd web && npm run build`
+5. Refreshed:
+   - `docs/contest/VALIDATION_REPORT.md`
+   - `docs/contest/EVIDENCE_CHECKLIST.md`
+6. Marked screenshot evidence `Stale` because this lane did not include a new human screenshot capture after the recent UI merges.
+7. Added the required PR note:
+   - `docs/superpowers/pr-notes/2026-04-24-t036-contest-evidence-refresh.md`
+
+### Status
+
+- Task `T036_CONTEST_EVIDENCE_REFRESH`: smoke and docs refresh complete on branch `docs/t036-contest-evidence-refresh`
+- Next: run final docs/control-plane validation, self-review, and publish the docs lane for CI
+
 ## T033 Suggested Learning Path Sequencing — Merge Complete
 
 ### Completed in this cycle

--- a/docs/contest/EVIDENCE_CHECKLIST.md
+++ b/docs/contest/EVIDENCE_CHECKLIST.md
@@ -8,15 +8,15 @@ Refresh these only when the UI changed or when the latest smoke-backed validatio
 
 | Area | Evidence | Refresh mode | Status | Notes |
 | --- | --- | --- | --- | --- |
-| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Human capture | Current | [`01-knowledge-pack-metadata.png`](./screenshots/01-knowledge-pack-metadata.png) |
-| Knowledge Pack | Metadata still visible after reload | Human capture | Current | [`02-knowledge-pack-after-reload.png`](./screenshots/02-knowledge-pack-after-reload.png) |
-| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Human capture | Current | [`04-assessment-config.png`](./screenshots/04-assessment-config.png) |
-| Assessment | Generated questions visible | Human capture | Current | [`07-assessment-generated-questions.png`](./screenshots/07-assessment-generated-questions.png) |
-| Assessment | Common-mistake or feedback guidance visible | Human capture | Current | [`08-assessment-common-mistakes.png`](./screenshots/08-assessment-common-mistakes.png) |
-| Tutor Agent | Student asks a follow-up question | Human capture | Current | [`06-tutor-agent-answer.png`](./screenshots/06-tutor-agent-answer.png) |
-| Tutor Agent | Tutor response with learning context | Human capture | Current | [`06-tutor-agent-answer.png`](./screenshots/06-tutor-agent-answer.png) |
-| Dashboard | Summary cards visible | Human capture | Current | [`05-dashboard-summary-and-activity.png`](./screenshots/05-dashboard-summary-and-activity.png) |
-| Dashboard | Recent activity includes assessment/tutoring distinction and Knowledge Pack reference | Human capture | Current | [`05-dashboard-summary-and-activity.png`](./screenshots/05-dashboard-summary-and-activity.png) |
+| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
+| Knowledge Pack | Metadata still visible after reload | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
+| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
+| Assessment | Generated questions visible | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
+| Assessment | Common-mistake or feedback guidance visible | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
+| Tutor Agent | Student asks a follow-up question | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
+| Tutor Agent | Tutor response with learning context | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
+| Dashboard | Summary cards visible | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
+| Dashboard | Recent activity includes assessment/tutoring distinction and Knowledge Pack reference | Human capture | Stale | Existing capture is still linked, but recent merged UI changes were not followed by a new screenshot pass. |
 
 ## Required Command Evidence
 
@@ -24,14 +24,14 @@ Refresh these automatically after every successful smoke pass.
 
 | Command | Refresh mode | Status | Source |
 | --- | --- | --- | --- |
-| `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Auto before smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run; see `VALIDATION_REPORT.md`. |
-| `cd web && npm run build` | Auto after smoke | Current | Passed in the 2026-04-19 scripted-reset smoke run with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing lockfile warning. |
+| `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Auto before smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
+| `cd web && npm run build` | Auto after smoke | Current | Passed on 2026-04-24 after `npm ci`, with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing lockfile warning. |
 
 ## Optional Video
 
@@ -59,6 +59,6 @@ Video status follows the same freshness states:
 | --- | --- | --- |
 | Full MVP story can be followed from docs | Passed | Start with `docs/contest/README.md`. |
 | Product commands have smoke-backed validation evidence | Passed | See `VALIDATION_REPORT.md`. |
-| Screenshots are captured and linked | Passed | All screenshot entries are currently marked `Current`. |
+| Screenshots are captured and linked | Stale | Existing screenshot links remain available, but a fresh human capture is still required after recent UI merges. |
 | Video is captured or explicitly deferred | Deferred | Optional unless submission requires it. |
 | No secrets or private data in evidence | Passed | Screenshots use demo-safe Knowledge Pack and session data. |

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -1,6 +1,6 @@
 # Validation Report
 
-Last updated: 2026-04-19
+Last updated: 2026-04-24
 
 ## Scope
 
@@ -10,13 +10,13 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Evidence Freshness Status
 
-Latest smoke-backed refresh: 2026-04-19
+Latest smoke-backed refresh: 2026-04-24
 
 | Evidence group | Refresh mode | Status | Latest source |
 | --- | --- | --- | --- |
-| Backend and API reachability | Auto after smoke | Current | Scripted-reset smoke run recorded in `ai_first/daily/2026-04-19.md`. |
-| Frontend production build | Auto after smoke | Current | `npm run build` passed with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` during the scripted-reset smoke run. |
-| Screenshot bundle | Human capture after smoke when the UI changes | Current | Existing contest screenshots still match the smoke-verified MVP path. |
+| Backend and API reachability | Auto after smoke | Current | Scripted-reset smoke run recorded in `ai_first/daily/2026-04-24.md`. |
+| Frontend production build | Auto after smoke | Current | `npm run build` passed on 2026-04-24 with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` after installing worktree dependencies. |
+| Screenshot bundle | Human capture after smoke when the UI changes | Stale | Recent merged UI changes were smoke-validated on 2026-04-24, but no new human screenshot capture was performed in this lane. |
 | Optional video | Human capture only | Deferred | No external video is required yet. |
 
 Use these status values consistently:
@@ -30,18 +30,18 @@ Use these status values consistently:
 
 | Area | Command | Result |
 | --- | --- | --- |
-| Scripted demo reset | `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Passed in the 2026-04-19 scripted-reset smoke run; it reported `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`. |
-| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed in the 2026-04-19 scripted-reset smoke run. |
-| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed in the 2026-04-19 scripted-reset smoke run; `contest-demo-quadratics` was present with teacher metadata. |
-| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed in the 2026-04-19 scripted-reset smoke run with one assessment and one tutoring session. |
-| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed in the 2026-04-19 scripted-reset smoke run with assessment and tutor activity grounded in `contest-demo-quadratics`. |
-| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed in the 2026-04-19 scripted-reset smoke run. |
-| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed in the 2026-04-19 scripted-reset smoke run. |
-| Frontend production build | `cd web && npm run build` | Passed in the 2026-04-19 scripted-reset smoke run with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing multiple-lockfile warning. |
+| Scripted demo reset | `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Passed on 2026-04-24; it reported `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`. |
+| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed on 2026-04-24 with backend `online`, configured `gpt-4o-mini`, and local fallback search. |
+| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed on 2026-04-24; `contest-demo-quadratics` was present with demo-safe metadata and `sharing_status=demo`. |
+| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed on 2026-04-24 with one assessment, one tutoring session, analytics totals, and recent activity grounded in `contest-demo-quadratics`. |
+| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed on 2026-04-24 with assessment and tutor activity grounded in `contest-demo-quadratics`. |
+| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed on 2026-04-24. |
+| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed on 2026-04-24. |
+| Frontend production build | `cd web && npm run build` | Passed on 2026-04-24 after `npm ci`, with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing multiple-lockfile warning. |
 
 ## Current Known Limitations
 
-- Screenshot evidence is captured under `docs/contest/screenshots/`.
+- Screenshot evidence is captured under `docs/contest/screenshots/`, but the current bundle is stale until a new human capture refresh happens.
 - Video evidence is deferred unless the final contest submission requires it.
 - The frontend build emits a Next.js warning about multiple lockfiles and inferred workspace root. The build still completes successfully.
 - Screenshot freshness still requires a human capture step when the UI meaningfully changes.
@@ -53,8 +53,8 @@ Use these status values consistently:
 The latest smoke-backed evidence refresh used local demo data only:
 
 - Reset: `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
-- Backend: `.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`
-- Frontend validation: `npm run build` in `web/` with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local`
+- Backend: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`
+- Frontend validation: `npm ci && npm run build` in `web/` with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local`
 - Knowledge Pack: `contest-demo-quadratics`
 - Demo sessions:
   - `contest-assessment-demo`
@@ -74,13 +74,13 @@ The first frontend build attempt failed in sandbox because Next.js could not fet
 
 ## Smoke-backed Verification Record
 
-The 2026-04-19 scripted-reset smoke run verified the full MVP path in order:
+The 2026-04-24 scripted-reset smoke run verified the full MVP path in order:
 
 1. scripted reset recreated the demo-safe Knowledge Pack and assessment/tutor sessions;
 2. backend started successfully with the repository-local virtual environment through the CLI server path;
 3. system status, knowledge list, dashboard overview, dashboard recent, assessment session, and tutor session endpoints all returned the expected demo-safe data;
 4. the frontend production build passed against `http://localhost:8001`;
-5. the existing screenshot bundle still matched the smoke-verified flow, so screenshot status remains `Current` instead of requiring immediate recapture.
+5. the existing screenshot bundle was not recaptured during this lane, so screenshot status is now `Stale` until a human refresh confirms the latest UI.
 
 ## Manual Verification Template
 

--- a/docs/superpowers/pr-notes/2026-04-24-t036-contest-evidence-refresh.md
+++ b/docs/superpowers/pr-notes/2026-04-24-t036-contest-evidence-refresh.md
@@ -1,0 +1,25 @@
+# T036 Contest Smoke and Evidence Refresh
+
+## Summary
+
+- Re-ran the contest smoke lane on 2026-04-24 using the scripted demo reset plus current local backend/frontend validation.
+- Refreshed command-backed evidence status in `docs/contest/VALIDATION_REPORT.md`.
+- Marked screenshot evidence `Stale` in `docs/contest/EVIDENCE_CHECKLIST.md` because recent UI merges were not followed by a fresh human capture.
+- Updated AI-first control-plane docs to track the derived short task and the refreshed evidence state.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Reset["reset_demo_data.py"] --> Backend["local backend serve"]
+  Backend --> Probes["API smoke probes"]
+  Probes --> Build["web npm run build"]
+  Build --> Validation["VALIDATION_REPORT.md"]
+  Validation --> Checklist["EVIDENCE_CHECKLIST.md"]
+  Checklist --> ControlPlane["AI operating prompt + queue + registry + daily log"]
+```
+
+## Notes
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane changed evidence and control-plane docs only.
+- The smoke run passed on 2026-04-24, but screenshot evidence remains stale until a human recapture refreshes the UI bundle.

--- a/docs/superpowers/tasks/2026-04-24-T036-contest-evidence-refresh.md
+++ b/docs/superpowers/tasks/2026-04-24-T036-contest-evidence-refresh.md
@@ -1,0 +1,79 @@
+# Feature Pod Task: Contest Smoke and Evidence Refresh
+
+Owner: Codex
+Branch: `docs/t036-contest-evidence-refresh`
+GitHub Issue: `#95`
+
+## Goal
+
+Refresh the contest smoke-backed validation record against current `main`, update evidence freshness honestly, and repair any control-plane drift uncovered during the refresh.
+
+## User-visible outcome
+
+- Contest validation docs reflect a real 2026-04-24 smoke run instead of the older 2026-04-19 record.
+- Command evidence is marked `Current` based on the new smoke run.
+- Screenshot evidence is marked `Stale` until a human recapture happens after the recent UI merges.
+
+## Owned files/modules
+
+- `docs/contest/VALIDATION_REPORT.md`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `docs/contest/SMOKE_RUNBOOK.md` only if the executed smoke path needs clarification
+- `docs/superpowers/tasks/2026-04-24-T036-contest-evidence-refresh.md`
+- `docs/superpowers/pr-notes/2026-04-24-t036-contest-evidence-refresh.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-24.md`
+
+## Do-not-touch files/modules
+
+- Product/runtime source files unless the smoke lane finds a real blocker that must be fixed first
+- Screenshot image assets themselves
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless the lane unexpectedly changes product/runtime architecture
+- Root license and upstream attribution files
+
+## Evidence contract
+
+- Use the scripted local reset command before the smoke pass:
+  - `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
+- Use the existing local backend startup path:
+  - `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`
+- Verify:
+  - `curl -s http://127.0.0.1:8001/api/v1/system/status`
+  - `curl -s http://127.0.0.1:8001/api/v1/knowledge/list`
+  - `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview`
+  - `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent`
+  - `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo`
+  - `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo`
+  - `cd web && npm run build`
+
+## Acceptance criteria
+
+- Validation docs cite the 2026-04-24 smoke-backed pass with concrete commands and outcomes.
+- Any stale screenshot state is called out explicitly instead of left as `Current`.
+- AI-first task tracking shows `T036` as the active short task on this branch.
+- No product/runtime scope is broadened beyond the evidence refresh lane.
+
+## Required tests
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `rg -n "2026-04-24|Current|Stale|Blocked|contest-demo-quadratics|contest-assessment-demo|contest-tutor-demo" docs/contest ai_first`
+- `git diff --check`
+
+## Manual verification
+
+- Confirm the reset script recreates `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`.
+- Confirm backend endpoints return the expected demo-safe metadata and recent activity.
+- Confirm the frontend production build passes from the fresh worktree after dependency install.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+## Handoff notes
+
+- `T035` merged to `main` through PR `#93`, and docs-only sync merged through PR `#94`.
+- The strict-order feature queue was empty before deriving this short task.
+- Treat screenshot freshness conservatively: if no new capture happened, mark it `Stale`.


### PR DESCRIPTION
## Summary
- rerun the scripted contest smoke lane on 2026-04-24 against current `main`
- refresh `docs/contest/VALIDATION_REPORT.md` and `docs/contest/EVIDENCE_CHECKLIST.md` with the real command results
- add `T036` task tracking and mark screenshot evidence `Stale` pending human recapture

## Validation
- `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`
- `curl -s http://127.0.0.1:8001/api/v1/system/status`
- `curl -s http://127.0.0.1:8001/api/v1/knowledge/list`
- `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview`
- `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent`
- `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo`
- `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo`
- `cd web && npm ci`
- `cd web && npm run build`
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `rg -n "2026-04-24|Current|Stale|Blocked|contest-demo-quadratics|contest-assessment-demo|contest-tutor-demo|T036" docs/contest ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
- `git diff --check`

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-24-t036-contest-evidence-refresh.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane is docs/control-plane only.
