### PR TITLE
[Docs] T038 Contest submission package freshness sync

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, batch marketplace import, offline-ready imported-pack fallback, offline quiz-result sync queue, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, and backend/frontend/docs CI are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `T036 Contest Smoke and Evidence Refresh` merged into `main` through PR `#96`, command-backed contest evidence is refreshed on `main`, and screenshot freshness is currently marked `Stale` pending human recapture. The current derived short task is `T037 Contest Screenshot Evidence Refresh` on branch `docs/t037-contest-screenshot-refresh`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `T037 Contest Screenshot Evidence Refresh` merged into `main` through PR `#99`, screenshot evidence is current again on `main`, and the remaining obvious docs drift is in the contest-facing entry docs. The current derived short task is `T038 Contest Submission Package Freshness Sync` on branch `docs/t038-submission-readiness-sync`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -175,7 +175,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; the strict-order registry queue is currently empty, so derive the next short task from smoke gaps, evidence freshness, or the MVP goal before opening a new lane. The current derived short task is `T037 Contest Screenshot Evidence Refresh`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass; the strict-order registry queue is currently empty, so derive the next short task from smoke gaps, evidence freshness, or the MVP goal before opening a new lane. The current derived short task is `T038 Contest Submission Package Freshness Sync`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,28 +7,28 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#96 [Docs] T036 Contest smoke and evidence refresh`
-- `#96` refreshed the command-backed contest smoke evidence on 2026-04-24 and correctly marked screenshot evidence as `Stale` pending a new capture pass.
+- Latest merged PR: `#99 [Docs] T037 Contest screenshot evidence refresh`
+- `#99` refreshed the linked contest screenshot bundle on 2026-04-24, so screenshot evidence is `Current` again on `main`.
 - Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, batch import, offline-ready imported-pack fallback, offline quiz-result sync queue, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, tutor follow-up prompts, knowledge-pack version metadata, student learning-path sequencing, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- Active short task: `T037 Contest Screenshot Evidence Refresh`
-- Branch: `docs/t037-contest-screenshot-refresh`
-- Goal: refresh the linked screenshot bundle so contest screenshot evidence can move from `Stale` back to `Current`.
+- Active short task: `T038 Contest Submission Package Freshness Sync`
+- Branch: `docs/t038-submission-readiness-sync`
+- Goal: sync the contest-facing README and submission package with the latest 2026-04-24 smoke and screenshot evidence state.
 
 ## Next recommended task
 
-Publish the screenshot-refresh lane, then reassess whether any remaining contest evidence gaps or MVP/runtime gaps still need a new short task.
+Publish the submission-readiness sync lane, then reassess whether any remaining contest evidence gaps or MVP/runtime gaps still need a new short task.
 
 ## Status Update (2026-04-24)
 
 **Queue Advance**:
-1. `#96` merged to `main` after all required CI checks passed
-2. Issue `#95` was closed after the merge
-3. `T036 Contest Smoke and Evidence Refresh` is now complete on `main`
-4. Opened issue `#97` for `T037 Contest Screenshot Evidence Refresh`
-5. The next lane is screenshot recapture because screenshot evidence remains the explicit stale item
+1. `#99` merged to `main` after all required CI checks passed
+2. Issue `#97` auto-closed with the merge
+3. `T037 Contest Screenshot Evidence Refresh` is now complete on `main`
+4. Opened issue `#100` for `T038 Contest Submission Package Freshness Sync`
+5. The next lane syncs contest-facing entry docs that still point at the older 2026-04-19 evidence state
 
 ## AI-owned blockers
 
@@ -36,7 +36,7 @@ Publish the screenshot-refresh lane, then reassess whether any remaining contest
 
 ## Human-review blockers
 
-- Screenshot freshness is `Stale` until a fresh recapture refreshes the linked UI bundle. This is the active short-task target for `T037`.
+- None currently. Command evidence and screenshot evidence are both current on `main`; the remaining gap is submission-facing doc freshness.
 
 ## Read path
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,14 +1,14 @@
 {
   "metadata": {
-    "last_updated": "2026-04-24T18:10:00Z",
+    "last_updated": "2026-04-24T18:35:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
-    "total_tasks": 37
+    "total_tasks": 38
   },
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 28,
+      "count": 29,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -37,14 +37,15 @@
         "T033_LEARNING_PATH_SEQUENCING",
         "T034_BATCH_ASSESSMENT_IMPORT",
         "T035_OFFLINE_MODE_SUPPORT",
-        "T036_CONTEST_EVIDENCE_REFRESH"
+        "T036_CONTEST_EVIDENCE_REFRESH",
+        "T037_CONTEST_SCREENSHOT_REFRESH"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
       "count": 1,
       "tasks": [
-        "T037_CONTEST_SCREENSHOT_REFRESH"
+        "T038_CONTEST_SUBMISSION_FRESHNESS_SYNC"
       ]
     },
     "blocked": {
@@ -552,8 +553,25 @@
       "complexity": "Low",
       "estimated_hours": 2,
       "dependencies": ["T036 merged to main", "Fresh screenshot capture path"],
+      "status": "completed",
+      "notes": "Merged to main through PR #99. Contest screenshot evidence was refreshed to current on 2026-04-24 and linked docs now point at the latest screenshot bundle."
+    },
+    {
+      "id": "T038_CONTEST_SUBMISSION_FRESHNESS_SYNC",
+      "category": "Low",
+      "priority": 30,
+      "title": "Contest Submission Package Freshness Sync",
+      "description": "Sync the contest-facing README and submission package with the latest merged smoke and screenshot evidence state so submission entry docs no longer point at the older validation window.",
+      "scope": {
+        "docs": "docs/contest/README.md, docs/contest/SUBMISSION_PACKAGE.md, docs/superpowers/tasks/, docs/superpowers/pr-notes/",
+        "control_plane": "ai_first/AI_OPERATING_PROMPT.md, ai_first/EXECUTION_QUEUE.md, ai_first/TASK_REGISTRY.json, ai_first/daily/2026-04-24.md"
+      },
+      "affected_features": ["Contest Evidence", "Submission Docs", "AI-first Control Plane"],
+      "complexity": "Low",
+      "estimated_hours": 1.5,
+      "dependencies": ["T037 merged to main"],
       "status": "in-progress",
-      "notes": "Issue #97 opened and task packet created at docs/superpowers/tasks/2026-04-24-T037-contest-screenshot-refresh.md. Active branch: docs/t037-contest-screenshot-refresh."
+      "notes": "Issue #100 opened for docs freshness sync. Active branch: docs/t038-submission-readiness-sync."
     }
   ],
   "github_issues_template": {

--- a/ai_first/daily/2026-04-24.md
+++ b/ai_first/daily/2026-04-24.md
@@ -512,3 +512,34 @@
 
 - Task `T037_CONTEST_SCREENSHOT_REFRESH`: screenshot bundle and docs refresh complete on branch `docs/t037-contest-screenshot-refresh`
 - Next: run final docs/control-plane validation, self-review, and publish the screenshot-refresh lane for CI
+
+## T037 Contest Screenshot Evidence Refresh — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#99` passed required CI and merged to `main`.
+2. Issue `#97` closed with the merge.
+3. `T037` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T037_CONTEST_SCREENSHOT_REFRESH`: moved to `completed`
+- Next: sync contest-facing entry docs that still point at the older validation window
+
+## T038 Contest Submission Package Freshness Sync — Task Selection
+
+### Completed in this cycle
+
+1. Derived the next short task from the remaining contest-facing doc drift after `T037` merged.
+2. Opened GitHub issue `#100` for `T038`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-24-T038-contest-submission-readiness-sync.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T038_CONTEST_SUBMISSION_FRESHNESS_SYNC`: moved to `in-progress`
+- Next: sync the contest-facing README and submission package to the latest 2026-04-24 smoke and screenshot evidence state

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -18,8 +18,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Current Status
 
 - Product MVP path is implemented through merged PRs for Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard.
-- The latest scripted-reset smoke-backed MVP verification passed on 2026-04-19 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
-- Screenshot evidence is captured in [`screenshots/`](./screenshots/).
+- The latest scripted-reset smoke-backed MVP verification passed on 2026-04-24 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
+- Screenshot evidence is captured in [`screenshots/`](./screenshots/) and is current again after the `T037` refresh on 2026-04-24.
 - Video capture is optional and deferred to avoid storing large media in the repository.
 
 ## Evidence Refresh Rules

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -28,7 +28,7 @@ Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/com
 
 ## Latest Validation
 
-The latest smoke-backed refresh passed on 2026-04-19 after running the scripted local reset. It verified:
+The latest smoke-backed refresh passed on 2026-04-24 after running the scripted local reset. It verified:
 
 - demo-safe Knowledge Pack `contest-demo-quadratics`;
 - assessment session `contest-assessment-demo`;
@@ -36,7 +36,7 @@ The latest smoke-backed refresh passed on 2026-04-19 after running the scripted 
 - dashboard overview and recent activity;
 - frontend production build with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
 
-Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The execution PR is `#40`.
+Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` for smoke-backed evidence and `#99` for the screenshot bundle.
 
 ## Human Review Checklist
 
@@ -55,7 +55,7 @@ Before final submission, a human should review:
 - Provider-backed AI quality depends on configured model credentials.
 - The backend `deeptutor.api.run_server` path has a reload/absolute-pattern incompatibility with the installed `uvicorn`; latest smoke used the CLI server path with reload disabled.
 - Frontend build may need network access to fetch Google Fonts.
-- Screenshots should be recaptured only if the UI meaningfully changes.
+- Screenshots are current as of the 2026-04-24 `T037` refresh and should be recaptured only if the UI meaningfully changes again.
 
 ## Review Flow
 

--- a/docs/superpowers/pr-notes/2026-04-24-t038-contest-submission-readiness-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-24-t038-contest-submission-readiness-sync.md
@@ -1,0 +1,28 @@
+# T038 Contest Submission Package Freshness Sync
+
+## Summary
+
+- synced the contest-facing README and submission package to the latest 2026-04-24 smoke/evidence state
+- advanced control-plane tracking from `T037` complete to `T038` in progress
+- kept the change docs-only; `ai_first/architecture/MAIN_SYSTEM_MAP.md` did not change
+
+## Flow
+
+```mermaid
+flowchart LR
+    A["T037 merged on main"] --> B["Screenshot evidence current"]
+    B --> C["Contest README synced"]
+    B --> D["Submission package synced"]
+    C --> E["Control-plane mirrors updated"]
+    D --> E
+```
+
+## Files
+
+- `docs/contest/README.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-24.md`
+- `docs/superpowers/tasks/2026-04-24-T038-contest-submission-readiness-sync.md`

--- a/docs/superpowers/tasks/2026-04-24-T038-contest-submission-readiness-sync.md
+++ b/docs/superpowers/tasks/2026-04-24-T038-contest-submission-readiness-sync.md
@@ -1,0 +1,50 @@
+# Feature Pod Task: Contest Submission Package Freshness Sync
+
+Owner: Codex
+Branch: `docs/t038-submission-readiness-sync`
+GitHub Issue: `#100`
+
+## Goal
+
+Sync the contest-facing entry docs with the latest 2026-04-24 smoke and screenshot evidence so reviewers do not land on stale submission-facing summaries.
+
+## User-visible outcome
+
+- `docs/contest/README.md` reflects the current smoke-backed validation date.
+- `docs/contest/SUBMISSION_PACKAGE.md` points at the latest evidence lanes and current screenshot state.
+- AI-first tracking reflects `T037` complete and `T038` active.
+
+## Owned files/modules
+
+- `docs/contest/README.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `docs/superpowers/tasks/2026-04-24-T038-contest-submission-readiness-sync.md`
+- `docs/superpowers/pr-notes/` for the PR note
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-24.md`
+
+## Do-not-touch files/modules
+
+- Product/runtime source files
+- `docs/contest/VALIDATION_REPORT.md` and `docs/contest/EVIDENCE_CHECKLIST.md` unless a documentation inconsistency is discovered while syncing entry docs
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## Acceptance criteria
+
+- Contest entry docs no longer mention the old 2026-04-19 validation window.
+- Contest entry docs reflect that screenshot evidence is current again after `T037`.
+- AI-first queue mirrors `T037` as complete and `T038` as the active short task.
+
+## Required tests
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `rg -n "2026-04-24|T037|T038|Current|Deferred|#99|#100" docs/contest ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+


### PR DESCRIPTION
## Summary
- sync the contest-facing README and submission package to the latest 2026-04-24 evidence state
- mark T037 complete and move AI-first tracking to T038
- add the task packet and PR note for the submission-readiness sync lane

## Validation
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `rg -n "2026-04-24|T037|T038|Current|Deferred|#99|#100" docs/contest ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
- `git diff --check`

Closes #100
