### PR TITLE
[docs] Two-person AI-first collaboration workflow

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -1,0 +1,26 @@
+# Active Assignments
+
+Use this file as the short-lived coordination board for active work.
+
+Rules:
+
+- Add an assignment before starting code work.
+- One person should hold one active task at a time.
+- Keep entries short and factual.
+- Update the entry when blocked, paused, moved to review, or merged.
+
+## Template
+
+### Assignment
+
+- Owner:
+- Machine:
+- Task:
+- Status:
+- Branch:
+- Task packet:
+- Owned files:
+- PR:
+- Last update:
+- Next action:
+- Blocker:

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -67,6 +67,14 @@ Before edits:
 - Every PR must include a Markdown architecture note under `docs/superpowers/pr-notes/` with at least one Mermaid diagram.
 - Every PR must state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
 
+## Collaboration rules
+
+- For two-person collaboration, prefer one person, one active task, one branch, and one PR.
+- Do not start code work until the task is reflected in `ai_first/ACTIVE_ASSIGNMENTS.md`.
+- Keep task packets current with owned files and do-not-touch scope before parallel work begins.
+- Do not split one feature across two people unless it has been decomposed into separate task packets with separate ownership.
+- Treat `ai_first/ACTIVE_ASSIGNMENTS.md` as the short-term coordination memory for active work.
+
 ## Autonomous completion loop
 
 After opening or updating a PR, classify it before handing off:

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -1,169 +1,22 @@
-# Daily Log — 2026-04-25
+# Daily Log - 2026-04-25
 
-## T038 Contest Submission Package Freshness Sync — Merge Complete
+## Summary
 
-### Completed in this cycle
+- Added a design baseline for two-person AI-first collaboration on one shared repository.
+- Added a lightweight active-assignment template under `ai_first/`.
+- Updated the operating prompt with a short rule set for two-person task coordination.
 
-1. PR `#101` passed required CI and merged to `main`.
-2. Issue `#100` closed with the merge.
-3. `T038` status was advanced to `completed` in the task tracking flow.
+## Documents added
 
-### Status
+- `docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
 
-- Task `T038_CONTEST_SUBMISSION_FRESHNESS_SYNC`: moved to `completed`
-- Next: align the final submission checklist with AI-verifiable repo evidence
+## Operating updates
 
-## T039 Submission Checklist Evidence Alignment — Task Selection
+- Added a collaboration rule set to `ai_first/AI_OPERATING_PROMPT.md`
+- Locked the recommended model to one person, one active task, one branch, and one PR
 
-### Completed in this cycle
+## Notes
 
-1. Derived the next short task from the remaining final-submission checklist gap after `T038` merged.
-2. Opened GitHub issue `#102` for `T039`.
-3. Added task packet:
-   - `docs/superpowers/tasks/2026-04-25-T039-submission-checklist-alignment.md`
-4. Updated task tracking mirrors:
-   - `ai_first/TASK_REGISTRY.json`
-   - `ai_first/EXECUTION_QUEUE.md`
-   - `ai_first/AI_OPERATING_PROMPT.md`
-
-### Status
-
-- Task `T039_SUBMISSION_CHECKLIST_ALIGNMENT`: moved to `in-progress`
-- Next: mark AI-verifiable checklist items from current repo evidence and keep human-only items explicit
-
-## T039 Submission Checklist Evidence Alignment — Merge Complete
-
-### Completed in this cycle
-
-1. PR `#103` passed required CI and merged to `main`.
-2. Issue `#102` closed with the merge.
-3. `T039` status was advanced to `completed` in the task tracking flow.
-
-### Status
-
-- Task `T039_SUBMISSION_CHECKLIST_ALIGNMENT`: moved to `completed`
-- Next: draft the missing contest product description
-
-## T040 Contest Product Description Draft — Task Selection
-
-### Completed in this cycle
-
-1. Derived the next short task from the remaining missing submission text after `T039` merged.
-2. Opened GitHub issue `#104` for `T040`.
-3. Added task packet:
-   - `docs/superpowers/tasks/2026-04-25-T040-contest-product-description.md`
-4. Updated task tracking mirrors:
-   - `ai_first/TASK_REGISTRY.json`
-   - `ai_first/EXECUTION_QUEUE.md`
-   - `ai_first/AI_OPERATING_PROMPT.md`
-
-### Status
-
-- Task `T040_CONTEST_PRODUCT_DESCRIPTION`: moved to `in-progress`
-- Next: write the contest product description draft and link it into the submission package
-
-## T040 Contest Product Description Draft — Merge Complete
-
-### Completed in this cycle
-
-1. PR `#105` passed required CI and merged to `main`.
-2. Issue `#104` closed with the merge.
-3. `T040` status was advanced to `completed` in the task tracking flow.
-
-### Status
-
-- Task `T040_CONTEST_PRODUCT_DESCRIPTION`: moved to `completed`
-- Next: describe the contest-specific fork modifications from current repo evidence
-
-## T041 Contest Fork Modifications Note — Task Selection
-
-### Completed in this cycle
-
-1. Derived the next short task from the remaining AI-doable submission checklist gap after `T040` merged.
-2. Opened GitHub issue `#106` for `T041`.
-3. Added task packet:
-   - `docs/superpowers/tasks/2026-04-25-T041-contest-fork-modifications.md`
-4. Updated task tracking mirrors:
-   - `ai_first/TASK_REGISTRY.json`
-   - `ai_first/EXECUTION_QUEUE.md`
-   - `ai_first/AI_OPERATING_PROMPT.md`
-
-### Status
-
-- Task `T041_CONTEST_FORK_MODIFICATIONS_NOTE`: moved to `in-progress`
-- Next: add a repo-backed fork modifications note and wire it into the final submission checklist
-
-## T041 Contest Fork Modifications Note — Merge Complete
-
-### Completed in this cycle
-
-1. PR `#107` passed required CI and merged to `main`.
-2. Issue `#106` closed with the merge.
-3. `T041` status was advanced to `completed` in the task tracking flow.
-
-### Status
-
-- Task `T041_CONTEST_FORK_MODIFICATIONS_NOTE`: moved to `completed`
-- Next: package the remaining human-only submission work into a focused handoff note
-
-## T042 Contest Human Review Handoff — Task Selection
-
-### Completed in this cycle
-
-1. Derived the next short task from the remaining human-only submission steps after `T041` merged.
-2. Opened GitHub issue `#108` for `T042`.
-3. Added task packet:
-   - `docs/superpowers/tasks/2026-04-25-T042-contest-human-review-handoff.md`
-4. Updated task tracking mirrors:
-   - `ai_first/TASK_REGISTRY.json`
-   - `ai_first/EXECUTION_QUEUE.md`
-   - `ai_first/AI_OPERATING_PROMPT.md`
-
-### Status
-
-- Task `T042_CONTEST_HUMAN_REVIEW_HANDOFF`: moved to `in-progress`
-- Next: write the shortest manual review handoff doc and link it from the submission package
-
-## T042 Contest Human Review Handoff — Merge Complete
-
-### Completed in this cycle
-
-1. PR `#109` passed required CI and merged to `main`.
-2. Issue `#108` closed with the merge.
-3. `T042` status was advanced to `completed` in the task tracking flow.
-
-### Status
-
-- Task `T042_CONTEST_HUMAN_REVIEW_HANDOFF`: moved to `completed`
-- Next: wait for human review of the contest submission package or open a final archival sync only if humans request one
-
-## T043 Optional Contest Video Capture Runbook — Task Selection
-
-### Completed in this cycle
-
-1. Derived the next short task from the explicitly allowed optional-video path after the queue reached a waiting-on-human-review state.
-2. Opened GitHub issue `#112` for `T043`.
-3. Added task packet:
-   - `docs/superpowers/tasks/2026-04-25-T043-optional-video-capture-runbook.md`
-4. Updated task tracking mirrors:
-   - `ai_first/TASK_REGISTRY.json`
-   - `ai_first/EXECUTION_QUEUE.md`
-   - `ai_first/AI_OPERATING_PROMPT.md`
-
-### Status
-
-- Task `T043_OPTIONAL_CONTEST_VIDEO_CAPTURE_RUNBOOK`: moved to `in-progress`
-- Next: write the optional video storyboard/runbook and link it into contest evidence docs without marking the video as captured
-
-## T043 Optional Contest Video Capture Runbook — Merge Complete
-
-### Completed in this cycle
-
-1. PR `#113` passed required CI and merged to `main`.
-2. Issue `#112` closed with the merge.
-3. `T043` status was advanced to `completed` in the task tracking flow.
-
-### Status
-
-- Task `T043_OPTIONAL_CONTEST_VIDEO_CAPTURE_RUNBOOK`: moved to `completed`
-- Next: wait for human review, or use the optional video runbook only if the team decides to record a video artifact
+- This design intentionally avoids a larger multi-machine scheduler
+- The target is pragmatic two-person throughput, not generalized distributed execution

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -5,16 +5,29 @@
 - Added a design baseline for two-person AI-first collaboration on one shared repository.
 - Added a lightweight active-assignment template under `ai_first/`.
 - Updated the operating prompt with a short rule set for two-person task coordination.
+- Tightened shared task and handoff templates so owned scope and assignment-before-code are explicit.
+- Added a PR architecture note and task-packet README guidance for the active-assignment workflow.
 
 ## Documents added
 
 - `docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md`
 - `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md`
+
+## Templates and docs updated
+
+- `ai_first/templates/feature-pod-task.md`
+- `docs/superpowers/tasks/templates/feature-pod-task.md`
+- `ai_first/templates/handoff-note.md`
+- `docs/superpowers/tasks/README.md`
 
 ## Operating updates
 
 - Added a collaboration rule set to `ai_first/AI_OPERATING_PROMPT.md`
 - Locked the recommended model to one person, one active task, one branch, and one PR
+- Added `Active assignment` and `Parallel-work notes` to both feature-pod templates
+- Added `Owned files in scope` and `Current blocker` to the handoff template
+- Added the active-assignment startup flow to the task-packet README
 
 ## Notes
 

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -1,22 +1,185 @@
-# Daily Log - 2026-04-25
+# Daily Log — 2026-04-25
 
-## Summary
+## T038 Contest Submission Package Freshness Sync — Merge Complete
 
-- Added a design baseline for two-person AI-first collaboration on one shared repository.
-- Added a lightweight active-assignment template under `ai_first/`.
-- Updated the operating prompt with a short rule set for two-person task coordination.
+### Completed in this cycle
 
-## Documents added
+1. PR `#101` passed required CI and merged to `main`.
+2. Issue `#100` closed with the merge.
+3. `T038` status was advanced to `completed` in the task tracking flow.
 
-- `docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md`
-- `ai_first/ACTIVE_ASSIGNMENTS.md`
+### Status
 
-## Operating updates
+- Task `T038_CONTEST_SUBMISSION_FRESHNESS_SYNC`: moved to `completed`
+- Next: align the final submission checklist with AI-verifiable repo evidence
 
-- Added a collaboration rule set to `ai_first/AI_OPERATING_PROMPT.md`
-- Locked the recommended model to one person, one active task, one branch, and one PR
+## T039 Submission Checklist Evidence Alignment — Task Selection
 
-## Notes
+### Completed in this cycle
 
-- This design intentionally avoids a larger multi-machine scheduler
-- The target is pragmatic two-person throughput, not generalized distributed execution
+1. Derived the next short task from the remaining final-submission checklist gap after `T038` merged.
+2. Opened GitHub issue `#102` for `T039`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-25-T039-submission-checklist-alignment.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T039_SUBMISSION_CHECKLIST_ALIGNMENT`: moved to `in-progress`
+- Next: mark AI-verifiable checklist items from current repo evidence and keep human-only items explicit
+
+## T039 Submission Checklist Evidence Alignment — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#103` passed required CI and merged to `main`.
+2. Issue `#102` closed with the merge.
+3. `T039` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T039_SUBMISSION_CHECKLIST_ALIGNMENT`: moved to `completed`
+- Next: draft the missing contest product description
+
+## T040 Contest Product Description Draft — Task Selection
+
+### Completed in this cycle
+
+1. Derived the next short task from the remaining missing submission text after `T039` merged.
+2. Opened GitHub issue `#104` for `T040`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-25-T040-contest-product-description.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T040_CONTEST_PRODUCT_DESCRIPTION`: moved to `in-progress`
+- Next: write the contest product description draft and link it into the submission package
+
+## T040 Contest Product Description Draft — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#105` passed required CI and merged to `main`.
+2. Issue `#104` closed with the merge.
+3. `T040` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T040_CONTEST_PRODUCT_DESCRIPTION`: moved to `completed`
+- Next: describe the contest-specific fork modifications from current repo evidence
+
+## T041 Contest Fork Modifications Note — Task Selection
+
+### Completed in this cycle
+
+1. Derived the next short task from the remaining AI-doable submission checklist gap after `T040` merged.
+2. Opened GitHub issue `#106` for `T041`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-25-T041-contest-fork-modifications.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T041_CONTEST_FORK_MODIFICATIONS_NOTE`: moved to `in-progress`
+- Next: add a repo-backed fork modifications note and wire it into the final submission checklist
+
+## T041 Contest Fork Modifications Note — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#107` passed required CI and merged to `main`.
+2. Issue `#106` closed with the merge.
+3. `T041` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T041_CONTEST_FORK_MODIFICATIONS_NOTE`: moved to `completed`
+- Next: package the remaining human-only submission work into a focused handoff note
+
+## T042 Contest Human Review Handoff — Task Selection
+
+### Completed in this cycle
+
+1. Derived the next short task from the remaining human-only submission steps after `T041` merged.
+2. Opened GitHub issue `#108` for `T042`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-25-T042-contest-human-review-handoff.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T042_CONTEST_HUMAN_REVIEW_HANDOFF`: moved to `in-progress`
+- Next: write the shortest manual review handoff doc and link it from the submission package
+
+## T042 Contest Human Review Handoff — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#109` passed required CI and merged to `main`.
+2. Issue `#108` closed with the merge.
+3. `T042` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T042_CONTEST_HUMAN_REVIEW_HANDOFF`: moved to `completed`
+- Next: wait for human review of the contest submission package or open a final archival sync only if humans request one
+
+## T043 Optional Contest Video Capture Runbook — Task Selection
+
+### Completed in this cycle
+
+1. Derived the next short task from the explicitly allowed optional-video path after the queue reached a waiting-on-human-review state.
+2. Opened GitHub issue `#112` for `T043`.
+3. Added task packet:
+   - `docs/superpowers/tasks/2026-04-25-T043-optional-video-capture-runbook.md`
+4. Updated task tracking mirrors:
+   - `ai_first/TASK_REGISTRY.json`
+   - `ai_first/EXECUTION_QUEUE.md`
+   - `ai_first/AI_OPERATING_PROMPT.md`
+
+### Status
+
+- Task `T043_OPTIONAL_CONTEST_VIDEO_CAPTURE_RUNBOOK`: moved to `in-progress`
+- Next: write the optional video storyboard/runbook and link it into contest evidence docs without marking the video as captured
+
+## T043 Optional Contest Video Capture Runbook — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#113` passed required CI and merged to `main`.
+2. Issue `#112` closed with the merge.
+3. `T043` status was advanced to `completed` in the task tracking flow.
+
+### Status
+
+- Task `T043_OPTIONAL_CONTEST_VIDEO_CAPTURE_RUNBOOK`: moved to `completed`
+- Next: wait for human review, or use the optional video runbook only if the team decides to record a video artifact
+
+## Two-Person AI-First Collaboration Workflow
+
+### Completed in this cycle
+
+1. Added a design baseline for two-person AI-first collaboration on one shared repository.
+2. Added a lightweight active-assignment template under `ai_first/`.
+3. Updated the operating prompt with a short rule set for two-person task coordination.
+4. Tightened shared task and handoff templates so owned scope and assignment-before-code are explicit.
+5. Added a PR architecture note and task-packet README guidance for the active-assignment workflow.
+
+### Status
+
+- Branch: `docs/two-person-ai-first-collab`
+- Scope: docs-only operating workflow update
+- Next: open or update the PR for review after local validation

--- a/ai_first/templates/feature-pod-task.md
+++ b/ai_first/templates/feature-pod-task.md
@@ -3,6 +3,7 @@
 Owner:
 Branch:
 GitHub Issue:
+Active assignment:
 
 ## Goal
 
@@ -19,6 +20,12 @@ GitHub Issue:
 ## Required tests
 
 ## Manual verification
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Keep owned files concrete; do not use broad labels like "frontend" or "backend".
+- Update this packet before scope expands.
 
 ## PR architecture note
 

--- a/ai_first/templates/handoff-note.md
+++ b/ai_first/templates/handoff-note.md
@@ -4,9 +4,13 @@
 
 ## Why
 
+## Owned files in scope
+
 ## Tests run
 
 ## Tests not run
+
+## Current blocker
 
 ## Risks
 

--- a/docs/superpowers/plans/2026-04-25-two-person-ai-first-collaboration.md
+++ b/docs/superpowers/plans/2026-04-25-two-person-ai-first-collaboration.md
@@ -1,0 +1,460 @@
+# Two-Person AI-First Collaboration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a minimal, repo-native coordination workflow so two people on two machines can work on separate tasks in parallel without losing context or stepping on each other.
+
+**Architecture:** Keep the current AI-first operating model intact and add only one new short-lived coordination artifact, `ai_first/ACTIVE_ASSIGNMENTS.md`. Tighten the operating prompt and shared templates so assignment-before-code, owned-file scope, and short handoff become explicit rules instead of tribal knowledge.
+
+**Tech Stack:** Markdown, git workflow, existing AI-first docs/templates, GitHub Draft PR flow
+
+---
+
+## File Structure
+
+- Create: `ai_first/ACTIVE_ASSIGNMENTS.md`
+  Single short-lived coordination board for active work.
+- Modify: `ai_first/AI_OPERATING_PROMPT.md`
+  Add repo-level collaboration rules for two-person parallel work.
+- Modify: `ai_first/templates/feature-pod-task.md`
+  Keep task packet template aligned with assignment-first and explicit scope rules.
+- Modify: `docs/superpowers/tasks/templates/feature-pod-task.md`
+  Mirror the same task packet template change in the docs-facing copy.
+- Modify: `ai_first/templates/handoff-note.md`
+  Make the handoff template capture files in scope and blockers explicitly.
+- Modify: `docs/superpowers/tasks/README.md`
+  Add the active-assignment workflow to the task packet read path.
+- Create: `docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md`
+  Required PR architecture note with Mermaid diagram.
+- Modify: `ai_first/daily/2026-04-25.md`
+  Record the operating change and adoption notes.
+
+### Task 1: Add The Active Assignment Board
+
+**Files:**
+- Create: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Test: repo-root validation commands only
+
+- [ ] **Step 1: Verify the board does not already exist**
+
+Run:
+
+```bash
+test -f ai_first/ACTIVE_ASSIGNMENTS.md && echo "exists" || echo "missing"
+```
+
+Expected: `missing`
+
+- [ ] **Step 2: Add the board with a short template**
+
+```md
+# Active Assignments
+
+Use this file as the short-lived coordination board for active work.
+
+Rules:
+
+- Add an assignment before starting code work.
+- One person should hold one active task at a time.
+- Keep entries short and factual.
+- Update the entry when blocked, paused, moved to review, or merged.
+
+## Template
+
+### Assignment
+
+- Owner:
+- Machine:
+- Task:
+- Status:
+- Branch:
+- Task packet:
+- Owned files:
+- PR:
+- Last update:
+- Next action:
+- Blocker:
+```
+
+- [ ] **Step 3: Verify the new board contains the required fields**
+
+Run:
+
+```bash
+rg -n "Owner:|Machine:|Task:|Owned files:|Next action:|Blocker:" ai_first/ACTIVE_ASSIGNMENTS.md
+```
+
+Expected: six matches in `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+- [ ] **Step 4: Check formatting**
+
+Run:
+
+```bash
+git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md
+```
+
+Expected: no output
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md
+git commit -m "docs: add active assignments board"
+```
+
+### Task 2: Encode Collaboration Rules In Shared Operating Docs
+
+**Files:**
+- Modify: `ai_first/AI_OPERATING_PROMPT.md`
+- Modify: `ai_first/templates/feature-pod-task.md`
+- Modify: `docs/superpowers/tasks/templates/feature-pod-task.md`
+- Modify: `ai_first/templates/handoff-note.md`
+- Modify: `docs/superpowers/tasks/README.md`
+- Test: repo-root validation commands only
+
+- [ ] **Step 1: Verify the collaboration rule section is not already present**
+
+Run:
+
+```bash
+rg -n "## Collaboration rules|ACTIVE_ASSIGNMENTS.md" ai_first/AI_OPERATING_PROMPT.md docs/superpowers/tasks/README.md ai_first/templates/feature-pod-task.md docs/superpowers/tasks/templates/feature-pod-task.md ai_first/templates/handoff-note.md
+```
+
+Expected: either no matches or only historical references that do not define the new workflow
+
+- [ ] **Step 2: Add the collaboration rules to the operating prompt**
+
+Insert this block after `## AI-first operating rules` and before `## Autonomous completion loop`:
+
+```md
+## Collaboration rules
+
+- For two-person collaboration, prefer one person, one active task, one branch, and one PR.
+- Do not start code work until the task is reflected in `ai_first/ACTIVE_ASSIGNMENTS.md`.
+- Keep task packets current with owned files and do-not-touch scope before parallel work begins.
+- Do not split one feature across two people unless it has been decomposed into separate task packets with separate ownership.
+- Treat `ai_first/ACTIVE_ASSIGNMENTS.md` as the short-term coordination memory for active work.
+```
+
+- [ ] **Step 3: Tighten both task packet templates**
+
+Replace the template body in both `ai_first/templates/feature-pod-task.md` and `docs/superpowers/tasks/templates/feature-pod-task.md` with:
+
+```md
+# Feature Pod Task: <feature name>
+
+Owner:
+Branch:
+GitHub Issue:
+Active assignment:
+
+## Goal
+
+## User-visible outcome
+
+## Owned files/modules
+
+## Do-not-touch files/modules
+
+## API/data contract
+
+## Acceptance criteria
+
+## Required tests
+
+## Manual verification
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Keep owned files concrete; do not use broad labels like "frontend" or "backend".
+- Update this packet before scope expands.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if feature structure changes.
+
+## Handoff notes
+```
+
+- [ ] **Step 4: Tighten the handoff note and task README**
+
+Replace `ai_first/templates/handoff-note.md` with:
+
+```md
+# Handoff Note
+
+## Changed
+
+## Why
+
+## Owned files in scope
+
+## Tests run
+
+## Tests not run
+
+## Current blocker
+
+## Risks
+
+## Next AI should read
+
+## Suggested next action
+```
+
+Append this section to `docs/superpowers/tasks/README.md`:
+
+```md
+## Active assignment workflow
+
+Before code work starts on a task:
+
+1. Confirm the task packet is current.
+2. Add the task to `ai_first/ACTIVE_ASSIGNMENTS.md`.
+3. Create or switch to the task branch.
+4. Work only inside the packet's owned-file scope.
+
+Use `ai_first/ACTIVE_ASSIGNMENTS.md` for short-lived active coordination and the task packet for the execution contract.
+```
+
+- [ ] **Step 5: Run validation**
+
+Run:
+
+```bash
+rg -n "Collaboration rules|one person, one active task|Active assignment:|Owned files in scope|Active assignment workflow" ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md docs/superpowers/tasks/templates/feature-pod-task.md ai_first/templates/handoff-note.md docs/superpowers/tasks/README.md
+```
+
+Expected: matches in all five files
+
+Run:
+
+```bash
+git diff --check -- ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md docs/superpowers/tasks/templates/feature-pod-task.md ai_first/templates/handoff-note.md docs/superpowers/tasks/README.md
+```
+
+Expected: no output
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md docs/superpowers/tasks/templates/feature-pod-task.md ai_first/templates/handoff-note.md docs/superpowers/tasks/README.md
+git commit -m "docs: add two-person collaboration rules"
+```
+
+### Task 3: Record The Change In PR And Daily History
+
+**Files:**
+- Create: `docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md`
+- Modify: `ai_first/daily/2026-04-25.md`
+- Test: repo-root validation commands only
+
+- [ ] **Step 1: Verify the PR note does not already exist**
+
+Run:
+
+```bash
+test -f docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md && echo "exists" || echo "missing"
+```
+
+Expected: `missing`
+
+- [ ] **Step 2: Add the PR architecture note**
+
+```md
+# PR Note - Two-Person AI-First Collaboration
+
+## Summary
+
+This PR adds the minimal coordination layer for two people working on separate tasks in parallel on the same AI-first repository.
+
+## Why
+
+The repo already had task packets, branches, and PRs, but it lacked one short-lived coordination surface showing who currently owns which active task. This PR fills that gap without introducing a larger distributed scheduler.
+
+## Scope
+
+- added `ai_first/ACTIVE_ASSIGNMENTS.md`
+- added collaboration rules to the operating prompt
+- updated task packet and handoff templates
+- updated the task packet README
+- recorded the change in the daily log
+
+## Architecture impact
+
+- no runtime or API behavior changes
+- no `MAIN_SYSTEM_MAP.md` update required
+- active coordination now lives in `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+```mermaid
+flowchart TD
+  Queue["TASK_REGISTRY.json / queue"] --> Packet["Task packet"]
+  Packet --> Assign["ACTIVE_ASSIGNMENTS.md"]
+  Assign --> Branch["Task branch"]
+  Branch --> PR["Draft PR"]
+  PR --> Merge["Merge after review/CI"]
+```
+
+## Validation
+
+- `rg -n "ACTIVE_ASSIGNMENTS|Collaboration rules|Active assignment workflow|Owned files in scope" ai_first docs/superpowers`
+- `git diff --check`
+```
+
+- [ ] **Step 3: Update the daily log entry**
+
+Use this content for `ai_first/daily/2026-04-25.md`:
+
+```md
+# Daily Log - 2026-04-25
+
+## Summary
+
+- Added a design baseline for two-person AI-first collaboration on one shared repository.
+- Added a lightweight active-assignment template under `ai_first/`.
+- Updated the operating prompt and shared templates with a short rule set for two-person task coordination.
+
+## Documents added
+
+- `docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md`
+- `docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Operating updates
+
+- Added a collaboration rule set to `ai_first/AI_OPERATING_PROMPT.md`
+- Added active-assignment workflow guidance to shared templates and task docs
+- Locked the recommended model to one person, one active task, one branch, and one PR
+
+## Notes
+
+- This design intentionally avoids a larger multi-machine scheduler
+- The target is pragmatic two-person throughput, not generalized distributed execution
+```
+
+- [ ] **Step 4: Run final validation**
+
+Run:
+
+```bash
+rg -n "Two-Person AI-First Collaboration|ACTIVE_ASSIGNMENTS|one person, one active task|Draft PR" docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md ai_first/daily/2026-04-25.md
+```
+
+Expected: matches in both files
+
+Run:
+
+```bash
+git diff --check -- docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md ai_first/daily/2026-04-25.md
+```
+
+Expected: no output
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md ai_first/daily/2026-04-25.md
+git commit -m "docs: record two-person collaboration workflow"
+```
+
+### Task 4: Final Review And Publish Preparation
+
+**Files:**
+- Modify: none
+- Test: repo-root validation commands only
+
+- [ ] **Step 1: Review spec coverage against the approved design**
+
+Run:
+
+```bash
+rg -n "Core operating model|Minimal coordination layer|Task assignment workflow|ACTIVE_ASSIGNMENTS|Handoff rules|Scope safety" docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md
+```
+
+Expected: matches for every major section named in the approved spec
+
+- [ ] **Step 2: Run repo-wide docs validation for this change**
+
+Run:
+
+```bash
+rg -n "ACTIVE_ASSIGNMENTS|Collaboration rules|Active assignment workflow|Owned files in scope" ai_first docs/superpowers
+```
+
+Expected: matches in the new board, operating prompt, templates, task docs, and PR note
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output
+
+- [ ] **Step 3: Review the staged diff for scope safety**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+```
+
+Expected: only docs and AI-first workflow files related to two-person coordination
+
+- [ ] **Step 4: Create the final publish commit if any review fixes were needed**
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md docs/superpowers/tasks/templates/feature-pod-task.md ai_first/templates/handoff-note.md docs/superpowers/tasks/README.md docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md ai_first/daily/2026-04-25.md
+git commit -m "docs: finalize two-person ai-first collaboration workflow"
+```
+
+- [ ] **Step 5: Prepare Draft PR body**
+
+Use this PR body:
+
+```md
+## Summary
+- add `ai_first/ACTIVE_ASSIGNMENTS.md` as the short-lived coordination board
+- add two-person collaboration rules to the operating prompt
+- tighten task packet, handoff, and task docs templates for assignment-before-code workflow
+- add a PR note and daily log entry for the new operating pattern
+
+## Why
+- two people on two machines need a simple way to work in parallel without adding a heavy distributed scheduler
+- the repo already has task packets and PRs; this PR adds the missing active coordination layer
+
+## Validation
+- `rg -n "ACTIVE_ASSIGNMENTS|Collaboration rules|Active assignment workflow|Owned files in scope" ai_first docs/superpowers`
+- `git diff --check`
+
+## Main System Map
+- Not updated; this PR is docs/workflow-only and does not change product/runtime architecture.
+```
+
+## Self-Review
+
+### Spec coverage
+
+- Core operating model: covered by Task 1 and Task 2
+- Minimal coordination layer: covered by Task 1 and Task 2
+- Task assignment workflow: covered by Task 1 and Task 2
+- Handoff rules: covered by Task 2 and Task 3
+- Scope safety: covered by Task 2 and Task 4
+
+No spec gaps found for the intended implementation slice.
+
+### Placeholder scan
+
+- No `TBD`, `TODO`, or deferred placeholders remain
+- All file paths are explicit
+- All validation commands are explicit
+- All template content is included inline
+
+### Type consistency
+
+- `ACTIVE_ASSIGNMENTS.md` naming is consistent across all tasks
+- The operating prompt, templates, README, PR note, and daily log use the same assignment-before-code terminology
+- Status and ownership wording stay aligned with the approved spec

--- a/docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md
+++ b/docs/superpowers/pr-notes/2026-04-25-two-person-ai-first-collaboration.md
@@ -1,0 +1,30 @@
+# Two-Person AI-First Collaboration
+
+## Summary
+
+- added a lightweight `ai_first/ACTIVE_ASSIGNMENTS.md` coordination board for active work
+- encoded assignment-before-code and explicit scope rules in the operating prompt and shared templates
+- kept the change process-only; `ai_first/architecture/MAIN_SYSTEM_MAP.md` did not change
+
+## Flow
+
+```mermaid
+flowchart LR
+    A["Select task from registry or queue"] --> B["Confirm task packet scope"]
+    B --> C["Add assignment to ACTIVE_ASSIGNMENTS.md"]
+    C --> D["Work on branch for that task only"]
+    D --> E["Open Draft PR with architecture note"]
+    E --> F["Handoff through assignment, packet, and daily log"]
+```
+
+## Files
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/templates/feature-pod-task.md`
+- `ai_first/templates/handoff-note.md`
+- `docs/superpowers/tasks/templates/feature-pod-task.md`
+- `docs/superpowers/tasks/README.md`
+- `docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md`
+- `docs/superpowers/plans/2026-04-25-two-person-ai-first-collaboration.md`
+- `ai_first/daily/2026-04-25.md`

--- a/docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md
+++ b/docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md
@@ -1,0 +1,182 @@
+# Two-Person AI-First Collaboration Design
+
+Date: 2026-04-25
+Status: Approved design baseline
+Scope: Two people, two machines, one shared git repository, AI-first coordination with minimal process overhead
+
+## Purpose
+
+This design defines the simplest coordination model that lets two people work faster on the same AI-first repository without stepping on each other, losing context, or forcing a heavy distributed control plane into `ai_first/`.
+
+The goal is not to solve general multi-machine orchestration. The goal is to make two collaborators productive right now.
+
+## Core operating model
+
+Recommended model:
+
+- one person = one active task
+- one task = one task packet
+- one task = one branch
+- one task = one PR
+
+This model is intentionally narrow. It optimizes for throughput, auditability, and clean handoff while keeping the repo structure close to the current AI-first operating model.
+
+## What this design is not
+
+This design does not try to add:
+
+- distributed lane leasing
+- multi-worker reclaim systems
+- automatic remote claiming
+- coordinator services
+
+Those are possible future directions, but they are outside the current need.
+
+## Collaboration principles
+
+1. Each person should work on a separate task whenever possible.
+2. A task should not be started unless a task packet exists or is updated first.
+3. Every active task must have explicit owned files and do-not-touch scope.
+4. A collaborator should claim a task before writing code.
+5. Branches and PRs are the isolation and merge boundaries.
+6. `ai_first/` should hold coordination memory, not a full distributed scheduler.
+
+## Minimal coordination layer
+
+The recommended coordination stack is:
+
+- `TASK_REGISTRY.json` for backlog truth
+- `docs/superpowers/tasks/` for execution contracts
+- `ai_first/ACTIVE_ASSIGNMENTS.md` for short-term active coordination
+- branch-per-task for isolation
+- PR-per-task for merge control
+
+This keeps each artifact focused:
+
+- backlog selection
+- scope contract
+- active assignment visibility
+- code isolation
+- merge validation
+
+## Task assignment workflow
+
+Recommended workflow:
+
+1. Select a task from the active queue or task registry.
+2. Confirm the task packet is present and has clear scope.
+3. Add the assignment to `ai_first/ACTIVE_ASSIGNMENTS.md`.
+4. Create or switch to the task branch.
+5. Work only inside the owned-file scope.
+6. Open a Draft PR.
+7. Update assignment and packet when blocked, paused, or merged.
+
+Hard rule:
+
+No assignment entry means no task start.
+
+## ACTIVE_ASSIGNMENTS.md contract
+
+This file should stay short and human- and AI-readable.
+
+Recommended fields per assignment:
+
+- `Owner`
+- `Machine`
+- `Task`
+- `Status`
+- `Branch`
+- `Task packet`
+- `Owned files`
+- `PR`
+- `Last update`
+- `Next action`
+- `Blocker`
+
+Recommended status values:
+
+- `in_progress`
+- `blocked`
+- `in_review`
+- `paused`
+- `merged`
+
+## Handoff rules
+
+Short handoff is mandatory at these points:
+
+- task claimed
+- scope changed
+- blocked
+- PR opened or updated
+- stopping work
+- merged
+
+The handoff surfaces have distinct purposes:
+
+- `ACTIVE_ASSIGNMENTS.md` = current working state
+- task packet = execution contract
+- daily log = short dated history
+- PR = technical merge and review context
+
+Every handoff should answer:
+
+- what is being worked on
+- what is left
+- which files are in scope
+- what was validated
+- what the next action is
+
+## Scope safety
+
+The design assumes the two collaborators avoid shared edits by default.
+
+Therefore:
+
+- do not split one feature across two people unless it has been decomposed into separate task packets
+- do not use broad ownership labels like "frontend" or "backend"
+- update the task packet before expanding scope
+- if two tasks may collide, re-scope before coding
+
+## Why this works
+
+This approach is effective because it avoids coordination theater.
+
+It gives the team:
+
+- speed from parallel work
+- low merge conflict risk
+- clear read paths for AI workers
+- enough shared memory to continue across machines
+
+It avoids:
+
+- overbuilt lane systems
+- stale distributed state
+- hard-to-debug ownership conflicts
+- process overhead that cancels out the value of having two machines
+
+## Recommended files and operating updates
+
+This design should be reflected in:
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-25.md`
+
+## Immediate next-step ideas
+
+### Now
+
+- Add the minimal `ACTIVE_ASSIGNMENTS.md` template
+- Add short collaboration rules to the operating prompt
+- Use the pattern on the next two independent tasks
+
+### Next
+
+- Tighten task packet templates so owned files and do-not-touch files are always present
+- Add a small checklist for "before claiming" and "before merge"
+
+### Later
+
+- If the team grows beyond two people, evaluate whether a richer lane registry becomes worth the added complexity

--- a/docs/superpowers/tasks/README.md
+++ b/docs/superpowers/tasks/README.md
@@ -18,3 +18,14 @@ Each task packet must define:
 - handoff notes.
 
 Mirror active task packets to GitHub Issues when two AI agents are working in parallel.
+
+## Active assignment workflow
+
+Before code work starts on a task:
+
+1. Confirm the task packet is current.
+2. Add the task to `ai_first/ACTIVE_ASSIGNMENTS.md`.
+3. Create or switch to the task branch.
+4. Work only inside the packet's owned-file scope.
+
+Use `ai_first/ACTIVE_ASSIGNMENTS.md` for short-lived active coordination and the task packet for the execution contract.

--- a/docs/superpowers/tasks/templates/feature-pod-task.md
+++ b/docs/superpowers/tasks/templates/feature-pod-task.md
@@ -3,6 +3,7 @@
 Owner:
 Branch:
 GitHub Issue:
+Active assignment:
 
 ## Goal
 
@@ -19,6 +20,12 @@ GitHub Issue:
 ## Required tests
 
 ## Manual verification
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Keep owned files concrete; do not use broad labels like "frontend" or "backend".
+- Update this packet before scope expands.
 
 ## PR architecture note
 


### PR DESCRIPTION
# Two-Person AI-First Collaboration

## Summary

- added a lightweight `ai_first/ACTIVE_ASSIGNMENTS.md` coordination board for active work
- encoded assignment-before-code and explicit scope rules in the operating prompt and shared templates
- kept the change process-only; `ai_first/architecture/MAIN_SYSTEM_MAP.md` did not change

## Flow

```mermaid
flowchart LR
    A["Select task from registry or queue"] --> B["Confirm task packet scope"]
    B --> C["Add assignment to ACTIVE_ASSIGNMENTS.md"]
    C --> D["Work on branch for that task only"]
    D --> E["Open Draft PR with architecture note"]
    E --> F["Handoff through assignment, packet, and daily log"]
```

## Files

- `ai_first/ACTIVE_ASSIGNMENTS.md`
- `ai_first/AI_OPERATING_PROMPT.md`
- `ai_first/templates/feature-pod-task.md`
- `ai_first/templates/handoff-note.md`
- `docs/superpowers/tasks/templates/feature-pod-task.md`
- `docs/superpowers/tasks/README.md`
- `docs/superpowers/specs/2026-04-25-two-person-ai-first-collaboration-design.md`
- `docs/superpowers/plans/2026-04-25-two-person-ai-first-collaboration.md`
- `ai_first/daily/2026-04-25.md`
