### PR TITLE
[docs] Roll out two-lane contest MVP backlog and same-machine worktree rules

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -15,6 +15,7 @@ Rules:
 
 - Owner:
 - Machine:
+- Worktree:
 - Task:
 - Status:
 - Branch:
@@ -31,6 +32,7 @@ Rules:
 
 - Owner: Codex
 - Machine: MacBook-Air-cua-Loc.local
+- Worktree: /Users/nguyenhuuloc/Documents/Multiagent-learning-platform
 - Task: T047/T048 two-lane contest MVP backlog rollout
 - Status: in_progress
 - Branch: docs/t044-two-lane-parallel-backlog

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -20,7 +20,7 @@ Rules:
 - Branch:
 - Task packet:
 - Owned files:
-- PR: `#118`
+- PR:
 - Last update:
 - Next action:
 - Blocker:
@@ -31,12 +31,12 @@ Rules:
 
 - Owner: Codex
 - Machine: MacBook-Air-cua-Loc.local
-- Task: Post-118 control-plane sync
-- Status: in_review
-- Branch: docs/task-registry-count-sync
-- Task packet: docs/superpowers/tasks/2026-04-25-post-118-control-plane-sync.md
-- Owned files: ai_first/AI_OPERATING_PROMPT.md; ai_first/EXECUTION_QUEUE.md; ai_first/ACTIVE_ASSIGNMENTS.md; ai_first/CURRENT_STATE.md; ai_first/NEXT_ACTIONS.md; ai_first/daily/2026-04-25.md; docs/superpowers/tasks/2026-04-25-post-118-control-plane-sync.md; docs/superpowers/pr-notes/2026-04-25-post-118-control-plane-sync.md
-- PR: `#119`
-- Last update: 2026-04-25 18:30 +07
-- Next action: Move PR `#119` to Ready for review after final validation.
+- Task: T047/T048 two-lane contest MVP backlog rollout
+- Status: in_progress
+- Branch: docs/t044-two-lane-parallel-backlog
+- Task packet: docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md
+- Owned files: ai_first/TASK_REGISTRY.json; ai_first/AI_OPERATING_PROMPT.md; ai_first/EXECUTION_QUEUE.md; ai_first/ACTIVE_ASSIGNMENTS.md; ai_first/CURRENT_STATE.md; ai_first/NEXT_ACTIONS.md; ai_first/daily/2026-04-25.md; docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md; docs/superpowers/tasks/2026-04-25-T044-contest-vietnamese-coverage.md; docs/superpowers/tasks/2026-04-25-T045-marketplace-knowledge-polish.md; docs/superpowers/tasks/2026-04-25-T046-dashboard-review-polish.md; docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md; docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md; docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md; docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md; docs/superpowers/tasks/2026-04-25-T051-session-context-quality-pass.md; docs/superpowers/pr-notes/2026-04-25-t047-t048-two-lane-rollout.md
+- PR:
+- Last update: 2026-04-25 19:25 +07
+- Next action: Finish registry expansion and publish lane task packets for the two-account experiment.
 - Blocker: None

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -35,8 +35,9 @@ Before edits:
 1. Read `AGENTS.md`.
 2. Read this file.
 3. Run `git status --short --branch`.
-4. Read the relevant spec, plan, task packet, or compatibility snapshot only if the prompt points to one.
-5. Confirm the assigned task scope, owned files, and do-not-touch files.
+4. Check `ai_first/ACTIVE_ASSIGNMENTS.md` if any parallel lane may already be active.
+5. Read the relevant spec, plan, task packet, or compatibility snapshot only if the prompt points to one.
+6. Confirm the assigned task scope, owned files, and do-not-touch files.
 
 ## Work rules
 
@@ -83,6 +84,24 @@ Before edits:
 - Keep task packets current with owned files and do-not-touch scope before parallel work begins.
 - Do not split one feature across two people unless it has been decomposed into separate task packets with separate ownership.
 - Treat `ai_first/ACTIVE_ASSIGNMENTS.md` as the short-term coordination memory for active work.
+
+## Same-machine parallel rules
+
+- Two AI sessions on the same machine must not edit from the same filesystem checkout.
+- If two sessions are active on one machine, each session must use a different git worktree under `.worktrees/` or another explicitly assigned path.
+- Record the worktree path in `ai_first/ACTIVE_ASSIGNMENTS.md` before code starts.
+- When starting a new lane on the same machine, first run `git fetch origin main`, then create the lane branch and worktree from `origin/main`.
+- If a lane is continuing existing work, reopen its assigned worktree instead of reusing another lane's checkout.
+- Do not run two sessions against the repo root at the same time unless one of them is docs-only and not editing files.
+
+## Sync rules
+
+- Prefer explicit `git fetch origin main` plus `git merge origin/main` inside the active lane worktree.
+- Do not rely on plain `git pull` for lane sync because it hides which upstream branch was integrated.
+- After another lane merges to `main`, every still-active lane must `git fetch origin main` and merge `origin/main` into its own feature branch before the next substantial edit.
+- Do not merge one feature branch into another feature branch.
+- Do not rebase a shared or review-active branch unless the human explicitly asks for that cleanup.
+- If merge conflicts appear after syncing `origin/main`, resolving those conflicts becomes the current task before new feature edits continue.
 
 ## Autonomous completion loop
 

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, batch marketplace import, offline-ready imported-pack fallback, offline quiz-result sync queue, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, contest submission-package sync, checklist evidence alignment, contest product-description drafting, and contest fork-modifications documentation are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, PR `#118` merged the post-116 control-plane sync into `main`, `ai_first/ACTIVE_ASSIGNMENTS.md` is the active coordination board, and the contest submission queue remains waiting on human review rather than an active AI implementation lane.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `ai_first/ACTIVE_ASSIGNMENTS.md` is the active coordination board, and the current docs/control-plane branch `docs/t044-two-lane-parallel-backlog` is bootstrapping a two-lane contest MVP polish experiment through `T047` and `T048` before two parallel implementation lanes begin.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -145,7 +145,7 @@ Tasks flow through states:
 - **P1 Critical**: Blockers for contest submission, MVP incomplete
 - **P2-P3 High**: Essential for MVP, fix next
 - **P4-P10 Medium**: Important UX/features, schedule for later
-- **P11-P27 Low**: Nice-to-have, polish items
+- **P11-P43 Low**: Nice-to-have, polish items
 
 ### Workflow: MVP Gap Analysis to Execution
 
@@ -193,7 +193,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass; the strict-order registry queue is currently empty. While the contest package is waiting on human review, do not open another AI implementation lane unless humans request follow-up changes, actual video capture work based on `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`, or a final archival sync after submission.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass. The queue is no longer empty: finish `T047` and `T048`, then start the two-lane contest MVP polish experiment with `T044` in Lane 1 and one bounded depth slice from `T049`, `T050`, or `T051` in Lane 2.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -29,15 +29,15 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Active Branches and PRs
 
 - Latest merged workflow PR: `#118 [docs] Post-116 collaboration workflow status sync`
-- Current branch for this sync: `docs/task-registry-count-sync`
+- Current branch for this sync: `docs/t044-two-lane-parallel-backlog`
 - Product MVP path status: Knowledge Pack, assessment, tutor, dashboard, marketplace, offline, analytics, contest evidence, submission docs, optional video runbook, two-person collaboration workflow, and control-plane sync are merged to `main`.
-- Current purpose: keep the contest submission package ready for human review and use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new implementation lane.
+- Current purpose: bootstrap a two-lane contest MVP polish backlog while keeping the contest submission package ready for human review.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
 
-- Spec: `docs/superpowers/specs/2026-04-12-ai-first-project-os-design.md`
-- Plan: `docs/superpowers/plans/2026-04-12-ai-first-project-os.md`
+- Spec: `docs/superpowers/specs/2026-04-25-two-lane-contest-mvp-polish-design.md`
+- Plan: `docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md`
 
 ## Known Worktree Notes
 
@@ -59,16 +59,16 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-19-contest-submission-package.md`
-- Current open GitHub issue: `#41`
+- Current open task packet: `docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md`
+- Current open GitHub issue:
 - Latest completed smoke run result: scripted reset passed, backend online through the CLI server path, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
-- Recently completed merged work: Knowledge Pack (`#6`), Assessment + Student Tutor (`#8`), Teacher Dashboard (`#11`), contest evidence (`#13`, `#14`, `#15`), CI (`#17`, `#18`), execution queue status board (`#21`), smoke lane packet (`#23`), smoke execution result (`#24`), contest evidence refresh packet (`#27`), and contest evidence refresh execution (`#28`)
+- Recently completed merged work: marketplace, knowledge, assessment, tutor, dashboard, contest evidence, control-plane sync, and engineering doctrine updates are all merged to `main`; the current branch is preparing the next two-lane experiment rather than closing a product bug.
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Wait for human review of the contest submission package. If the team decides a video is required, use `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`; otherwise no AI implementation lane is active.
+Finish `T047` and `T048` so the queue, assignment board, and lane packets are ready for two parallel accounts to start `T044` and one of `T049`/`T050`/`T051`.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,44 +7,50 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#118 [docs] Post-116 collaboration workflow status sync`
-- `#118` synced the queue, prompt, snapshots, and assignment board after the two-person collaboration workflow had already landed in `main`.
-- Previous workflow result: `#116` added the `ai_first/ACTIVE_ASSIGNMENTS.md` coordination board, encoded collaboration rules in the operating prompt, and tightened task/handoff templates for assignment-before-code work.
+- Latest merged PR: `#87 [docs] Teacher-agent platform doctrine and AI-first engineering philosophy`
+- `#87` merged the long-form engineering doctrine and reinforced the repo's bias toward bounded modules, explicit contracts, and future-safe parallel work.
+- Previous workflow result: `#118` synced the queue, prompt, snapshots, and assignment board after the two-person collaboration workflow had already landed in `main`.
 - Previous contest result: `#113` added the optional video storyboard/runbook without changing the deferred status of the video artifact itself.
 - Core MVP path in `main` now includes marketplace import, preview, ratings, sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, batch import, offline-ready imported-pack fallback, offline quiz-result sync queue, assessment insights, adaptive difficulty selection, teacher analytics, assessment timing metrics, tutor follow-up prompts, knowledge-pack version metadata, student learning-path sequencing, PDF export, tutoring session replay, recommendation flow, KB context badges, student progress dashboard, Vietnamese prompts, route error boundaries, API rate limiting, and teacher collaboration metadata in addition to the earlier Knowledge Pack, assessment, tutor, dashboard, and contest evidence flows.
 
 ## Active queue
 
-- No active AI implementation task.
-- Current state: contest submission package is waiting on manual review, with optional video support docs ready if the team decides to record.
+- Active docs/control-plane rollout: `T047 Contest Flow Operating Hygiene Refresh`
+- Active docs/control-plane rollout: `T048 Parallel Lane Task Packet Set`
+- Current purpose: prepare a two-lane contest MVP polish experiment for two accounts or machines without overlapping file ownership by default.
 
 ## Next recommended task
 
-Wait for human review of the submission package. If the team decides a video is required, use `docs/contest/VIDEO_CAPTURE_RUNBOOK.md` to record it; otherwise no further AI lane is required.
+Finish `T047` and `T048`, then start two parallel lanes:
+
+1. Lane 1: `T044` Vietnamese coverage, then `T045` marketplace/knowledge polish, then `T046` dashboard/review polish
+2. Lane 2: choose one bounded depth slice from `T049`, `T050`, or `T051`
 
 ## Status Update (2026-04-25)
 
 **Queue Advance**:
-1. `#118` merged to `main` after all required CI checks passed
-2. The queue, prompt, compatibility snapshots, and assignment board were synced to the latest merged state
-3. `T043 Optional Contest Video Capture Runbook` remains complete on `main`
-4. The contest queue is still waiting on manual review unless the team chooses to record the optional video
+1. The old "wait on human review only" queue state has been replaced by a two-lane contest MVP polish experiment.
+2. `T047` refreshes stale coordination state before the experiment starts.
+3. `T048` creates bounded task packets for both lanes so each account has explicit owned files.
+4. Contest submission docs remain ready for human review in parallel with this product-quality backlog refresh.
 
 ## AI-owned blockers
 
-- None currently. The contest submission package is now blocked only by human review actions and the optional choice of whether to record video.
+- None currently. The immediate AI work is a docs/control-plane bootstrap before two bounded implementation lanes start.
 
 ## Human-review blockers
 
-- Human-only submission items still remain, including IP commitment review, optional video decision, and final package sign-off.
+- Human-only submission items still remain for the contest package, including IP commitment review, optional video decision, and final package sign-off.
+- Those human blockers no longer prevent the repo from running a separate contest MVP polish backlog.
 
 ## Read path
 
 1. `ai_first/AI_OPERATING_PROMPT.md`
 2. `ai_first/EXECUTION_QUEUE.md`
 3. `ai_first/ACTIVE_ASSIGNMENTS.md`
-4. `docs/contest/HUMAN_REVIEW_HANDOFF.md`
-5. `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`
+4. `docs/superpowers/specs/2026-04-25-two-lane-contest-mvp-polish-design.md`
+5. `docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md`
+6. `docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md`
 
 ---
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,20 +6,21 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Keep `ai_first/EXECUTION_QUEUE.md` current after merges and blocker changes.
-2. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new implementation lane.
-3. Review IP commitment, final product description wording, and optional video requirements.
-4. If optional video is required, create a separate focused video capture task from `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`.
-5. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
-6. If a future smoke fails, create or update the next focused product/runtime bug task from the first hard failure.
-7. Keep open issues aligned with active task packets and unfinished work only.
-8. Preserve unrelated dirty files until they are intentionally handled.
+1. Finish `T047 Contest Flow Operating Hygiene Refresh`.
+2. Finish `T048 Parallel Lane Task Packet Set`.
+3. Start Lane 1 with `T044 Contest MVP Vietnamese Coverage Audit and Fix Pass`.
+4. Start Lane 2 with one bounded depth slice from `T049`, `T050`, or `T051`.
+5. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting or switching any lane.
+6. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, lane changes, and blocker changes.
+7. Review IP commitment, final product description wording, and optional video requirements in parallel with the polish backlog.
+8. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
 
 ## After Milestone 0
 
 1. Keep the main system map updated when shared contracts change.
 2. Keep `ai_first/AI_FIRST_ROADMAP.md` current when the autonomous operating loop changes.
 3. Keep CI green and treat CI failures as the next task before starting another runtime/product feature.
+4. Preserve lane ownership boundaries so two-account parallel execution stays low-conflict.
 
 ## Human Review Needed
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "last_updated": "2026-04-25T18:20:00Z",
+    "last_updated": "2026-04-25T12:25:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
-    "total_tasks": 35
+    "total_tasks": 43
   },
   "task_categories": {
     "completed": {
@@ -49,8 +49,11 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 2,
+      "tasks": [
+        "T047_CONTEST_FLOW_OPERATING_HYGIENE_REFRESH",
+        "T048_PARALLEL_LANE_TASK_PACKET_SET"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -59,8 +62,15 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 0,
-      "tasks": []
+      "count": 6,
+      "tasks": [
+        "T044_CONTEST_MVP_VIETNAMESE_COVERAGE",
+        "T045_MARKETPLACE_KNOWLEDGE_POLISH",
+        "T046_DASHBOARD_REVIEW_POLISH",
+        "T049_METADATA_DEPTH_PASS",
+        "T050_DASHBOARD_INSIGHT_DEPTH",
+        "T051_SESSION_CONTEXT_QUALITY_PASS"
+      ]
     }
   },
   "tasks": [
@@ -661,6 +671,142 @@
       "dependencies": ["T042 merged to main", "docs/contest/DEMO_SCRIPT.md", "docs/contest/HUMAN_REVIEW_HANDOFF.md"],
       "status": "completed",
       "notes": "Merged to main through PR #113. Added docs/contest/VIDEO_CAPTURE_RUNBOOK.md and linked it into contest evidence/submission docs without marking video as captured."
+    },
+    {
+      "id": "T044_CONTEST_MVP_VIETNAMESE_COVERAGE",
+      "category": "High",
+      "priority": 36,
+      "title": "Contest MVP Vietnamese Coverage Audit and Fix Pass",
+      "description": "Close obvious English leakage on contest MVP screens and align Vietnamese wording across the contest-facing teacher and student workflow.",
+      "scope": {
+        "frontend": "web/app/(utility)/marketplace/page.tsx, web/app/(utility)/knowledge/page.tsx, web/app/(workspace)/dashboard/page.tsx, web/app/(workspace)/dashboard/student/page.tsx, web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx, web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx",
+        "locales": "web/locales/vi/app.json, web/locales/vi/common.json"
+      },
+      "affected_features": ["Contest MVP Screens", "Vietnamese UI", "Teacher and Student Workflow"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["Current contest MVP screens on main", "Existing locale loader"],
+      "status": "pending",
+      "notes": "Planned as Lane 1 bootstrap implementation task after T047/T048 establish the two-account experiment."
+    },
+    {
+      "id": "T045_MARKETPLACE_KNOWLEDGE_POLISH",
+      "category": "Medium",
+      "priority": 37,
+      "title": "Marketplace and Knowledge Pack Screen Polish",
+      "description": "Improve the teacher-facing marketplace and knowledge-pack surfaces so discovery, metadata editing, preview, and import feedback feel more complete and less prototype-like.",
+      "scope": {
+        "frontend": "web/app/(utility)/marketplace/page.tsx, web/app/(utility)/marketplace/error.tsx, web/app/(utility)/knowledge/page.tsx"
+      },
+      "affected_features": ["Marketplace", "Knowledge Pack Management", "Contest Demo UX"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["T044 started or completed", "Current marketplace and knowledge UI on main"],
+      "status": "pending",
+      "notes": "Lane 1 follow-up task that stays frontend-only by default and should not widen into backend contracts without a packet update."
+    },
+    {
+      "id": "T046_DASHBOARD_REVIEW_POLISH",
+      "category": "Medium",
+      "priority": 38,
+      "title": "Dashboard and Review Screen Copy and UX Polish",
+      "description": "Refine teacher dashboard, assessment review, and tutoring replay screen copy and empty-state quality so the contest flow reads like one coherent workflow.",
+      "scope": {
+        "frontend": "web/app/(workspace)/dashboard/page.tsx, web/app/(workspace)/dashboard/student/page.tsx, web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx, web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx, web/components/assessment/LearningJourneySummary.tsx, web/components/assessment/ProgressIndicator.tsx"
+      },
+      "affected_features": ["Teacher Dashboard", "Assessment Review", "Session Replay"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["T044 started or completed", "Current dashboard UI contracts on main"],
+      "status": "pending",
+      "notes": "Lane 1 polish task that should avoid backend changes during the same window."
+    },
+    {
+      "id": "T047_CONTEST_FLOW_OPERATING_HYGIENE_REFRESH",
+      "category": "High",
+      "priority": 39,
+      "title": "Contest Flow Operating Hygiene Refresh",
+      "description": "Refresh stale coordination docs, assignment state, and queue mirrors so two parallel sessions can start the contest MVP polish experiment with accurate ownership and status.",
+      "scope": {
+        "control_plane": "ai_first/ACTIVE_ASSIGNMENTS.md, ai_first/EXECUTION_QUEUE.md, ai_first/AI_OPERATING_PROMPT.md, ai_first/CURRENT_STATE.md, ai_first/NEXT_ACTIONS.md, ai_first/daily/2026-04-25.md",
+        "registry": "ai_first/TASK_REGISTRY.json"
+      },
+      "affected_features": ["AI-first Control Plane", "Parallel Execution Hygiene"],
+      "complexity": "Low",
+      "estimated_hours": 1.5,
+      "dependencies": ["Approved spec docs/superpowers/specs/2026-04-25-two-lane-contest-mvp-polish-design.md"],
+      "status": "in-progress",
+      "notes": "Current branch docs/t044-two-lane-parallel-backlog is implementing this bootstrap task before opening the two lane experiment."
+    },
+    {
+      "id": "T048_PARALLEL_LANE_TASK_PACKET_SET",
+      "category": "High",
+      "priority": 40,
+      "title": "Parallel Lane Task Packet Set",
+      "description": "Create explicit task packets and rollout notes for the two-lane contest MVP polish experiment so each account has bounded owned files and do-not-touch rules.",
+      "scope": {
+        "docs": "docs/superpowers/tasks/2026-04-25-T044-contest-vietnamese-coverage.md, docs/superpowers/tasks/2026-04-25-T045-marketplace-knowledge-polish.md, docs/superpowers/tasks/2026-04-25-T046-dashboard-review-polish.md, docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md, docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md, docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md, docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md, docs/superpowers/tasks/2026-04-25-T051-session-context-quality-pass.md, docs/superpowers/pr-notes/2026-04-25-t047-t048-two-lane-rollout.md"
+      },
+      "affected_features": ["AI-first Control Plane", "Parallel Task Contracts"],
+      "complexity": "Low",
+      "estimated_hours": 2.0,
+      "dependencies": ["T047 started", "Approved spec docs/superpowers/specs/2026-04-25-two-lane-contest-mvp-polish-design.md"],
+      "status": "in-progress",
+      "notes": "Current branch docs/t044-two-lane-parallel-backlog is creating the lane packets and rollout note as the second bootstrap step."
+    },
+    {
+      "id": "T049_METADATA_DEPTH_PASS",
+      "category": "Medium",
+      "priority": 41,
+      "title": "Knowledge and Marketplace Metadata Depth Pass",
+      "description": "Deepen teacher-facing pack metadata and marketplace detail contracts so metadata quality feels more complete without redesigning the product.",
+      "scope": {
+        "backend": "deeptutor/api/routers/knowledge.py, deeptutor/api/routers/marketplace.py, deeptutor/knowledge/manager.py",
+        "api_client": "web/lib/knowledge-api.ts, web/lib/marketplace-api.ts",
+        "tests": "tests/api/test_knowledge_router.py, tests/api/test_marketplace_router.py, tests/knowledge/test_kb_metadata_normalization.py"
+      },
+      "affected_features": ["Knowledge Pack Management", "Marketplace Preview", "Teacher Metadata Flow"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["T048 packet set complete", "Current metadata contracts on main"],
+      "status": "pending",
+      "notes": "Lane 2 bounded depth slice. It should add contract depth without forcing simultaneous Lane 1 page rewrites."
+    },
+    {
+      "id": "T050_DASHBOARD_INSIGHT_DEPTH",
+      "category": "Medium",
+      "priority": 42,
+      "title": "Dashboard Insight Depth Pass",
+      "description": "Make teacher dashboard summaries and assessment review outputs more actionable through bounded contract additions rather than a new analytics subsystem.",
+      "scope": {
+        "backend": "deeptutor/api/routers/dashboard.py, deeptutor/services/session/assessment_review.py",
+        "api_client": "web/lib/dashboard-api.ts",
+        "tests": "tests/api/test_dashboard_router.py, tests/api/test_session_review_router.py"
+      },
+      "affected_features": ["Teacher Dashboard", "Assessment Review"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["T048 packet set complete", "Current dashboard and review routes on main"],
+      "status": "pending",
+      "notes": "Lane 2 depth slice for actionable dashboard signals. Keep contract additions incremental and documented."
+    },
+    {
+      "id": "T051_SESSION_CONTEXT_QUALITY_PASS",
+      "category": "Medium",
+      "priority": 43,
+      "title": "Tutor and Assessment Session Context Quality Pass",
+      "description": "Improve session review and tutoring context quality so the contest learning loop feels less thin while staying inside existing session and reply flows.",
+      "scope": {
+        "backend": "deeptutor/api/routers/sessions.py, deeptutor/agents/chat/agentic_pipeline.py",
+        "api_client": "web/lib/session-api.ts",
+        "tests": "tests/api/test_assessment_router.py, tests/api/test_session_review_router.py, tests/agents/chat/test_agentic_followup_prompts.py"
+      },
+      "affected_features": ["Student Tutor Workspace", "Assessment Review", "Session Replay"],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": ["T048 packet set complete", "Current session and tutoring flows on main"],
+      "status": "pending",
+      "notes": "Lane 2 depth slice focused on contextual quality and bounded follow-up improvements."
     }
   ],
   "github_issues_template": {

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -258,3 +258,17 @@
 - Branch: `docs/t044-two-lane-parallel-backlog`
 - Scope: docs-only backlog rollout for the next parallel execution experiment
 - Next: finish validation, then use `T044` for Lane 1 and one of `T049`/`T050`/`T051` for Lane 2
+
+## Same-Machine Parallel Worktree Rules
+
+### Completed in this cycle
+
+1. Added explicit same-machine parallel-work rules to the operating prompt.
+2. Required separate worktree paths for simultaneous AI sessions on one machine.
+3. Added explicit `fetch origin main` plus `merge origin/main` guidance for active lane sync.
+4. Extended the assignment board and task templates so each active lane can record its worktree path.
+
+### Status
+
+- Same-machine parallel execution is now documented as worktree-required, not just branch-required.
+- Next: when a second session starts on this machine, create its lane in a separate worktree before editing files.

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -240,3 +240,21 @@
 - Branch: `docs/task-registry-count-sync`
 - Scope: docs-only control-plane sync
 - Next: move PR `#119` to Ready for review after final validation
+
+## Two-Lane Contest MVP Backlog Rollout
+
+### Completed in this cycle
+
+1. Wrote and approved a dedicated design for a two-lane contest MVP polish experiment sized for two accounts or machines.
+2. Added a rollout plan to convert that design into real registry entries, task packets, and control-plane state.
+3. Expanded `ai_first/TASK_REGISTRY.json` with `T044` through `T051`.
+4. Marked `T047` and `T048` as the active bootstrap tasks for the experiment.
+5. Replaced the stale active assignment entry with the current backlog rollout branch and ownership list.
+6. Updated the queue, prompt, and compatibility snapshots so they no longer describe the repo as only waiting on human review.
+7. Added lane-specific task packets and a rollout PR note for the two-lane experiment.
+
+### Status
+
+- Branch: `docs/t044-two-lane-parallel-backlog`
+- Scope: docs-only backlog rollout for the next parallel execution experiment
+- Next: finish validation, then use `T044` for Lane 1 and one of `T049`/`T050`/`T051` for Lane 2

--- a/ai_first/templates/feature-pod-task.md
+++ b/ai_first/templates/feature-pod-task.md
@@ -24,6 +24,8 @@ Active assignment:
 ## Parallel-work notes
 
 - Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- If another session is active on the same machine, use a separate worktree and record its path in `ai_first/ACTIVE_ASSIGNMENTS.md`.
+- Before new work on an active lane, run `git fetch origin main` and merge `origin/main` in that lane's own worktree when `main` has advanced.
 - Keep owned files concrete; do not use broad labels like "frontend" or "backend".
 - Update this packet before scope expands.
 

--- a/docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md
+++ b/docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md
@@ -161,7 +161,7 @@ It must include:
 
 ```markdown
 # T047/T048 Two-Lane Contest MVP Rollout
-``` 
+```
 
 And one Mermaid diagram describing:
 - bootstrap docs refresh

--- a/docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md
+++ b/docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md
@@ -1,0 +1,203 @@
+# Two-Lane Contest MVP Polish Rollout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Roll the approved two-lane contest MVP polish design into the AI-first control plane by adding the new backlog, creating task packets, and refreshing coordination state for parallel execution.
+
+**Architecture:** This is a docs-and-control-plane rollout, not product implementation. The work is split into three bounded units: backlog metadata in `ai_first/TASK_REGISTRY.json`, operating-state mirrors in `ai_first/`, and execution contracts in `docs/superpowers/tasks/` plus one PR note. The rollout should leave the repo ready for two accounts to start work without sharing ownership by default.
+
+**Tech Stack:** Markdown, JSON, ripgrep, git, existing AI-first task packet conventions.
+
+---
+
+### Task 1: Add the rollout plan and verify current control-plane context
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md`
+- Read: `docs/superpowers/specs/2026-04-25-two-lane-contest-mvp-polish-design.md`
+- Read: `ai_first/TASK_REGISTRY.json`
+- Read: `ai_first/AI_OPERATING_PROMPT.md`
+- Read: `ai_first/EXECUTION_QUEUE.md`
+
+- [ ] **Step 1: Confirm branch and working tree**
+
+Run: `git status --short --branch`
+Expected: current branch is `docs/t044-two-lane-parallel-backlog` and only the approved spec commit exists.
+
+- [ ] **Step 2: Re-read the approved design and current control plane**
+
+Run:
+
+```bash
+sed -n '1,260p' docs/superpowers/specs/2026-04-25-two-lane-contest-mvp-polish-design.md
+sed -n '1,220p' ai_first/AI_OPERATING_PROMPT.md
+sed -n '1,220p' ai_first/EXECUTION_QUEUE.md
+```
+
+Expected: the design names `T044` through `T051`, and the current queue still reflects the older "wait for human review" state.
+
+- [ ] **Step 3: Save this rollout plan**
+
+Content to preserve in this file:
+
+```markdown
+# Two-Lane Contest MVP Polish Rollout Implementation Plan
+...
+```
+
+Expected: the plan exists at `docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md`.
+
+- [ ] **Step 4: Commit the plan if it was created separately**
+
+```bash
+git add docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md
+git commit -m "docs: add rollout plan for two-lane contest backlog"
+```
+
+Expected: either a new commit exists or the plan is intentionally batched with the rollout commit.
+
+### Task 2: Update backlog metadata and AI-first operating mirrors
+
+**Files:**
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/AI_OPERATING_PROMPT.md`
+- Modify: `ai_first/EXECUTION_QUEUE.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/CURRENT_STATE.md`
+- Modify: `ai_first/NEXT_ACTIONS.md`
+- Modify: `ai_first/daily/2026-04-25.md`
+
+- [ ] **Step 1: Add new tasks `T044` through `T051` to the registry**
+
+Required structure:
+
+```json
+{
+  "id": "T047_CONTEST_FLOW_OPERATING_HYGIENE_REFRESH",
+  "category": "High",
+  "priority": 37,
+  "title": "Contest Flow Operating Hygiene Refresh",
+  "status": "in-progress"
+}
+```
+
+Rules:
+- `total_tasks` becomes `43`
+- `completed.count` stays `35`
+- `in_progress.count` becomes `2` for `T047` and `T048`
+- `pending.count` becomes `6` for `T044`, `T045`, `T046`, `T049`, `T050`, `T051`
+- `last_updated` moves to the current rollout time
+
+- [ ] **Step 2: Update the AI operating prompt**
+
+Add the new working state:
+
+```markdown
+- Latest operating status: the repo is preparing a two-lane contest MVP polish experiment...
+```
+
+And update next actions so the queue no longer says "no further AI lane is required." It should instead point to `T047` bootstrap, then the two-lane experiment.
+
+- [ ] **Step 3: Refresh the execution queue and snapshots**
+
+Required changes:
+- `ai_first/EXECUTION_QUEUE.md` should name the two-lane experiment as the active queue
+- `ai_first/CURRENT_STATE.md` should stop pointing at the stale `docs/task-registry-count-sync` branch
+- `ai_first/NEXT_ACTIONS.md` should list `T047`, `T048`, and then the lane start order
+
+- [ ] **Step 4: Replace the stale assignment board entry**
+
+Update `ai_first/ACTIVE_ASSIGNMENTS.md` so it contains one current assignment:
+
+```markdown
+- Owner: Codex
+- Task: T047/T048 two-lane contest MVP backlog rollout
+- Branch: docs/t044-two-lane-parallel-backlog
+```
+
+Expected: no stale `#119` assignment remains.
+
+- [ ] **Step 5: Validate the registry and mirrors**
+
+Run:
+
+```bash
+python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+rg -n "T044|T045|T046|T047|T048|T049|T050|T051|two-lane|docs/t044-two-lane-parallel-backlog" ai_first docs/superpowers/specs -S
+```
+
+Expected: JSON is valid and the new tasks appear in the control-plane files.
+
+### Task 3: Create task packets and PR note for the rollout
+
+**Files:**
+- Create: `docs/superpowers/tasks/2026-04-25-T044-contest-vietnamese-coverage.md`
+- Create: `docs/superpowers/tasks/2026-04-25-T045-marketplace-knowledge-polish.md`
+- Create: `docs/superpowers/tasks/2026-04-25-T046-dashboard-review-polish.md`
+- Create: `docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md`
+- Create: `docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md`
+- Create: `docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md`
+- Create: `docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md`
+- Create: `docs/superpowers/tasks/2026-04-25-T051-session-context-quality-pass.md`
+- Create: `docs/superpowers/pr-notes/2026-04-25-t047-t048-two-lane-rollout.md`
+
+- [ ] **Step 1: Draft task packets using the current template**
+
+Every packet must include:
+- owner
+- branch
+- active assignment pointer
+- owned files
+- do-not-touch files
+- acceptance criteria
+- required tests
+- parallel-work notes
+
+The packets must reflect the lane boundaries from the approved design.
+
+- [ ] **Step 2: Write the rollout PR note**
+
+It must include:
+
+```markdown
+# T047/T048 Two-Lane Contest MVP Rollout
+``` 
+
+And one Mermaid diagram describing:
+- bootstrap docs refresh
+- task packet creation
+- handoff into Lane 1 and Lane 2
+
+- [ ] **Step 3: Record the rollout in the daily log**
+
+Add a new 2026-04-25 section covering:
+- design approval
+- registry expansion to `T044-T051`
+- assignment board cleanup
+- task packet creation for both lanes
+
+- [ ] **Step 4: Run final validation**
+
+Run:
+
+```bash
+git diff --check
+rg -n "T044|T045|T046|T047|T048|T049|T050|T051" docs/superpowers/tasks docs/superpowers/pr-notes ai_first -S
+```
+
+Expected: no diff formatting errors and all task files are discoverable.
+
+- [ ] **Step 5: Commit the rollout**
+
+```bash
+git add ai_first/TASK_REGISTRY.json ai_first/AI_OPERATING_PROMPT.md ai_first/EXECUTION_QUEUE.md ai_first/ACTIVE_ASSIGNMENTS.md ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md ai_first/daily/2026-04-25.md docs/superpowers/tasks docs/superpowers/pr-notes docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md
+git commit -m "docs: roll out two-lane contest MVP backlog"
+```
+
+Expected: one clean rollout commit is ready for push and PR creation.
+
+## Self-Review
+
+- Spec coverage: Task 2 covers control-plane rollout and registry expansion. Task 3 covers packet creation and PR-note requirements from the design.
+- Placeholder scan: no `TODO`, `TBD`, or hand-wavy "appropriate handling" language remains.
+- Type consistency: task ids, branch names, and file paths match the approved design and current repo conventions.

--- a/docs/superpowers/pr-notes/2026-04-25-t047-t048-two-lane-rollout.md
+++ b/docs/superpowers/pr-notes/2026-04-25-t047-t048-two-lane-rollout.md
@@ -1,0 +1,55 @@
+# T047/T048 Two-Lane Contest MVP Rollout
+
+This docs/control-plane rollout turns the approved two-lane contest MVP polish design into executable repo state.
+
+It does three things:
+
+- expands `ai_first/TASK_REGISTRY.json` with `T044` through `T051`
+- refreshes queue, prompt, snapshots, and assignment state so the repo no longer presents itself as waiting-only
+- creates explicit task packets for both parallel lanes before product implementation starts
+
+## Why
+
+The original MVP backlog is complete, but the current app still shows product-polish gaps and uneven Vietnamese coverage on contest MVP screens.
+
+The team also wants to test whether two real sessions on two accounts or machines can make progress in parallel without frequent file collisions.
+
+That requires concrete ownership contracts, not just a prose design.
+
+## Scope
+
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-25.md`
+- `docs/superpowers/tasks/2026-04-25-T044-contest-vietnamese-coverage.md`
+- `docs/superpowers/tasks/2026-04-25-T045-marketplace-knowledge-polish.md`
+- `docs/superpowers/tasks/2026-04-25-T046-dashboard-review-polish.md`
+- `docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md`
+- `docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md`
+- `docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md`
+- `docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md`
+- `docs/superpowers/tasks/2026-04-25-T051-session-context-quality-pass.md`
+
+## Architecture
+
+```mermaid
+flowchart TD
+  Spec["Approved two-lane design"] --> T047["T047 refresh control-plane state"]
+  T047 --> T048["T048 create task packet set"]
+  T048 --> Lane1["Lane 1 frontend polish"]
+  T048 --> Lane2["Lane 2 feature depth"]
+  Lane1 --> T044["T044 Vietnamese coverage"]
+  Lane1 --> T045["T045 Marketplace + Knowledge polish"]
+  Lane1 --> T046["T046 Dashboard + Review polish"]
+  Lane2 --> T049["T049 Metadata depth"]
+  Lane2 --> T050["T050 Dashboard insight depth"]
+  Lane2 --> T051["T051 Session context quality"]
+```
+
+## Main system map
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated in this PR because the rollout only changes planning and operating docs, not the runtime feature structure itself.

--- a/docs/superpowers/specs/2026-04-25-two-lane-contest-mvp-polish-design.md
+++ b/docs/superpowers/specs/2026-04-25-two-lane-contest-mvp-polish-design.md
@@ -1,0 +1,322 @@
+# Two-Lane Contest MVP Polish Design
+
+Date: 2026-04-25
+Scope: New post-MVP backlog for contest-facing quality improvements, optimized for two parallel AI sessions on two accounts or machines
+
+## Context
+
+The original MVP backlog is complete in the sense that the major contest features are merged into `main`.
+
+That does not mean the product is finished.
+
+Current repo state still shows three practical gaps:
+
+1. Contest MVP screens are not fully polished for Vietnamese-first use. Some UI text is still English, translations are uneven, and empty/loading/error states are not consistently localized.
+2. Several merged features are only first-slice implementations. They function, but the user experience still feels thin or abrupt in key contest flows.
+3. The repo now has rules for parallel work, but the next real test is operational: can two AI sessions on two accounts or machines make progress in parallel without excessive file conflicts or coordination drift?
+
+The next backlog should therefore optimize for:
+
+- visible product quality improvements on contest MVP screens
+- deeper behavior in already-merged MVP flows
+- clean ownership boundaries so two sessions can run in parallel with low merge friction
+
+## Goal
+
+Create a focused two-lane backlog for the next iteration so the team can:
+
+- improve the contest MVP product quality in user-visible ways
+- stress-test real two-session execution on separate accounts or machines
+- measure where ownership rules and operating docs do or do not prevent conflicts
+
+## Non-goals
+
+- broad polish for non-contest playground surfaces
+- large architectural rewrites across unrelated modules
+- opening more than two simultaneous active implementation lanes
+- forcing both lanes to touch the same route, component, or data contract at the same time
+
+## Recommended structure
+
+Use two lanes with intentionally different ownership boundaries.
+
+### Lane 1: Contest Screen Polish and Vietnamese UI Depth
+
+Primary outcome:
+Contest-facing MVP screens feel locally coherent, more complete, and less obviously English-first.
+
+Primary file ownership:
+
+- `web/app/(utility)/marketplace/`
+- `web/app/(utility)/knowledge/`
+- `web/app/(workspace)/dashboard/`
+- `web/app/(workspace)/dashboard/assessments/`
+- `web/app/(workspace)/dashboard/sessions/`
+- `web/components/assessment/`
+- `web/components/quiz/`
+- `web/locales/vi/`
+
+Do-not-touch by default:
+
+- backend API routers
+- `web/lib/` contracts unless a task packet explicitly widens scope
+- `ai_first/` control-plane files
+
+Why this lane exists:
+
+- it produces immediately visible improvement
+- it is mostly frontend-only
+- it is the lowest-conflict way to validate whether contest MVP screens really feel finished
+
+### Lane 2: Feature Depth and Two-Session Operating Hygiene
+
+Primary outcome:
+Contest MVP flows feel less shallow, and the repo becomes more reliable for real parallel execution.
+
+Primary file ownership:
+
+- `deeptutor/api/routers/knowledge.py`
+- `deeptutor/api/routers/marketplace.py`
+- `deeptutor/api/routers/dashboard.py`
+- `deeptutor/api/routers/sessions.py`
+- `deeptutor/services/`
+- `web/lib/`
+- `ai_first/`
+- `docs/superpowers/tasks/`
+- `docs/superpowers/pr-notes/`
+
+Do-not-touch by default:
+
+- contest screen page components already assigned to Lane 1
+- `web/locales/vi/` unless a task packet explicitly requires new keys and coordinates with Lane 1
+
+Why this lane exists:
+
+- it deepens behavior instead of only polishing labels
+- it exercises backend and operating-layer coordination at the same time
+- it lets the team learn where two sessions still collide in practice
+
+## Proposed backlog
+
+The proposed backlog is intentionally small enough for one focused parallel experiment, but large enough to keep both lanes busy without forcing overlap.
+
+### Lane 1 task set
+
+#### T044: Contest MVP Vietnamese Coverage Audit and Fix Pass
+
+Goal:
+Close obvious English leakage on contest MVP screens and align Vietnamese wording across the user-facing flow.
+
+Owned files:
+
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/dashboard/student/page.tsx`
+- `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- `web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx`
+- `web/locales/vi/app.json`
+- `web/locales/vi/common.json`
+
+Acceptance shape:
+
+- no obvious English-only labels remain on contest MVP screens when Vietnamese is selected
+- empty/loading/error states use deliberate Vietnamese copy instead of fallback raw English strings
+- wording is consistent for repeated concepts such as Knowledge Pack, assessment, tutor, dashboard, review, and replay
+
+#### T045: Marketplace and Knowledge Pack Screen Polish
+
+Goal:
+Make the teacher-facing pack creation and discovery surfaces feel less prototype-like.
+
+Owned files:
+
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/app/(utility)/marketplace/error.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+
+Acceptance shape:
+
+- marketplace cards and filters read clearly in Vietnamese
+- pack preview, import, and empty states feel intentional rather than generic
+- knowledge metadata editing flow exposes clearer labels, hints, and status feedback
+
+#### T046: Dashboard and Review Screen Copy and UX Polish
+
+Goal:
+Improve the readability and flow quality of dashboard, assessment review, and tutor replay screens without changing backend contracts.
+
+Owned files:
+
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/dashboard/student/page.tsx`
+- `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- `web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx`
+- `web/components/assessment/LearningJourneySummary.tsx`
+- `web/components/assessment/ProgressIndicator.tsx`
+
+Acceptance shape:
+
+- dashboard sections have clearer labels and more intentional empty states
+- review and replay pages explain status and next actions more cleanly
+- the overall contest demo path reads like a coherent teacher workflow rather than a collection of raw slices
+
+### Lane 2 task set
+
+#### T047: Contest Flow Operating Hygiene Refresh
+
+Goal:
+Refresh stale coordination docs so two parallel sessions can start with accurate state and ownership contracts.
+
+Owned files:
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-25.md`
+
+Acceptance shape:
+
+- no stale active assignment remains from merged work
+- the queue explicitly describes the new two-lane experiment
+- startup instructions for parallel work point future workers to assignment-before-code discipline
+
+#### T048: Parallel Lane Task Packet Set
+
+Goal:
+Create explicit task packets for the new two-lane experiment so each account has bounded owned files and do-not-touch rules.
+
+Owned files:
+
+- `docs/superpowers/tasks/`
+- `docs/superpowers/pr-notes/`
+
+Acceptance shape:
+
+- each active task has a packet with owned files and do-not-touch files
+- packets avoid shared ownership by default
+- packets define how to coordinate if one lane needs contract changes from the other
+
+#### T049: Knowledge and Marketplace Metadata Depth Pass
+
+Goal:
+Make teacher-facing pack metadata and marketplace details feel more complete without redesigning the overall product.
+
+Owned files:
+
+- `deeptutor/api/routers/knowledge.py`
+- `deeptutor/api/routers/marketplace.py`
+- `deeptutor/knowledge/manager.py`
+- `web/lib/knowledge-api.ts`
+- `web/lib/marketplace-api.ts`
+- targeted tests for the same contracts
+
+Acceptance shape:
+
+- marketplace preview and pack metadata expose richer teacher-useful detail
+- metadata contracts stay backward compatible
+- new fields are test-covered and do not force Lane 1 page rewrites during the same window
+
+#### T050: Dashboard Insight Depth Pass
+
+Goal:
+Make teacher dashboard summaries and review outputs more actionable without expanding into a new analytics subsystem.
+
+Owned files:
+
+- `deeptutor/api/routers/dashboard.py`
+- `deeptutor/services/session/assessment_review.py`
+- `web/lib/dashboard-api.ts`
+- targeted dashboard tests
+
+Acceptance shape:
+
+- dashboard and review payloads surface clearer next-step signals
+- additional depth remains explainable and bounded by existing routes
+- frontend contract additions are incremental and documented for Lane 1
+
+#### T051: Tutor and Assessment Session Context Quality Pass
+
+Goal:
+Improve the usefulness of assessment-review and tutoring-session context so the contest learning loop feels less thin.
+
+Owned files:
+
+- `deeptutor/api/routers/sessions.py`
+- `deeptutor/agents/chat/agentic_pipeline.py`
+- `web/lib/session-api.ts`
+- targeted session and agent tests
+
+Acceptance shape:
+
+- session review and tutoring traces expose cleaner context for downstream UI
+- changes stay within existing session and reply flows rather than creating new route families
+- follow-up behavior remains grounded and testable
+
+## Execution order
+
+Start with one bootstrap task in Lane 2, then open both lanes in parallel.
+
+1. Land `T047` first so the control plane reflects the experiment.
+2. Open `T048` immediately after or in the same PR if the scope remains docs-only and tightly coupled.
+3. Once assignment board and task packets are current, run:
+   - Lane 1 on `T044`, then continue to `T045` and `T046`
+   - Lane 2 on `T049`, `T050`, or `T051` based on smallest clean slice
+
+This sequence matters because the operating layer should describe the experiment before the experiment starts.
+
+## Conflict minimization rules
+
+To make the two-session test meaningful, conflict avoidance must be built into the backlog rather than left to luck.
+
+Rules:
+
+- Lane 1 owns contest page components and Vietnamese locale files.
+- Lane 2 owns backend contracts, API clients, task packets, and AI-first coordination docs.
+- `web/lib/` is Lane 2-owned unless explicitly delegated.
+- If Lane 2 adds response fields consumed by Lane 1, that contract must be written in the task packet before Lane 1 touches the UI.
+- No task should require simultaneous edits to both `web/locales/vi/` and backend routers.
+- Only one active task at a time per account.
+- Assignment entries must be added before code work begins.
+
+## Success criteria for the experiment
+
+The experiment succeeds if:
+
+- both lanes produce merged improvements that are visible and defensible
+- each lane can complete work without repeated manual untangling of overlapping files
+- any conflicts that do occur are traceable to a specific ownership gap that can be fixed in the operating docs
+- the team learns whether two-account parallel execution is practically faster than a single serial lane
+
+## Risks
+
+- Lane 1 may discover missing API data and try to widen scope into Lane 2 territory.
+- Lane 2 may add API fields that tempt frontend edits outside its ownership boundary.
+- Locale fixes can become unbounded if the team expands beyond contest MVP surfaces.
+- The stale `ACTIVE_ASSIGNMENTS.md` state shows that the operating layer itself already needs cleanup before parallel work starts.
+
+## Recommendation
+
+Approve this design as the next backlog shape, then convert the selected tasks into:
+
+- updated `ai_first/TASK_REGISTRY.json` entries
+- lane-specific task packets
+- refreshed assignment board entries when the two accounts begin work
+
+## Mermaid
+
+```mermaid
+flowchart TD
+  Start["Post-MVP backlog refresh"] --> T047["T047 control-plane hygiene"]
+  T047 --> T048["T048 task packet set"]
+  T048 --> Lane1["Lane 1: UI + i18n polish"]
+  T048 --> Lane2["Lane 2: feature depth + operating hygiene"]
+  Lane1 --> T044["T044 Vietnamese coverage"]
+  Lane1 --> T045["T045 Marketplace + Knowledge polish"]
+  Lane1 --> T046["T046 Dashboard + Review polish"]
+  Lane2 --> T049["T049 Metadata depth"]
+  Lane2 --> T050["T050 Dashboard insight depth"]
+  Lane2 --> T051["T051 Session context quality"]
+```

--- a/docs/superpowers/tasks/2026-04-25-T044-contest-vietnamese-coverage.md
+++ b/docs/superpowers/tasks/2026-04-25-T044-contest-vietnamese-coverage.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: Contest MVP Vietnamese Coverage Audit and Fix Pass
+
+Owner:
+Branch: `pod-a/t044-vi-contest-coverage`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Close obvious English leakage on contest MVP screens and align Vietnamese wording across the user-facing contest flow.
+
+## User-visible outcome
+
+- Contest MVP screens read coherently in Vietnamese when the locale is set to `vi`.
+- Loading, empty, and error states avoid raw English fallback copy.
+- Repeated concepts use stable Vietnamese wording across marketplace, knowledge, dashboard, assessment review, and tutor replay.
+
+## Owned files/modules
+
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/dashboard/student/page.tsx`
+- `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- `web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx`
+- `web/locales/vi/app.json`
+- `web/locales/vi/common.json`
+
+## Do-not-touch files/modules
+
+- `deeptutor/api/routers/`
+- `deeptutor/services/`
+- `web/lib/`
+- `ai_first/`
+
+## API/data contract
+
+No backend or API-client contract changes in this slice.
+
+## Acceptance criteria
+
+- No obvious English-only contest labels remain when Vietnamese is selected.
+- Vietnamese copy is consistent for Knowledge Pack, assessment, tutor, dashboard, review, and replay.
+- The slice remains frontend-only unless the task packet is updated first.
+
+## Required tests
+
+- `rg -n "Loading|Error|Back to Dashboard|Assessment Review|Tutoring Session Replay|Create Knowledge Pack|Marketplace" web/app web/components web/locales/vi -S`
+- `cd web && npm run build`
+- `git diff --check`
+
+## Manual verification
+
+- Switch the app to Vietnamese.
+- Visit marketplace, knowledge, dashboard overview, assessment review, and tutor replay.
+- Confirm those contest screens no longer show obvious English fallback strings.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Do not widen scope into `web/lib/` or backend routers without updating this packet first.
+- Coordinate new translation-key needs through the task packet before another lane touches locale files.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated unless screen structure or route behavior materially changes.
+
+## Handoff notes

--- a/docs/superpowers/tasks/2026-04-25-T045-marketplace-knowledge-polish.md
+++ b/docs/superpowers/tasks/2026-04-25-T045-marketplace-knowledge-polish.md
@@ -1,0 +1,62 @@
+# Feature Pod Task: Marketplace and Knowledge Pack Screen Polish
+
+Owner:
+Branch: `pod-a/t045-marketplace-knowledge-polish`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Make the marketplace and knowledge-pack teacher surfaces feel less prototype-like while staying inside the existing page architecture.
+
+## User-visible outcome
+
+- Marketplace discovery feels clearer and more intentional.
+- Preview, import, and empty states communicate progress and outcomes better.
+- Knowledge Pack metadata editing exposes clearer labels, hints, and status feedback.
+
+## Owned files/modules
+
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/app/(utility)/marketplace/error.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+
+## Do-not-touch files/modules
+
+- `deeptutor/api/routers/`
+- `web/lib/`
+- `web/locales/vi/`
+- `ai_first/`
+
+## API/data contract
+
+Use existing UI contracts only. No backend contract expansion in this slice.
+
+## Acceptance criteria
+
+- Marketplace filters, cards, and preview feel intentionally labeled and organized.
+- Knowledge metadata editing flow provides clearer status and guidance.
+- No backend or API-client changes are required to finish the slice.
+
+## Required tests
+
+- `cd web && npm run build`
+- `git diff --check`
+
+## Manual verification
+
+- Open marketplace and confirm search, filters, cards, preview, and import feedback read clearly.
+- Open the knowledge page and confirm metadata edit flow feels coherent and contest-demo ready.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Do not modify `web/lib/marketplace-api.ts` or `web/lib/knowledge-api.ts` in this slice.
+- If missing API data blocks the UX, stop and convert that gap into a Lane 2 contract task.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated unless route structure changes.
+
+## Handoff notes

--- a/docs/superpowers/tasks/2026-04-25-T046-dashboard-review-polish.md
+++ b/docs/superpowers/tasks/2026-04-25-T046-dashboard-review-polish.md
@@ -1,0 +1,66 @@
+# Feature Pod Task: Dashboard and Review Screen Copy and UX Polish
+
+Owner:
+Branch: `pod-a/t046-dashboard-review-polish`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Refine the teacher dashboard, assessment review, and tutor replay screens so the contest demo path reads like one coherent workflow.
+
+## User-visible outcome
+
+- Dashboard sections have clearer labels and empty states.
+- Assessment review explains progress and next actions more cleanly.
+- Tutor replay reads as a deliberate teacher-facing review surface instead of a raw transcript page.
+
+## Owned files/modules
+
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/dashboard/student/page.tsx`
+- `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- `web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx`
+- `web/components/assessment/LearningJourneySummary.tsx`
+- `web/components/assessment/ProgressIndicator.tsx`
+
+## Do-not-touch files/modules
+
+- `deeptutor/api/routers/`
+- `deeptutor/services/`
+- `web/lib/`
+- `web/locales/vi/`
+- `ai_first/`
+
+## API/data contract
+
+Use existing dashboard, review, and replay contracts only.
+
+## Acceptance criteria
+
+- Dashboard and review surfaces present clearer next-step messaging.
+- Empty states and supporting labels feel intentional and teacher-readable.
+- The slice remains frontend-only.
+
+## Required tests
+
+- `cd web && npm run build`
+- `git diff --check`
+
+## Manual verification
+
+- Open dashboard overview, student dashboard, assessment review, and tutor replay.
+- Confirm the copy and information hierarchy feel polished and consistent.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Do not change `web/lib/dashboard-api.ts` or backend response shapes in this slice.
+- If UI polish reveals a contract gap, hand it off to Lane 2 rather than widening scope.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated unless route behavior changes materially.
+
+## Handoff notes

--- a/docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md
+++ b/docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md
@@ -1,0 +1,68 @@
+# Feature Pod Task: Contest Flow Operating Hygiene Refresh
+
+Owner: Codex
+Branch: `docs/t044-two-lane-parallel-backlog`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Refresh stale coordination docs so the repo can start a two-lane contest MVP polish experiment with accurate state, branch references, and ownership guidance.
+
+## User-visible outcome
+
+- The queue no longer claims the repo is only waiting on human review.
+- The assignment board no longer shows stale merged work.
+- Future workers can see the two-lane experiment before starting code.
+
+## Owned files/modules
+
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-25.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `docs/contest/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## API/data contract
+
+No runtime API or data contract changes.
+
+## Acceptance criteria
+
+- `T044` through `T051` exist in `ai_first/TASK_REGISTRY.json`.
+- `T047` and `T048` are the active bootstrap tasks.
+- The assignment board reflects the current backlog-rollout branch.
+- Queue and snapshots point to the two-lane experiment.
+
+## Required tests
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `rg -n "T044|T045|T046|T047|T048|T049|T050|T051|two-lane|docs/t044-two-lane-parallel-backlog" ai_first docs/superpowers -S`
+- `git diff --check`
+
+## Manual verification
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` contains no stale `#119` entry.
+- Confirm `ai_first/EXECUTION_QUEUE.md` names the two-lane experiment as active.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Keep this slice docs-only and bounded to the control plane.
+- Do not start Lane 1 or Lane 2 implementation until this bootstrap packet is current.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated because this is control-plane only.
+
+## Handoff notes

--- a/docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md
+++ b/docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md
@@ -1,0 +1,68 @@
+# Feature Pod Task: Parallel Lane Task Packet Set
+
+Owner: Codex
+Branch: `docs/t044-two-lane-parallel-backlog`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Create explicit task packets for the two-lane contest MVP polish experiment so each account starts from a bounded contract instead of an implied scope.
+
+## User-visible outcome
+
+- Lane 1 and Lane 2 each have concrete task packets with owned files and do-not-touch files.
+- Future workers do not need to infer ownership from a prose spec.
+- The parallel experiment becomes executable rather than only conceptual.
+
+## Owned files/modules
+
+- `docs/superpowers/tasks/2026-04-25-T044-contest-vietnamese-coverage.md`
+- `docs/superpowers/tasks/2026-04-25-T045-marketplace-knowledge-polish.md`
+- `docs/superpowers/tasks/2026-04-25-T046-dashboard-review-polish.md`
+- `docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md`
+- `docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md`
+- `docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md`
+- `docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md`
+- `docs/superpowers/tasks/2026-04-25-T051-session-context-quality-pass.md`
+- `docs/superpowers/pr-notes/2026-04-25-t047-t048-two-lane-rollout.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `docs/contest/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## API/data contract
+
+No runtime contract changes. This slice only documents the contracts future workers must honor.
+
+## Acceptance criteria
+
+- Every task in the new two-lane experiment has a task packet.
+- Task packets define owned files, do-not-touch files, acceptance criteria, and tests.
+- Lane boundaries are concrete enough that two accounts can start without ad hoc scope negotiation.
+
+## Required tests
+
+- `rg -n "T044|T045|T046|T047|T048|T049|T050|T051" docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## Manual verification
+
+- Confirm the packet set covers both lanes.
+- Confirm no packet claims both page components and backend router ownership in the same slice unless intentional.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Keep owned files concrete; avoid broad labels like "frontend" or "backend".
+- If a future task needs scope expansion, update the packet before implementation starts.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated because this is task-contract documentation only.
+
+## Handoff notes

--- a/docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md
+++ b/docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md
@@ -1,0 +1,69 @@
+# Feature Pod Task: Knowledge and Marketplace Metadata Depth Pass
+
+Owner:
+Branch: `pod-b/t049-metadata-depth`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Deepen teacher-facing pack metadata and marketplace detail contracts so metadata quality feels more complete without redesigning the product.
+
+## User-visible outcome
+
+- Marketplace preview exposes richer teacher-useful detail.
+- Knowledge Pack metadata feels more complete and informative.
+- The UI has cleaner data to render without forcing same-PR page rewrites.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/knowledge.py`
+- `deeptutor/api/routers/marketplace.py`
+- `deeptutor/knowledge/manager.py`
+- `web/lib/knowledge-api.ts`
+- `web/lib/marketplace-api.ts`
+- `tests/api/test_knowledge_router.py`
+- `tests/api/test_marketplace_router.py`
+- `tests/knowledge/test_kb_metadata_normalization.py`
+
+## Do-not-touch files/modules
+
+- `web/app/(utility)/marketplace/`
+- `web/app/(utility)/knowledge/`
+- `web/app/(workspace)/dashboard/`
+- `web/locales/vi/`
+- `ai_first/`
+
+## API/data contract
+
+This slice may expand metadata fields, but all additions must remain backward compatible and documented in the PR note.
+
+## Acceptance criteria
+
+- Metadata and preview contracts expose richer teacher-useful detail.
+- Existing clients remain compatible.
+- Added fields are covered by targeted tests.
+
+## Required tests
+
+- `python3 -m pytest tests/api/test_knowledge_router.py tests/api/test_marketplace_router.py tests/knowledge/test_kb_metadata_normalization.py -q`
+- `python3 -m py_compile deeptutor/api/routers/knowledge.py deeptutor/api/routers/marketplace.py deeptutor/knowledge/manager.py`
+- `git diff --check`
+
+## Manual verification
+
+- Confirm API payloads still load for existing packs.
+- Confirm new metadata fields are additive rather than breaking.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Do not modify Lane 1 page components in this slice.
+- If frontend changes become necessary, document the contract and hand off to Lane 1 in a later packet update.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if data-contract or workflow structure changes materially.
+
+## Handoff notes

--- a/docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md
+++ b/docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md
@@ -1,0 +1,65 @@
+# Feature Pod Task: Dashboard Insight Depth Pass
+
+Owner:
+Branch: `pod-b/t050-dashboard-insight-depth`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Make teacher dashboard summaries and assessment review outputs more actionable through bounded route and service depth rather than a new analytics subsystem.
+
+## User-visible outcome
+
+- Dashboard signals feel more useful for teacher follow-up.
+- Assessment review communicates clearer next-step insights.
+- Lane 1 can consume better data later without changing this slice's ownership.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/dashboard.py`
+- `deeptutor/services/session/assessment_review.py`
+- `web/lib/dashboard-api.ts`
+- `tests/api/test_dashboard_router.py`
+- `tests/api/test_session_review_router.py`
+
+## Do-not-touch files/modules
+
+- `web/app/(workspace)/dashboard/`
+- `web/components/assessment/`
+- `web/locales/vi/`
+- `ai_first/`
+
+## API/data contract
+
+This slice may add incremental dashboard and review payload fields, but existing route behavior must remain compatible.
+
+## Acceptance criteria
+
+- Dashboard and review payloads surface clearer next-step signals.
+- Changes stay inside existing routes rather than opening new route families.
+- Added contract depth is documented and test-covered.
+
+## Required tests
+
+- `python3 -m pytest tests/api/test_dashboard_router.py tests/api/test_session_review_router.py -q`
+- `python3 -m py_compile deeptutor/api/routers/dashboard.py deeptutor/services/session/assessment_review.py`
+- `git diff --check`
+
+## Manual verification
+
+- Confirm dashboard and review payloads still load through current API clients.
+- Confirm added fields remain understandable and bounded.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Do not modify dashboard page components in this slice.
+- If UI changes are needed to expose the new depth, hand them off to Lane 1 or a later frontend packet.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if the dashboard workflow structure changes materially.
+
+## Handoff notes

--- a/docs/superpowers/tasks/2026-04-25-T051-session-context-quality-pass.md
+++ b/docs/superpowers/tasks/2026-04-25-T051-session-context-quality-pass.md
@@ -1,0 +1,66 @@
+# Feature Pod Task: Tutor and Assessment Session Context Quality Pass
+
+Owner:
+Branch: `pod-b/t051-session-context-quality`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Improve session review and tutoring context quality so the contest learning loop feels less thin while staying inside the current session and reply flows.
+
+## User-visible outcome
+
+- Tutoring session context becomes easier to understand downstream.
+- Assessment review has cleaner contextual support data.
+- The learning loop feels more grounded without introducing a separate subsystem.
+
+## Owned files/modules
+
+- `deeptutor/api/routers/sessions.py`
+- `deeptutor/agents/chat/agentic_pipeline.py`
+- `web/lib/session-api.ts`
+- `tests/api/test_assessment_router.py`
+- `tests/api/test_session_review_router.py`
+- `tests/agents/chat/test_agentic_followup_prompts.py`
+
+## Do-not-touch files/modules
+
+- `web/app/(workspace)/dashboard/`
+- `web/components/assessment/`
+- `web/locales/vi/`
+- `ai_first/`
+
+## API/data contract
+
+This slice may refine session and tutoring payload detail, but it must stay within the existing session/review/reply flow families.
+
+## Acceptance criteria
+
+- Session review and tutoring traces expose cleaner context for downstream UI.
+- Follow-up behavior remains grounded and testable.
+- No new route family is introduced.
+
+## Required tests
+
+- `python3 -m pytest tests/api/test_assessment_router.py tests/api/test_session_review_router.py tests/agents/chat/test_agentic_followup_prompts.py -q`
+- `python3 -m py_compile deeptutor/api/routers/sessions.py deeptutor/agents/chat/agentic_pipeline.py`
+- `git diff --check`
+
+## Manual verification
+
+- Confirm session payloads remain consumable by the existing frontend client.
+- Confirm the tutoring path still returns stable response structure.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- Do not modify Lane 1 screen files in this slice.
+- If frontend exposure is needed, document the contract and hand off the UI work instead of widening scope here.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if session workflow structure changes materially.
+
+## Handoff notes

--- a/docs/superpowers/tasks/README.md
+++ b/docs/superpowers/tasks/README.md
@@ -25,7 +25,9 @@ Before code work starts on a task:
 
 1. Confirm the task packet is current.
 2. Add the task to `ai_first/ACTIVE_ASSIGNMENTS.md`.
-3. Create or switch to the task branch.
-4. Work only inside the packet's owned-file scope.
+3. If another session is active on the same machine, create or switch to a separate worktree for this task.
+4. Create or switch to the task branch inside that task's own worktree.
+5. Run `git fetch origin main` and merge `origin/main` into the task branch when `main` has advanced before continuing feature edits.
+6. Work only inside the packet's owned-file scope.
 
 Use `ai_first/ACTIVE_ASSIGNMENTS.md` for short-lived active coordination and the task packet for the execution contract.

--- a/docs/superpowers/tasks/templates/feature-pod-task.md
+++ b/docs/superpowers/tasks/templates/feature-pod-task.md
@@ -24,6 +24,8 @@ Active assignment:
 ## Parallel-work notes
 
 - Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- If another session is active on the same machine, use a separate worktree and record its path in `ai_first/ACTIVE_ASSIGNMENTS.md`.
+- Before new work on an active lane, run `git fetch origin main` and merge `origin/main` in that lane's own worktree when `main` has advanced.
 - Keep owned files concrete; do not use broad labels like "frontend" or "backend".
 - Update this packet before scope expands.
 


### PR DESCRIPTION
## Summary
- add the two-lane contest MVP polish design and rollout plan
- expand the AI-first task registry with T044-T051 and create lane task packets
- add same-machine parallel worktree rules for two AI sessions on one machine

## Validation
- python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
- git diff --check
- git diff --check origin/main...HEAD