### PR TITLE
feat: deepen dashboard insight payloads (T050)

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -53,7 +53,23 @@ Rules:
 - Branch: pod-b/t049-metadata-depth-pass
 - Task packet: docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md
 - Owned files: deeptutor/api/routers/knowledge.py; deeptutor/api/routers/marketplace.py; deeptutor/knowledge/manager.py; web/lib/knowledge-api.ts; web/lib/marketplace-api.ts; tests/api/test_knowledge_router.py; tests/api/test_marketplace_router.py; tests/knowledge/test_kb_metadata_normalization.py
- - PR: https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/121 (Ready for review)
- - Last update: 2026-04-25 21:05 +07
- - Next action: Monitor CI and address any failures; merge when green
+ - PR: https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/121 (merged)
+ - Last update: 2026-04-25 21:10 +07
+ - Status: completed
+ - Next action: None (completed in this cycle)
  - Blocker: None
+
+### Assignment
+
+- Owner: GitHub Copilot
+- Machine: MacBook-Air-cua-Loc.local
+- Worktree: /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2
+- Task: T050 dashboard insight depth
+- Status: in_progress
+- Branch: pod-b/t050-dashboard-insight-depth
+- Task packet: docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md
+- Owned files: deeptutor/api/routers/dashboard.py; deeptutor/services/session/assessment_review.py; web/lib/dashboard-api.ts; tests/api/test_dashboard_router.py; tests/api/test_session_review_router.py
+- PR:
+- Last update: 2026-04-25 21:12 +07
+- Next action: Implement API additions and tests for dashboard insight signals
+- Blocker: None

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -73,3 +73,7 @@ Rules:
 - Last update: 2026-04-25 21:12 +07
 - Next action: Implement API additions and tests for dashboard insight signals
 - Blocker: None
+ - PR: https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/123 (draft)
+ - Last update: 2026-04-25 21:35 +07
+ - Next action: Self-review, mark PR Ready for review
+ - Blocker: None

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-25T14:52:00Z",
+    "last_updated": "2026-04-25T15:20:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 43
@@ -50,10 +50,11 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 2,
+      "count": 3,
       "tasks": [
         "T047_CONTEST_FLOW_OPERATING_HYGIENE_REFRESH",
-        "T048_PARALLEL_LANE_TASK_PACKET_SET"
+        "T048_PARALLEL_LANE_TASK_PACKET_SET",
+        "T050_DASHBOARD_INSIGHT_DEPTH"
       ]
     },
     "blocked": {
@@ -63,12 +64,11 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 5,
+      "count": 4,
       "tasks": [
         "T044_CONTEST_MVP_VIETNAMESE_COVERAGE",
         "T045_MARKETPLACE_KNOWLEDGE_POLISH",
         "T046_DASHBOARD_REVIEW_POLISH",
-        "T050_DASHBOARD_INSIGHT_DEPTH",
         "T051_SESSION_CONTEXT_QUALITY_PASS"
       ]
     }
@@ -686,7 +686,7 @@
       "complexity": "Medium",
       "estimated_hours": 4,
       "dependencies": ["Current contest MVP screens on main", "Existing locale loader"],
-      "status": "pending",
+      "status": "in_progress",
       "notes": "Planned as Lane 1 bootstrap implementation task after T047/T048 establish the two-account experiment."
     },
     {

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-25T12:25:00Z",
+    "last_updated": "2026-04-25T14:52:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 43
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 35,
+      "count": 36,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -44,16 +44,16 @@
         "T040_CONTEST_PRODUCT_DESCRIPTION",
         "T041_CONTEST_FORK_MODIFICATIONS_NOTE",
         "T042_CONTEST_HUMAN_REVIEW_HANDOFF",
-        "T043_OPTIONAL_CONTEST_VIDEO_CAPTURE_RUNBOOK"
+        "T043_OPTIONAL_CONTEST_VIDEO_CAPTURE_RUNBOOK",
+        "T049_METADATA_DEPTH_PASS"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 3,
+      "count": 2,
       "tasks": [
         "T047_CONTEST_FLOW_OPERATING_HYGIENE_REFRESH",
-        "T048_PARALLEL_LANE_TASK_PACKET_SET",
-        "T049_METADATA_DEPTH_PASS"
+        "T048_PARALLEL_LANE_TASK_PACKET_SET"
       ]
     },
     "blocked": {
@@ -769,7 +769,7 @@
       "complexity": "Medium",
       "estimated_hours": 4,
       "dependencies": ["T048 packet set complete", "Current metadata contracts on main"],
-      "status": "in_progress",
+      "status": "completed",
       "notes": "Lane 2 bounded depth slice. It should add contract depth without forcing simultaneous Lane 1 page rewrites."
     },
     {

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -304,3 +304,18 @@
 
 - Task `T049_METADATA_DEPTH_PASS`: moved to `completed`
 - Next: begin `T050_DASHBOARD_INSIGHT_DEPTH` (Lane 2)
+
+## T050 Dashboard Insight Depth — Initial Slice
+
+### Completed in this cycle
+
+1. Implemented teacher-facing `GET /api/v1/dashboard/insights` with optional filters (`knowledge_base`, `start_ts`, `end_ts`).
+2. Updated TypeScript client `web/lib/dashboard-api.ts` to accept filters and encode query params.
+3. Added focused unit tests for filters (`tests/api/test_dashboard_router.py`) and a PR architecture note under `docs/superpowers/pr-notes/`.
+4. Opened Draft PR `#123` with the initial slice and pushed updates to `pod-b/t050-dashboard-insight-depth`.
+
+### Status
+
+- Task `T050_DASHBOARD_INSIGHT_DEPTH`: initial slice implemented (Draft PR #123)
+- Next: self-review, mark PR Ready for review, and iterate on requested filters/UX items.
+

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -291,3 +291,16 @@
 - Branch: `pod-b/t049-metadata-depth-pass`
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2`
 - Next: validate changes and open PR for review
+
+## T049 Metadata Depth Pass — Merge Complete
+
+### Completed in this cycle
+
+1. PR `#121` passed required CI and was merged to `main`.
+2. `T049_METADATA_DEPTH_PASS` status advanced to `completed` in the task registry.
+3. Updated active assignments and daily log; created a new branch to start `T050`.
+
+### Status
+
+- Task `T049_METADATA_DEPTH_PASS`: moved to `completed`
+- Next: begin `T050_DASHBOARD_INSIGHT_DEPTH` (Lane 2)

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -475,7 +475,12 @@ def _build_teacher_insights(
 
 
 @router.get("/insights")
-async def get_dashboard_insights(limit: int = 100):
+async def get_dashboard_insights(
+    limit: int = 100,
+    knowledge_base: str | None = None,
+    start_ts: int | None = None,
+    end_ts: int | None = None,
+):
     """Teacher-facing aggregated insights for a class or cohort.
 
     This endpoint reuses existing activity aggregation and returns a compact
@@ -484,6 +489,21 @@ async def get_dashboard_insights(limit: int = 100):
     store = get_sqlite_session_store()
     sessions = await store.list_sessions(limit=limit, offset=0)
     activities = [await _activity_with_review(store, session) for session in sessions]
+
+    # Apply optional filters: knowledge_base and timestamp window
+    filtered_activities: list[dict[str, Any]] = []
+    for activity in activities:
+        if knowledge_base or start_ts or end_ts:
+            if knowledge_base and not _matches_dashboard_filters(
+                activity, knowledge_base=knowledge_base
+            ):
+                continue
+            ts = activity.get("timestamp") or 0
+            if start_ts is not None and ts < start_ts:
+                continue
+            if end_ts is not None and ts > end_ts:
+                continue
+        filtered_activities.append(activity)
 
     assessment_rows = [
         {
@@ -497,11 +517,11 @@ async def get_dashboard_insights(limit: int = 100):
                 extract_assessment_review(await store.get_session_with_messages(activity["id"])) or {}
             ).get("results", []),
         }
-        for activity in activities
+        for activity in filtered_activities
         if activity["type"] == "assessment" and activity.get("assessment_summary")
     ]
 
-    return _build_teacher_insights(activities, assessment_rows)
+    return _build_teacher_insights(filtered_activities, assessment_rows)
 
 
 @router.get("/{entry_id}")

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -451,6 +451,59 @@ async def get_student_progress(limit: int = 50):
     }
 
 
+def _build_teacher_insights(
+    activities: list[dict[str, Any]],
+    assessment_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    analytics = _build_dashboard_analytics(activities, assessment_rows)
+    focus = analytics.get("learning_signals", {}).get("focus_topics", [])
+    recommendations: list[str] = []
+    avg = analytics.get("assessment_trend", {}).get("average_score_percent", 0)
+
+    if avg < 70:
+        recommendations.append("Schedule a targeted review for top focus topics.")
+    if analytics.get("assessment_trend", {}).get("score_delta", 0) < 0:
+        recommendations.append("Follow up with students from recent lower-scoring assessments.")
+    if not focus:
+        recommendations.append("No clear focus topics — consider a short diagnostic quiz.")
+
+    return {
+        "analytics": analytics,
+        "at_risk_topics": focus,
+        "recommendations": recommendations,
+    }
+
+
+@router.get("/insights")
+async def get_dashboard_insights(limit: int = 100):
+    """Teacher-facing aggregated insights for a class or cohort.
+
+    This endpoint reuses existing activity aggregation and returns a compact
+    set of actionable signals and recommendations for teachers.
+    """
+    store = get_sqlite_session_store()
+    sessions = await store.list_sessions(limit=limit, offset=0)
+    activities = [await _activity_with_review(store, session) for session in sessions]
+
+    assessment_rows = [
+        {
+            "session_id": activity["id"],
+            "title": activity["title"],
+            "timestamp": activity["timestamp"],
+            "knowledge_bases": activity["knowledge_bases"],
+            "summary": activity.get("assessment_summary"),
+            "review_ref": activity.get("review_ref"),
+            "assessment_results": activity.get("assessment_summary") and (
+                extract_assessment_review(await store.get_session_with_messages(activity["id"])) or {}
+            ).get("results", []),
+        }
+        for activity in activities
+        if activity["type"] == "assessment" and activity.get("assessment_summary")
+    ]
+
+    return _build_teacher_insights(activities, assessment_rows)
+
+
 @router.get("/{entry_id}")
 async def get_activity_entry(entry_id: str):
     store = get_sqlite_session_store()

--- a/docs/superpowers/examples/dashboard-insights-usage.md
+++ b/docs/superpowers/examples/dashboard-insights-usage.md
@@ -1,0 +1,53 @@
+# Dashboard Insights — Quick Frontend Usage (T050)
+
+This short example shows how to call the new `GET /api/v1/dashboard/insights` endpoint
+from the frontend using the existing client helper `getDashboardInsights()` in
+`web/lib/dashboard-api.ts`.
+
+Client-side React (Next.js) example:
+
+```tsx
+import React, { useEffect, useState } from "react";
+import { getDashboardInsights, DashboardInsights } from "@/lib/dashboard-api";
+
+export default function DashboardInsightsExample() {
+  const [insights, setInsights] = useState<DashboardInsights | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getDashboardInsights(100);
+        setInsights(data);
+      } catch (err) {
+        console.error("Failed to load dashboard insights", err);
+      }
+    })();
+  }, []);
+
+  if (!insights) return <div>Loading insights…</div>;
+
+  return (
+    <div>
+      <h2>Analytics</h2>
+      <pre>{JSON.stringify(insights.analytics, null, 2)}</pre>
+
+      <h3>At-risk topics</h3>
+      <pre>{JSON.stringify(insights.at_risk_topics, null, 2)}</pre>
+
+      <h3>Recommendations</h3>
+      <ul>
+        {insights.recommendations.map((r) => (
+          <li key={r}>{r}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+Notes:
+
+- This example uses the TypeScript client `getDashboardInsights()` added in T050.
+- Place this component in a convenient UI location or use it as a quick dev/debug page.
+- The example is intentionally small: production placement and styling should be
+  handled by Lane 1 if the UI exposure is requested.

--- a/docs/superpowers/pr-notes/2026-04-25-t050-dashboard-insight-depth.md
+++ b/docs/superpowers/pr-notes/2026-04-25-t050-dashboard-insight-depth.md
@@ -1,0 +1,19 @@
+# T050 Dashboard Insight Depth
+
+## Scope
+
+- Add a teacher-facing `GET /api/v1/dashboard/insights` endpoint with bounded filters.
+- Expose a small TypeScript client contract for frontend consumers.
+- Keep the change additive and inside the existing dashboard route family.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because the workflow structure is unchanged.
+
+## Architecture Note
+
+```mermaid
+flowchart LR
+  Sessions["SQLite session store"] --> Dashboard["dashboard router"]
+  Dashboard --> Activities["aggregated activities"]
+  Activities --> Insights["/api/v1/dashboard/insights"]
+  Insights --> Signals["analytics + at_risk_topics"]
+  Insights --> Client["web/lib/dashboard-api.ts"]
+```

--- a/docs/superpowers/pr-notes/T050-dashboard-insight-pr-note.md
+++ b/docs/superpowers/pr-notes/T050-dashboard-insight-pr-note.md
@@ -1,0 +1,28 @@
+**T050 — Dashboard Insight Depth (PR Note)**
+
+Summary: This PR adds a teacher-facing dashboard insights endpoint (`GET /api/v1/dashboard/insights`) with optional filters (knowledge_base, start_ts, end_ts), TypeScript client bindings, tests, and examples. It contains an initial set of analytics and recommendations derived from session and assessment activity.
+
+Mermaid architecture diagram:
+
+```mermaid
+graph LR
+  UI[Teachers UI] --> APIClient[web/lib/dashboard-api.ts]
+  APIClient --> API[GET /api/v1/dashboard/insights]
+  API --> Router[deeptutor.api.routers.dashboard]
+  Router --> Store[SessionStore / SQLite]
+  Router --> Aggregator[Insights Aggregator (_build_teacher_insights)]
+  Aggregator --> Recommendations[Recommendations + Actionable Signals]
+```
+
+Checklist:
+
+- [x] Adds filters: `knowledge_base`, `start_ts`, `end_ts`.
+- [x] TypeScript client updated to accept filters.
+- [x] Unit tests added for filter behavior.
+- [x] Local focused tests passed (`tests/api/test_dashboard_router.py`).
+- [ ] PR self-review completed; mark Ready for review when approved.
+
+Notes for reviewers:
+
+- The insights endpoint is intentionally lightweight and returns aggregated summary objects; downstream filtering and pagination are available via query params. CI will run the full test matrix.
+- See `docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md` for the task plan and next steps.

--- a/docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md
+++ b/docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md
@@ -15,6 +15,19 @@ Make teacher dashboard summaries and assessment review outputs more actionable t
 - Assessment review communicates clearer next-step insights.
 - Lane 1 can consume better data later without changing this slice's ownership.
 
+## Progress (in this cycle)
+
+- Implemented backend endpoint: `GET /api/v1/dashboard/insights` in `deeptutor/api/routers/dashboard.py`.
+- Added unit test coverage: `tests/api/test_dashboard_router.py` includes `test_dashboard_insights_returns_teacher_recommendations`.
+- Added a minimal TypeScript client wrapper and types in `web/lib/dashboard-api.ts` (`getDashboardInsights`, `DashboardInsights`).
+- Draft PR opened on branch `pod-b/t050-dashboard-insight-depth` (PR #123).
+
+## Next steps
+
+- Expand `insights` payload with cohort- and teacher-scoped filters (if requested).
+- Add front-end consumption examples or a small widget if Lane 1 requests UI exposure.
+- Add additional tests and refine recommendations language.
+
 ## Owned files/modules
 
 - `deeptutor/api/routers/dashboard.py`

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -379,6 +379,61 @@ async def test_dashboard_insights_returns_teacher_recommendations(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_insights_filters_by_knowledge_base_and_time(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+
+    # older assessment in math-pack
+    await _seed_session(
+        store,
+        session_id="old-assessment",
+        capability="deep_question",
+        message="Old quiz",
+        knowledge_bases=["math-pack"],
+    )
+    await store.add_message(
+        "old-assessment",
+        "user",
+        "[Quiz Performance]\nScore: 1/2 (50%)",
+        capability="deep_question",
+    )
+    _set_session_timestamp(store, "old-assessment", 1_700_000_000)
+
+    # recent assessment in fractions-pack
+    await _seed_session(
+        store,
+        session_id="recent-assessment",
+        capability="deep_question",
+        message="Recent quiz",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "recent-assessment",
+        "user",
+        "[Quiz Performance]\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+    _set_session_timestamp(store, "recent-assessment", 1_710_000_000)
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        resp_all = client.get("/api/v1/dashboard/insights")
+        assert resp_all.status_code == 200
+        payload_all = resp_all.json()
+        assert payload_all["analytics"]["assessment_trend"]["assessments_completed"] == 2
+
+        resp_kb = client.get("/api/v1/dashboard/insights?knowledge_base=fractions-pack")
+        assert resp_kb.status_code == 200
+        payload_kb = resp_kb.json()
+        assert payload_kb["analytics"]["assessment_trend"]["assessments_completed"] == 1
+
+        resp_time = client.get("/api/v1/dashboard/insights?start_ts=1710000000")
+        assert resp_time.status_code == 200
+        payload_time = resp_time.json()
+        assert payload_time["analytics"]["assessment_trend"]["assessments_completed"] == 1
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_applies_search_kb_type_and_min_score_filters(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -333,6 +333,52 @@ def test_learning_path_builder_includes_kb_objectives_and_skips_mastered(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_insights_returns_teacher_recommendations(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    # Create a lower-scoring older assessment
+    await _seed_session(
+        store,
+        session_id="assessment-older",
+        capability="deep_question",
+        message="Generate a quiz on algebra",
+        knowledge_bases=["algebra-pack"],
+    )
+    await store.add_message(
+        "assessment-older",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: x+2=5 -> Answered: 3 (Correct)\nScore: 1/1 (100%)",
+        capability="deep_question",
+    )
+
+    # Create a recent lower-scoring assessment to drive recommendations
+    await _seed_session(
+        store,
+        session_id="assessment-latest",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "assessment-latest",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/5 (Incorrect)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/insights")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "analytics" in payload
+    assert "at_risk_topics" in payload
+    assert isinstance(payload["recommendations"], list)
+    assert len(payload["recommendations"]) >= 1
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_applies_search_kb_type_and_min_score_filters(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -243,11 +243,25 @@ export interface DashboardInsights {
   recommendations: string[];
 }
 
+export interface DashboardInsightsFilters {
+  knowledge_base?: string;
+  start_ts?: number;
+  end_ts?: number;
+}
+
 /**
  * Teacher-facing insights: actionable signals and recommendations.
  */
-export async function getDashboardInsights(limit = 100): Promise<DashboardInsights> {
-  const response = await fetch(apiUrl(`/api/v1/dashboard/insights?limit=${limit}`), {
+export async function getDashboardInsights(
+  limit = 100,
+  filters: DashboardInsightsFilters = {},
+): Promise<DashboardInsights> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (filters.knowledge_base) params.set("knowledge_base", filters.knowledge_base);
+  if (typeof filters.start_ts === "number") params.set("start_ts", String(filters.start_ts));
+  if (typeof filters.end_ts === "number") params.set("end_ts", String(filters.end_ts));
+
+  const response = await fetch(apiUrl(`/api/v1/dashboard/insights?${params.toString()}`), {
     cache: "no-store",
   });
   return expectJson<DashboardInsights>(response);

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -236,3 +236,19 @@ export async function getDashboardActivityDetail(entryId: string): Promise<Dashb
   });
   return expectJson<DashboardActivityDetail>(response);
 }
+
+export interface DashboardInsights {
+  analytics: DashboardOverview["analytics"];
+  at_risk_topics: StudentProgressTopic[];
+  recommendations: string[];
+}
+
+/**
+ * Teacher-facing insights: actionable signals and recommendations.
+ */
+export async function getDashboardInsights(limit = 100): Promise<DashboardInsights> {
+  const response = await fetch(apiUrl(`/api/v1/dashboard/insights?limit=${limit}`), {
+    cache: "no-store",
+  });
+  return expectJson<DashboardInsights>(response);
+}


### PR DESCRIPTION
## Summary
- add a teacher-facing `GET /api/v1/dashboard/insights` endpoint within the existing dashboard route family
- expose filtered dashboard insight helpers in `web/lib/dashboard-api.ts`
- document the client contract and add the required architecture note with Mermaid

## Validation
- `python3 -m pytest tests/api/test_dashboard_router.py tests/api/test_session_review_router.py -q`
- `python3 -m py_compile deeptutor/api/routers/dashboard.py deeptutor/services/session/assessment_review.py`
- `git diff --check`

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-25-t050-dashboard-insight-depth.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because workflow structure is unchanged
