### PR TITLE
[codex] T046 dashboard review polish

### DIFF
--- a/docs/superpowers/plans/2026-04-25-t046-dashboard-review-polish.md
+++ b/docs/superpowers/plans/2026-04-25-t046-dashboard-review-polish.md
@@ -1,0 +1,185 @@
+# T046 Dashboard Review Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refine dashboard, assessment review, and tutor replay surfaces so the contest demo path reads like one coherent teacher workflow.
+
+**Architecture:** Keep the slice frontend-only and work entirely inside the six owned files. Improve information hierarchy, next-step guidance, and teacher-facing framing by reorganizing existing sections and deriving small UI-only summaries from current route state.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript, `react-i18next`, Tailwind CSS, lucide-react
+
+---
+
+### Task 1: Strengthen dashboard overview hierarchy
+
+**Files:**
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+- Modify: `web/app/(workspace)/dashboard/student/page.tsx`
+
+- [ ] **Step 1: Audit the teacher dashboard hotspots**
+
+```bash
+rg -n "History filters|Engagement|Assessment trend|Learning signals|Recent activity|Knowledge Packs" \
+  'web/app/(workspace)/dashboard/page.tsx' \
+  'web/app/(workspace)/dashboard/student/page.tsx' -S
+```
+
+Expected: overview sections are present but still read as separate cards rather than a guided teacher workflow.
+
+- [ ] **Step 2: Add small derived summaries above the return blocks**
+
+```tsx
+  const nextActionLabel =
+    (analytics?.learning_signals.focus_topics?.length ?? 0) > 0
+      ? t("Review the weakest topics first")
+      : t("Open the latest session and confirm the student is ready for the next pack");
+```
+
+- [ ] **Step 3: Rework dashboard hero and section headers so they explain why each block matters**
+
+```tsx
+        <header className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
+          ...
+          <div className="rounded-xl bg-[var(--background)] px-4 py-3 text-[12px] text-[var(--muted-foreground)]">
+            {nextActionLabel}
+          </div>
+        </header>
+```
+
+- [ ] **Step 4: Reframe student dashboard cards and empty states as progress coaching**
+
+```tsx
+            <TopicList
+              title={t("Focus next")}
+              ...
+              emptyLabel={t("No weak topics detected yet. The student is ready for a stretch goal.")}
+            />
+```
+
+- [ ] **Step 5: Verify the dashboard pass**
+
+```bash
+cd web && npm run build
+```
+
+Expected: build passes after the dashboard-only polish.
+
+### Task 2: Polish assessment review as a teacher debrief surface
+
+**Files:**
+- Modify: `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- Modify: `web/components/assessment/ProgressIndicator.tsx`
+- Modify: `web/components/assessment/LearningJourneySummary.tsx`
+
+- [ ] **Step 1: Add a teacher-facing summary panel near the review header**
+
+```tsx
+        <section className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">...</div>
+        </section>
+```
+
+- [ ] **Step 2: Rework `ProgressIndicator` so recommendations read like explicit next actions**
+
+```tsx
+      <div className="rounded-2xl border border-[var(--border)] bg-gradient-to-br ...">
+        ...
+        <h3>{t("Teacher review summary")}</h3>
+      </div>
+```
+
+- [ ] **Step 3: Rework `LearningJourneySummary` to present a review timeline instead of a generic learner card**
+
+```tsx
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6">
+        <h3>{t("Session recap")}</h3>
+        ...
+      </div>
+```
+
+- [ ] **Step 4: Tighten question-review cards with clearer verdict and action framing**
+
+```tsx
+                <div className="mt-3 rounded-xl bg-[var(--background)] p-3 text-[13px] text-[var(--muted-foreground)]">
+                  ...
+                </div>
+```
+
+- [ ] **Step 5: Re-run the required verification**
+
+```bash
+cd web && npm run build
+git diff --check
+```
+
+Expected: both commands pass after review-surface changes.
+
+### Task 3: Polish tutoring replay as a deliberate follow-up surface
+
+**Files:**
+- Modify: `web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx`
+
+- [ ] **Step 1: Add replay-level framing and a short teacher summary**
+
+```tsx
+        <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+          <p className="text-[12px] ...">{t("Teacher replay note")}</p>
+        </section>
+```
+
+- [ ] **Step 2: Rework message cards to make role, timestamp, and content easier to scan**
+
+```tsx
+                <article className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
+                  ...
+                </article>
+```
+
+- [ ] **Step 3: Upgrade the empty state so it suggests the intended follow-up**
+
+```tsx
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 text-center ...">
+              {t("This tutoring session does not have replayable message content yet.")}
+            </div>
+```
+
+- [ ] **Step 4: Run final verification**
+
+```bash
+cd web && npm run build
+git diff --check
+```
+
+Expected: build and diff check pass for the full T046 slice.
+
+### Task 4: Document the T046 architecture note
+
+**Files:**
+- Create: `docs/superpowers/pr-notes/2026-04-25-t046-dashboard-review-polish.md`
+
+- [ ] **Step 1: Write the PR note with Mermaid**
+
+```md
+# T046 Dashboard Review Polish
+
+## Scope
+
+- Improve dashboard hierarchy and next-step framing.
+- Improve assessment review and tutoring replay readability without changing contracts.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because route behavior is unchanged.
+
+```mermaid
+flowchart LR
+  Dashboard[Teacher dashboard] --> Review[Assessment review]
+  Dashboard --> Replay[Tutoring replay]
+  Review --> Summary[Progress and journey summaries]
+  Replay --> FollowUp[Teacher follow-up reading]
+```
+```
+
+- [ ] **Step 2: Commit the architecture note with the implementation**
+
+```bash
+git add docs/superpowers/pr-notes/2026-04-25-t046-dashboard-review-polish.md
+git commit -m "docs: add t046 architecture note"
+```

--- a/docs/superpowers/pr-notes/2026-04-25-t046-dashboard-review-polish.md
+++ b/docs/superpowers/pr-notes/2026-04-25-t046-dashboard-review-polish.md
@@ -1,0 +1,17 @@
+# T046 Dashboard Review Polish
+
+## Scope
+
+- Improve dashboard hierarchy and next-step framing.
+- Improve assessment review and tutoring replay readability without changing contracts.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because route behavior is unchanged.
+
+## Architecture Note
+
+```mermaid
+flowchart LR
+  Dashboard[Teacher dashboard] --> Review[Assessment review]
+  Dashboard --> Replay[Tutoring replay]
+  Review --> Summary[Progress and journey summaries]
+  Replay --> FollowUp[Teacher follow-up reading]
+```

--- a/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
+++ b/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
@@ -161,6 +161,35 @@ export default function AssessmentReviewPage() {
           </button>
         </header>
 
+        <section className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
+            <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+              {t("Next Steps")}
+            </div>
+            <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+              {review.summary.score_percent < 75
+                ? t("Review challenging topics")
+                : t("Take another assessment to track improvement")}
+            </div>
+          </div>
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
+            <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+              {t("Knowledge Pack")}
+            </div>
+            <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+              {review.knowledge_bases[0] || t("Assessment review not found.")}
+            </div>
+          </div>
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
+            <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+              {t("Overall Score")}
+            </div>
+            <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+              {review.summary.score_percent}%
+            </div>
+          </div>
+        </section>
+
         <ProgressIndicator
           totalQuestions={review.summary.total_questions}
           correctCount={review.summary.correct_count}
@@ -219,7 +248,7 @@ export default function AssessmentReviewPage() {
             review.results.map((result, index) => (
               <article
                 key={result.question_id || `${index}`}
-                className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4"
+                className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div>
@@ -236,7 +265,7 @@ export default function AssessmentReviewPage() {
                     <XCircle size={19} className="shrink-0 text-red-600" />
                   )}
                 </div>
-                <div className="mt-3 grid gap-2 text-[13px] text-[var(--muted-foreground)] md:grid-cols-2">
+                <div className="mt-3 grid gap-2 rounded-xl bg-[var(--background)] p-3 text-[13px] text-[var(--muted-foreground)] md:grid-cols-2">
                   <p>
                     <span className="font-medium text-[var(--foreground)]">
                       {t("Student answer")}:

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -77,6 +77,8 @@ export default function DashboardPage() {
 
   const totals = overview?.totals;
   const analytics = overview?.analytics;
+  const focusTopics = analytics?.learning_signals.focus_topics ?? [];
+  const masteredTopics = analytics?.learning_signals.mastered_topics ?? [];
   const cards = useMemo(
     () => [
       {
@@ -103,32 +105,66 @@ export default function DashboardPage() {
     [t, totals],
   );
   const activeFilterCount = [searchTerm, activityType, knowledgeBase, minScore].filter(Boolean).length;
+  const nextActionLabel =
+    focusTopics.length > 0
+      ? t("Review the weakest topics first")
+      : t("Open the latest session and confirm the student is ready for the next pack");
+  const recentActivity = overview?.recent_activity ?? [];
+  const knowledgePackActivity = overview?.knowledge_packs ?? [];
 
   return (
     <main className="h-full overflow-y-auto bg-[var(--background)]">
       <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-6 px-6 py-8">
-        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <div>
-            <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
-              {t("Teacher Dashboard")}
-            </p>
-            <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
-              {t("Class activity")}
-            </h1>
-            <p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
-              {t("Review recent assessments, tutoring sessions, and Knowledge Pack usage.")}
-            </p>
+        <header className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+                {t("Teacher Dashboard")}
+              </p>
+              <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
+                {t("Class activity")}
+              </h1>
+              <p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
+                {t("Review recent assessments, tutoring sessions, and Knowledge Pack usage.")}
+              </p>
+            </div>
+            <Link
+              href="/dashboard/student"
+              className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--background)] px-4 py-2 text-[13px] font-medium text-[var(--foreground)] transition hover:border-[var(--foreground)]"
+            >
+              {t("Open student progress")}
+              <ArrowRight size={15} />
+            </Link>
           </div>
-          <Link
-            href="/dashboard/student"
-            className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--card)] px-4 py-2 text-[13px] font-medium text-[var(--foreground)] transition hover:border-[var(--foreground)]"
-          >
-            {t("Open student progress")}
-            <ArrowRight size={15} />
-          </Link>
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            <div className="rounded-xl bg-[var(--background)] px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+                {t("Next Steps")}
+              </div>
+              <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+                {nextActionLabel}
+              </div>
+            </div>
+            <div className="rounded-xl bg-[var(--background)] px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+                {t("Needs attention")}
+              </div>
+              <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+                {focusTopics.length > 0 ? focusTopics[0]?.topic : t("No weak topics yet")}
+              </div>
+            </div>
+            <div className="rounded-xl bg-[var(--background)] px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+                {t("Strong areas")}
+              </div>
+              <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+                {masteredTopics.length > 0 ? masteredTopics[0]?.topic : t("No strong topics yet")}
+              </div>
+            </div>
+          </div>
         </header>
 
-        <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+        <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
           <div className="mb-3 flex items-center justify-between gap-3">
             <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--muted-foreground)]">
               <Filter size={14} />
@@ -236,7 +272,7 @@ export default function DashboardPage() {
         </section>
 
         <section className="grid gap-4 lg:grid-cols-3">
-          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-[16px] font-semibold text-[var(--foreground)]">
                 {t("Engagement")}
@@ -265,7 +301,7 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-[16px] font-semibold text-[var(--foreground)]">
                 {t("Assessment trend")}
@@ -302,7 +338,7 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-[16px] font-semibold text-[var(--foreground)]">
                 {t("Learning signals")}
@@ -315,8 +351,8 @@ export default function DashboardPage() {
                   {t("Needs attention")}
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {(analytics?.learning_signals.focus_topics ?? []).length > 0 ? (
-                    analytics?.learning_signals.focus_topics.map((topic) => (
+                  {focusTopics.length > 0 ? (
+                    focusTopics.map((topic) => (
                       <span
                         key={`focus-${topic.topic}`}
                         className="rounded-full bg-rose-50 px-3 py-1 text-[12px] text-rose-700"
@@ -336,8 +372,8 @@ export default function DashboardPage() {
                   {t("Strong areas")}
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {(analytics?.learning_signals.mastered_topics ?? []).length > 0 ? (
-                    analytics?.learning_signals.mastered_topics.map((topic) => (
+                  {masteredTopics.length > 0 ? (
+                    masteredTopics.map((topic) => (
                       <span
                         key={`mastered-${topic.topic}`}
                         className="rounded-full bg-emerald-50 px-3 py-1 text-[12px] text-emerald-700"
@@ -369,9 +405,9 @@ export default function DashboardPage() {
                 </span>
               )}
             </div>
-            <div className="overflow-hidden rounded-lg border border-[var(--border)]">
-              {(overview?.recent_activity ?? []).length > 0 ? (
-                overview?.recent_activity.map((activity) => {
+            <div className="overflow-hidden rounded-2xl border border-[var(--border)] shadow-sm">
+              {recentActivity.length > 0 ? (
+                recentActivity.map((activity) => {
                   const activityHref =
                     activity.type === "assessment" && activity.review_ref
                       ? `/${activity.review_ref}`
@@ -446,9 +482,9 @@ export default function DashboardPage() {
             <h2 className="mb-3 text-[16px] font-semibold text-[var(--foreground)]">
               {t("Knowledge Packs")}
             </h2>
-            <div className="rounded-lg border border-[var(--border)] bg-[var(--card)]">
-              {(overview?.knowledge_packs ?? []).length > 0 ? (
-                overview?.knowledge_packs.map((pack) => (
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-sm">
+              {knowledgePackActivity.length > 0 ? (
+                knowledgePackActivity.map((pack) => (
                   <div
                     key={pack.name}
                     className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3 last:border-b-0"

--- a/web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx
+++ b/web/app/(workspace)/dashboard/sessions/[sessionId]/page.tsx
@@ -121,6 +121,17 @@ export default function SessionReplayPage() {
           )}
         </header>
 
+        <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
+          <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+            {t("Next Steps")}
+          </p>
+          <p className="mt-2 text-[14px] leading-6 text-[var(--muted-foreground)]">
+            {replayMessages.length > 0
+              ? t("Review your incorrect answers")
+              : t("This tutoring session does not have replayable message content yet.")}
+          </p>
+        </section>
+
         <section className="space-y-4">
           {replayMessages.length > 0 ? (
             replayMessages.map((message) => {
@@ -128,7 +139,7 @@ export default function SessionReplayPage() {
               return (
                 <article
                   key={message.id}
-                  className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4"
+                  className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--foreground)]">
@@ -139,7 +150,7 @@ export default function SessionReplayPage() {
                       {formatTime(message.created_at)}
                     </span>
                   </div>
-                  <div className="mt-3 whitespace-pre-wrap text-[14px] leading-6 text-[var(--foreground)]">
+                  <div className="mt-3 rounded-xl bg-[var(--background)] px-4 py-3 whitespace-pre-wrap text-[14px] leading-6 text-[var(--foreground)]">
                     {message.content}
                   </div>
                 </article>

--- a/web/app/(workspace)/dashboard/student/page.tsx
+++ b/web/app/(workspace)/dashboard/student/page.tsx
@@ -245,6 +245,9 @@ export default function StudentDashboardPage() {
   }, []);
 
   const totals = overview?.totals;
+  const focusTopics = overview?.focus_topics ?? [];
+  const masteredTopics = overview?.mastered_topics ?? [];
+  const suggestedPath = overview?.suggested_learning_path ?? [];
   const statCards = useMemo(
     () => [
       {
@@ -311,6 +314,34 @@ export default function StudentDashboardPage() {
               </div>
             )}
           </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            <div className="rounded-2xl bg-[var(--muted)]/50 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+                {t("Next Steps")}
+              </div>
+              <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+                {focusTopics.length > 0
+                  ? t("Review the weakest topic before assigning a harder pack")
+                  : t("No weak topics detected yet. The student is ready for a stretch goal.")}
+              </div>
+            </div>
+            <div className="rounded-2xl bg-[var(--muted)]/50 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+                {t("Focus next")}
+              </div>
+              <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+                {focusTopics[0]?.topic || t("No weak topics detected yet.")}
+              </div>
+            </div>
+            <div className="rounded-2xl bg-[var(--muted)]/50 px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+                {t("Suggested learning path")}
+              </div>
+              <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+                {suggestedPath[0]?.topic || t("No learning path suggestions yet. Complete an assessment or add pack objectives to unlock the next-step sequence.")}
+              </div>
+            </div>
+          </div>
         </section>
 
         {error && (
@@ -371,13 +402,13 @@ export default function StudentDashboardPage() {
               title={t("Focus next")}
               icon={Target}
               rows={overview?.focus_topics ?? []}
-              emptyLabel={t("No weak topics detected yet.")}
+              emptyLabel={t("No weak topics detected yet. The student is ready for a stretch goal.")}
               t={t}
             />
             <TopicList
               title={t("Mastered topics")}
               icon={LineChart}
-              rows={overview?.mastered_topics ?? []}
+              rows={masteredTopics}
               emptyLabel={t("Mastered topics will appear after completed assessments.")}
               t={t}
             />

--- a/web/components/assessment/LearningJourneySummary.tsx
+++ b/web/components/assessment/LearningJourneySummary.tsx
@@ -38,11 +38,11 @@ export function LearningJourneySummary({
   };
 
   return (
-    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-6">
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <div className="flex items-center gap-2 mb-4">
         <TrendingUp size={18} className="text-blue-600" />
         <h3 className="text-[14px] font-semibold text-[var(--foreground)]">
-          {t("Your Learning Journey")}
+          {t("Session recap")}
         </h3>
       </div>
 
@@ -73,7 +73,7 @@ export function LearningJourneySummary({
           </div>
         </div>
 
-        {/* Streak */}
+        {/* Session Status */}
         <div className="flex items-start gap-3 p-3 rounded-md bg-[var(--muted)]/50">
           <Target size={16} className="text-[var(--muted-foreground)] mt-0.5 shrink-0" />
           <div className="min-w-0">
@@ -85,6 +85,12 @@ export function LearningJourneySummary({
             </p>
           </div>
         </div>
+      </div>
+
+      <div className="mb-6 rounded-xl bg-[var(--background)] px-4 py-3 text-[13px] text-[var(--muted-foreground)]">
+        {nextTopics.length > 0
+          ? t("Next Steps")
+          : t("Review your incorrect answers")}
       </div>
 
       {/* Mastered Topics */}

--- a/web/components/assessment/ProgressIndicator.tsx
+++ b/web/components/assessment/ProgressIndicator.tsx
@@ -34,22 +34,46 @@ export function ProgressIndicator({
   };
 
   const rating = getScoreRating(scorePercent);
-  const percentageCorrect = totalQuestions > 0 ? (correctCount / totalQuestions) * 100 : 0;
+  const weakestTopic = analysis?.performance_by_topic
+    ?.slice()
+    .sort((left, right) => left.accuracy_percent - right.accuracy_percent)?.[0];
+  const strongestTopic = analysis?.performance_by_topic
+    ?.slice()
+    .sort((left, right) => right.accuracy_percent - left.accuracy_percent)?.[0];
 
   return (
     <div className="space-y-4">
       {/* Main Progress Card */}
-      <div className="rounded-lg border border-[var(--border)] bg-gradient-to-br from-[var(--card)] to-[var(--card)]/50 p-6">
+      <div className="rounded-2xl border border-[var(--border)] bg-gradient-to-br from-[var(--card)] to-[var(--card)]/50 p-6 shadow-sm">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
             <TrendingUp size={20} className={rating.color} />
             <h3 className="text-[14px] font-semibold text-[var(--foreground)]">
-              {t("Learning Progress")}
+              {t("Teacher review summary")}
             </h3>
           </div>
           <span className={`text-[12px] font-medium px-2 py-1 rounded ${rating.color} opacity-80`}>
             {rating.label}
           </span>
+        </div>
+
+        <div className="mb-4 grid gap-3 md:grid-cols-2">
+          <div className="rounded-xl bg-[var(--background)] px-4 py-3">
+            <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+              {t("Needs attention")}
+            </div>
+            <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+              {weakestTopic?.topic || t("Review your incorrect answers")}
+            </div>
+          </div>
+          <div className="rounded-xl bg-[var(--background)] px-4 py-3">
+            <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+              {t("Strong areas")}
+            </div>
+            <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
+              {strongestTopic?.topic || t("Excellent performance!")}
+            </div>
+          </div>
         </div>
 
         {/* Main Progress Bar */}
@@ -124,7 +148,7 @@ export function ProgressIndicator({
       {/* Expandable Recommendations */}
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 hover:bg-[var(--card)]/80 transition-colors"
+        className="w-full rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 hover:bg-[var(--card)]/80 transition-colors shadow-sm"
       >
         <div className="flex items-center justify-between">
           <h3 className="text-[13px] font-semibold text-[var(--foreground)]">
@@ -143,7 +167,7 @@ export function ProgressIndicator({
       </button>
 
       {expanded && (
-        <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 space-y-3">
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 space-y-3 shadow-sm">
           {analysis && analysis.performance_by_topic.length > 0 && (
             <div className="rounded-md border border-[var(--border)] p-3">
               <p className="text-[12px] font-semibold text-[var(--foreground)] mb-2">


### PR DESCRIPTION
## Summary
- polish the teacher dashboard and student progress surfaces so the contest demo path reads with clearer hierarchy and next-step guidance
- reframe assessment review and tutoring replay screens as teacher-facing debrief surfaces using existing contracts only
- add a T046 implementation plan and PR architecture note with Mermaid for lane 1 handoff

## Validation
- `cd web && npm run build`
- `git diff --check`

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-25-t046-dashboard-review-polish.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because route behavior is unchanged
