### PR TITLE
docs: refresh smoke evidence after lane rollout

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -33,12 +33,12 @@ Rules:
 - Owner: Codex
 - Machine: MacBook-Air-cua-Loc.local
 - Worktree: /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/post-lane-sync
-- Task: T047/T048 post-lane control-plane sync
+- Task: T036 contest smoke and evidence refresh
 - Status: in_progress
-- Branch: docs/post-lane-sync
-- Task packet: docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md
-- Owned files: ai_first/TASK_REGISTRY.json; ai_first/AI_OPERATING_PROMPT.md; ai_first/EXECUTION_QUEUE.md; ai_first/ACTIVE_ASSIGNMENTS.md; ai_first/CURRENT_STATE.md; ai_first/NEXT_ACTIONS.md; ai_first/daily/2026-04-25.md; docs/superpowers/plans/2026-04-25-two-lane-contest-mvp-polish-rollout.md; docs/superpowers/tasks/2026-04-25-T044-contest-vietnamese-coverage.md; docs/superpowers/tasks/2026-04-25-T045-marketplace-knowledge-polish.md; docs/superpowers/tasks/2026-04-25-T046-dashboard-review-polish.md; docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md; docs/superpowers/tasks/2026-04-25-T048-parallel-lane-task-packets.md; docs/superpowers/tasks/2026-04-25-T049-metadata-depth-pass.md; docs/superpowers/tasks/2026-04-25-T050-dashboard-insight-depth.md; docs/superpowers/tasks/2026-04-25-T051-session-context-quality-pass.md; docs/superpowers/pr-notes/2026-04-25-t047-t048-two-lane-rollout.md
+- Branch: docs/demo-readiness-refresh
+- Task packet: docs/superpowers/tasks/2026-04-24-T036-contest-evidence-refresh.md
+- Owned files: docs/contest/VALIDATION_REPORT.md; docs/contest/EVIDENCE_CHECKLIST.md; docs/contest/SMOKE_RUNBOOK.md; docs/superpowers/tasks/2026-04-24-T036-contest-evidence-refresh.md; docs/superpowers/pr-notes/2026-04-24-t036-contest-evidence-refresh.md; ai_first/TASK_REGISTRY.json; ai_first/EXECUTION_QUEUE.md; ai_first/AI_OPERATING_PROMPT.md; ai_first/ACTIVE_ASSIGNMENTS.md; ai_first/daily/2026-04-25.md
 - PR:
-- Last update: 2026-04-25 22:25 +07
-- Next action: Sync registry, queue, prompt, snapshots, and daily log after T044-T051 all merged to main.
+- Last update: 2026-04-25 22:31 +07
+- Next action: Run the local smoke/evidence refresh loop against the merged T044-T051 product state and record either a fresh pass or a blocker.
 - Blocker: None

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, batch marketplace import, offline-ready imported-pack fallback, offline quiz-result sync queue, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, contest-facing Vietnamese UI coverage, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, marketplace and knowledge-screen polish, dashboard/review polish, dashboard insight depth, metadata depth, session context quality, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, contest submission-package sync, checklist evidence alignment, contest product-description drafting, and contest fork-modifications documentation are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `ai_first/ACTIVE_ASSIGNMENTS.md` is the active coordination board, and the docs branch `docs/post-lane-sync` is synchronizing the control plane after the two-lane contest MVP polish experiment finished end to end.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `ai_first/ACTIVE_ASSIGNMENTS.md` is the active coordination board, and the docs branch `docs/demo-readiness-refresh` is running the smoke/evidence refresh lane after the two-lane contest MVP polish experiment finished end to end.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -212,7 +212,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass. The two-lane contest MVP polish experiment (`T044` through `T051`) is now complete, so the next operational step is demo-readiness smoke and evidence freshness validation.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass. The two-lane contest MVP polish experiment (`T044` through `T051`) is complete and the 2026-04-25 smoke refresh passed, so the next operational step is screenshot refresh or explicit human review of the stale screenshot bundle.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,10 +28,10 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Latest merged product PR: `#126 feat: improve session context quality (T051)`
-- Current branch for this sync: `docs/post-lane-sync`
+- Latest merged docs/control-plane PR: `#127 docs: sync control plane after lane rollout`
+- Current branch for this sync: `docs/demo-readiness-refresh`
 - Product MVP path status: Knowledge Pack, assessment, tutor, dashboard, marketplace, offline, analytics, contest evidence, submission docs, optional video runbook, two-person collaboration workflow, and the full two-lane contest MVP polish experiment are merged to `main`.
-- Current purpose: sync the control plane after `T044` through `T051` all merged and point the repo back to smoke/evidence validation.
+- Current purpose: keep smoke-backed evidence current after `T044` through `T051` merged and record screenshot freshness honestly.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -59,16 +59,16 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-25-T047-contest-operating-hygiene-refresh.md`
+- Current open task packet: `docs/superpowers/tasks/2026-04-24-T036-contest-evidence-refresh.md`
 - Current open GitHub issue:
-- Latest completed smoke run result: scripted reset passed, backend online through the CLI server path, frontend build passed, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
-- Recently completed merged work: `T044`, `T045`, `T046`, `T049`, `T050`, and `T051` are all merged to `main`; the current branch is refreshing queue and status mirrors rather than adding new product behavior.
+- Latest completed smoke run result: the 2026-04-25 scripted-reset smoke pass succeeded with backend online through the CLI server path, frontend build passed after `npm ci`, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
+- Recently completed merged work: `T044`, `T045`, `T046`, `T049`, `T050`, `T051`, and the post-lane control-plane sync are all merged to `main`; the current branch is refreshing evidence freshness rather than adding new product behavior.
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Finish the post-lane control-plane sync, then run the demo-readiness smoke/evidence refresh loop against the now-merged product state.
+Finish the smoke/evidence refresh lane, then refresh the stale screenshot bundle or carry that gap as an explicit human follow-up.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,24 +7,24 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#126 feat: improve session context quality (T051)`
+- Latest merged PR: `#127 docs: sync control plane after lane rollout`
+- Latest smoke result: the 2026-04-25 scripted-reset smoke pass succeeded against current `main`.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
-- Current workflow result: the lane task packets created by `T047` and `T048` were exercised end to end and the control plane is now being synced to match the merged reality.
 - Core MVP path in `main` now also includes contest-facing Vietnamese UI coverage, marketplace and knowledge-screen polish, dashboard/review polish, deeper dashboard insight payloads, richer metadata contracts, and improved session context support on top of the earlier marketplace, assessment, tutor, dashboard, offline, analytics, evidence, and submission flows.
 
 ## Active queue
 
-- Active docs/control-plane sync: post-lane status refresh for `T047` and `T048`
-- Current purpose: replace stale pre-lane bootstrap state with the merged lane results and point the queue to the next smoke/evidence step.
+- Active docs/evidence lane: `T036 Contest Smoke and Evidence Refresh`
+- Current purpose: keep command-backed evidence current and mark screenshot freshness honestly after the merged contest UI changes.
 
 ## Next recommended task
 
-Run the demo-readiness smoke and evidence refresh loop against the now-merged product state:
+Refresh the screenshot bundle or complete the human evidence review step:
 
-1. Use `docs/contest/DEMO_DATA_RESET.md` to reset demo-safe local state if needed
-2. Run the existing smoke lane and update `docs/contest/VALIDATION_REPORT.md` if the evidence freshness changes
-3. Treat any smoke failure as the next product task before starting new polish work
+1. Capture a fresh screenshot bundle for the contest-facing UI updated by `T044`, `T045`, and `T046`
+2. Update `docs/contest/EVIDENCE_CHECKLIST.md` from `Stale` to `Current` only after the new capture exists
+3. If screenshot capture cannot happen now, keep the current command evidence and carry the screenshot freshness gap as an explicit human follow-up
 
 ## Status Update (2026-04-25)
 
@@ -32,11 +32,13 @@ Run the demo-readiness smoke and evidence refresh loop against the now-merged pr
 1. `T047` and `T048` succeeded: the two-lane experiment had bounded ownership and clean merge flow.
 2. Lane 1 completed `T044`, `T045`, and `T046`.
 3. Lane 2 completed `T049`, `T050`, and `T051`.
-4. Contest submission docs still remain available for human review in parallel with the next smoke/evidence validation pass.
+4. The 2026-04-25 scripted-reset smoke run passed on current `main`.
+5. Screenshot evidence is now explicitly `Stale` because the last capture predates the merged contest-facing UI changes.
 
 ## AI-owned blockers
 
-- None currently. The immediate AI work after this sync is smoke/evidence validation, not another bootstrap packet.
+- None currently for command-backed validation.
+- Screenshot freshness remains a human capture follow-up unless a browser-capable worker refreshes the bundle.
 
 ## Human-review blockers
 
@@ -48,9 +50,9 @@ Run the demo-readiness smoke and evidence refresh loop against the now-merged pr
 1. `ai_first/AI_OPERATING_PROMPT.md`
 2. `ai_first/EXECUTION_QUEUE.md`
 3. `ai_first/ACTIVE_ASSIGNMENTS.md`
-4. `docs/contest/DEMO_DATA_RESET.md`
-5. `docs/contest/VALIDATION_REPORT.md`
-6. `docs/superpowers/tasks/2026-04-19-demo-readiness-smoke.md`
+4. `docs/contest/VALIDATION_REPORT.md`
+5. `docs/contest/EVIDENCE_CHECKLIST.md`
+6. `docs/contest/DEMO_DATA_RESET.md`
 
 ---
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,14 +6,14 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Finish the post-lane sync for `T047` and `T048`.
-2. Run the demo-readiness smoke flow against the merged `T044`-`T051` product state.
-3. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when demo-safe Knowledge Pack or session state may be stale.
-4. Update `docs/contest/VALIDATION_REPORT.md` and evidence freshness mirrors if smoke findings or artifact timestamps changed.
-5. Treat any smoke failure as the next product task before opening another polish slice.
+1. Finish the current `T036` smoke/evidence refresh branch.
+2. Capture a fresh screenshot bundle for the contest-facing UI changed by `T044`, `T045`, and `T046`.
+3. Update `docs/contest/EVIDENCE_CHECKLIST.md` from `Stale` to `Current` only after the new screenshot capture exists.
+4. Keep `docs/contest/VALIDATION_REPORT.md` as the latest command-backed smoke record.
+5. Treat any future smoke failure as the next product task before opening another polish slice.
 6. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting or switching any new lane or docs sync.
-7. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, smoke passes, lane changes, and blocker changes.
-8. Review IP commitment, final product description wording, and optional video requirements in parallel with the smoke/evidence lane.
+7. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, smoke passes, screenshot refreshes, lane changes, and blocker changes.
+8. Review IP commitment, final product description wording, and optional video requirements in parallel with the remaining screenshot/human evidence step.
 
 ## After Milestone 0
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-25T15:20:00Z",
+    "last_updated": "2026-04-25T15:35:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 43
@@ -548,7 +548,7 @@
       "estimated_hours": 2,
       "dependencies": ["T035 merged to main", "scripts/contest/reset_demo_data.py"],
       "status": "completed",
-      "notes": "Merged to main through PR #96. Command-backed contest smoke evidence is refreshed to 2026-04-24 and screenshot evidence is explicitly marked stale pending recapture."
+      "notes": "Merged to main through PR #96. Re-run on 2026-04-25 after T044-T051 merged: command-backed smoke evidence is current again and screenshot evidence remains explicitly stale pending recapture."
     },
     {
       "id": "T037_CONTEST_SCREENSHOT_REFRESH",

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -274,6 +274,23 @@
 - Latest merged commits: `0a88416`, `4dfe27a`, `097c937`, `bf3c9d6`, `7b3770e`, `649c47d`
 - Next: sync the control plane and move the queue back to demo-readiness smoke/evidence validation
 
+## T036 Contest Smoke and Evidence Refresh — 2026-04-25 Pass
+
+### Completed in this cycle
+
+1. Started the backend locally with `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`.
+2. Ran `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` in a fresh worktree and recreated `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`.
+3. Verified the smoke endpoints for system status, knowledge list, dashboard overview, dashboard recent, assessment session, and tutor session.
+4. Installed frontend dependencies in the fresh worktree with `npm ci` and passed `npm run build`.
+5. Updated `docs/contest/VALIDATION_REPORT.md` and `docs/contest/EVIDENCE_CHECKLIST.md` to record the 2026-04-25 smoke-backed pass and to mark screenshots `Stale` after the merged lane-1 UI changes.
+
+### Status
+
+- Smoke lane: passed on 2026-04-25
+- Command-backed evidence: current
+- Screenshot bundle: stale until a new capture is taken against the merged contest-facing UI
+- Next: merge the smoke/evidence refresh docs and either refresh screenshots or carry that gap as an explicit human follow-up
+
 ## Same-Machine Parallel Worktree Rules
 
 ### Completed in this cycle

--- a/docs/contest/EVIDENCE_CHECKLIST.md
+++ b/docs/contest/EVIDENCE_CHECKLIST.md
@@ -8,15 +8,15 @@ Refresh these only when the UI changed or when the latest smoke-backed validatio
 
 | Area | Evidence | Refresh mode | Status | Notes |
 | --- | --- | --- | --- | --- |
-| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Human capture | Current | Refreshed on 2026-04-24 in `T037` from the current Knowledge Pack edit surface. |
-| Knowledge Pack | Metadata still visible after reload | Human capture | Current | Refreshed on 2026-04-24 in `T037` after reload against the current Knowledge Pack UI. |
-| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Human capture | Current | Refreshed on 2026-04-24 in `T037` from the live assessment configuration flow. |
-| Assessment | Generated questions visible | Human capture | Current | Refreshed on 2026-04-24 in `T037` from the seeded contest assessment session. |
-| Assessment | Common-mistake or feedback guidance visible | Human capture | Current | Refreshed on 2026-04-24 in `T037` from the seeded contest assessment guidance view. |
-| Tutor Agent | Student asks a follow-up question | Human capture | Current | Refreshed on 2026-04-24 in `T037` from the seeded tutor replay session. |
-| Tutor Agent | Tutor response with learning context | Human capture | Current | Refreshed on 2026-04-24 in `T037` from the seeded tutor replay session. |
-| Dashboard | Summary cards visible | Human capture | Current | Refreshed on 2026-04-24 in `T037` from the current dashboard summary view. |
-| Dashboard | Recent activity includes assessment/tutoring distinction and Knowledge Pack reference | Human capture | Current | Refreshed on 2026-04-24 in `T037` from the current dashboard activity feed. |
+| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Human capture | Stale | Last captured on 2026-04-24 in `T037`; lane-1 UI changed after `T044` and `T045`. |
+| Knowledge Pack | Metadata still visible after reload | Human capture | Stale | Last captured on 2026-04-24 in `T037`; lane-1 UI changed after `T044` and `T045`. |
+| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Human capture | Stale | Last captured on 2026-04-24 in `T037`; lane-1 UI changed after `T046`. |
+| Assessment | Generated questions visible | Human capture | Stale | Last captured on 2026-04-24 in `T037`; assessment review surfaces changed after `T046`. |
+| Assessment | Common-mistake or feedback guidance visible | Human capture | Stale | Last captured on 2026-04-24 in `T037`; assessment review surfaces changed after `T046`. |
+| Tutor Agent | Student asks a follow-up question | Human capture | Stale | Last captured on 2026-04-24 in `T037`; supporting replay/context surfaces changed after `T046` and `T051`. |
+| Tutor Agent | Tutor response with learning context | Human capture | Stale | Last captured on 2026-04-24 in `T037`; supporting replay/context surfaces changed after `T046` and `T051`. |
+| Dashboard | Summary cards visible | Human capture | Stale | Last captured on 2026-04-24 in `T037`; dashboard summary UI changed after `T046`. |
+| Dashboard | Recent activity includes assessment/tutoring distinction and Knowledge Pack reference | Human capture | Stale | Last captured on 2026-04-24 in `T037`; dashboard/review context changed after `T046`, `T050`, and `T051`. |
 
 ## Required Command Evidence
 
@@ -24,14 +24,14 @@ Refresh these automatically after every successful smoke pass.
 
 | Command | Refresh mode | Status | Source |
 | --- | --- | --- | --- |
-| `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Auto before smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed on 2026-04-24; see `VALIDATION_REPORT.md`. |
-| `cd web && npm run build` | Auto after smoke | Current | Passed on 2026-04-24 after `npm ci`, with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing lockfile warning. |
+| `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Auto before smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
+| `cd web && npm ci && npm run build` | Auto after smoke | Current | Passed on 2026-04-25 in the fresh smoke worktree, with the existing lockfile warning. |
 
 ## Optional Video
 
@@ -61,6 +61,6 @@ Video status follows the same freshness states:
 | --- | --- | --- |
 | Full MVP story can be followed from docs | Passed | Start with `docs/contest/README.md`. |
 | Product commands have smoke-backed validation evidence | Passed | See `VALIDATION_REPORT.md`. |
-| Screenshots are captured and linked | Passed | Screenshot bundle was refreshed on 2026-04-24 in `T037`. |
+| Screenshots are captured and linked | Stale | The latest screenshot bundle predates the merged contest-facing UI changes from `T044` through `T046`. |
 | Video is captured or explicitly deferred | Deferred | Optional unless submission requires it. |
 | No secrets or private data in evidence | Passed | Screenshots use demo-safe Knowledge Pack and session data. |

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -1,6 +1,6 @@
 # Validation Report
 
-Last updated: 2026-04-24
+Last updated: 2026-04-25
 
 ## Scope
 
@@ -10,13 +10,13 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Evidence Freshness Status
 
-Latest smoke-backed refresh: 2026-04-24
+Latest smoke-backed refresh: 2026-04-25
 
 | Evidence group | Refresh mode | Status | Latest source |
 | --- | --- | --- | --- |
-| Backend and API reachability | Auto after smoke | Current | Scripted-reset smoke run recorded in `ai_first/daily/2026-04-24.md`. |
-| Frontend production build | Auto after smoke | Current | `npm run build` passed on 2026-04-24 with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` after installing worktree dependencies. |
-| Screenshot bundle | Human capture after smoke when the UI changes | Current | Refreshed on 2026-04-24 in `T037` against the latest merged UI after the 2026-04-24 smoke baseline. |
+| Backend and API reachability | Auto after smoke | Current | Scripted-reset smoke run recorded in `ai_first/daily/2026-04-25.md`. |
+| Frontend production build | Auto after smoke | Current | `npm ci && npm run build` passed on 2026-04-25 with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` in the fresh smoke worktree. |
+| Screenshot bundle | Human capture after smoke when the UI changes | Stale | The last capture was on 2026-04-24, but `T044`, `T045`, and `T046` changed contest-facing UI after that bundle. |
 | Optional video | Human capture only | Deferred | No external video is required yet. |
 
 Use these status values consistently:
@@ -30,18 +30,18 @@ Use these status values consistently:
 
 | Area | Command | Result |
 | --- | --- | --- |
-| Scripted demo reset | `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Passed on 2026-04-24; it reported `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`. |
-| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed on 2026-04-24 with backend `online`, configured `gpt-4o-mini`, and local fallback search. |
-| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed on 2026-04-24; `contest-demo-quadratics` was present with demo-safe metadata and `sharing_status=demo`. |
-| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed on 2026-04-24 with one assessment, one tutoring session, analytics totals, and recent activity grounded in `contest-demo-quadratics`. |
-| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed on 2026-04-24 with assessment and tutor activity grounded in `contest-demo-quadratics`. |
-| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed on 2026-04-24. |
-| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed on 2026-04-24. |
-| Frontend production build | `cd web && npm run build` | Passed on 2026-04-24 after `npm ci`, with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing multiple-lockfile warning. |
+| Scripted demo reset | `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Passed on 2026-04-25; it recreated `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo` in the fresh worktree. |
+| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed on 2026-04-25 with backend `online`, configured `gpt-4o-mini`, and local fallback search. |
+| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed on 2026-04-25; `contest-demo-quadratics` was present with demo-safe metadata and `sharing_status=demo`. |
+| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed on 2026-04-25 with one assessment, one tutoring session, and recent activity grounded in `contest-demo-quadratics`. |
+| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed on 2026-04-25 with assessment and tutor activity grounded in `contest-demo-quadratics`. |
+| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed on 2026-04-25 and returned `context_support` plus demo-safe Knowledge Pack references. |
+| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed on 2026-04-25 and returned `context_support` plus demo-safe Knowledge Pack references. |
+| Frontend production build | `cd web && npm ci && npm run build` | Passed on 2026-04-25 in the fresh smoke worktree, with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing multiple-lockfile warning. |
 
 ## Current Known Limitations
 
-- Screenshot evidence is captured under `docs/contest/screenshots/`, and the current bundle was refreshed on 2026-04-24 in `T037`.
+- Screenshot evidence is captured under `docs/contest/screenshots/`, but the current bundle is now stale because contest-facing UI changed after the 2026-04-24 capture.
 - Video evidence is deferred unless the final contest submission requires it.
 - The frontend build emits a Next.js warning about multiple lockfiles and inferred workspace root. The build still completes successfully.
 - Screenshot freshness still requires a human capture step when the UI meaningfully changes.
@@ -74,13 +74,13 @@ The first frontend build attempt failed in sandbox because Next.js could not fet
 
 ## Smoke-backed Verification Record
 
-The 2026-04-24 scripted-reset smoke run verified the full MVP path in order:
+The 2026-04-25 scripted-reset smoke run verified the MVP path in the current merged state:
 
-1. scripted reset recreated the demo-safe Knowledge Pack and assessment/tutor sessions;
+1. scripted reset recreated the demo-safe Knowledge Pack and assessment/tutor sessions in the fresh worktree;
 2. backend started successfully with the repository-local virtual environment through the CLI server path;
 3. system status, knowledge list, dashboard overview, dashboard recent, assessment session, and tutor session endpoints all returned the expected demo-safe data;
-4. the frontend production build passed against `http://localhost:8001`;
-5. the screenshot bundle was refreshed in `T037`, so screenshot status is back to `Current` for the latest merged UI.
+4. the frontend production build passed against `http://localhost:8001` after `npm ci` in the new worktree;
+5. screenshot evidence remains `Stale` because the 2026-04-24 capture predates the merged UI changes from `T044`, `T045`, and `T046`.
 
 ## Manual Verification Template
 

--- a/docs/superpowers/pr-notes/2026-04-25-t036-smoke-refresh-rerun.md
+++ b/docs/superpowers/pr-notes/2026-04-25-t036-smoke-refresh-rerun.md
@@ -1,0 +1,20 @@
+# T036 Smoke Refresh Rerun
+
+## Scope
+
+- Re-run the local contest smoke lane after `T044` through `T051` merged.
+- Refresh `VALIDATION_REPORT.md` with 2026-04-25 command-backed evidence.
+- Mark screenshot evidence `Stale` in `EVIDENCE_CHECKLIST.md` because the last capture predates the merged contest-facing UI changes.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because this PR only refreshes docs and control-plane evidence state.
+
+## Architecture Note
+
+```mermaid
+flowchart LR
+  Reset["Demo reset script"] --> Backend["Local backend smoke"]
+  Backend --> ApiChecks["Endpoint verification"]
+  ApiChecks --> Frontend["Frontend build"]
+  Frontend --> Report["VALIDATION_REPORT.md"]
+  Frontend --> Checklist["EVIDENCE_CHECKLIST.md"]
+  Checklist --> Human["Screenshot refresh / human review"]
+```


### PR DESCRIPTION
## Summary
- rerun the local contest smoke lane after the merged `T044`-`T051` product changes
- refresh `docs/contest/VALIDATION_REPORT.md` with the 2026-04-25 smoke-backed pass
- mark screenshot evidence `Stale` in `docs/contest/EVIDENCE_CHECKLIST.md` because the last capture predates the merged contest-facing UI changes

## Validation
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `rg -n "2026-04-25|Current|Stale|Blocked|contest-demo-quadratics|contest-assessment-demo|contest-tutor-demo" docs/contest ai_first`
- `git diff --check`

## Smoke commands run
- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`
- `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
- `curl -s http://127.0.0.1:8001/api/v1/system/status`
- `curl -s http://127.0.0.1:8001/api/v1/knowledge/list`
- `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview`
- `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent`
- `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo`
- `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo`
- `cd web && npm ci && npm run build`

## Architecture
- PR note: `docs/superpowers/pr-notes/2026-04-25-t036-smoke-refresh-rerun.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because this PR only refreshes docs and control-plane evidence state
