### PR TITLE
docs: sync post-merge screenshot status

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -33,12 +33,12 @@ Rules:
 - Owner: Codex
 - Machine: `MacBook-Air-cua-Loc.local`
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/t037-screenshot-refresh-pass`
-- Task: `T037_CONTEST_SCREENSHOT_REFRESH`
-- Status: Ready for review
-- Branch: `docs/t037-contest-screenshot-refresh-pass`
-- Task packet: `docs/superpowers/tasks/2026-04-24-T037-contest-screenshot-refresh.md`
-- Owned files: `docs/contest/screenshots/*`, `docs/contest/EVIDENCE_CHECKLIST.md`, `docs/contest/VALIDATION_REPORT.md`, `docs/superpowers/tasks/2026-04-24-T037-contest-screenshot-refresh.md`, `docs/superpowers/pr-notes/*`, `ai_first/TASK_REGISTRY.json`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/AI_OPERATING_PROMPT.md`, `ai_first/daily/2026-04-25.md`
-- PR: `#130`
+- Task: `POST_130_SCREENSHOT_SYNC`
+- Status: In progress
+- Branch: `docs/post-130-screenshot-sync`
+- Task packet: `docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md`
+- Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/AI_OPERATING_PROMPT.md`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`, `ai_first/daily/2026-04-25.md`, `docs/contest/README.md`, `docs/contest/SUBMISSION_PACKAGE.md`, `docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md`, `docs/superpowers/pr-notes/*`
+- PR: Not opened yet
 - Last update: 2026-04-25
-- Next action: Wait for CI on `#130`, then merge when the docs lane is green and mergeable.
+- Next action: Remove stale post-merge lane status and refresh contest entry docs after PR `#130`.
 - Blocker: None

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, batch marketplace import, offline-ready imported-pack fallback, offline quiz-result sync queue, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, contest-facing Vietnamese UI coverage, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, marketplace and knowledge-screen polish, dashboard/review polish, dashboard insight depth, metadata depth, session context quality, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, contest submission-package sync, checklist evidence alignment, contest product-description drafting, and contest fork-modifications documentation are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `ai_first/ACTIVE_ASSIGNMENTS.md` is the active coordination board, the 2026-04-25 smoke/evidence refresh is merged, and the screenshot-refresh docs lane is active to move screenshot evidence back to current.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `ai_first/ACTIVE_ASSIGNMENTS.md` is the active coordination board, the 2026-04-25 smoke/evidence refresh is merged, and the 2026-04-25 screenshot-refresh re-run is merged through PR `#130`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -212,7 +212,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass. The two-lane contest MVP polish experiment (`T044` through `T051`) is complete, the 2026-04-25 smoke refresh passed, and the current operational step is to finish review/merge of the refreshed screenshot bundle.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass. The two-lane contest MVP polish experiment (`T044` through `T051`) is complete, the 2026-04-25 smoke refresh passed, and the refreshed screenshot bundle is now merged, so the next operational step is the remaining human review or optional video decision.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -29,9 +29,9 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Active Branches and PRs
 
 - Latest merged docs/control-plane PR: `#129 docs: clean up control plane after smoke refresh`
-- Current branch for this sync: `docs/t037-contest-screenshot-refresh-pass`
+- Current branch for this sync: `docs/post-130-screenshot-sync`
 - Product MVP path status: Knowledge Pack, assessment, tutor, dashboard, marketplace, offline, analytics, contest evidence, submission docs, optional video runbook, two-person collaboration workflow, and the full two-lane contest MVP polish experiment are merged to `main`.
-- Current purpose: move the refreshed screenshot bundle and evidence-doc sync through review.
+- Current purpose: clear the stale post-merge lane status and keep the merged evidence state visible.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -59,16 +59,16 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-24-T037-contest-screenshot-refresh.md`
-- Current open GitHub issue: `#97`
+- Current open task packet: `docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md`
+- Current open GitHub issue:
 - Latest completed smoke run result: the 2026-04-25 scripted-reset smoke pass succeeded with backend online through the CLI server path, frontend build passed after `npm ci`, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
-- Recently completed local work: the screenshot bundle was refreshed again on 2026-04-25, and evidence docs now mark screenshots `Current` in the active docs lane.
+- Recently completed merged work: the screenshot bundle refresh re-run merged on 2026-04-25 through PR `#130`, and evidence docs now mark screenshots `Current`.
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Run the final docs review flow for the refreshed screenshot lane, then open the PR in Draft and move it toward merge.
+Keep the merged screenshot evidence state reflected in the compact mirrors and contest entry docs.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#128 docs: refresh smoke evidence after lane rollout`
+- Latest merged PR: `#130 docs: refresh contest screenshot evidence`
 - Latest smoke result: the 2026-04-25 scripted-reset smoke pass succeeded against current `main`.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -15,16 +15,16 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Active queue
 
-- Active docs lane: `T037_CONTEST_SCREENSHOT_REFRESH` on `docs/t037-contest-screenshot-refresh-pass`
-- Current purpose: finish the screenshot refresh docs pass and move the refreshed evidence bundle through review.
+- No active AI-owned implementation or docs lane is open right now.
+- Current purpose: keep the refreshed screenshot evidence visible and leave only human-only submission follow-ups explicit.
 
 ## Next recommended task
 
-Complete the screenshot-refresh review lane:
+Review the remaining human-owned submission items:
 
-1. Keep the refreshed screenshot bundle from 2026-04-25 attached to the current docs lane
-2. Validate the updated evidence docs and control-plane mirrors
-3. Open the screenshot-refresh PR in Draft, then move it to Ready after local review
+1. Keep the 2026-04-25 smoke and screenshot evidence bundle as the current repo-backed source of truth
+2. Decide whether an optional video artifact is required for final submission
+3. Complete the final human review items in the contest submission checklist
 
 ## Status Update (2026-04-25)
 
@@ -33,12 +33,11 @@ Complete the screenshot-refresh review lane:
 2. Lane 1 completed `T044`, `T045`, and `T046`.
 3. Lane 2 completed `T049`, `T050`, and `T051`.
 4. The 2026-04-25 scripted-reset smoke run passed on current `main`.
-5. Screenshot evidence was refreshed on 2026-04-25 against the current merged UI and is now ready for docs review.
+5. Screenshot evidence was refreshed and merged on 2026-04-25 through PR `#130`.
 
 ## AI-owned blockers
 
-- None currently for command-backed validation.
-- The screenshot bundle is refreshed locally; only the review/merge step remains for the docs lane.
+- None currently for command-backed validation or screenshot evidence.
 
 ## Human-review blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,13 +6,12 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Keep the refreshed screenshot bundle and evidence-doc updates on `docs/t037-contest-screenshot-refresh-pass`.
-2. Open the screenshot-refresh PR in Draft after local review, then move it to Ready when the docs lane is clean.
-3. Keep `docs/contest/VALIDATION_REPORT.md` as the latest command-backed smoke record and screenshot freshness mirror.
-4. Treat any future smoke failure as the next product task before opening another polish slice.
-5. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new lane or docs sync.
-6. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, smoke passes, screenshot refreshes, lane changes, and blocker changes.
-7. Review IP commitment, final product description wording, and optional video requirements in parallel with the final evidence review step.
+1. Keep the merged screenshot bundle and evidence-doc updates from PR `#130` as the current contest evidence baseline.
+2. Refresh the compact mirrors after the merged screenshot lane so they no longer describe that lane as active.
+3. Treat any future smoke failure as the next product task before opening another polish slice.
+4. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new lane or docs sync.
+5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, smoke passes, screenshot refreshes, lane changes, and blocker changes.
+6. Review IP commitment, final product description wording, and optional video requirements in parallel with the remaining human-only submission work.
 
 ## After Milestone 0
 

--- a/ai_first/daily/2026-04-25.md
+++ b/ai_first/daily/2026-04-25.md
@@ -274,6 +274,20 @@
 - Task `T037_CONTEST_SCREENSHOT_REFRESH`: re-run complete locally on `docs/t037-contest-screenshot-refresh-pass`
 - Next: run final docs validation, open the screenshot-refresh PR in Draft, then move it through review
 
+## T037 Contest Screenshot Evidence Refresh — Merge Complete
+
+### Completed in this cycle
+
+1. Opened PR `#130` in Draft for the screenshot-refresh re-run.
+2. Moved PR `#130` to Ready for review after local validation.
+3. Merged PR `#130` to `main` at `de5adcb`.
+4. Reopened a short post-merge sync lane so the compact mirrors and contest entry docs no longer describe the screenshot-refresh lane as still active.
+
+### Status
+
+- Task `T037_CONTEST_SCREENSHOT_REFRESH`: merged to `main` through `#130`
+- Next: finish the post-merge mirror sync and leave only human-only submission follow-ups in the queue
+
 ## Two-Lane Contest MVP Polish Experiment — Merge Complete
 
 ### Completed in this cycle

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -18,8 +18,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Current Status
 
 - Product MVP path is implemented through merged PRs for Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard.
-- The latest scripted-reset smoke-backed MVP verification passed on 2026-04-24 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
-- Screenshot evidence is captured in [`screenshots/`](./screenshots/) and is current again after the `T037` refresh on 2026-04-24.
+- The latest scripted-reset smoke-backed MVP verification passed on 2026-04-25 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
+- Screenshot evidence is captured in [`screenshots/`](./screenshots/) and is current again after the refreshed `T037` re-run merged on 2026-04-25.
 - Video capture is optional and deferred to avoid storing large media in the repository.
 
 ## Evidence Refresh Rules
@@ -27,7 +27,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 Run [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) first when local demo data may be stale, then run [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md), then refresh evidence using these rules:
 
 - Auto-refresh evidence: smoke-backed command results, API reachability checks, and the evidence status table in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
-- Human-triggered refresh: screenshots and any optional video, because they require an interactive capture step.
+- Browser-triggered refresh: screenshots and any optional video, because they require an interactive capture step.
 - Status vocabulary:
   - `Current`: evidence still matches the latest successful smoke run.
   - `Stale`: the MVP path changed after the last capture or validation.

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -32,7 +32,7 @@ Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/com
 
 ## Latest Validation
 
-The latest smoke-backed refresh passed on 2026-04-24 after running the scripted local reset. It verified:
+The latest smoke-backed refresh passed on 2026-04-25 after running the scripted local reset. It verified:
 
 - demo-safe Knowledge Pack `contest-demo-quadratics`;
 - assessment session `contest-assessment-demo`;
@@ -40,7 +40,7 @@ The latest smoke-backed refresh passed on 2026-04-24 after running the scripted 
 - dashboard overview and recent activity;
 - frontend production build with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
 
-Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` for smoke-backed evidence and `#99` for the screenshot bundle.
+Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` and `#128` for smoke-backed evidence, and `#99` plus `#130` for the screenshot bundle.
 
 ## Human Review Checklist
 
@@ -63,7 +63,7 @@ If the submission requires video, use [`VIDEO_CAPTURE_RUNBOOK.md`](./VIDEO_CAPTU
 - Provider-backed AI quality depends on configured model credentials.
 - The backend `deeptutor.api.run_server` path has a reload/absolute-pattern incompatibility with the installed `uvicorn`; latest smoke used the CLI server path with reload disabled.
 - Frontend build may need network access to fetch Google Fonts.
-- Screenshots are current as of the 2026-04-24 `T037` refresh and should be recaptured only if the UI meaningfully changes again.
+- Screenshots are current as of the 2026-04-25 `T037` re-run and should be recaptured only if the UI meaningfully changes again.
 
 ## Review Flow
 

--- a/docs/superpowers/pr-notes/2026-04-25-post-130-screenshot-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-25-post-130-screenshot-sync.md
@@ -1,0 +1,17 @@
+# Post-130 Screenshot Merge Sync
+
+## Scope
+
+- Remove the stale active-lane wording left behind after PR `#130` merged.
+- Update the compact mirrors and contest entry docs to reflect the 2026-04-25 screenshot-refresh merge.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated because this PR only syncs docs and operating mirrors.
+
+## Architecture Note
+
+```mermaid
+flowchart LR
+  Merge["Merged screenshot refresh (#130)"] --> Mirrors["AI prompt / queue / snapshots"]
+  Merge --> ContestDocs["README.md / SUBMISSION_PACKAGE.md"]
+  Mirrors --> Idle["No active AI-owned lane"]
+  ContestDocs --> Human["Human-only submission follow-up"]
+```

--- a/docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md
+++ b/docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md
@@ -1,0 +1,41 @@
+# Feature Pod Task: Post-130 Screenshot Merge Sync
+
+Owner: Codex
+Branch: `docs/post-130-screenshot-sync`
+
+## Goal
+
+Sync the control-plane mirrors and contest entry docs after PR `#130` merged so the repository no longer reports the screenshot-refresh lane as active.
+
+## Owned files/modules
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-25.md`
+- `docs/contest/README.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md`
+- `docs/superpowers/pr-notes/` for the post-merge sync PR note
+
+## Do-not-touch files/modules
+
+- Product/runtime source files
+- `docs/contest/screenshots/*`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## Acceptance criteria
+
+- No active assignment remains for the merged screenshot lane.
+- Queue and prompt no longer describe the screenshot-refresh lane as still active.
+- Contest entry docs reference the 2026-04-25 screenshot refresh instead of the older 2026-04-24 wording.
+- PR note includes a Mermaid diagram and states whether `MAIN_SYSTEM_MAP.md` changed.
+
+## Required tests
+
+- `rg -n "2026-04-24|#130|screenshot refresh|active docs lane" ai_first docs/contest docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`


### PR DESCRIPTION
## Summary
- remove the stale active-lane wording left behind after PR #130 merged
- refresh compact mirrors and contest entry docs to the 2026-04-25 screenshot baseline
- add a short post-merge sync task packet and PR note

## Validation
- `rg -n "2026-04-24|#130|screenshot refresh|active docs lane" ai_first docs/contest docs/superpowers/tasks docs/superpowers/pr-notes -S`
- `git diff --check`
