### PR TITLE
feat: add wave 1 evidence spine

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -42,3 +42,18 @@ Rules:
 - Last update: 2026-04-25
 - Next action: Remove stale post-merge lane status and refresh contest entry docs after PR `#130`.
 - Blocker: None
+
+### Assignment
+
+- Owner: Codex
+- Machine: `MacBook-Air-cua-Loc.local`
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
+- Task: `CONTEST_MVP_HYBRID_LANES_DESIGN`
+- Status: In progress
+- Branch: `docs/contest-mvp-hybrid-lanes-design`
+- Task packet: None
+- Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md`
+- PR: Not opened
+- Last update: 2026-04-26
+- Next action: Write and self-review the Contest MVP+ hybrid lanes design spec.
+- Blocker: None

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -48,12 +48,12 @@ Rules:
 - Owner: Codex
 - Machine: `MacBook-Air-cua-Loc.local`
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: `CONTEST_MVP_HYBRID_LANES_DESIGN`
-- Status: In progress
+- Task: `CONTEST_MVP_SPINE_PLAN`
+- Status: In review
 - Branch: `docs/contest-mvp-hybrid-lanes-design`
 - Task packet: None
-- Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md`
+- Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md`, `docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md`
 - PR: Not opened
 - Last update: 2026-04-26
-- Next action: Write and self-review the Contest MVP+ hybrid lanes design spec.
+- Next action: Hand off the Wave 1 spine implementation plan and wait for execution mode selection.
 - Blocker: None

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -49,11 +49,11 @@ Rules:
 - Machine: `MacBook-Air-cua-Loc.local`
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-a-wave1-evidence-spine`
 - Task: `WAVE_1_EVIDENCE_SPINE`
-- Status: In progress
+- Status: In review
 - Branch: `pod-a/wave1-evidence-spine`
 - Task packet: `docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md`
-- Owned files: `deeptutor/services/evidence/*`, `deeptutor/services/session/sqlite_store.py`, `deeptutor/services/session/__init__.py`, `deeptutor/api/routers/assessment.py`, `deeptutor/api/routers/dashboard.py`, `tests/services/evidence/*`, `tests/services/session/test_sqlite_store.py`, `tests/api/test_assessment_router.py`, `tests/api/test_dashboard_router.py`, `web/components/dashboard/TeacherInsightPanel.tsx`, `web/lib/dashboard-api.ts`, `web/app/(workspace)/dashboard/page.tsx`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md`, `docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md`
+- Owned files: `deeptutor/services/evidence/*`, `deeptutor/services/session/sqlite_store.py`, `deeptutor/services/session/__init__.py`, `deeptutor/api/routers/assessment.py`, `deeptutor/api/routers/dashboard.py`, `tests/services/evidence/*`, `tests/services/session/test_sqlite_store.py`, `tests/api/test_assessment_router.py`, `tests/api/test_dashboard_router.py`, `web/components/dashboard/TeacherInsightPanel.tsx`, `web/lib/dashboard-api.ts`, `web/app/(workspace)/dashboard/page.tsx`, `ai_first/architecture/MAIN_SYSTEM_MAP.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md`, `docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md`
 - PR: Not opened
 - Last update: 2026-04-26
-- Next action: Run baseline tests, then implement backend evidence spine in the task packet scope.
+- Next action: Review validation results and decide whether to open a PR for the Wave 1 spine branch.
 - Blocker: None

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -47,13 +47,13 @@ Rules:
 
 - Owner: Codex
 - Machine: `MacBook-Air-cua-Loc.local`
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: `CONTEST_MVP_SPINE_PLAN`
-- Status: In review
-- Branch: `docs/contest-mvp-hybrid-lanes-design`
-- Task packet: None
-- Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md`, `docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md`
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-a-wave1-evidence-spine`
+- Task: `WAVE_1_EVIDENCE_SPINE`
+- Status: In progress
+- Branch: `pod-a/wave1-evidence-spine`
+- Task packet: `docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md`
+- Owned files: `deeptutor/services/evidence/*`, `deeptutor/services/session/sqlite_store.py`, `deeptutor/services/session/__init__.py`, `deeptutor/api/routers/assessment.py`, `deeptutor/api/routers/dashboard.py`, `tests/services/evidence/*`, `tests/services/session/test_sqlite_store.py`, `tests/api/test_assessment_router.py`, `tests/api/test_dashboard_router.py`, `web/components/dashboard/TeacherInsightPanel.tsx`, `web/lib/dashboard-api.ts`, `web/app/(workspace)/dashboard/page.tsx`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md`, `docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md`
 - PR: Not opened
 - Last update: 2026-04-26
-- Next action: Hand off the Wave 1 spine implementation plan and wait for execution mode selection.
+- Next action: Run baseline tests, then implement backend evidence spine in the task packet scope.
 - Blocker: None

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -1,6 +1,6 @@
 # Main System Map
 
-Last updated: 2026-04-24
+Last updated: 2026-04-26
 
 This is the required top-level Mermaid map for the project. Any PR that adds, removes, or materially changes product features, capabilities, tools, routers, routes, data models, or AI-first workflow must update this map.
 
@@ -58,8 +58,12 @@ flowchart TD
   AssessmentBuilder --> QuizGrounding["Knowledge Pack Grounded Quiz Config"]
   AssessmentBuilder --> AdaptiveDifficulty["Adaptive Difficulty from Recent Quiz Performance"]
   AssessmentBuilder --> AssessmentRecommendAPI["POST /api/v1/assessment/recommend"]
+  AssessmentBuilder --> AssessmentDiagnosisAPI["GET /api/v1/assessment/diagnosis/{session_id}"]
   AssessmentRecommendAPI --> RecommendEngine["Assessment Recommendation Engine"]
   RecommendEngine --> AssessmentSignals["Weak topics + score trend + KB context"]
+  AssessmentDiagnosisAPI --> EvidenceExtractor["Observation extractor from quiz review"]
+  EvidenceExtractor --> ObservationStore["SQLite observations + student_states"]
+  ObservationStore --> DiagnosisEngine["Rule-first diagnosis + action selection"]
   AdaptiveDifficulty --> QuizHistory["[Quiz Performance] session context"]
   AdaptiveDifficulty --> DeepQuestion
   
@@ -74,9 +78,13 @@ flowchart TD
   TeacherDashboard --> DashboardSummary["Session Activity Summary"]
   DashboardSummary --> DashboardFilters["History filters: type + KB + search + min score"]
   DashboardSummary --> TeacherAnalytics["Teacher Analytics Signals"]
+  TeacherDashboard --> TeacherInsights["Teacher Insight Panel"]
   TeacherAnalytics --> EngagementSignals["Engagement: active days + streak + KB usage"]
   TeacherAnalytics --> AssessmentTrend["Assessment trend: average + latest + delta"]
   TeacherAnalytics --> DifficultySignals["Learning signals: focus topics + strong areas"]
+  TeacherInsights --> InsightsAPI["GET /api/v1/dashboard/insights"]
+  InsightsAPI --> DiagnosisEngine
+  InsightsAPI --> SmallGroupRecommendations["Small-group recommendation clusters"]
   TeacherDashboard --> StudentDashboard["Student Progress Dashboard"]
   TeacherDashboard --> AssessmentReview["Assessment Review Drill-down"]
   StudentDashboard --> StudentRoute["/dashboard/student"]

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -1,0 +1,27 @@
+# Daily Log: 2026-04-26
+
+## Pod A
+
+- Branch: `docs/contest-mvp-hybrid-lanes-design`
+- Task: `CONTEST_MVP_HYBRID_LANES_DESIGN`
+- Done: Drafted and self-reviewed the Contest MVP+ hybrid lanes design spec for a 6-8 week roadmap centered on teacher-defined authoring plus an evidence-backed recommendation loop.
+- Tests: `rg -n "TBD|TODO|FIXME|\\bplaceholder\\b" docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md ai_first/daily/2026-04-26.md ai_first/ACTIVE_ASSIGNMENTS.md -S`; `git diff --check`
+- Blockers: None.
+- Next: User review of the written spec before any implementation planning.
+
+## Pod B
+
+- Branch: None.
+- Task: None.
+- Done: None.
+- Tests: None.
+- Blockers: None.
+- Next: None.
+
+## Human Review Needed
+
+- Review `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md` and confirm whether the lane structure and sequencing should become the implementation planning baseline.
+
+## Architecture Map Updates
+
+- None yet.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -2,12 +2,12 @@
 
 ## Pod A
 
-- Branch: `docs/contest-mvp-hybrid-lanes-design`
-- Task: `CONTEST_MVP_HYBRID_LANES_DESIGN` -> `CONTEST_MVP_SPINE_PLAN`
-- Done: Drafted and self-reviewed the Contest MVP+ hybrid lanes design spec, then converted the first shippable subproject into a detailed Wave 1 spine implementation plan covering observation capture, diagnosis, teacher insights, and dashboard surfacing.
-- Tests: `rg -n "TBD|TODO|FIXME|\\bplaceholder\\b" docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md ai_first/daily/2026-04-26.md ai_first/ACTIVE_ASSIGNMENTS.md -S`; `rg -n "TBD|TODO|FIXME|<new-note>|placeholder" docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md -S`; `git diff --check`
+- Branch: `pod-a/wave1-evidence-spine`
+- Task: `WAVE_1_EVIDENCE_SPINE`
+- Done: Added the Wave 1 evidence spine backend and dashboard surface: normalized assessment observations, SQLite-backed student-state persistence, structured diagnosis endpoint, structured dashboard insights, and a teacher insight panel on `/dashboard`.
+- Tests: `pytest tests/services/evidence/test_extractor.py tests/services/evidence/test_diagnosis.py tests/services/session/test_sqlite_store.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`; `npm run lint` in the worktree fails on pre-existing repo-wide errors outside this lane; targeted frontend lint passes via `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx lib/dashboard-api.ts components/dashboard/TeacherInsightPanel.tsx`; `git diff --check`
 - Blockers: None.
-- Next: User chooses execution mode for the Wave 1 spine plan.
+- Next: Review the Wave 1 evidence spine branch, then decide whether to continue into Wave 2 or open a PR for this lane.
 
 ## Pod B
 
@@ -20,8 +20,8 @@
 
 ## Human Review Needed
 
-- Review `docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md` and choose whether execution should be subagent-driven or inline.
+- Review the Wave 1 evidence spine implementation and confirm whether this lane should be prepared as a PR.
 
 ## Architecture Map Updates
 
-- None yet.
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the structured evidence spine and teacher insight panel.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -3,11 +3,11 @@
 ## Pod A
 
 - Branch: `docs/contest-mvp-hybrid-lanes-design`
-- Task: `CONTEST_MVP_HYBRID_LANES_DESIGN`
-- Done: Drafted and self-reviewed the Contest MVP+ hybrid lanes design spec for a 6-8 week roadmap centered on teacher-defined authoring plus an evidence-backed recommendation loop.
-- Tests: `rg -n "TBD|TODO|FIXME|\\bplaceholder\\b" docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md ai_first/daily/2026-04-26.md ai_first/ACTIVE_ASSIGNMENTS.md -S`; `git diff --check`
+- Task: `CONTEST_MVP_HYBRID_LANES_DESIGN` -> `CONTEST_MVP_SPINE_PLAN`
+- Done: Drafted and self-reviewed the Contest MVP+ hybrid lanes design spec, then converted the first shippable subproject into a detailed Wave 1 spine implementation plan covering observation capture, diagnosis, teacher insights, and dashboard surfacing.
+- Tests: `rg -n "TBD|TODO|FIXME|\\bplaceholder\\b" docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md ai_first/daily/2026-04-26.md ai_first/ACTIVE_ASSIGNMENTS.md -S`; `rg -n "TBD|TODO|FIXME|<new-note>|placeholder" docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md -S`; `git diff --check`
 - Blockers: None.
-- Next: User review of the written spec before any implementation planning.
+- Next: User chooses execution mode for the Wave 1 spine plan.
 
 ## Pod B
 
@@ -20,7 +20,7 @@
 
 ## Human Review Needed
 
-- Review `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md` and confirm whether the lane structure and sequencing should become the implementation planning baseline.
+- Review `docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md` and choose whether execution should be subagent-driven or inline.
 
 ## Architecture Map Updates
 

--- a/deeptutor/api/routers/assessment.py
+++ b/deeptutor/api/routers/assessment.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from deeptutor.services.assessment import recommend_next_assessment
+from deeptutor.services.evidence.diagnosis import build_student_diagnosis
+from deeptutor.services.evidence.extractor import extract_observations_from_review
 from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
 
 router = APIRouter()
@@ -55,3 +57,34 @@ async def _collect_assessment_rows(
 async def recommend_assessment(payload: AssessmentRecommendationRequest):
     rows = await _collect_assessment_rows(session_id=payload.session_id, limit=payload.limit)
     return recommend_next_assessment(rows, preferred_session_id=payload.session_id)
+
+
+@router.get("/diagnosis/{session_id}")
+async def get_assessment_diagnosis(session_id: str):
+    store = get_sqlite_session_store()
+    detail = await store.get_session_with_messages(session_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail="Assessment session not found")
+
+    review = extract_assessment_review(detail)
+    if review is None:
+        raise HTTPException(status_code=404, detail="Assessment review not found")
+
+    review["student_id"] = str((detail.get("preferences") or {}).get("student_id") or session_id)
+    observations = extract_observations_from_review(review)
+    await store.save_observations(observations)
+
+    student_id = review["student_id"]
+    state = {
+        "student_id": student_id,
+        "repeated_mistakes": sorted({row["topic"] for row in observations if not row["is_correct"]}),
+        "support_level": "guided" if any(not row["is_correct"] for row in observations) else "independent",
+        "confidence_trend": "down" if any(not row["is_correct"] for row in observations) else "flat",
+    }
+    await store.upsert_student_state(student_id, state)
+
+    return build_student_diagnosis(
+        student_id=student_id,
+        observations=observations,
+        student_state=await store.get_student_state(student_id),
+    )

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -7,6 +7,9 @@ import fitz
 from fastapi import APIRouter, HTTPException, Response
 
 from deeptutor.services.assessment import build_assessment_analysis
+from deeptutor.services.evidence.diagnosis import build_student_diagnosis
+from deeptutor.services.evidence.extractor import extract_observations_from_review
+from deeptutor.services.evidence.teacher_insights import build_teacher_insights_payload
 from deeptutor.services.learning_path import build_suggested_learning_path
 from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
 
@@ -458,29 +461,6 @@ async def get_student_progress(limit: int = 50):
     }
 
 
-def _build_teacher_insights(
-    activities: list[dict[str, Any]],
-    assessment_rows: list[dict[str, Any]],
-) -> dict[str, Any]:
-    analytics = _build_dashboard_analytics(activities, assessment_rows)
-    focus = analytics.get("learning_signals", {}).get("focus_topics", [])
-    recommendations: list[str] = []
-    avg = analytics.get("assessment_trend", {}).get("average_score_percent", 0)
-
-    if avg < 70:
-        recommendations.append("Schedule a targeted review for top focus topics.")
-    if analytics.get("assessment_trend", {}).get("score_delta", 0) < 0:
-        recommendations.append("Follow up with students from recent lower-scoring assessments.")
-    if not focus:
-        recommendations.append("No clear focus topics — consider a short diagnostic quiz.")
-
-    return {
-        "analytics": analytics,
-        "at_risk_topics": focus,
-        "recommendations": recommendations,
-    }
-
-
 @router.get("/insights")
 async def get_dashboard_insights(
     limit: int = 100,
@@ -489,47 +469,55 @@ async def get_dashboard_insights(
     start_ts: int | None = None,
     end_ts: int | None = None,
 ):
-    """Teacher-facing aggregated insights for a class or cohort.
-
-    This endpoint reuses existing activity aggregation and returns a compact
-    set of actionable signals and recommendations for teachers.
-    """
     store = get_sqlite_session_store()
     sessions = await store.list_sessions(limit=limit, offset=0)
-    activities = [await _activity_with_review(store, session) for session in sessions]
+    student_payloads: list[dict[str, Any]] = []
 
-    # Apply optional filters: knowledge_base and timestamp window
-    filtered_activities: list[dict[str, Any]] = []
-    for activity in activities:
-        if knowledge_base or cohort or start_ts or end_ts:
-            if not _matches_dashboard_filters(
-                activity, knowledge_base=knowledge_base, cohort=cohort
-            ):
-                continue
-            ts = activity.get("timestamp") or 0
-            if start_ts is not None and ts < start_ts:
-                continue
-            if end_ts is not None and ts > end_ts:
-                continue
-        filtered_activities.append(activity)
+    for session in sessions:
+        activity = await _activity_with_review(store, session)
+        if activity["type"] != "assessment":
+            continue
+        if not _matches_dashboard_filters(
+            activity,
+            knowledge_base=knowledge_base,
+            cohort=cohort,
+        ):
+            continue
+        ts = activity.get("timestamp") or 0
+        if start_ts is not None and ts < start_ts:
+            continue
+        if end_ts is not None and ts > end_ts:
+            continue
 
-    assessment_rows = [
-        {
-            "session_id": activity["id"],
-            "title": activity["title"],
-            "timestamp": activity["timestamp"],
-            "knowledge_bases": activity["knowledge_bases"],
-            "summary": activity.get("assessment_summary"),
-            "review_ref": activity.get("review_ref"),
-            "assessment_results": activity.get("assessment_summary") and (
-                extract_assessment_review(await store.get_session_with_messages(activity["id"])) or {}
-            ).get("results", []),
-        }
-        for activity in filtered_activities
-        if activity["type"] == "assessment" and activity.get("assessment_summary")
-    ]
+        detail = await store.get_session_with_messages(activity["id"])
+        review = extract_assessment_review(detail) if detail else None
+        if review is None:
+            continue
 
-    return _build_teacher_insights(filtered_activities, assessment_rows)
+        student_id = str((detail.get("preferences") or {}).get("student_id") or activity["id"])
+        review["student_id"] = student_id
+        observations = extract_observations_from_review(review)
+        await store.save_observations(observations)
+
+        state = await store.get_student_state(student_id)
+        if state is None:
+            state = {
+                "student_id": student_id,
+                "repeated_mistakes": sorted({row["topic"] for row in observations if not row["is_correct"]}),
+                "support_level": "guided" if any(not row["is_correct"] for row in observations) else "independent",
+                "confidence_trend": "down" if any(not row["is_correct"] for row in observations) else "flat",
+            }
+            await store.upsert_student_state(student_id, state)
+
+        student_payloads.append(
+            build_student_diagnosis(
+                student_id=student_id,
+                observations=observations,
+                student_state=state,
+            )
+        )
+
+    return build_teacher_insights_payload(student_payloads=student_payloads)
 
 
 @router.get("/{entry_id}")

--- a/deeptutor/services/evidence/__init__.py
+++ b/deeptutor/services/evidence/__init__.py
@@ -1,0 +1,9 @@
+from .diagnosis import build_student_diagnosis
+from .extractor import extract_observations_from_review
+from .teacher_insights import build_teacher_insights_payload
+
+__all__ = [
+    "build_student_diagnosis",
+    "build_teacher_insights_payload",
+    "extract_observations_from_review",
+]

--- a/deeptutor/services/evidence/contracts.py
+++ b/deeptutor/services/evidence/contracts.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+
+ObservationSource = Literal["assessment", "tutoring"]
+DiagnosisType = Literal["concept_gap", "careless_error", "low_confidence", "needs_scaffold"]
+ConfidenceTag = Literal["low", "medium", "high"]
+SupportLevel = Literal["independent", "guided", "intensive"]
+ConfidenceTrend = Literal["up", "flat", "down"]
+
+
+class ObservationRecord(TypedDict):
+    observation_id: str
+    session_id: str
+    student_id: str
+    source: ObservationSource
+    topic: str
+    question_id: str
+    is_correct: bool
+    latency_seconds: int | None
+    hint_count: int
+    retry_count: int
+    dominant_error: DiagnosisType | None
+
+
+class StudentStateRecord(TypedDict):
+    student_id: str
+    repeated_mistakes: list[str]
+    support_level: SupportLevel
+    confidence_trend: ConfidenceTrend
+
+
+class DiagnosisRecord(TypedDict):
+    diagnosis_type: DiagnosisType
+    confidence_tag: ConfidenceTag
+    topic: str
+    evidence: list[str]
+
+
+class RecommendationRecord(TypedDict):
+    action_id: str
+    action_type: Literal[
+        "review_prerequisite",
+        "retry_easier",
+        "increase_scaffold",
+        "small_group_support",
+    ]
+    target_student_ids: list[str]
+    topic: str
+    rationale: str

--- a/deeptutor/services/evidence/diagnosis.py
+++ b/deeptutor/services/evidence/diagnosis.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+
+def _confidence_tag(observations: list[dict[str, Any]]) -> str:
+    if len(observations) >= 3:
+        return "high"
+    if len(observations) == 2:
+        return "medium"
+    return "low"
+
+
+def _support_level(observations: list[dict[str, Any]]) -> str:
+    if any((row.get("hint_count") or 0) >= 2 for row in observations):
+        return "intensive"
+    if any(not row.get("is_correct") for row in observations):
+        return "guided"
+    return "independent"
+
+
+def build_student_diagnosis(
+    *,
+    student_id: str,
+    observations: list[dict[str, Any]],
+    student_state: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not observations:
+        return {
+            "student_id": student_id,
+            "observed": None,
+            "student_state": student_state,
+            "inferred": [],
+            "recommended_actions": [],
+        }
+
+    topic_counter = Counter(row["topic"] for row in observations if not row.get("is_correct"))
+    if topic_counter:
+        dominant_topic, _ = topic_counter.most_common(1)[0]
+        dominant_rows = [row for row in observations if row["topic"] == dominant_topic]
+    else:
+        dominant_rows = observations
+        dominant_topic = observations[0]["topic"]
+
+    error_counter = Counter(row["dominant_error"] for row in dominant_rows if row.get("dominant_error"))
+    dominant_error = error_counter.most_common(1)[0][0] if error_counter else "low_confidence"
+    confidence = _confidence_tag(dominant_rows)
+    avg_latency_values = [
+        int(row.get("latency_seconds") or 0)
+        for row in dominant_rows
+        if row.get("latency_seconds") is not None
+    ]
+    derived_state = student_state or {
+        "student_id": student_id,
+        "repeated_mistakes": [dominant_topic],
+        "support_level": _support_level(dominant_rows),
+        "confidence_trend": "down",
+    }
+    recommendation_type = "review_prerequisite" if dominant_error == "concept_gap" else "increase_scaffold"
+
+    return {
+        "student_id": student_id,
+        "observed": {
+            "topic": dominant_topic,
+            "miss_count": sum(1 for row in dominant_rows if not row.get("is_correct")),
+            "avg_latency_seconds": round(sum(avg_latency_values) / len(avg_latency_values))
+            if avg_latency_values
+            else 0,
+        },
+        "student_state": derived_state,
+        "inferred": [
+            {
+                "diagnosis_type": dominant_error,
+                "confidence_tag": confidence,
+                "topic": dominant_topic,
+                "evidence": [
+                    f"{len(dominant_rows)} missed question(s) in {dominant_topic}",
+                    f"support_level={_support_level(dominant_rows)}",
+                ],
+            }
+        ],
+        "recommended_actions": [
+            {
+                "action_id": f"{student_id}:{dominant_topic}:{recommendation_type}",
+                "action_type": recommendation_type,
+                "target_student_ids": [student_id],
+                "topic": dominant_topic,
+                "rationale": f"Revisit {dominant_topic} before moving to mixed practice.",
+            }
+        ],
+    }

--- a/deeptutor/services/evidence/extractor.py
+++ b/deeptutor/services/evidence/extractor.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from deeptutor.services.assessment.analysis import infer_topic_from_question
+
+from .contracts import ObservationRecord
+
+
+def _dominant_error(result: dict[str, Any], repeated_topic_misses: int) -> str | None:
+    if bool(result.get("is_correct")):
+        return None
+    duration = int(result.get("duration_seconds") or 0)
+    if repeated_topic_misses >= 2:
+        return "concept_gap"
+    if duration <= 15:
+        return "careless_error"
+    return "needs_scaffold"
+
+
+def extract_observations_from_review(review: dict[str, Any]) -> list[ObservationRecord]:
+    results = review.get("results") if isinstance(review.get("results"), list) else []
+    topic_miss_counts: dict[str, int] = {}
+    for item in results:
+        topic = infer_topic_from_question(str(item.get("question") or ""), fallback="general")
+        if not bool(item.get("is_correct")):
+            topic_miss_counts[topic] = topic_miss_counts.get(topic, 0) + 1
+
+    rows: list[ObservationRecord] = []
+    for item in results:
+        topic = infer_topic_from_question(str(item.get("question") or ""), fallback="general")
+        rows.append(
+            {
+                "observation_id": f"obs_{uuid.uuid4().hex[:12]}",
+                "session_id": str(review.get("session_id") or ""),
+                "student_id": str(review.get("student_id") or review.get("session_id") or "unknown"),
+                "source": "assessment",
+                "topic": topic,
+                "question_id": str(item.get("question_id") or ""),
+                "is_correct": bool(item.get("is_correct")),
+                "latency_seconds": int(item.get("duration_seconds")) if item.get("duration_seconds") else None,
+                "hint_count": int(item.get("hint_count") or 0),
+                "retry_count": int(item.get("retry_count") or 0),
+                "dominant_error": _dominant_error(item, topic_miss_counts.get(topic, 0)),
+            }
+        )
+    return rows

--- a/deeptutor/services/evidence/teacher_insights.py
+++ b/deeptutor/services/evidence/teacher_insights.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+
+def build_teacher_insights_payload(
+    *,
+    student_payloads: list[dict[str, Any]],
+) -> dict[str, Any]:
+    grouped: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for payload in student_payloads:
+        inferred = payload.get("inferred") or []
+        if not inferred:
+            continue
+        key = (inferred[0]["topic"], inferred[0]["diagnosis_type"])
+        grouped[key].append(payload["student_id"])
+
+    small_groups = [
+        {
+            "topic": topic,
+            "diagnosis_type": diagnosis_type,
+            "student_ids": sorted(student_ids),
+            "recommended_action": "small_group_support",
+        }
+        for (topic, diagnosis_type), student_ids in grouped.items()
+        if len(student_ids) >= 2
+    ]
+
+    return {
+        "students": student_payloads,
+        "small_groups": small_groups,
+    }

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -145,6 +145,32 @@ class SQLiteSessionStore:
 
                 CREATE INDEX IF NOT EXISTS idx_turn_events_turn_seq
                     ON turn_events(turn_id, seq);
+
+                CREATE TABLE IF NOT EXISTS observations (
+                    observation_id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    student_id TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    topic TEXT NOT NULL,
+                    question_id TEXT DEFAULT '',
+                    is_correct INTEGER NOT NULL,
+                    latency_seconds INTEGER,
+                    hint_count INTEGER NOT NULL DEFAULT 0,
+                    retry_count INTEGER NOT NULL DEFAULT 0,
+                    dominant_error TEXT DEFAULT '',
+                    created_at REAL NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_observations_student_created
+                    ON observations(student_id, created_at DESC);
+
+                CREATE TABLE IF NOT EXISTS student_states (
+                    student_id TEXT PRIMARY KEY,
+                    repeated_mistakes_json TEXT NOT NULL DEFAULT '[]',
+                    support_level TEXT NOT NULL DEFAULT 'independent',
+                    confidence_trend TEXT NOT NULL DEFAULT 'flat',
+                    updated_at REAL NOT NULL
+                );
                 """
             )
             columns = {row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()}
@@ -465,6 +491,121 @@ class SQLiteSessionStore:
 
     async def get_turn_events(self, turn_id: str, after_seq: int = 0) -> list[dict[str, Any]]:
         return await self._run(self._get_turn_events_sync, turn_id, after_seq)
+
+    def _save_observations_sync(self, observations: list[dict[str, Any]]) -> None:
+        now = time.time()
+        with self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT OR REPLACE INTO observations (
+                    observation_id, session_id, student_id, source, topic, question_id,
+                    is_correct, latency_seconds, hint_count, retry_count, dominant_error, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        row["observation_id"],
+                        row["session_id"],
+                        row["student_id"],
+                        row["source"],
+                        row["topic"],
+                        row["question_id"],
+                        1 if row["is_correct"] else 0,
+                        row["latency_seconds"],
+                        row["hint_count"],
+                        row["retry_count"],
+                        row["dominant_error"] or "",
+                        now,
+                    )
+                    for row in observations
+                ],
+            )
+            conn.commit()
+
+    async def save_observations(self, observations: list[dict[str, Any]]) -> None:
+        return await self._run(self._save_observations_sync, observations)
+
+    def _upsert_student_state_sync(self, student_id: str, state: dict[str, Any]) -> None:
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO student_states (
+                    student_id, repeated_mistakes_json, support_level, confidence_trend, updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(student_id) DO UPDATE SET
+                    repeated_mistakes_json = excluded.repeated_mistakes_json,
+                    support_level = excluded.support_level,
+                    confidence_trend = excluded.confidence_trend,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    student_id,
+                    _json_dumps(state.get("repeated_mistakes", [])),
+                    state.get("support_level", "independent"),
+                    state.get("confidence_trend", "flat"),
+                    now,
+                ),
+            )
+            conn.commit()
+
+    async def upsert_student_state(self, student_id: str, state: dict[str, Any]) -> None:
+        return await self._run(self._upsert_student_state_sync, student_id, state)
+
+    def _get_student_state_sync(self, student_id: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT student_id, repeated_mistakes_json, support_level, confidence_trend, updated_at
+                FROM student_states
+                WHERE student_id = ?
+                """,
+                (student_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "student_id": row["student_id"],
+            "repeated_mistakes": _json_loads(row["repeated_mistakes_json"], []),
+            "support_level": row["support_level"],
+            "confidence_trend": row["confidence_trend"],
+            "updated_at": row["updated_at"],
+        }
+
+    async def get_student_state(self, student_id: str) -> dict[str, Any] | None:
+        return await self._run(self._get_student_state_sync, student_id)
+
+    def _list_observations_sync(self, student_id: str) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT observation_id, session_id, student_id, source, topic, question_id, is_correct,
+                       latency_seconds, hint_count, retry_count, dominant_error
+                FROM observations
+                WHERE student_id = ?
+                ORDER BY created_at DESC
+                """,
+                (student_id,),
+            ).fetchall()
+        return [
+            {
+                "observation_id": row["observation_id"],
+                "session_id": row["session_id"],
+                "student_id": row["student_id"],
+                "source": row["source"],
+                "topic": row["topic"],
+                "question_id": row["question_id"],
+                "is_correct": bool(row["is_correct"]),
+                "latency_seconds": row["latency_seconds"],
+                "hint_count": row["hint_count"],
+                "retry_count": row["retry_count"],
+                "dominant_error": row["dominant_error"] or None,
+            }
+            for row in rows
+        ]
+
+    async def list_observations(self, student_id: str) -> list[dict[str, Any]]:
+        return await self._run(self._list_observations_sync, student_id)
 
     def _update_session_title_sync(self, session_id: str, title: str) -> bool:
         with self._connect() as conn:

--- a/docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md
+++ b/docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md
@@ -1,0 +1,1166 @@
+# Contest MVP+ Spine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first working `Observed -> Inferred -> Recommended Action` spine on top of the current assessment, session, and dashboard stack.
+
+**Architecture:** This plan only covers `Wave 1` from the approved spec because the full spec spans multiple independent subsystems. The implementation adds a small evidence service layer, persists observation and student-state summaries in SQLite, upgrades backend diagnosis/insight endpoints, and exposes the new signals on the existing teacher dashboard without attempting full spec authoring yet.
+
+**Tech Stack:** Python, FastAPI, SQLite, pytest, Next.js, TypeScript, React, ESLint
+
+---
+
+## Scope Boundary
+
+This plan intentionally covers only the first shippable subproject from the approved design:
+
+- In scope: `Lane 3`, `Lane 4`, and the minimum viable dashboard surface from `Lane 5`
+- Out of scope: full `Agent Spec Pack` authoring UI, runtime prompt assembly changes, marketplace exposure, and contest evidence refresh for later waves
+
+Follow-on plans should be written separately for `Wave 2` and `Wave 3` after this spine lands.
+
+## File Structure
+
+### Backend evidence layer
+
+- Create: `deeptutor/services/evidence/__init__.py`
+  Exports the new evidence extraction, diagnosis, and teacher insight helpers.
+- Create: `deeptutor/services/evidence/contracts.py`
+  Defines the normalized observation, student-state, diagnosis, and recommendation shapes.
+- Create: `deeptutor/services/evidence/extractor.py`
+  Converts assessment review payloads into normalized observed signals.
+- Create: `deeptutor/services/evidence/diagnosis.py`
+  Implements the rule-first diagnosis and recommendation engine.
+- Create: `deeptutor/services/evidence/teacher_insights.py`
+  Aggregates per-student and small-group insights for the dashboard.
+
+### Session persistence
+
+- Modify: `deeptutor/services/session/sqlite_store.py`
+  Adds SQLite tables and helpers for observations and student-state summaries.
+- Modify: `deeptutor/services/session/__init__.py`
+  Re-exports any new store helpers if needed by routers and services.
+
+### API layer
+
+- Modify: `deeptutor/api/routers/assessment.py`
+  Adds a structured diagnosis endpoint while preserving the existing recommendation route.
+- Modify: `deeptutor/api/routers/dashboard.py`
+  Replaces the string-only insight endpoint with a structured teacher insight payload.
+
+### Tests
+
+- Create: `tests/services/evidence/test_extractor.py`
+- Create: `tests/services/evidence/test_diagnosis.py`
+- Modify: `tests/services/session/test_sqlite_store.py`
+- Modify: `tests/api/test_assessment_router.py`
+- Modify: `tests/api/test_dashboard_router.py`
+
+### Frontend
+
+- Create: `web/components/dashboard/TeacherInsightPanel.tsx`
+  Renders per-student cards, grouped recommendations, and evidence trace summaries.
+- Modify: `web/lib/dashboard-api.ts`
+  Adds strong types for the new insight payload.
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+  Loads and renders the structured teacher insight panel.
+
+## Task 1: Normalize Assessment Observations
+
+**Files:**
+- Create: `deeptutor/services/evidence/contracts.py`
+- Create: `deeptutor/services/evidence/extractor.py`
+- Create: `deeptutor/services/evidence/__init__.py`
+- Test: `tests/services/evidence/test_extractor.py`
+
+- [ ] **Step 1: Write the failing extractor tests**
+
+```python
+from deeptutor.services.evidence.extractor import extract_observations_from_review
+
+
+def test_extract_observations_from_review_builds_topic_level_signals() -> None:
+    review = {
+        "session_id": "quiz-1",
+        "student_id": "student-a",
+        "results": [
+            {
+                "question_id": "q1",
+                "question": "Solve fractions subtraction 3/4 - 1/2",
+                "is_correct": False,
+                "duration_seconds": 48,
+            },
+            {
+                "question_id": "q2",
+                "question": "Solve fractions subtraction 5/6 - 1/3",
+                "is_correct": False,
+                "duration_seconds": 61,
+            },
+        ],
+    }
+
+    rows = extract_observations_from_review(review)
+
+    assert len(rows) == 2
+    assert rows[0]["student_id"] == "student-a"
+    assert rows[0]["topic"] == "fractions subtraction"
+    assert rows[0]["source"] == "assessment"
+    assert rows[0]["is_correct"] is False
+    assert rows[0]["latency_seconds"] == 48
+
+
+def test_extract_observations_from_review_marks_dominant_error_for_repeated_misses() -> None:
+    review = {
+        "session_id": "quiz-2",
+        "student_id": "student-b",
+        "results": [
+            {
+                "question_id": "q1",
+                "question": "Solve algebra equation 2x = 10",
+                "is_correct": False,
+                "duration_seconds": 20,
+            },
+            {
+                "question_id": "q2",
+                "question": "Solve algebra equation x + 2 = 5",
+                "is_correct": False,
+                "duration_seconds": 18,
+            },
+        ],
+    }
+
+    rows = extract_observations_from_review(review)
+
+    assert {row["dominant_error"] for row in rows} == {"concept_gap"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/evidence/test_extractor.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'deeptutor.services.evidence'`
+
+- [ ] **Step 3: Write the contracts and extractor**
+
+```python
+# deeptutor/services/evidence/contracts.py
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+
+ObservationSource = Literal["assessment", "tutoring"]
+DiagnosisType = Literal["concept_gap", "careless_error", "low_confidence", "needs_scaffold"]
+
+
+class ObservationRecord(TypedDict):
+    observation_id: str
+    session_id: str
+    student_id: str
+    source: ObservationSource
+    topic: str
+    question_id: str
+    is_correct: bool
+    latency_seconds: int | None
+    hint_count: int
+    retry_count: int
+    dominant_error: DiagnosisType | None
+
+
+class StudentStateRecord(TypedDict):
+    student_id: str
+    repeated_mistakes: list[str]
+    support_level: Literal["independent", "guided", "intensive"]
+    confidence_trend: Literal["up", "flat", "down"]
+
+
+class DiagnosisRecord(TypedDict):
+    diagnosis_type: DiagnosisType
+    confidence_tag: Literal["low", "medium", "high"]
+    topic: str
+    evidence: list[str]
+
+
+class RecommendationRecord(TypedDict):
+    action_id: str
+    action_type: Literal["review_prerequisite", "retry_easier", "increase_scaffold", "small_group_support"]
+    target_student_ids: list[str]
+    topic: str
+    rationale: str
+```
+
+```python
+# deeptutor/services/evidence/extractor.py
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from deeptutor.services.assessment.analysis import infer_topic_from_question
+
+from .contracts import ObservationRecord
+
+
+def _dominant_error(result: dict[str, Any], repeated_topic_misses: int) -> str | None:
+    if bool(result.get("is_correct")):
+        return None
+    duration = int(result.get("duration_seconds") or 0)
+    if repeated_topic_misses >= 2:
+        return "concept_gap"
+    if duration <= 15:
+        return "careless_error"
+    return "needs_scaffold"
+
+
+def extract_observations_from_review(review: dict[str, Any]) -> list[ObservationRecord]:
+    results = review.get("results") if isinstance(review.get("results"), list) else []
+    topic_miss_counts: dict[str, int] = {}
+    for item in results:
+        topic = infer_topic_from_question(str(item.get("question") or ""), fallback="general")
+        if not bool(item.get("is_correct")):
+            topic_miss_counts[topic] = topic_miss_counts.get(topic, 0) + 1
+
+    rows: list[ObservationRecord] = []
+    for item in results:
+        topic = infer_topic_from_question(str(item.get("question") or ""), fallback="general")
+        rows.append(
+            {
+                "observation_id": f"obs_{uuid.uuid4().hex[:12]}",
+                "session_id": str(review.get("session_id") or ""),
+                "student_id": str(review.get("student_id") or review.get("session_id") or "unknown"),
+                "source": "assessment",
+                "topic": topic,
+                "question_id": str(item.get("question_id") or ""),
+                "is_correct": bool(item.get("is_correct")),
+                "latency_seconds": int(item.get("duration_seconds")) if item.get("duration_seconds") else None,
+                "hint_count": int(item.get("hint_count") or 0),
+                "retry_count": int(item.get("retry_count") or 0),
+                "dominant_error": _dominant_error(item, topic_miss_counts.get(topic, 0)),
+            }
+        )
+    return rows
+```
+
+```python
+# deeptutor/services/evidence/__init__.py
+from .extractor import extract_observations_from_review
+
+__all__ = [
+    "extract_observations_from_review",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/evidence/test_extractor.py -v`
+Expected: PASS with `2 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/services/evidence/test_extractor.py deeptutor/services/evidence/__init__.py deeptutor/services/evidence/contracts.py deeptutor/services/evidence/extractor.py
+git commit -m "feat: add evidence observation extraction"
+```
+
+## Task 2: Persist Observations and Student State in SQLite
+
+**Files:**
+- Modify: `deeptutor/services/session/sqlite_store.py`
+- Modify: `tests/services/session/test_sqlite_store.py`
+
+- [ ] **Step 1: Write the failing SQLite store test**
+
+```python
+import pytest
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_persists_observations_and_student_state(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+
+    await store.save_observations(
+        [
+            {
+                "observation_id": "obs_1",
+                "session_id": "quiz-1",
+                "student_id": "student-a",
+                "source": "assessment",
+                "topic": "fractions subtraction",
+                "question_id": "q1",
+                "is_correct": False,
+                "latency_seconds": 48,
+                "hint_count": 0,
+                "retry_count": 1,
+                "dominant_error": "concept_gap",
+            }
+        ]
+    )
+    await store.upsert_student_state(
+        "student-a",
+        {
+            "student_id": "student-a",
+            "repeated_mistakes": ["fractions subtraction"],
+            "support_level": "guided",
+            "confidence_trend": "down",
+        },
+    )
+
+    observations = await store.list_observations(student_id="student-a")
+    state = await store.get_student_state("student-a")
+
+    assert len(observations) == 1
+    assert observations[0]["topic"] == "fractions subtraction"
+    assert state["support_level"] == "guided"
+    assert state["confidence_trend"] == "down"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/services/session/test_sqlite_store.py::test_sqlite_store_persists_observations_and_student_state -v`
+Expected: FAIL with `AttributeError: 'SQLiteSessionStore' object has no attribute 'save_observations'`
+
+- [ ] **Step 3: Add the schema migration and store helpers**
+
+```python
+# sqlite_store.py - inside _initialize()
+conn.executescript(
+    """
+    CREATE TABLE IF NOT EXISTS observations (
+        observation_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        student_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        topic TEXT NOT NULL,
+        question_id TEXT DEFAULT '',
+        is_correct INTEGER NOT NULL,
+        latency_seconds INTEGER,
+        hint_count INTEGER NOT NULL DEFAULT 0,
+        retry_count INTEGER NOT NULL DEFAULT 0,
+        dominant_error TEXT DEFAULT '',
+        created_at REAL NOT NULL DEFAULT (strftime('%s', 'now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_observations_student_created
+        ON observations(student_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS student_states (
+        student_id TEXT PRIMARY KEY,
+        repeated_mistakes_json TEXT NOT NULL DEFAULT '[]',
+        support_level TEXT NOT NULL DEFAULT 'independent',
+        confidence_trend TEXT NOT NULL DEFAULT 'flat',
+        updated_at REAL NOT NULL
+    );
+    """
+)
+```
+
+```python
+# sqlite_store.py - add new methods
+def _save_observations_sync(self, observations: list[dict[str, Any]]) -> None:
+    now = time.time()
+    with self._connect() as conn:
+        conn.executemany(
+            """
+            INSERT OR REPLACE INTO observations (
+                observation_id, session_id, student_id, source, topic, question_id,
+                is_correct, latency_seconds, hint_count, retry_count, dominant_error, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    row["observation_id"],
+                    row["session_id"],
+                    row["student_id"],
+                    row["source"],
+                    row["topic"],
+                    row["question_id"],
+                    1 if row["is_correct"] else 0,
+                    row["latency_seconds"],
+                    row["hint_count"],
+                    row["retry_count"],
+                    row["dominant_error"] or "",
+                    now,
+                )
+                for row in observations
+            ],
+        )
+        conn.commit()
+
+
+async def save_observations(self, observations: list[dict[str, Any]]) -> None:
+    await self._run(self._save_observations_sync, observations)
+
+
+def _upsert_student_state_sync(self, student_id: str, state: dict[str, Any]) -> None:
+    now = time.time()
+    with self._connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO student_states (
+                student_id, repeated_mistakes_json, support_level, confidence_trend, updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(student_id) DO UPDATE SET
+                repeated_mistakes_json = excluded.repeated_mistakes_json,
+                support_level = excluded.support_level,
+                confidence_trend = excluded.confidence_trend,
+                updated_at = excluded.updated_at
+            """,
+            (
+                student_id,
+                _json_dumps(state.get("repeated_mistakes", [])),
+                state.get("support_level", "independent"),
+                state.get("confidence_trend", "flat"),
+                now,
+            ),
+        )
+        conn.commit()
+```
+
+```python
+# sqlite_store.py - add readers
+async def upsert_student_state(self, student_id: str, state: dict[str, Any]) -> None:
+    await self._run(self._upsert_student_state_sync, student_id, state)
+
+
+def _get_student_state_sync(self, student_id: str) -> dict[str, Any] | None:
+    with self._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT student_id, repeated_mistakes_json, support_level, confidence_trend, updated_at
+            FROM student_states
+            WHERE student_id = ?
+            """,
+            (student_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "student_id": row["student_id"],
+        "repeated_mistakes": _json_loads(row["repeated_mistakes_json"], []),
+        "support_level": row["support_level"],
+        "confidence_trend": row["confidence_trend"],
+        "updated_at": row["updated_at"],
+    }
+
+
+async def get_student_state(self, student_id: str) -> dict[str, Any] | None:
+    return await self._run(self._get_student_state_sync, student_id)
+
+
+def _list_observations_sync(self, student_id: str) -> list[dict[str, Any]]:
+    with self._connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT observation_id, session_id, student_id, source, topic, question_id, is_correct,
+                   latency_seconds, hint_count, retry_count, dominant_error
+            FROM observations
+            WHERE student_id = ?
+            ORDER BY created_at DESC
+            """,
+            (student_id,),
+        ).fetchall()
+    return [
+        {
+            "observation_id": row["observation_id"],
+            "session_id": row["session_id"],
+            "student_id": row["student_id"],
+            "source": row["source"],
+            "topic": row["topic"],
+            "question_id": row["question_id"],
+            "is_correct": bool(row["is_correct"]),
+            "latency_seconds": row["latency_seconds"],
+            "hint_count": row["hint_count"],
+            "retry_count": row["retry_count"],
+            "dominant_error": row["dominant_error"] or None,
+        }
+        for row in rows
+    ]
+
+
+async def list_observations(self, student_id: str) -> list[dict[str, Any]]:
+    return await self._run(self._list_observations_sync, student_id)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/services/session/test_sqlite_store.py::test_sqlite_store_persists_observations_and_student_state -v`
+Expected: PASS with `1 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deeptutor/services/session/sqlite_store.py tests/services/session/test_sqlite_store.py
+git commit -m "feat: persist evidence observations and student state"
+```
+
+## Task 3: Add Rule-First Diagnosis and Structured Assessment Output
+
+**Files:**
+- Create: `deeptutor/services/evidence/diagnosis.py`
+- Create: `tests/services/evidence/test_diagnosis.py`
+- Modify: `deeptutor/api/routers/assessment.py`
+- Modify: `tests/api/test_assessment_router.py`
+
+- [ ] **Step 1: Write the failing diagnosis tests**
+
+```python
+from deeptutor.services.evidence.diagnosis import build_student_diagnosis
+
+
+def test_build_student_diagnosis_returns_structured_hypotheses_and_actions() -> None:
+    observations = [
+        {
+            "observation_id": "obs_1",
+            "session_id": "quiz-1",
+            "student_id": "student-a",
+            "source": "assessment",
+            "topic": "fractions subtraction",
+            "question_id": "q1",
+            "is_correct": False,
+            "latency_seconds": 48,
+            "hint_count": 0,
+            "retry_count": 1,
+            "dominant_error": "concept_gap",
+        },
+        {
+            "observation_id": "obs_2",
+            "session_id": "quiz-1",
+            "student_id": "student-a",
+            "source": "assessment",
+            "topic": "fractions subtraction",
+            "question_id": "q2",
+            "is_correct": False,
+            "latency_seconds": 61,
+            "hint_count": 0,
+            "retry_count": 1,
+            "dominant_error": "concept_gap",
+        },
+    ]
+    state = {
+        "student_id": "student-a",
+        "repeated_mistakes": ["fractions subtraction"],
+        "support_level": "guided",
+        "confidence_trend": "down",
+    }
+
+    payload = build_student_diagnosis(student_id="student-a", observations=observations, student_state=state)
+
+    assert payload["student_id"] == "student-a"
+    assert payload["observed"]["topic"] == "fractions subtraction"
+    assert payload["inferred"][0]["diagnosis_type"] == "concept_gap"
+    assert payload["recommended_actions"][0]["action_type"] == "review_prerequisite"
+```
+
+```python
+@pytest.mark.asyncio
+async def test_assessment_diagnosis_endpoint_returns_structured_payload(tmp_path, monkeypatch) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="assessment-recent",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "assessment-recent",
+        "user",
+        "[Quiz Performance]\\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4, time: 48s)\\n"
+        "2. [q2] Q: Solve fractions subtraction 5/6 - 1/3 -> Answered: 1/6 (Incorrect, correct: 1/2, time: 61s)\\n"
+        "Score: 0/2 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/assessment/diagnosis/assessment-recent")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["student_id"] == "assessment-recent"
+    assert payload["inferred"][0]["diagnosis_type"] == "concept_gap"
+    assert payload["recommended_actions"][0]["topic"] == "fractions subtraction"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py::test_assessment_diagnosis_endpoint_returns_structured_payload -v`
+Expected: FAIL with `ModuleNotFoundError` for `deeptutor.services.evidence.diagnosis` and `404` for the missing route
+
+- [ ] **Step 3: Implement the diagnosis service and endpoint**
+
+```python
+# deeptutor/services/evidence/diagnosis.py
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+
+def _confidence_tag(observations: list[dict[str, Any]]) -> str:
+    if len(observations) >= 3:
+        return "high"
+    if len(observations) == 2:
+        return "medium"
+    return "low"
+
+
+def _support_level(observations: list[dict[str, Any]]) -> str:
+    if any((row.get("hint_count") or 0) >= 2 for row in observations):
+        return "intensive"
+    if any(not row.get("is_correct") for row in observations):
+        return "guided"
+    return "independent"
+
+
+def build_student_diagnosis(
+    *,
+    student_id: str,
+    observations: list[dict[str, Any]],
+    student_state: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not observations:
+        return {
+            "student_id": student_id,
+            "observed": None,
+            "inferred": [],
+            "recommended_actions": [],
+        }
+
+    topic_counter = Counter(row["topic"] for row in observations if not row.get("is_correct"))
+    dominant_topic, _ = topic_counter.most_common(1)[0]
+    dominant_rows = [row for row in observations if row["topic"] == dominant_topic]
+    dominant_error = Counter(
+        row["dominant_error"] for row in dominant_rows if row.get("dominant_error")
+    ).most_common(1)[0][0]
+    confidence = _confidence_tag(dominant_rows)
+
+    diagnosis = {
+        "diagnosis_type": dominant_error,
+        "confidence_tag": confidence,
+        "topic": dominant_topic,
+        "evidence": [
+            f"{len(dominant_rows)} missed question(s) in {dominant_topic}",
+            f"support_level={_support_level(dominant_rows)}",
+        ],
+    }
+    recommendation_type = "review_prerequisite" if dominant_error == "concept_gap" else "increase_scaffold"
+    recommendation = {
+        "action_id": f"{student_id}:{dominant_topic}:{recommendation_type}",
+        "action_type": recommendation_type,
+        "target_student_ids": [student_id],
+        "topic": dominant_topic,
+        "rationale": f"Revisit {dominant_topic} before moving to mixed practice.",
+    }
+    return {
+        "student_id": student_id,
+        "observed": {
+            "topic": dominant_topic,
+            "miss_count": len(dominant_rows),
+            "avg_latency_seconds": round(
+                sum(int(row.get('latency_seconds') or 0) for row in dominant_rows) / len(dominant_rows)
+            ),
+        },
+        "student_state": student_state or {
+            "student_id": student_id,
+            "repeated_mistakes": [dominant_topic],
+            "support_level": _support_level(dominant_rows),
+            "confidence_trend": "down",
+        },
+        "inferred": [diagnosis],
+        "recommended_actions": [recommendation],
+    }
+```
+
+```python
+# assessment.py
+from deeptutor.services.evidence.diagnosis import build_student_diagnosis
+from deeptutor.services.evidence.extractor import extract_observations_from_review
+
+
+@router.get("/diagnosis/{session_id}")
+async def get_assessment_diagnosis(session_id: str):
+    store = get_sqlite_session_store()
+    detail = await store.get_session_with_messages(session_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail="Assessment session not found")
+
+    review = extract_assessment_review(detail)
+    if review is None:
+        raise HTTPException(status_code=404, detail="Assessment review not found")
+
+    review["student_id"] = str((detail.get("preferences") or {}).get("student_id") or session_id)
+    observations = extract_observations_from_review(review)
+    await store.save_observations(observations)
+
+    student_id = review["student_id"]
+    state = {
+        "student_id": student_id,
+        "repeated_mistakes": sorted({row["topic"] for row in observations if not row["is_correct"]}),
+        "support_level": "guided" if any(not row["is_correct"] for row in observations) else "independent",
+        "confidence_trend": "down" if any(not row["is_correct"] for row in observations) else "flat",
+    }
+    await store.upsert_student_state(student_id, state)
+
+    return build_student_diagnosis(
+        student_id=student_id,
+        observations=observations,
+        student_state=await store.get_student_state(student_id),
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py::test_assessment_diagnosis_endpoint_returns_structured_payload -v`
+Expected: PASS with `2 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deeptutor/services/evidence/diagnosis.py deeptutor/api/routers/assessment.py tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py
+git commit -m "feat: add structured assessment diagnosis endpoint"
+```
+
+## Task 4: Aggregate Teacher Insights and Small-Group Recommendations
+
+**Files:**
+- Create: `deeptutor/services/evidence/teacher_insights.py`
+- Modify: `deeptutor/api/routers/dashboard.py`
+- Modify: `tests/api/test_dashboard_router.py`
+
+- [ ] **Step 1: Write the failing dashboard insight test**
+
+```python
+@pytest.mark.asyncio
+async def test_dashboard_insights_returns_students_and_small_groups(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {"student_id": "student-a", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4, time: 48s)\\n"
+        "Score: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    await _seed_session(
+        store,
+        session_id="student-b-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-b-session",
+        {"student_id": "student-b", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-b-session",
+        "user",
+        "[Quiz Performance]\\n"
+        "1. [q1] Q: Solve fractions subtraction 5/6 - 1/3 -> Answered: 1/6 (Incorrect, correct: 1/2, time: 52s)\\n"
+        "Score: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/insights")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["students"][0]["student_id"] in {"student-a", "student-b"}
+    assert payload["small_groups"][0]["topic"] == "fractions subtraction"
+    assert sorted(payload["small_groups"][0]["student_ids"]) == ["student-a", "student-b"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -v`
+Expected: FAIL because `/api/v1/dashboard/insights` does not yet return `students` or `small_groups`
+
+- [ ] **Step 3: Implement the teacher insight aggregator and router wiring**
+
+```python
+# deeptutor/services/evidence/teacher_insights.py
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from .diagnosis import build_student_diagnosis
+
+
+def build_teacher_insights_payload(
+    *,
+    student_payloads: list[dict[str, Any]],
+) -> dict[str, Any]:
+    grouped: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for payload in student_payloads:
+        inferred = payload.get("inferred") or []
+        if not inferred:
+            continue
+        key = (inferred[0]["topic"], inferred[0]["diagnosis_type"])
+        grouped[key].append(payload["student_id"])
+
+    small_groups = [
+        {
+            "topic": topic,
+            "diagnosis_type": diagnosis_type,
+            "student_ids": sorted(student_ids),
+            "recommended_action": "small_group_support",
+        }
+        for (topic, diagnosis_type), student_ids in grouped.items()
+        if len(student_ids) >= 2
+    ]
+
+    return {
+        "students": student_payloads,
+        "small_groups": small_groups,
+    }
+```
+
+```python
+# dashboard.py
+from deeptutor.services.evidence.diagnosis import build_student_diagnosis
+from deeptutor.services.evidence.extractor import extract_observations_from_review
+from deeptutor.services.evidence.teacher_insights import build_teacher_insights_payload
+
+
+@router.get("/insights")
+async def get_dashboard_insights(
+    limit: int = 100,
+    knowledge_base: str | None = None,
+    cohort: str | None = None,
+    start_ts: int | None = None,
+    end_ts: int | None = None,
+):
+    store = get_sqlite_session_store()
+    sessions = await store.list_sessions(limit=limit, offset=0)
+    student_payloads: list[dict[str, Any]] = []
+
+    for session in sessions:
+        activity = await _activity_with_review(store, session)
+        if activity["type"] != "assessment":
+            continue
+        if not _matches_dashboard_filters(activity, knowledge_base=knowledge_base, cohort=cohort):
+            continue
+        ts = activity.get("timestamp") or 0
+        if start_ts is not None and ts < start_ts:
+            continue
+        if end_ts is not None and ts > end_ts:
+            continue
+
+        detail = await store.get_session_with_messages(activity["id"])
+        review = extract_assessment_review(detail) if detail else None
+        if review is None:
+            continue
+        student_id = str((detail.get("preferences") or {}).get("student_id") or activity["id"])
+        review["student_id"] = student_id
+        observations = extract_observations_from_review(review)
+        await store.save_observations(observations)
+        state = await store.get_student_state(student_id)
+        if state is None:
+            state = {
+                "student_id": student_id,
+                "repeated_mistakes": sorted({row["topic"] for row in observations if not row["is_correct"]}),
+                "support_level": "guided" if any(not row["is_correct"] for row in observations) else "independent",
+                "confidence_trend": "down" if any(not row["is_correct"] for row in observations) else "flat",
+            }
+            await store.upsert_student_state(student_id, state)
+
+        student_payloads.append(
+            build_student_diagnosis(
+                student_id=student_id,
+                observations=observations,
+                student_state=state,
+            )
+        )
+
+    return build_teacher_insights_payload(student_payloads=student_payloads)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -v`
+Expected: PASS with `1 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deeptutor/services/evidence/teacher_insights.py deeptutor/api/routers/dashboard.py tests/api/test_dashboard_router.py
+git commit -m "feat: add structured teacher insights aggregation"
+```
+
+## Task 5: Render Structured Teacher Insights on the Dashboard
+
+**Files:**
+- Create: `web/components/dashboard/TeacherInsightPanel.tsx`
+- Modify: `web/lib/dashboard-api.ts`
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+
+- [ ] **Step 1: Write the failing frontend type integration**
+
+```ts
+export interface TeacherInsightStudent {
+  student_id: string;
+  observed: {
+    topic: string;
+    miss_count: number;
+    avg_latency_seconds: number;
+  } | null;
+  inferred: Array<{
+    diagnosis_type: string;
+    confidence_tag: string;
+    topic: string;
+    evidence: string[];
+  }>;
+  recommended_actions: Array<{
+    action_id: string;
+    action_type: string;
+    target_student_ids: string[];
+    topic: string;
+    rationale: string;
+  }>;
+}
+
+export interface DashboardInsights {
+  students: TeacherInsightStudent[];
+  small_groups: Array<{
+    topic: string;
+    diagnosis_type: string;
+    student_ids: string[];
+    recommended_action: string;
+  }>;
+}
+```
+
+Run: `cd web && npm run lint`
+Expected: FAIL because `getDashboardInsights()` still returns the old analytics-only shape and the dashboard page does not use the new payload
+
+- [ ] **Step 2: Add the API types and fetch helper**
+
+```ts
+// web/lib/dashboard-api.ts
+export interface TeacherInsightStudent {
+  student_id: string;
+  observed: {
+    topic: string;
+    miss_count: number;
+    avg_latency_seconds: number;
+  } | null;
+  student_state?: {
+    support_level: string;
+    confidence_trend: string;
+  } | null;
+  inferred: Array<{
+    diagnosis_type: string;
+    confidence_tag: string;
+    topic: string;
+    evidence: string[];
+  }>;
+  recommended_actions: Array<{
+    action_id: string;
+    action_type: string;
+    target_student_ids: string[];
+    topic: string;
+    rationale: string;
+  }>;
+}
+
+export interface DashboardInsights {
+  students: TeacherInsightStudent[];
+  small_groups: Array<{
+    topic: string;
+    diagnosis_type: string;
+    student_ids: string[];
+    recommended_action: string;
+  }>;
+}
+```
+
+- [ ] **Step 3: Create the dashboard insight panel**
+
+```tsx
+// web/components/dashboard/TeacherInsightPanel.tsx
+import type { DashboardInsights } from "@/lib/dashboard-api";
+
+export function TeacherInsightPanel({
+  insights,
+}: {
+  insights: DashboardInsights | null;
+}) {
+  if (!insights || (insights.students.length === 0 && insights.small_groups.length === 0)) {
+    return (
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5">
+        <h2 className="text-[16px] font-semibold text-[var(--foreground)]">Teacher insights</h2>
+        <p className="mt-2 text-[13px] text-[var(--muted-foreground)]">
+          No structured evidence yet. Complete at least one assessment to unlock diagnosis and next-step actions.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5">
+      <h2 className="text-[16px] font-semibold text-[var(--foreground)]">Teacher insights</h2>
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <div className="space-y-3">
+          {insights.students.map((student) => (
+            <article key={student.student_id} className="rounded-2xl bg-[var(--muted)]/50 p-4">
+              <div className="text-[12px] font-semibold uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+                {student.student_id}
+              </div>
+              <div className="mt-2 text-[14px] font-medium text-[var(--foreground)]">
+                {student.observed?.topic ?? "No dominant topic"}
+              </div>
+              <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
+                {student.inferred[0]?.diagnosis_type ?? "No diagnosis"} · {student.inferred[0]?.confidence_tag ?? "n/a"} confidence
+              </div>
+              <div className="mt-3 text-[13px] text-[var(--foreground)]">
+                {student.recommended_actions[0]?.rationale ?? "No recommendation"}
+              </div>
+            </article>
+          ))}
+        </div>
+        <div className="space-y-3">
+          {insights.small_groups.map((group) => (
+            <article key={`${group.topic}:${group.diagnosis_type}`} className="rounded-2xl bg-[var(--muted)]/50 p-4">
+              <div className="text-[14px] font-medium text-[var(--foreground)]">{group.topic}</div>
+              <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
+                {group.diagnosis_type} · {group.student_ids.join(", ")}
+              </div>
+              <div className="mt-3 text-[13px] text-[var(--foreground)]">
+                Recommended action: {group.recommended_action}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Wire the dashboard page to the new endpoint and verify lint**
+
+```tsx
+// dashboard/page.tsx
+import { TeacherInsightPanel } from "@/components/dashboard/TeacherInsightPanel";
+import {
+  getDashboardInsights,
+  getDashboardOverview,
+  type DashboardInsights,
+  type DashboardOverview,
+  type DashboardOverviewFilters,
+} from "@/lib/dashboard-api";
+
+const [insights, setInsights] = useState<DashboardInsights | null>(null);
+
+useEffect(() => {
+  let cancelled = false;
+  Promise.all([getDashboardOverview(50, filters), getDashboardInsights(50, { knowledge_base: filters.knowledge_base })])
+    .then(([overviewData, insightsData]) => {
+      if (!cancelled) {
+        setOverview(overviewData);
+        setInsights(insightsData);
+        setError(null);
+      }
+    })
+    .catch((err) => {
+      if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+    })
+    .finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+  return () => {
+    cancelled = true;
+  };
+}, [filters]);
+```
+
+```tsx
+<TeacherInsightPanel insights={insights} />
+```
+
+Run: `cd web && npm run lint`
+Expected: PASS with no ESLint errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/lib/dashboard-api.ts web/components/dashboard/TeacherInsightPanel.tsx 'web/app/(workspace)/dashboard/page.tsx'
+git commit -m "feat: surface structured teacher insights on dashboard"
+```
+
+## Task 6: End-to-End Verification and Handoff
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-26.md`
+- Create: `docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md`
+
+- [ ] **Step 1: Run the backend test slice**
+
+Run: `pytest tests/services/evidence/test_extractor.py tests/services/evidence/test_diagnosis.py tests/services/session/test_sqlite_store.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -v`
+Expected: PASS with all new evidence, assessment, session, and dashboard tests green
+
+- [ ] **Step 2: Run the frontend verification**
+
+Run: `cd web && npm run lint`
+Expected: PASS with no ESLint errors
+
+- [ ] **Step 3: Run a manual API smoke check**
+
+Run:
+
+```bash
+python - <<'PY'
+from fastapi.testclient import TestClient
+from deeptutor.api.main import app
+
+with TestClient(app) as client:
+    response = client.get("/api/v1/dashboard/insights")
+    print(response.status_code)
+PY
+```
+
+Expected: `200` in a seeded environment, or `200` with an empty `students` list in a clean environment
+
+- [ ] **Step 4: Update the daily log and PR note**
+
+```md
+- Done: Implemented Wave 1 evidence spine with observation capture, student-state persistence, structured diagnosis, and teacher dashboard insights.
+- Tests: pytest tests/services/evidence/test_extractor.py tests/services/evidence/test_diagnosis.py tests/services/session/test_sqlite_store.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -v; cd web && npm run lint
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai_first/daily/2026-04-26.md docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md
+git commit -m "docs: record wave 1 evidence spine validation"
+```
+
+## Self-Review Notes
+
+- Spec coverage for this plan:
+  - `Lane 3` covered by Tasks 1-2
+  - `Lane 4` covered by Tasks 3-4
+  - minimum `Lane 5` surface covered by Task 5
+- Deferred to later plans:
+  - `Lane 1` agent spec authoring
+  - deeper `Lane 2` runtime policy assembly
+  - `Lane 6` contest evidence refresh beyond local verification

--- a/docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md
+++ b/docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md
@@ -1,0 +1,32 @@
+# PR Note: Wave 1 Evidence Spine
+
+## Summary
+
+- add a new evidence service layer for observation extraction, rule-first diagnosis, and teacher insight aggregation
+- persist observations and student-state summaries in the unified SQLite session store
+- expose structured assessment diagnosis and teacher dashboard insight payloads
+- surface the structured teacher insight panel on the dashboard
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Review["Assessment Review Transcript"] --> Extractor["Evidence Extractor"]
+  Extractor --> ObservationStore["SQLite observations"]
+  ObservationStore --> StudentState["student_states summary"]
+  ObservationStore --> Diagnosis["Rule-first diagnosis engine"]
+  StudentState --> Diagnosis
+  Diagnosis --> AssessmentAPI["/api/v1/assessment/diagnosis/{session_id}"]
+  Diagnosis --> DashboardAPI["/api/v1/dashboard/insights"]
+  DashboardAPI --> DashboardUI["TeacherInsightPanel"]
+```
+
+## Validation
+
+- `pytest tests/services/evidence/test_extractor.py tests/services/evidence/test_diagnosis.py tests/services/session/test_sqlite_store.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
+- `eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx lib/dashboard-api.ts components/dashboard/TeacherInsightPanel.tsx`
+- `git diff --check`
+
+## Main System Map
+
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` to include the Wave 1 evidence spine and structured teacher insight panel.

--- a/docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md
+++ b/docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md
@@ -1,0 +1,303 @@
+# Contest MVP+ Hybrid Lanes Design
+
+Date: 2026-04-26
+Status: Drafted for user review
+Scope: A 6-8 week Contest MVP+ roadmap that proves both teacher-defined agent authoring and an evidence-backed teaching insight loop on top of the current codebase
+
+## Purpose
+
+This design defines a near-term product roadmap for the Multiagent Learning Platform after the current contest MVP baseline. The target is a usable `Hybrid proof`:
+
+- teachers can define the soul and operating rules of a teaching agent through a Markdown-first spec standard with a narrow authoring UI;
+- students can learn through one teacher-authored agent template while retaining distinct student states;
+- the system can transform learning activity into `Observed -> Inferred -> Recommended Action` outputs for teachers.
+
+The roadmap is intentionally constrained to what can be executed on the current repository in 6-8 weeks. It does not attempt a full true multi-agent system yet.
+
+## Product Thesis for This Phase
+
+The product should prove three claims at the same time:
+
+1. Teacher authorship matters.
+   A teacher-defined spec pack should materially shape tutor behavior, assessment framing, and intervention tone.
+2. Evidence matters.
+   The system should not jump directly from chat logs to vague advice. It should record observations, produce bounded diagnosis, and recommend explicit next actions.
+3. Personalization should happen through state, not agent sprawl.
+   One teacher-defined agent template should serve many students, with differentiation carried by `Student State` and `Session State`.
+
+## Phase Decisions
+
+The roadmap assumes these product decisions:
+
+- Delivery horizon: `Contest MVP+` in 6-8 weeks.
+- Success mode: `Hybrid proof`, not authoring-only and not analytics-only.
+- Core runtime model: `one agent template + many student states`.
+- Authoring mode: `Hybrid narrow`.
+- Diagnosis mode: `Hybrid balanced`.
+- Teacher action surface: `per-student + small-group`.
+- Backbone priority: `Observation / Diagnosis / Recommendation Pipeline`.
+- Delivery structure: `6 lanes`.
+
+## Design Principles
+
+- Keep `Teacher Spec`, `Student State`, and `Session State` separate.
+- Keep `Observed`, `Inferred`, and `Recommended Action` as three distinct layers.
+- Let Markdown remain the source of truth even when a form UI edits part of the spec.
+- Prefer policy-driven behavior over hardcoded feature-specific prompt fragments.
+- Build only the smallest authoring, diagnosis, and dashboard surfaces needed to show the thesis end to end.
+- Reuse existing tutor, assessment, dashboard, knowledge-pack, and contest evidence infrastructure where possible.
+
+## Architecture Shape
+
+```mermaid
+flowchart LR
+  Teacher["Teacher Spec Authoring"] --> SpecPack["Markdown Spec Pack"]
+  SpecPack --> Runtime["Spec Runtime Assembly"]
+  Runtime --> Tutor["Tutor + Assessment Runtime"]
+  Tutor --> Observed["Observed Signals"]
+  Observed --> StudentState["Student State"]
+  Observed --> Diagnosis["Diagnosis Engine"]
+  StudentState --> Diagnosis
+  Diagnosis --> Recommended["Recommended Actions"]
+  Recommended --> TeacherUI["Teacher Insight UI"]
+  TeacherUI --> Intervention["Teacher Intervention"]
+```
+
+This architecture keeps the system intentionally single-agent in runtime execution while preserving boundaries for future separation into tutor, assessment, diagnosis, and intervention agents.
+
+## Six-Lane Roadmap
+
+### Lane 1: Agent Spec Authoring
+
+Goal:
+Enable a teacher to define and maintain a usable teaching agent through a Markdown-backed spec pack, with a narrow UI for the highest-leverage files.
+
+Boundaries:
+- Owns teacher-authored policy artifacts.
+- Does not own student evidence, diagnosis logic, or dashboard interpretation.
+
+Output:
+- A versioned `Spec Pack` that can be compiled into runtime configuration.
+
+Tasks:
+1. Define the canonical folder structure for `agent_specs/<agent_id>/`.
+2. Define the required contract for `IDENTITY.md`, `SOUL.md`, `CURRICULUM.md`, `RULES.md`, `ASSESSMENT.md`, `WORKFLOW.md`, `KNOWLEDGE.md`, and `MARKETPLACE.md`.
+3. Create a light schema for `IDENTITY`, `SOUL`, and `RULES` so a form can map to Markdown without lossy translation.
+4. Design a `compiled spec pack` artifact that runtime code can consume without reading raw UI state.
+5. Build the narrow authoring flow for `IDENTITY`, `SOUL`, and `RULES`.
+6. Add manual or structured Markdown editing for `CURRICULUM`, `ASSESSMENT`, `WORKFLOW`, `KNOWLEDGE`, and `MARKETPLACE`.
+7. Add validation for required fields, subject scope, language, and guardrails.
+8. Add a runtime preview summary so the teacher can inspect how the current spec will steer the agent.
+9. Add version notes or change history metadata when a spec pack is edited.
+10. Add an internal `draft/published` state for a spec pack.
+11. Expose metadata summary fields that later marketplace views can read.
+12. Add import/export of the Markdown pack to prove portability and source-of-truth integrity.
+
+### Lane 2: Spec Runtime Assembly
+
+Goal:
+Compile teacher policy into a predictable runtime contract shared by tutoring and assessment flows.
+
+Boundaries:
+- Owns runtime assembly and policy application.
+- Does not own raw observation capture or teacher-facing interpretation.
+
+Output:
+- A reusable assembly layer that merges `Teacher Spec`, `Student State`, and `Session State` at runtime.
+
+Tasks:
+1. Define explicit contracts for `Teacher Spec`, `Student State`, and `Session State`.
+2. Create a loader that reads a spec pack and produces a compiled runtime payload.
+3. Build prompt assembly by slices instead of injecting the full pack into every request.
+4. Apply `SOUL` and `RULES` consistently to tutor responses.
+5. Apply `WORKFLOW` to the progression of instruction, practice, checking, and remediation.
+6. Apply `ASSESSMENT` to question framing, review behavior, and feedback tone.
+7. Apply `KNOWLEDGE` using a default `kb_preferred` policy.
+8. Enforce source priority: `teacher_kb > curriculum excerpt > teacher rules > llm prior knowledge`.
+9. Add safeguards that stop the tutor from drifting beyond teacher-defined scope.
+10. Unify the assembly contract so tutor and assessment paths use the same policy basis.
+11. Add runtime debug output that shows which slices were assembled for a request.
+12. Preserve clear seams so future specialized agents can take over without rewiring policy storage.
+
+### Lane 3: Observation and Student State
+
+Goal:
+Establish a reliable `Observed` layer and a separate dynamic student profile.
+
+Boundaries:
+- Owns event capture, observation schema, and state summary updates.
+- Does not own diagnosis claims or recommendation generation.
+
+Output:
+- A normalized observation stream and a bounded student state model.
+
+Tasks:
+1. Define the shared observation event schema for tutoring and assessment interactions.
+2. Capture core signals: topic, correctness, hint count, retry count, and latency.
+3. Add rule-based detection of dominant error types where feasible.
+4. Capture self-confidence or support-needed signals when the current interaction flow permits it.
+5. Define the initial `Student State` store or document contract.
+6. Build a summarizer that updates repeated mistakes, support level, and confidence trend.
+7. Keep raw observations separate from the summarized student profile.
+8. Add session-level rollups so each learning session produces a concise evidence snapshot.
+9. Add a conservative topic mastery proxy without claiming full learner modeling.
+10. Add recency weighting or decay rules so older evidence does not dominate forever.
+11. Backfill observation data from current quiz and review flows into the new schema.
+12. Expose evidence trace links so downstream insights can point back to observed facts.
+
+### Lane 4: Diagnosis and Recommendation Engine
+
+Goal:
+Turn observed evidence into bounded hypotheses and explicit next actions for teachers.
+
+Boundaries:
+- Owns `Inferred` and `Recommended Action`.
+- Must not rewrite, distort, or blur raw observations.
+
+Output:
+- A hybrid engine where rules propose hypotheses and the LLM explains or contextualizes them.
+
+Tasks:
+1. Define the MVP diagnosis taxonomy: `concept_gap`, `careless_error`, `low_confidence`, and `needs_scaffold`.
+2. Implement rule-engine logic that maps observed signals into structured hypotheses.
+3. Assign confidence tags through the engine rather than the LLM.
+4. Define the persisted contract for `Inferred` records.
+5. Create an LLM rationale step limited to available evidence and structured hypotheses.
+6. Define the action catalog for per-student recommendations.
+7. Add small-group recommendation rules based on dominant misconception or support need.
+8. Implement action types such as prerequisite review, easier follow-up practice, scaffold increase, or targeted regrouping.
+9. Rank recommended actions with rule logic before the LLM elaborates them.
+10. Use the LLM to explain why an action is appropriate and how the teacher should apply it.
+11. Add abstain behavior when evidence is weak, contradictory, or too sparse.
+12. Add evaluation cases that detect overreach beyond the available evidence.
+
+### Lane 5: Teacher Insight UI
+
+Goal:
+Show teachers the full evidence pipeline in a form that leads to action rather than passive reporting.
+
+Boundaries:
+- Owns teacher-facing insight and action surfaces.
+- Does not invent logic that the pipeline cannot support.
+
+Output:
+- A teacher dashboard or workflow view centered on what happened, what it likely means, and what to do next.
+
+Tasks:
+1. Design the teacher insight screen around `Observed -> Inferred -> Recommended Action`.
+2. Show per-student insight cards with short evidence traces.
+3. Show small-group recommendation cards with clear grouping logic.
+4. Add filters for topic, misconception, confidence level, and support need.
+5. Add a student detail view with signal history and prior interventions.
+6. Add a recommendation panel centered on the next suggested action.
+7. Clearly separate observation facts from diagnosis claims in the UI.
+8. Show simple intervention-effectiveness history where prior teacher actions exist.
+9. Add an acknowledge/apply/skip flow for recommendations.
+10. Add teacher note capture so educators can respond to or override the system.
+11. Add shortcuts from recommendations to relevant materials or follow-up tasks.
+12. Keep key teacher surfaces mobile-safe and demo-friendly.
+
+### Lane 6: Evaluation, Evidence, and Contest Readiness
+
+Goal:
+Make the hybrid proof repeatable, testable, and easy to demonstrate under contest constraints.
+
+Boundaries:
+- Owns validation, seeded scenarios, demo artifacts, and evidence freshness.
+- Does not redefine runtime policy or diagnosis semantics.
+
+Output:
+- A durable demo and validation layer that proves the design works in practice.
+
+Tasks:
+1. Define the end-to-end acceptance flow from teacher authoring to teacher insight.
+2. Seed demo data for multiple students with distinct support profiles.
+3. Create canned misconception scenarios that reliably trigger diagnosis and recommendation behavior.
+4. Add smoke coverage or scripts for the end-to-end hybrid proof.
+5. Create an evidence checklist specific to the Contest MVP+ hybrid proof.
+6. Capture screenshots and demo artifacts for authoring, tutoring, evidence, and teacher action.
+7. Require architecture notes with Mermaid diagrams for major PRs touching this roadmap.
+8. Track system limitations so contest materials do not overclaim beyond observed capability.
+9. Add evaluation cases that detect hallucinated or unsupported rationale.
+10. Write a demo script that highlights both teacher-defined soul and evidence-backed recommendation.
+11. Prepare a fallback demo mode if one lane slips but the end-to-end story must still run.
+12. Publish a final validation report at the end of the wave sequence.
+
+## Sequencing
+
+The six lanes should not run at full depth simultaneously. The roadmap should move in three waves.
+
+### Wave 1: Spine
+
+Primary lanes:
+- `Lane 3`
+- `Lane 4`
+- the minimum viable part of `Lane 2`
+
+Goal:
+Get a real end-to-end pipeline from student activity to teacher recommendation, even if spec authoring and dashboard polish are still narrow.
+
+### Wave 2: Policy Injection
+
+Primary lanes:
+- `Lane 1`
+- the remaining high-value work in `Lane 2`
+- hardening work in `Lane 4`
+
+Goal:
+Move from mostly hardcoded logic to teacher-defined runtime behavior shaped by the spec pack.
+
+### Wave 3: Teacher-Facing Proof
+
+Primary lanes:
+- `Lane 5`
+- `Lane 6`
+- hardening and integration passes across all prior lanes
+
+Goal:
+Turn the spine into a coherent product proof that a teacher can use and that the team can demonstrate repeatedly.
+
+## Timeline
+
+- Weeks 1-2: observation schema, student state, diagnosis backbone, minimum runtime assembly
+- Weeks 3-4: teacher spec pack authoring, deeper runtime policy integration, stronger action mapping
+- Weeks 5-6: teacher insight UI, evaluation scenarios, seeded demos, contest artifacts
+- Weeks 7-8: polish, validation, evidence refresh, fallback planning, and final demo hardening
+
+## Success Criteria
+
+This Contest MVP+ roadmap is successful if all of the following are true:
+
+- A teacher can create and maintain one usable `Teacher Spec`.
+- Multiple students can use the same agent template while retaining different student states.
+- The system can show `Observed`, `Inferred`, and `Recommended Action` as separate layers.
+- The recommendation layer supports both per-student and small-group action suggestions.
+- The end-to-end flow can be demonstrated with seeded data and repeatable evidence artifacts.
+
+## Risks and Scope Controls
+
+Primary risks:
+- overbuilding authoring before the evidence loop is credible;
+- letting the LLM generate diagnosis beyond what evidence supports;
+- mixing policy, runtime state, and observation into one prompt-driven blob;
+- building dashboard polish ahead of a trustworthy engine.
+
+Scope controls:
+- keep the authoring UI narrow;
+- use a rule-first diagnosis backbone;
+- require confidence tags and evidence traces;
+- postpone deep marketplace behavior and full multi-agent runtime decomposition until after this phase.
+
+## Out of Scope for This Phase
+
+- One bespoke agent per student as the primary architecture
+- A full true multi-agent runtime with autonomous agent-to-agent orchestration
+- High-granularity learner modeling or retention prediction
+- Fully automated intervention execution without teacher review
+- A complete marketplace economy for agent packs
+
+## Recommended Next Read Path
+
+1. `docs/superpowers/specs/2026-04-24-teacher-agent-platform-design.md`
+2. `ai_first/AI_OPERATING_PROMPT.md`
+3. the future implementation plan that will be derived from this document after user approval

--- a/docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md
+++ b/docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md
@@ -34,6 +34,7 @@ Implement the first end-to-end `Observed -> Inferred -> Recommended Action` spin
 - `web/components/dashboard/TeacherInsightPanel.tsx`
 - `web/lib/dashboard-api.ts`
 - `web/app/(workspace)/dashboard/page.tsx`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
 - `ai_first/ACTIVE_ASSIGNMENTS.md`
 - `ai_first/daily/2026-04-26.md`
 - `docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md`

--- a/docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md
+++ b/docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md
@@ -1,0 +1,92 @@
+# Feature Pod Task: Wave 1 Evidence Spine
+
+Owner: Codex
+Branch: `pod-a/wave1-evidence-spine`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Implement the first end-to-end `Observed -> Inferred -> Recommended Action` spine on top of the current assessment, session, and dashboard stack.
+
+## User-visible outcome
+
+- Assessment sessions produce structured observations and student-state summaries.
+- Teachers can view per-student diagnosis and small-group recommendations from the dashboard.
+- The assessment API exposes a structured diagnosis payload instead of only a topic recommendation.
+
+## Owned files/modules
+
+- `deeptutor/services/evidence/__init__.py`
+- `deeptutor/services/evidence/contracts.py`
+- `deeptutor/services/evidence/extractor.py`
+- `deeptutor/services/evidence/diagnosis.py`
+- `deeptutor/services/evidence/teacher_insights.py`
+- `deeptutor/services/session/sqlite_store.py`
+- `deeptutor/services/session/__init__.py`
+- `deeptutor/api/routers/assessment.py`
+- `deeptutor/api/routers/dashboard.py`
+- `tests/services/evidence/test_extractor.py`
+- `tests/services/evidence/test_diagnosis.py`
+- `tests/services/session/test_sqlite_store.py`
+- `tests/api/test_assessment_router.py`
+- `tests/api/test_dashboard_router.py`
+- `web/components/dashboard/TeacherInsightPanel.tsx`
+- `web/lib/dashboard-api.ts`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md`
+
+## Do-not-touch files/modules
+
+- `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md`
+- `docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md`
+- `web/app/(utility)/knowledge/`
+- `deeptutor/services/prompt/`
+- `deeptutor/knowledge/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+
+## API/data contract
+
+- Add normalized observation persistence in SQLite without changing existing session/message tables.
+- Add `GET /api/v1/assessment/diagnosis/{session_id}` returning structured observation, diagnosis, and recommendation data.
+- Change `GET /api/v1/dashboard/insights` to return structured `students` and `small_groups` payloads for the teacher dashboard.
+
+## Acceptance criteria
+
+- New evidence service layer exists and is covered by focused tests.
+- SQLite store can persist and read observations plus student-state summaries.
+- Assessment diagnosis endpoint returns structured diagnosis for seeded assessment sessions.
+- Dashboard insights endpoint aggregates per-student and small-group recommendation payloads.
+- Teacher dashboard renders the structured insight payload without lint errors.
+
+## Required tests
+
+- `pytest tests/services/evidence/test_extractor.py tests/services/evidence/test_diagnosis.py tests/services/session/test_sqlite_store.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -v`
+- `cd web && npm run lint`
+- `git diff --check`
+
+## Manual verification
+
+- Seed at least two assessment sessions with the same weak topic and verify a small-group recommendation appears.
+- Open `/dashboard` and verify teacher insight cards plus grouped recommendation cards render.
+- Call `/api/v1/assessment/diagnosis/{session_id}` for a seeded assessment and inspect the structured payload.
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- This lane owns only the Wave 1 evidence spine files listed above.
+- Do not expand into spec authoring, prompt assembly, or marketplace work in this lane.
+- If scope expands beyond the listed files, update this packet before implementation.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if the new evidence spine becomes part of the shipped product map.
+
+## Handoff notes
+
+- This lane executes the approved `Wave 1 spine` subproject from `docs/superpowers/plans/2026-04-26-contest-mvp-spine-implementation.md`.

--- a/tests/api/test_assessment_router.py
+++ b/tests/api/test_assessment_router.py
@@ -149,3 +149,36 @@ async def test_assessment_recommend_returns_clean_empty_state_without_reviews(
     assert payload["recommended_topic"] is None
     assert payload["suggested_action"] == "complete-assessment"
     assert payload["history_summary"]["assessments_considered"] == 0
+
+
+@pytest.mark.asyncio
+async def test_assessment_diagnosis_endpoint_returns_structured_payload(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="assessment-recent",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.add_message(
+        "assessment-recent",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4, time: 48s)\n"
+        "2. [q2] Q: Solve fractions subtraction 5/6 - 1/3 -> Answered: 1/6 (Incorrect, correct: 1/2, time: 61s)\n"
+        "Score: 0/2 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/assessment/diagnosis/assessment-recent")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["student_id"] == "assessment-recent"
+    assert payload["inferred"][0]["diagnosis_type"] == "concept_gap"
+    assert payload["recommended_actions"][0]["topic"] == "fractions subtraction"

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -372,10 +372,9 @@ async def test_dashboard_insights_returns_teacher_recommendations(
 
     assert response.status_code == 200
     payload = response.json()
-    assert "analytics" in payload
-    assert "at_risk_topics" in payload
-    assert isinstance(payload["recommendations"], list)
-    assert len(payload["recommendations"]) >= 1
+    assert len(payload["students"]) == 2
+    assert payload["students"][0]["recommended_actions"]
+    assert payload["students"][0]["inferred"]
 
 
 @pytest.mark.asyncio
@@ -420,17 +419,81 @@ async def test_dashboard_insights_filters_by_knowledge_base_and_time(
         resp_all = client.get("/api/v1/dashboard/insights")
         assert resp_all.status_code == 200
         payload_all = resp_all.json()
-        assert payload_all["analytics"]["assessment_trend"]["assessments_completed"] == 2
+        assert len(payload_all["students"]) == 2
 
         resp_kb = client.get("/api/v1/dashboard/insights?knowledge_base=fractions-pack")
         assert resp_kb.status_code == 200
         payload_kb = resp_kb.json()
-        assert payload_kb["analytics"]["assessment_trend"]["assessments_completed"] == 1
+        assert len(payload_kb["students"]) == 1
 
         resp_time = client.get("/api/v1/dashboard/insights?start_ts=1710000000")
         assert resp_time.status_code == 200
         payload_time = resp_time.json()
-        assert payload_time["analytics"]["assessment_trend"]["assessments_completed"] == 1
+        assert len(payload_time["students"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_dashboard_insights_returns_students_and_small_groups(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {
+            "student_id": "student-a",
+            "knowledge_bases": ["fractions-pack"],
+            "capability": "deep_question",
+        },
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4, time: 48s)\n"
+        "Score: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    await _seed_session(
+        store,
+        session_id="student-b-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-b-session",
+        {
+            "student_id": "student-b",
+            "knowledge_bases": ["fractions-pack"],
+            "capability": "deep_question",
+        },
+    )
+    await store.add_message(
+        "student-b-session",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions subtraction 5/6 - 1/3 -> Answered: 1/6 (Incorrect, correct: 1/2, time: 52s)\n"
+        "Score: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/dashboard/insights")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["students"][0]["student_id"] in {"student-a", "student-b"}
+    assert payload["small_groups"][0]["topic"] == "fractions subtraction"
+    assert sorted(payload["small_groups"][0]["student_ids"]) == ["student-a", "student-b"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/evidence/test_diagnosis.py
+++ b/tests/services/evidence/test_diagnosis.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from deeptutor.services.evidence.diagnosis import build_student_diagnosis
+
+
+def test_build_student_diagnosis_returns_structured_hypotheses_and_actions() -> None:
+    observations = [
+        {
+            "observation_id": "obs_1",
+            "session_id": "quiz-1",
+            "student_id": "student-a",
+            "source": "assessment",
+            "topic": "fractions subtraction",
+            "question_id": "q1",
+            "is_correct": False,
+            "latency_seconds": 48,
+            "hint_count": 0,
+            "retry_count": 1,
+            "dominant_error": "concept_gap",
+        },
+        {
+            "observation_id": "obs_2",
+            "session_id": "quiz-1",
+            "student_id": "student-a",
+            "source": "assessment",
+            "topic": "fractions subtraction",
+            "question_id": "q2",
+            "is_correct": False,
+            "latency_seconds": 61,
+            "hint_count": 0,
+            "retry_count": 1,
+            "dominant_error": "concept_gap",
+        },
+    ]
+    state = {
+        "student_id": "student-a",
+        "repeated_mistakes": ["fractions subtraction"],
+        "support_level": "guided",
+        "confidence_trend": "down",
+    }
+
+    payload = build_student_diagnosis(
+        student_id="student-a",
+        observations=observations,
+        student_state=state,
+    )
+
+    assert payload["student_id"] == "student-a"
+    assert payload["observed"]["topic"] == "fractions subtraction"
+    assert payload["inferred"][0]["diagnosis_type"] == "concept_gap"
+    assert payload["recommended_actions"][0]["action_type"] == "review_prerequisite"

--- a/tests/services/evidence/test_extractor.py
+++ b/tests/services/evidence/test_extractor.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from deeptutor.services.evidence.extractor import extract_observations_from_review
+
+
+def test_extract_observations_from_review_builds_topic_level_signals() -> None:
+    review = {
+        "session_id": "quiz-1",
+        "student_id": "student-a",
+        "results": [
+            {
+                "question_id": "q1",
+                "question": "Solve fractions subtraction 3/4 - 1/2",
+                "is_correct": False,
+                "duration_seconds": 48,
+            },
+            {
+                "question_id": "q2",
+                "question": "Solve fractions subtraction 5/6 - 1/3",
+                "is_correct": False,
+                "duration_seconds": 61,
+            },
+        ],
+    }
+
+    rows = extract_observations_from_review(review)
+
+    assert len(rows) == 2
+    assert rows[0]["student_id"] == "student-a"
+    assert rows[0]["topic"] == "fractions subtraction"
+    assert rows[0]["source"] == "assessment"
+    assert rows[0]["is_correct"] is False
+    assert rows[0]["latency_seconds"] == 48
+
+
+def test_extract_observations_from_review_marks_dominant_error_for_repeated_misses() -> None:
+    review = {
+        "session_id": "quiz-2",
+        "student_id": "student-b",
+        "results": [
+            {
+                "question_id": "q1",
+                "question": "Solve algebra equation 2x = 10",
+                "is_correct": False,
+                "duration_seconds": 20,
+            },
+            {
+                "question_id": "q2",
+                "question": "Solve algebra equation x + 2 = 5",
+                "is_correct": False,
+                "duration_seconds": 18,
+            },
+        ],
+    }
+
+    rows = extract_observations_from_review(review)
+
+    assert {row["dominant_error"] for row in rows} == {"concept_gap"}

--- a/tests/services/session/test_sqlite_store.py
+++ b/tests/services/session/test_sqlite_store.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from deeptutor.services.path_service import PathService
 from deeptutor.services.session.sqlite_store import SQLiteSessionStore
 
@@ -46,3 +48,44 @@ def test_sqlite_store_migrates_legacy_chat_history_db(tmp_path: Path) -> None:
     finally:
         service._project_root = original_root
         service._user_data_dir = original_user_dir
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_persists_observations_and_student_state(tmp_path: Path) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+
+    await store.save_observations(
+        [
+            {
+                "observation_id": "obs_1",
+                "session_id": "quiz-1",
+                "student_id": "student-a",
+                "source": "assessment",
+                "topic": "fractions subtraction",
+                "question_id": "q1",
+                "is_correct": False,
+                "latency_seconds": 48,
+                "hint_count": 0,
+                "retry_count": 1,
+                "dominant_error": "concept_gap",
+            }
+        ]
+    )
+    await store.upsert_student_state(
+        "student-a",
+        {
+            "student_id": "student-a",
+            "repeated_mistakes": ["fractions subtraction"],
+            "support_level": "guided",
+            "confidence_trend": "down",
+        },
+    )
+
+    observations = await store.list_observations(student_id="student-a")
+    state = await store.get_student_state("student-a")
+
+    assert len(observations) == 1
+    assert observations[0]["topic"] == "fractions subtraction"
+    assert state is not None
+    assert state["support_level"] == "guided"
+    assert state["confidence_trend"] == "down"

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -4,9 +4,12 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { Activity, ArrowRight, BookOpen, CheckCircle2, Filter, Loader2, PenLine, Search, Users } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { TeacherInsightPanel } from "@/components/dashboard/TeacherInsightPanel";
 import {
+  getDashboardInsights,
   getDashboardOverview,
   type DashboardActivity,
+  type DashboardInsights,
   type DashboardOverview,
   type DashboardOverviewFilters,
 } from "@/lib/dashboard-api";
@@ -37,7 +40,7 @@ function scoreDeltaTone(value: number): string {
 export default function DashboardPage() {
   const { t } = useTranslation();
   const [overview, setOverview] = useState<DashboardOverview | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [insights, setInsights] = useState<DashboardInsights | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [activityType, setActivityType] = useState("");
@@ -56,24 +59,27 @@ export default function DashboardPage() {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    getDashboardOverview(50, filters)
-      .then((data) => {
+    Promise.all([
+      getDashboardOverview(50, filters),
+      getDashboardInsights(50, { knowledge_base: filters.knowledge_base }),
+    ])
+      .then(([overviewData, insightData]) => {
         if (!cancelled) {
-          setOverview(data);
+          setOverview(overviewData);
+          setInsights(insightData);
           setError(null);
         }
       })
       .catch((err) => {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));
       })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+      .finally(() => undefined);
     return () => {
       cancelled = true;
     };
   }, [filters]);
+
+  const loading = overview === null;
 
   const totals = overview?.totals;
   const analytics = overview?.analytics;
@@ -391,6 +397,8 @@ export default function DashboardPage() {
             </div>
           </div>
         </section>
+
+        <TeacherInsightPanel insights={insights} />
 
         <section className="grid gap-5 lg:grid-cols-[1fr_320px]">
           <div>

--- a/web/components/dashboard/TeacherInsightPanel.tsx
+++ b/web/components/dashboard/TeacherInsightPanel.tsx
@@ -1,0 +1,109 @@
+import type { DashboardInsights } from "@/lib/dashboard-api";
+import { useTranslation } from "react-i18next";
+
+export function TeacherInsightPanel({
+  insights,
+}: {
+  insights: DashboardInsights | null;
+}) {
+  const { t } = useTranslation();
+
+  if (!insights || (insights.students.length === 0 && insights.small_groups.length === 0)) {
+    return (
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
+        <h2 className="text-[16px] font-semibold text-[var(--foreground)]">{t("Teacher insights")}</h2>
+        <p className="mt-2 text-[13px] leading-6 text-[var(--muted-foreground)]">
+          {t("No structured evidence yet. Complete at least one assessment to unlock diagnosis and next-step actions.")}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-[16px] font-semibold text-[var(--foreground)]">{t("Teacher insights")}</h2>
+          <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
+            {t("Evidence-backed diagnosis for individual students and small groups.")}
+          </p>
+        </div>
+        <div className="rounded-full bg-[var(--muted)] px-3 py-1 text-[12px] text-[var(--muted-foreground)]">
+          {t("{{count}} students", { count: insights.students.length })}
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-3">
+          {insights.students.map((student) => {
+            const diagnosis = student.inferred[0];
+            const recommendation = student.recommended_actions[0];
+            return (
+              <article key={student.student_id} className="rounded-2xl bg-[var(--muted)]/50 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-[12px] font-semibold uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+                      {student.student_id}
+                    </div>
+                    <div className="mt-1 text-[15px] font-medium text-[var(--foreground)]">
+                      {student.observed?.topic ?? t("No dominant topic")}
+                    </div>
+                  </div>
+                  <span className="rounded-full bg-[var(--card)] px-2.5 py-1 text-[11px] text-[var(--muted-foreground)]">
+                    {t("{{confidence}} confidence", { confidence: diagnosis?.confidence_tag ?? "n/a" })}
+                  </span>
+                </div>
+                <div className="mt-3 text-[13px] text-[var(--muted-foreground)]">
+                  {t("Diagnosis")}: <span className="text-[var(--foreground)]">{diagnosis?.diagnosis_type ?? t("None")}</span>
+                </div>
+                <div className="mt-2 text-[13px] leading-6 text-[var(--foreground)]">
+                  {recommendation?.rationale ?? t("No recommendation")}
+                </div>
+                {diagnosis?.evidence?.length ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {diagnosis.evidence.map((item) => (
+                      <span
+                        key={`${student.student_id}-${item}`}
+                        className="rounded-full bg-[var(--card)] px-2.5 py-1 text-[11px] text-[var(--muted-foreground)]"
+                      >
+                        {item}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+
+        <div className="space-y-3">
+          <div className="rounded-2xl bg-[var(--muted)]/40 p-4">
+            <div className="text-[12px] font-semibold uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+              {t("Small-group recommendations")}
+            </div>
+          </div>
+          {insights.small_groups.length > 0 ? (
+            insights.small_groups.map((group) => (
+              <article
+                key={`${group.topic}:${group.diagnosis_type}`}
+                className="rounded-2xl bg-[var(--muted)]/50 p-4"
+              >
+                <div className="text-[14px] font-medium text-[var(--foreground)]">{group.topic}</div>
+                <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
+                  {group.diagnosis_type} · {group.student_ids.join(", ")}
+                </div>
+                <div className="mt-3 text-[13px] text-[var(--foreground)]">
+                  {t("Recommended action")}: {group.recommended_action}
+                </div>
+              </article>
+            ))
+          ) : (
+            <div className="rounded-2xl bg-[var(--muted)]/50 p-4 text-[13px] text-[var(--muted-foreground)]">
+              {t("No shared misconception cluster yet.")}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -237,10 +237,40 @@ export async function getDashboardActivityDetail(entryId: string): Promise<Dashb
   return expectJson<DashboardActivityDetail>(response);
 }
 
+export interface TeacherInsightStudent {
+  student_id: string;
+  observed: {
+    topic: string;
+    miss_count: number;
+    avg_latency_seconds: number;
+  } | null;
+  student_state?: {
+    support_level: string;
+    confidence_trend: string;
+  } | null;
+  inferred: Array<{
+    diagnosis_type: string;
+    confidence_tag: string;
+    topic: string;
+    evidence: string[];
+  }>;
+  recommended_actions: Array<{
+    action_id: string;
+    action_type: string;
+    target_student_ids: string[];
+    topic: string;
+    rationale: string;
+  }>;
+}
+
 export interface DashboardInsights {
-  analytics: DashboardOverview["analytics"];
-  at_risk_topics: StudentProgressTopic[];
-  recommendations: string[];
+  students: TeacherInsightStudent[];
+  small_groups: Array<{
+    topic: string;
+    diagnosis_type: string;
+    student_ids: string[];
+    recommended_action: string;
+  }>;
 }
 
 export interface DashboardInsightsFilters {


### PR DESCRIPTION
## Summary
- add the Wave 1 evidence spine backend for normalized observations, SQLite student state, and structured diagnosis
- replace the teacher insights API payload with structured per-student and small-group recommendations
- surface the new teacher insight panel on `/dashboard` and update the main system map plus AI-first task/handoff docs

## Validation
- `pytest tests/services/evidence/test_extractor.py tests/services/evidence/test_diagnosis.py tests/services/session/test_sqlite_store.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
- `git diff --check`
- `GET /api/v1/dashboard/insights` smoke via `.venv/bin/python` + FastAPI TestClient returned `200`
- targeted frontend lint passed: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx lib/dashboard-api.ts components/dashboard/TeacherInsightPanel.tsx`
- full `npm run lint` still reports pre-existing repo-wide errors outside this lane (`settings`, `dashboard/student`, `dashboard/sessions`, `AppShellContext`, `VisualizationViewer`)

## Main System Map
- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the structured evidence spine and teacher insight panel.
