### PR TITLE
docs: add six lane session task packets

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,32 +28,20 @@ Rules:
 
 ## Active
 
+- No active AI-owned lane is open right now.
+- Use the six lane packets under `docs/superpowers/tasks/2026-04-26-lane-*.md` before starting any new session.
+
 ### Assignment
 
 - Owner: Codex
 - Machine: `MacBook-Air-cua-Loc.local`
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/t037-screenshot-refresh-pass`
-- Task: `POST_130_SCREENSHOT_SYNC`
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
+- Task: `SIX_LANE_SESSION_PACKETS`
 - Status: In progress
-- Branch: `docs/post-130-screenshot-sync`
-- Task packet: `docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md`
-- Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/AI_OPERATING_PROMPT.md`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`, `ai_first/daily/2026-04-25.md`, `docs/contest/README.md`, `docs/contest/SUBMISSION_PACKAGE.md`, `docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md`, `docs/superpowers/pr-notes/*`
-- PR: Not opened yet
-- Last update: 2026-04-25
-- Next action: Remove stale post-merge lane status and refresh contest entry docs after PR `#130`.
-- Blocker: None
-
-### Assignment
-
-- Owner: Codex
-- Machine: `MacBook-Air-cua-Loc.local`
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-a-wave1-evidence-spine`
-- Task: `WAVE_1_EVIDENCE_SPINE`
-- Status: In review
-- Branch: `pod-a/wave1-evidence-spine`
-- Task packet: `docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md`
-- Owned files: `deeptutor/services/evidence/*`, `deeptutor/services/session/sqlite_store.py`, `deeptutor/services/session/__init__.py`, `deeptutor/api/routers/assessment.py`, `deeptutor/api/routers/dashboard.py`, `tests/services/evidence/*`, `tests/services/session/test_sqlite_store.py`, `tests/api/test_assessment_router.py`, `tests/api/test_dashboard_router.py`, `web/components/dashboard/TeacherInsightPanel.tsx`, `web/lib/dashboard-api.ts`, `web/app/(workspace)/dashboard/page.tsx`, `ai_first/architecture/MAIN_SYSTEM_MAP.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/tasks/2026-04-26-wave-1-evidence-spine.md`, `docs/superpowers/pr-notes/2026-04-26-wave-1-evidence-spine.md`
+- Branch: `docs/six-lane-session-packets`
+- Task packet: None
+- Owned files: `ai_first/AI_OPERATING_PROMPT.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/tasks/2026-04-26-lane-*.md`, `docs/superpowers/pr-notes/*`
 - PR: Not opened
 - Last update: 2026-04-26
-- Next action: Review validation results and decide whether to open a PR for the Wave 1 spine branch.
+- Next action: Create six session-ready lane packets and refresh the AI-first control plane so workers can route themselves safely.
 - Blocker: None

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -25,7 +25,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - Mainline status: Milestone 0 AI-first operating layer merged into `main` on 2026-04-13.
 - Goal: keep the repo self-directing enough that an AI worker can start from this prompt, read the current context, and continue without manual orchestration.
 - Latest product status: Knowledge Pack, marketplace import, batch marketplace import, offline-ready imported-pack fallback, offline quiz-result sync queue, assessment generation and review insights, student tutoring context, KB context badges, Teacher Dashboard, Vietnamese MVP prompt variants, contest-facing Vietnamese UI coverage, marketplace sorting, cached marketplace browsing, mobile-first marketplace layout, metadata-driven marketplace search, marketplace and knowledge-screen polish, dashboard/review polish, dashboard insight depth, metadata depth, session context quality, assessment adaptive difficulty, teacher analytics, assessment PDF export, tutoring session replay, route error boundaries, API rate limiting, teacher invitation metadata, assessment time tracking, tutor follow-up prompts, knowledge-pack version metadata, contest evidence screenshots, contest submission-package sync, checklist evidence alignment, contest product-description drafting, and contest fork-modifications documentation are merged into `main`.
-- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `ai_first/ACTIVE_ASSIGNMENTS.md` is the active coordination board, the 2026-04-25 smoke/evidence refresh is merged, and the 2026-04-25 screenshot-refresh re-run is merged through PR `#130`.
+- Latest operating status: `ai_first/EXECUTION_QUEUE.md` is the shortest queue/status board, `ai_first/ACTIVE_ASSIGNMENTS.md` is the active coordination board, the Wave 1 evidence spine is merged through PR `#132`, and the six-lane Contest MVP+ roadmap now has session-ready task packets under `docs/superpowers/tasks/2026-04-26-lane-*.md`.
 - Operating model: Markdown is source of truth; GitHub Issues and PRs are execution mirrors; the prompt is the control plane.
 
 ## Required startup sequence
@@ -84,6 +84,18 @@ Before edits:
 - Keep task packets current with owned files and do-not-touch scope before parallel work begins.
 - Do not split one feature across two people unless it has been decomposed into separate task packets with separate ownership.
 - Treat `ai_first/ACTIVE_ASSIGNMENTS.md` as the short-term coordination memory for active work.
+- For the current Contest MVP+ split, prefer `1 session = 1 lane = 1 branch = 1 PR`.
+- If the human provides only this file as context, this file must still tell the AI how to choose or validate a lane before editing.
+
+## Session triage rules
+
+- When the human says they are splitting work into sessions, first check whether a lane-specific task packet already exists in `docs/superpowers/tasks/2026-04-26-lane-*.md`.
+- If a matching lane packet exists, treat that packet as the execution contract and stay inside its owned files.
+- If two candidate lane packets could both apply, stop and ask the human which session owns the task before editing.
+- If another active session already owns the relevant files or worktree area, stop and ask the human to resolve the conflict.
+- If the requested work spans more than one lane, do not silently proceed across boundaries; ask the human whether to narrow scope or update the task packets first.
+- When uncertain, recommend the safest lane or recommend creating a new packet rather than guessing.
+- Prefer concrete recommendations such as branch names, worktree paths, and likely owning lane when reporting ambiguity.
 
 ## Same-machine parallel rules
 
@@ -221,3 +233,4 @@ When starting a new feature or fix:
 13. Keep `docs/superpowers/tasks/` populated with current Feature Pod task packets before implementation starts.
 14. Mirror only the minimal status needed into `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md`.
 15. Use the approved docs/AI-first operating layer to drive feature pods, PRs, autonomous completion, and evidence.
+16. When the repo is in multi-session mode, route AI workers through the lane-specific task packets first and ask the human to resolve any detected session overlap or contract ambiguity.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -79,3 +79,8 @@ Keep the merged screenshot evidence state reflected in the compact mirrors and c
 ## Mirror Policy
 
 Use this file only as a compact status mirror. Do not rely on it for the full operating contract. For a human-friendly quick start, read `ai_first/USAGE_GUIDE.md`.
+## 2026-04-26
+
+- `main` now includes the Wave 1 evidence spine from PR `#132`.
+- The Contest MVP+ roadmap is now decomposed into six session-ready lane packets under `docs/superpowers/tasks/2026-04-26-lane-*.md`.
+- In multi-session mode, `ai_first/AI_OPERATING_PROMPT.md` is expected to route AI workers through those packets and ask the human to resolve conflicts or ambiguity.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -1,30 +1,35 @@
 # Execution Queue
 
-Last updated: 2026-04-25
+Last updated: 2026-04-26
 
 This is the compact status board for humans and AI workers.  
 The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#130 docs: refresh contest screenshot evidence`
+- Latest merged PR: `#132 feat: add wave 1 evidence spine`
 - Latest smoke result: the 2026-04-25 scripted-reset smoke pass succeeded against current `main`.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
-- Core MVP path in `main` now also includes contest-facing Vietnamese UI coverage, marketplace and knowledge-screen polish, dashboard/review polish, deeper dashboard insight payloads, richer metadata contracts, and improved session context support on top of the earlier marketplace, assessment, tutor, dashboard, offline, analytics, evidence, and submission flows.
+- Core MVP path in `main` now also includes the Wave 1 evidence spine: structured observations, student-state persistence, assessment diagnosis, and teacher insight payloads on top of the earlier marketplace, assessment, tutor, dashboard, offline, analytics, evidence, and submission flows.
 
 ## Active queue
 
-- No active AI-owned implementation or docs lane is open right now.
-- Current purpose: keep the refreshed screenshot evidence visible and leave only human-only submission follow-ups explicit.
+- No active AI-owned implementation lane is open right now.
+- Current purpose: prepare clean multi-session execution from `main` using one lane packet per session.
 
 ## Next recommended task
 
-Review the remaining human-owned submission items:
+Create or use one session per lane from `main` with these packets:
 
-1. Keep the 2026-04-25 smoke and screenshot evidence bundle as the current repo-backed source of truth
-2. Decide whether an optional video artifact is required for final submission
-3. Complete the final human review items in the contest submission checklist
+1. `docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md`
+2. `docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md`
+3. `docs/superpowers/tasks/2026-04-26-lane-3-observation-student-state.md`
+4. `docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md`
+5. `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md`
+6. `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
+
+If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
 
 ## Status Update (2026-04-25)
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -27,3 +27,8 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 ## Mirror Policy
 
 Use this file only as a compact queue mirror. Do not rely on it for the full operating contract. For a human-friendly quick start, read `ai_first/USAGE_GUIDE.md`.
+## 2026-04-26
+
+1. Start new AI sessions from `main`, one lane per session.
+2. Use the matching `docs/superpowers/tasks/2026-04-26-lane-*.md` packet before code edits.
+3. If a task appears to touch multiple lanes, stop and ask the human to clarify ownership first.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -11,16 +11,16 @@
 
 ## Pod B
 
-- Branch: None.
-- Task: None.
-- Done: None.
-- Tests: None.
+- Branch: `docs/six-lane-session-packets`
+- Task: `SIX_LANE_SESSION_PACKETS`
+- Done: Drafted six session-ready lane packets and refreshed the AI-first control plane so an AI given only `ai_first/AI_OPERATING_PROMPT.md` can route itself, detect session ambiguity, ask the human, and recommend the safest lane or branch.
+- Tests: `rg -n "lane-1|lane-2|lane-3|lane-4|lane-5|lane-6|Session triage rules|1 session = 1 lane" ai_first docs/superpowers/tasks -S`; `git diff --check`
 - Blockers: None.
-- Next: None.
+- Next: Open PR for the six-lane packet set, merge to `main`, then split new sessions from `main`.
 
 ## Human Review Needed
 
-- Review the Wave 1 evidence spine implementation and confirm whether this lane should be prepared as a PR.
+- Review the six-lane session packet split and confirm whether any lane ownership needs adjustment before parallel sessions start.
 
 ## Architecture Map Updates
 

--- a/docs/superpowers/pr-notes/2026-04-26-six-lane-session-packets.md
+++ b/docs/superpowers/pr-notes/2026-04-26-six-lane-session-packets.md
@@ -1,0 +1,30 @@
+# PR Note: Six Lane Session Packets
+
+## Summary
+
+- add six session-ready lane packets so future AI sessions can start from `main` with explicit ownership
+- refresh `ai_first/AI_OPERATING_PROMPT.md` so it can route an AI worker, detect session ambiguity, ask the human, and recommend a safe lane
+- update AI-first queue and compatibility mirrors for the new multi-session operating mode
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Prompt["AI_OPERATING_PROMPT.md"] --> Triage["Session triage rules"]
+  Triage --> L1["Lane 1 packet"]
+  Triage --> L2["Lane 2 packet"]
+  Triage --> L3["Lane 3 packet"]
+  Triage --> L4["Lane 4 packet"]
+  Triage --> L5["Lane 5 packet"]
+  Triage --> L6["Lane 6 packet"]
+  Triage --> Human["Ask human on ambiguity or conflict"]
+```
+
+## Validation
+
+- `rg -n "lane-1|lane-2|lane-3|lane-4|lane-5|lane-6|Session triage rules|1 session = 1 lane" ai_first docs/superpowers/tasks -S`
+- `git diff --check`
+
+## Main System Map
+
+- Not updated; this PR is docs/workflow-only and does not change product/runtime architecture.

--- a/docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md
@@ -1,0 +1,81 @@
+# Feature Pod Task: Lane 1 Agent Spec Authoring
+
+Owner: Session-specific
+Branch: `pod-a/agent-spec-authoring`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Create the teacher-facing authoring layer for the Markdown Agent Spec Pack without collapsing policy into runtime code.
+
+## User-visible outcome
+
+- Teachers can author the high-leverage parts of a teaching agent through a narrow UI.
+- The source of truth remains a versionable Markdown spec pack.
+- Authoring output is ready for later runtime compilation rather than being trapped in UI state.
+
+## Owned files/modules
+
+- `web/app/(workspace)/agents/`
+- `web/components/agents/`
+- `web/lib/agent-spec-api.ts`
+- `deeptutor/api/routers/agent_specs.py`
+- `deeptutor/services/agent_spec/`
+- `tests/api/test_agent_specs_router.py`
+- `tests/services/agent_spec/`
+- `docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/evidence/`
+- `deeptutor/api/routers/assessment.py`
+- `deeptutor/api/routers/dashboard.py`
+- `deeptutor/services/session/`
+- `web/app/(workspace)/dashboard/`
+- `web/components/dashboard/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless the authoring surface materially changes the system map
+
+## API/data contract
+
+- Define the canonical spec-pack storage contract under an `agent_specs/<agent_id>/` boundary.
+- Keep Markdown as the persisted source of truth even if the UI edits structured subsets of the pack.
+- Defer runtime assembly to Lane 2; this lane only produces clean authoring artifacts and metadata.
+
+## Acceptance criteria
+
+- `IDENTITY`, `SOUL`, and `RULES` have a narrow structured authoring surface.
+- The remaining pack files can be edited without breaking Markdown fidelity.
+- The authored pack is versionable and exportable.
+- The lane does not hardcode tutoring or diagnosis behavior into the UI layer.
+
+## Required tests
+
+- Focused router/service tests for spec pack create, update, validate, and export flows
+- Frontend lint/build checks for authoring screens
+- `git diff --check`
+
+## Manual verification
+
+- Create one sample teacher agent pack end to end.
+- Edit `IDENTITY`, `SOUL`, and `RULES`, then verify the stored Markdown remains readable and intact.
+- Export the pack and verify the file set matches the agreed Markdown standard.
+
+## Parallel-work notes
+
+- This session owns only authoring and storage concerns for the teacher spec pack.
+- Do not implement runtime prompt assembly here; hand off compiled-pack consumption to Lane 2.
+- If authoring raises a runtime ambiguity, stop and ask the human rather than inventing a hidden contract.
+- If another session is already editing the same authoring directories, ask the human to resolve the conflict before proceeding.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if the authoring surface becomes part of the shipped system map.
+
+## Handoff notes
+
+- This is Session = Lane 1.
+- Read `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md` before implementation.
+- Coordinate with Lane 2 only through explicit file/API contracts, not by shared unstated assumptions.

--- a/docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md
@@ -1,0 +1,80 @@
+# Feature Pod Task: Lane 2 Spec Runtime Assembly
+
+Owner: Session-specific
+Branch: `pod-a/spec-runtime-assembly`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Compile teacher policy into a predictable runtime contract shared by tutoring and assessment flows.
+
+## User-visible outcome
+
+- Tutor and assessment behavior can be shaped by the same teacher-defined spec pack.
+- Runtime assembly uses explicit slices instead of a monolithic hidden prompt blob.
+- The system is prepared for future multi-agent separation without redoing policy storage.
+
+## Owned files/modules
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/prompt/`
+- `deeptutor/runtime/orchestrator.py`
+- `deeptutor/capabilities/chat.py`
+- `deeptutor/capabilities/deep_question.py`
+- `tests/services/runtime_policy/`
+- `tests/core/test_capabilities_runtime.py`
+- `tests/services/test_prompt_manager.py`
+- `docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/evidence/`
+- `deeptutor/api/routers/dashboard.py`
+- `deeptutor/api/routers/assessment.py`
+- `web/app/(workspace)/dashboard/`
+- `web/components/dashboard/`
+- `web/app/(utility)/knowledge/`
+
+## API/data contract
+
+- Runtime consumes a compiled teacher spec plus student/session state boundaries.
+- Enforce source priority `teacher_kb > curriculum excerpt > teacher rules > llm prior knowledge`.
+- Keep policy assembly separate from observation, diagnosis, and recommendation execution.
+
+## Acceptance criteria
+
+- Tutor and assessment code paths both consume the same runtime policy contract.
+- `SOUL`, `RULES`, `WORKFLOW`, `ASSESSMENT`, and `KNOWLEDGE` influence runtime behavior through explicit slices.
+- Runtime debug output can explain which slices were assembled for a request.
+- No evidence or diagnosis logic is reimplemented inside prompt assembly.
+
+## Required tests
+
+- Focused capability/runtime tests for policy slice loading
+- Prompt manager or runtime-policy service tests
+- `git diff --check`
+
+## Manual verification
+
+- Run one tutoring session and one assessment session against the same authored pack.
+- Verify policy changes alter runtime behavior in both paths.
+- Verify knowledge-source priority behaves as documented.
+
+## Parallel-work notes
+
+- This lane depends on clear output contracts from Lane 1 but should not block on a polished authoring UI.
+- If the spec format is unclear or unstable, ask the human for a contract decision rather than embedding a temporary assumption.
+- Do not touch teacher insight UI or evidence storage in this lane.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` because this lane changes runtime boundaries.
+
+## Handoff notes
+
+- This is Session = Lane 2.
+- Coordinate with Lane 1 through documented compiled-pack format only.
+- Coordinate with Lanes 3-5 through explicit `Teacher Spec / Student State / Session State` boundaries.

--- a/docs/superpowers/tasks/2026-04-26-lane-3-observation-student-state.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-3-observation-student-state.md
@@ -1,0 +1,79 @@
+# Feature Pod Task: Lane 3 Observation and Student State
+
+Owner: Session-specific
+Branch: `pod-a/observation-student-state`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Extend the merged Wave 1 evidence spine so observation capture and student-state updates become broader, cleaner, and more reusable.
+
+## User-visible outcome
+
+- Student evidence is captured consistently across assessment and tutoring flows.
+- Student state becomes richer without blending facts and inference.
+- Downstream diagnosis and teacher insight features receive better evidence quality.
+
+## Owned files/modules
+
+- `deeptutor/services/evidence/extractor.py`
+- `deeptutor/services/session/sqlite_store.py`
+- `deeptutor/services/session/context_builder.py`
+- `deeptutor/services/session/turn_runtime.py`
+- `tests/services/evidence/test_extractor.py`
+- `tests/services/session/test_sqlite_store.py`
+- `tests/core/test_capabilities_runtime.py`
+- `docs/superpowers/tasks/2026-04-26-lane-3-observation-student-state.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/evidence/diagnosis.py`
+- `deeptutor/services/evidence/teacher_insights.py`
+- `deeptutor/api/routers/dashboard.py`
+- `web/app/(workspace)/dashboard/`
+- `web/components/dashboard/`
+
+## API/data contract
+
+- `Observed` must remain separate from `Inferred`.
+- Add tutoring-compatible observation capture without rewriting diagnosis rules.
+- Student-state summaries may evolve, but raw evidence must remain inspectable and reversible.
+
+## Acceptance criteria
+
+- Observation schema supports both assessment and tutoring inputs.
+- Student-state rollups include repeated mistakes, support level, confidence trend, and recency-aware summaries.
+- Raw observations remain queryable without depending on diagnosis output.
+- Existing Wave 1 evidence spine behavior does not regress.
+
+## Required tests
+
+- Evidence extractor tests
+- Session store persistence tests
+- Any required runtime tests for tutoring observation capture
+- `git diff --check`
+
+## Manual verification
+
+- Run one quiz session and one tutor session for the same learner.
+- Verify new observations appear in storage without corrupting old rows.
+- Verify student-state summaries update while preserving raw evidence trace.
+
+## Parallel-work notes
+
+- Start from merged `main`; do not reimplement Wave 1 from scratch.
+- This lane may strengthen observation quality, but must not silently change diagnosis semantics owned by Lane 4.
+- If evidence fields need a cross-lane rename, stop and ask the human before proceeding.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if the evidence layer contract or storage model changes materially.
+
+## Handoff notes
+
+- This is Session = Lane 3.
+- Treat `main` after PR `#132` as the baseline.
+- Hand off richer observation/state fields to Lane 4 and Lane 5 through explicit documented contracts.

--- a/docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md
@@ -1,0 +1,78 @@
+# Feature Pod Task: Lane 4 Diagnosis and Recommendation Engine
+
+Owner: Session-specific
+Branch: `pod-a/diagnosis-recommendation`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Evolve the merged Wave 1 diagnosis backbone into a stronger hybrid recommendation engine with clearer hypothesis taxonomy, confidence, and action mapping.
+
+## User-visible outcome
+
+- Teacher recommendations become more explicit, evidence-backed, and useful.
+- Small-group recommendations become less ad hoc and more consistent.
+- Diagnosis remains auditable rather than collapsing into free-form LLM claims.
+
+## Owned files/modules
+
+- `deeptutor/services/evidence/diagnosis.py`
+- `deeptutor/services/evidence/teacher_insights.py`
+- `deeptutor/api/routers/assessment.py`
+- `deeptutor/api/routers/dashboard.py`
+- `tests/services/evidence/test_diagnosis.py`
+- `tests/api/test_assessment_router.py`
+- `tests/api/test_dashboard_router.py`
+- `docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/session/sqlite_store.py`
+- `deeptutor/services/session/turn_runtime.py`
+- `deeptutor/services/prompt/`
+- `web/app/(workspace)/dashboard/`
+- `web/components/dashboard/TeacherInsightPanel.tsx`
+
+## API/data contract
+
+- `Inferred` must remain derived from observed evidence, never the other way around.
+- Confidence tags are engine-owned, not LLM-owned.
+- Recommended actions should map to explicit action types before any narrative explanation.
+
+## Acceptance criteria
+
+- Diagnosis taxonomy expands cleanly beyond the Wave 1 placeholder behavior.
+- Per-student and small-group actions are ranked deterministically before narrative wording is added.
+- The engine can abstain when evidence is weak or contradictory.
+- The lane does not rewrite storage schema or UI ownership without agreement.
+
+## Required tests
+
+- Diagnosis engine tests for taxonomy, confidence, and abstain behavior
+- Router tests for assessment diagnosis and teacher insight payloads
+- `git diff --check`
+
+## Manual verification
+
+- Seed at least two misconception patterns and confirm the engine distinguishes them.
+- Verify confidence tags track evidence density rather than arbitrary heuristics.
+- Verify small-group recommendations only appear when grouping criteria are met.
+
+## Parallel-work notes
+
+- Start from the merged Wave 1 spine on `main`.
+- This lane owns recommendation logic, not the raw observation capture contract.
+- If a change requires new observed fields, ask the human or coordinate through a documented Lane 3 contract update.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if diagnosis/recommendation pathways change materially.
+
+## Handoff notes
+
+- This is Session = Lane 4.
+- Coordinate with Lane 5 only through response payloads, not shared UI assumptions.
+- Coordinate with Lane 6 through explicit evaluation cases and demo scenarios.

--- a/docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md
@@ -1,0 +1,76 @@
+# Feature Pod Task: Lane 5 Teacher Insight UI
+
+Owner: Session-specific
+Branch: `pod-a/teacher-insight-ui`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Turn the merged Wave 1 teacher insight surface into a clearer teacher workflow that distinguishes facts, diagnosis, and next actions.
+
+## User-visible outcome
+
+- Teachers can inspect per-student evidence, diagnosis, and recommendation without ambiguity.
+- The dashboard supports small-group views and richer action surfaces.
+- The UI presents evidence-backed insight rather than a decorative analytics shell.
+
+## Owned files/modules
+
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/dashboard/student/page.tsx`
+- `web/components/dashboard/TeacherInsightPanel.tsx`
+- `web/components/dashboard/`
+- `web/lib/dashboard-api.ts`
+- `tests` only if frontend-specific test coverage is added in scope
+- `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/evidence/`
+- `deeptutor/services/session/`
+- `deeptutor/api/routers/assessment.py`
+- `deeptutor/api/routers/dashboard.py` unless an API contract bug blocks UI work and the human approves scope expansion
+
+## API/data contract
+
+- Consume the structured insight payload already merged in Wave 1 or its later compatible evolution from Lane 4.
+- Keep `Observed`, `Inferred`, and `Recommended Action` visually separate.
+- Do not invent new AI claims in the UI layer.
+
+## Acceptance criteria
+
+- Dashboard clearly distinguishes evidence facts from diagnosis claims.
+- Per-student insight and small-group recommendations are usable on both desktop and mobile.
+- UI supports next-step teacher actions and clear evidence trace display.
+- The lane does not embed diagnosis logic in the frontend.
+
+## Required tests
+
+- Frontend lint/build checks for owned dashboard files
+- Any targeted component tests added in scope
+- `git diff --check`
+
+## Manual verification
+
+- Open `/dashboard` with seeded insight data and verify evidence, diagnosis, and actions render distinctly.
+- Check mobile layout for teacher insight cards and grouped recommendations.
+- Verify no UI element implies certainty beyond the payload’s confidence/evidence.
+
+## Parallel-work notes
+
+- Start from merged Wave 1 UI on `main`.
+- This lane owns presentation and workflow, not diagnosis semantics.
+- If the payload is insufficient for the intended UX, ask the human whether Lane 4 should extend it before editing backend code here.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if the teacher workflow surface changes the top-level product map materially.
+
+## Handoff notes
+
+- This is Session = Lane 5.
+- Keep visual language aligned with existing dashboard patterns unless the human explicitly asks for redesign.
+- Treat backend payloads as contracts, not suggestions.

--- a/docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md
@@ -1,0 +1,76 @@
+# Feature Pod Task: Lane 6 Evaluation, Evidence, and Contest Readiness
+
+Owner: Session-specific
+Branch: `docs/evaluation-evidence-readiness`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Prepare the hybrid proof for repeated demo, validation, and contest evidence without changing product logic outside the validation contract.
+
+## User-visible outcome
+
+- The team has a repeatable acceptance flow for the hybrid teacher-authoring plus evidence-loop story.
+- Demo artifacts, validation notes, and fallback runbooks stay current.
+- Contest-facing materials do not overclaim beyond what the product actually proves.
+
+## Owned files/modules
+
+- `docs/contest/`
+- `ai_first/evidence/`
+- `docs/superpowers/pr-notes/`
+- `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/daily/2026-04-26.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/`
+- `deeptutor/api/routers/`
+- `web/app/`
+- `web/components/`
+- `ai_first/AI_OPERATING_PROMPT.md` unless the human explicitly requests an operating-layer update in this lane
+
+## API/data contract
+
+- This lane consumes the shipped behavior from other lanes and documents its proof.
+- Demo and evidence artifacts must reflect actual repo-backed behavior, not aspirational roadmap claims.
+
+## Acceptance criteria
+
+- End-to-end hybrid-proof validation steps are documented and reproducible.
+- Demo data, screenshots, checklist items, and fallback notes stay aligned.
+- Contest artifacts explain limitations honestly.
+- This lane does not mutate runtime/product code.
+
+## Required tests
+
+- Doc consistency checks as appropriate
+- Any scripted smoke or reset command relevant to updated evidence
+- `git diff --check`
+
+## Manual verification
+
+- Walk through the teacher-authoring plus evidence-loop demo story using current `main`.
+- Confirm screenshots/checklists map to the current product.
+- Confirm fallback notes cover incomplete lanes without misleading reviewers.
+
+## Parallel-work notes
+
+- This lane is docs/evidence-only.
+- If product behavior appears inconsistent with docs, ask the human whether to block on the relevant product lane or document the current limitation explicitly.
+- Do not “fix” runtime gaps from this lane.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is usually not updated in this lane unless a docs correction reveals the map is already stale.
+
+## Handoff notes
+
+- This is Session = Lane 6.
+- Use current `main` as the only source of truth for contest evidence.
+- Document reality, not desired future behavior.


### PR DESCRIPTION
## Summary
- add six session-ready lane packets so future AI sessions can split from `main` with explicit ownership
- update `ai_first/AI_OPERATING_PROMPT.md` so an AI given only that file can route itself, detect ambiguity, ask the human, and recommend a safe lane
- refresh queue and compatibility mirrors for the new `1 session = 1 lane = 1 branch = 1 PR` operating mode

## Validation
- `rg -n "lane-1|lane-2|lane-3|lane-4|lane-5|lane-6|Session triage rules|1 session = 1 lane" ai_first docs/superpowers/tasks -S`
- `git diff --check`

## Main System Map
- Not updated; this PR is docs/workflow-only and does not change product/runtime architecture.
