### PR TITLE
docs(ai-first): standardize task-tagged commits [OPS-COMMIT]

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -51,7 +51,24 @@ Before edits:
 - Do not remove Apache 2.0 license or upstream credit.
 - Do not modify lockfiles unless dependency changes require it.
 - Prefer small, reviewable commits.
+- Every commit must include the active task identifier from the task packet or task registry.
 - Do not broaden scope just because the repo contains more files; stay inside the task packet or bootstrap contract.
+
+## Commit message convention
+
+- Treat the task packet as the source of truth for commit tagging.
+- Every task packet should declare both a `Task ID` and a short `Commit tag`.
+- If the work maps to `ai_first/TASK_REGISTRY.json`, use that task's registry ID as the commit tag, such as `T010`.
+- If the work is a lane packet or operating/docs slice outside the registry, create a stable packet-local ID and short tag, such as `L3` or `OPS-COMMIT`.
+- Use this commit format: `<type>(<scope>): <summary> [<commit-tag>]`
+- Allowed `type` values: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
+- Keep `<summary>` imperative, specific, and easy to scan in `git log`.
+- Prefer one dominant task per commit. Include multiple tags only when one reviewable commit truly completes more than one owned task.
+- If no task packet or registry entry exposes a usable task identifier yet, stop and update the task packet first instead of inventing an ad hoc suffix.
+- Examples:
+  - `feat(evidence): add tutoring observation rollups [L3]`
+  - `docs(ai-first): define commit tagging convention [OPS-COMMIT]`
+  - `fix(dashboard): preserve recommendation confidence badge [T010]`
 
 ## AI-first operating rules
 
@@ -135,13 +152,14 @@ After opening or updating a PR, classify it before handing off:
 When starting work, do the following in order:
 
 1. Identify the active branch and task packet.
-2. Confirm owned files and do-not-touch files.
-3. Check whether the change is docs-only, workflow-only, or a runtime change.
-4. Read the minimum additional context needed.
-5. Make the smallest useful change.
-6. Run the relevant test or validation command.
-7. Update this file if the repo-level operating model changed.
-8. Update the daily log and handoff notes.
+2. Confirm the task ID and commit tag.
+3. Confirm owned files and do-not-touch files.
+4. Check whether the change is docs-only, workflow-only, or a runtime change.
+5. Read the minimum additional context needed.
+6. Make the smallest useful change.
+7. Run the relevant test or validation command.
+8. Update this file if the repo-level operating model changed.
+9. Update the daily log and handoff notes.
 
 ## Completion rules
 
@@ -198,6 +216,7 @@ When starting a new feature or fix:
 6. Link PR to issue
 7. Update JSON status → "in-progress" when starting
 8. Update JSON status → "completed" when merged to main
+9. Use the task packet or registry commit tag in every commit for that task
 
 ### Critical P1 Tasks (Block before contest submission)
 
@@ -211,6 +230,7 @@ When starting a new feature or fix:
 ### Integration with Existing Rules
 
 - Task packets created from TASK_REGISTRY inherit `Files:` field as owned-file contract
+- Task packets should expose a `Task ID` and `Commit tag` so the AI can commit without guessing
 - Every PR updates corresponding task status in JSON
 - Daily logs reference task IDs for tracking progress
 - Architecture changes trigger MAIN_SYSTEM_MAP.md updates per the task scope

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -22,6 +22,15 @@
 
 - Review the six-lane session packet split and confirm whether any lane ownership needs adjustment before parallel sessions start.
 
+## Docs Workflow
+
+- Branch: `docs/commit-message-task-id-standard`
+- Task: `OPS_COMMIT_MESSAGE_STANDARD`
+- Done: Added a repo-level commit-message convention that requires every commit to carry the active task identifier, taught `ai_first/AI_OPERATING_PROMPT.md` to route AI workers through `Task ID` and `Commit tag`, updated the task packet template and README, and added stable IDs/tags to all six lane packets.
+- Tests: `rg -n "Commit message convention|Task ID|Commit tag|OPS-COMMIT|\\[L[1-6]\\]" ai_first docs/superpowers/tasks -S`; `git diff --check`
+- Blockers: None.
+- Next: Open and merge the docs/workflow PR so all future sessions inherit the same commit standard from `main`.
+
 ## Architecture Map Updates
 
 - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the structured evidence spine and teacher insight panel.

--- a/docs/superpowers/pr-notes/2026-04-26-commit-message-task-id-standard.md
+++ b/docs/superpowers/pr-notes/2026-04-26-commit-message-task-id-standard.md
@@ -1,0 +1,27 @@
+# PR Note: Commit Message Task ID Standard
+
+## Summary
+
+- add one repo-level commit message convention that always carries the active task identifier
+- teach AI workers to read `Task ID` and `Commit tag` from the task packet before the first commit
+- update the six active lane packets and the task packet template so future sessions do not guess commit suffixes
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Prompt["AI_OPERATING_PROMPT.md"] --> Packet["Task packet"]
+  Packet --> Meta["Task ID + Commit tag"]
+  Meta --> Commit["git commit message"]
+  Registry["TASK_REGISTRY.json"] --> Meta
+  Commit --> Log["git log / PR history"]
+```
+
+## Validation
+
+- `rg -n "Commit message convention|Task ID|Commit tag|OPS-COMMIT|\\[L[1-6]\\]" ai_first docs/superpowers/tasks -S`
+- `git diff --check`
+
+## Main System Map
+
+- Not updated; this PR is docs/workflow-only and does not change product/runtime architecture.

--- a/docs/superpowers/tasks/2026-04-26-commit-message-task-id-standard.md
+++ b/docs/superpowers/tasks/2026-04-26-commit-message-task-id-standard.md
@@ -1,0 +1,71 @@
+# Feature Pod Task: Commit Message Task ID Standard
+
+Task ID: `OPS_COMMIT_MESSAGE_STANDARD`
+Commit tag: `OPS-COMMIT`
+Owner: Session-specific
+Branch: `docs/commit-message-task-id-standard`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Add one simple commit-message convention so every commit references the active task without forcing humans or AI workers to remember per-lane exceptions.
+
+## User-visible outcome
+
+- AI workers can read `ai_first/AI_OPERATING_PROMPT.md` and know how to format commits.
+- Task packets expose the task identifier needed for commit messages.
+- The six active lane packets already carry stable commit tags before new sessions start.
+
+## Owned files/modules
+
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/tasks/README.md`
+- `docs/superpowers/tasks/templates/feature-pod-task.md`
+- `docs/superpowers/tasks/2026-04-26-commit-message-task-id-standard.md`
+- `docs/superpowers/tasks/2026-04-26-lane-*.md`
+- `docs/superpowers/pr-notes/2026-04-26-commit-message-task-id-standard.md`
+
+## Do-not-touch files/modules
+
+- Product or runtime source files outside the docs/workflow control plane
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless the operating docs unexpectedly change system structure
+
+## API/data contract
+
+- Commit format must be easy to apply in both human and AI workflows.
+- The task packet becomes the first place to look for `Task ID` and `Commit tag`.
+- Registry-backed work should keep using registry task IDs rather than inventing duplicates.
+
+## Acceptance criteria
+
+- `ai_first/AI_OPERATING_PROMPT.md` defines one canonical commit format with examples.
+- The task packet template and task-packet README require `Task ID` and `Commit tag`.
+- The six lane packets expose stable task identifiers for future sessions.
+- The docs packet itself can be committed using the new convention.
+
+## Required tests
+
+- `rg -n "Commit message convention|Task ID|Commit tag|OPS-COMMIT|\\[L[1-6]\\]" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## Manual verification
+
+- Open `ai_first/AI_OPERATING_PROMPT.md` and confirm the commit format is visible without reading other docs.
+- Open any lane packet and confirm the task metadata appears before the goal section.
+- Confirm the branch's own commit message uses `[OPS-COMMIT]`.
+
+## Parallel-work notes
+
+- Keep this change docs/workflow-only.
+- If another session is already changing task packet headers or the operating prompt, ask the human to resolve overlap before editing.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged because this is control-plane only.
+
+## Handoff notes
+
+- This packet exists so the commit-tagging rule can apply to its own rollout.

--- a/docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md
@@ -1,5 +1,7 @@
 # Feature Pod Task: Lane 1 Agent Spec Authoring
 
+Task ID: `L1_AGENT_SPEC_AUTHORING`
+Commit tag: `L1`
 Owner: Session-specific
 Branch: `pod-a/agent-spec-authoring`
 GitHub Issue:

--- a/docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md
@@ -1,5 +1,7 @@
 # Feature Pod Task: Lane 2 Spec Runtime Assembly
 
+Task ID: `L2_SPEC_RUNTIME_ASSEMBLY`
+Commit tag: `L2`
 Owner: Session-specific
 Branch: `pod-a/spec-runtime-assembly`
 GitHub Issue:

--- a/docs/superpowers/tasks/2026-04-26-lane-3-observation-student-state.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-3-observation-student-state.md
@@ -1,5 +1,7 @@
 # Feature Pod Task: Lane 3 Observation and Student State
 
+Task ID: `L3_OBSERVATION_STUDENT_STATE`
+Commit tag: `L3`
 Owner: Session-specific
 Branch: `pod-a/observation-student-state`
 GitHub Issue:

--- a/docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md
@@ -1,5 +1,7 @@
 # Feature Pod Task: Lane 4 Diagnosis and Recommendation Engine
 
+Task ID: `L4_DIAGNOSIS_RECOMMENDATION`
+Commit tag: `L4`
 Owner: Session-specific
 Branch: `pod-a/diagnosis-recommendation`
 GitHub Issue:

--- a/docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md
@@ -1,5 +1,7 @@
 # Feature Pod Task: Lane 5 Teacher Insight UI
 
+Task ID: `L5_TEACHER_INSIGHT_UI`
+Commit tag: `L5`
 Owner: Session-specific
 Branch: `pod-a/teacher-insight-ui`
 GitHub Issue:

--- a/docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md
@@ -1,5 +1,7 @@
 # Feature Pod Task: Lane 6 Evaluation, Evidence, and Contest Readiness
 
+Task ID: `L6_EVALUATION_EVIDENCE_READINESS`
+Commit tag: `L6`
 Owner: Session-specific
 Branch: `docs/evaluation-evidence-readiness`
 GitHub Issue:

--- a/docs/superpowers/tasks/README.md
+++ b/docs/superpowers/tasks/README.md
@@ -4,6 +4,8 @@ Task packets are the execution contract for Feature Pods.
 
 Each task packet must define:
 
+- task ID;
+- commit tag;
 - owner;
 - branch;
 - GitHub issue;
@@ -28,6 +30,7 @@ Before code work starts on a task:
 3. If another session is active on the same machine, create or switch to a separate worktree for this task.
 4. Create or switch to the task branch inside that task's own worktree.
 5. Run `git fetch origin main` and merge `origin/main` into the task branch when `main` has advanced before continuing feature edits.
-6. Work only inside the packet's owned-file scope.
+6. Confirm the packet's `Task ID` and `Commit tag` before making the first commit.
+7. Work only inside the packet's owned-file scope.
 
 Use `ai_first/ACTIVE_ASSIGNMENTS.md` for short-lived active coordination and the task packet for the execution contract.

--- a/docs/superpowers/tasks/templates/feature-pod-task.md
+++ b/docs/superpowers/tasks/templates/feature-pod-task.md
@@ -1,5 +1,7 @@
 # Feature Pod Task: <feature name>
 
+Task ID:
+Commit tag:
 Owner:
 Branch:
 GitHub Issue:


### PR DESCRIPTION
## Summary
- add one repo-level commit message convention that always carries the active task identifier
- teach AI workers to read `Task ID` and `Commit tag` from the task packet before the first commit
- update the task packet template and the six active lane packets so future sessions do not guess commit suffixes

## Validation
- `rg -n "Commit message convention|Task ID|Commit tag|OPS-COMMIT|\\[L[1-6]\\]" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
- `git diff --check`

## Main System Map
- Not updated; this PR is docs/workflow-only and does not change product/runtime architecture.
