### PR TITLE
feat(runtime): assemble teacher spec runtime policy contract [L2]

### DIFF
--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -19,6 +19,10 @@ flowchart TD
   Runtime --> ToolRegistry["ToolRegistry"]
   Runtime --> CapabilityRegistry["CapabilityRegistry"]
   Runtime --> StreamBus["StreamBus"]
+  Runtime --> RuntimePolicy["Runtime Policy Assembly"]
+  RuntimePolicy --> PolicyCompiler["services/runtime_policy/compiler.py"]
+  RuntimePolicy --> PolicySlices["SOUL/RULES/WORKFLOW/ASSESSMENT/KNOWLEDGE"]
+  RuntimePolicy --> SourcePriority["teacher_kb > curriculum_excerpt > teacher_rules > llm_prior_knowledge"]
 
   ToolRegistry --> Tools["Built-in Tools"]
   Tools --> RagTool["rag"]
@@ -31,6 +35,8 @@ flowchart TD
   Capabilities --> Chat["chat"]
   Capabilities --> DeepSolve["deep_solve"]
   Capabilities --> DeepQuestion["deep_question"]
+  RuntimePolicy --> Chat
+  RuntimePolicy --> DeepQuestion
 
   Project --> Product["Contest MVP Product Layer"]
   Product --> TeacherWorkspace["Teacher Workspace"]

--- a/deeptutor/capabilities/chat.py
+++ b/deeptutor/capabilities/chat.py
@@ -7,6 +7,7 @@ from deeptutor.core.context import UnifiedContext
 from deeptutor.core.stream_bus import StreamBus
 from deeptutor.agents.chat.agentic_pipeline import CHAT_OPTIONAL_TOOLS, AgenticChatPipeline
 from deeptutor.capabilities.request_contracts import get_capability_request_schema
+from deeptutor.services.runtime_policy import ensure_runtime_policy, format_chat_system_context
 
 
 class ChatCapability(BaseCapability):
@@ -20,5 +21,18 @@ class ChatCapability(BaseCapability):
     )
 
     async def run(self, context: UnifiedContext, stream: StreamBus) -> None:
+        policy = ensure_runtime_policy(context, self.name)
+        policy_system_context = format_chat_system_context(policy)
+        if policy_system_context:
+            if context.memory_context.strip():
+                context.memory_context = f"{policy_system_context}\n\n{context.memory_context}"
+            else:
+                context.memory_context = policy_system_context
+        await stream.progress(
+            message="Runtime policy slices assembled.",
+            source=self.name,
+            stage="thinking",
+            metadata=context.metadata.get("runtime_policy", {}).get("debug", {}),
+        )
         pipeline = AgenticChatPipeline(language=context.language)
         await pipeline.run(context, stream)

--- a/deeptutor/capabilities/deep_question.py
+++ b/deeptutor/capabilities/deep_question.py
@@ -18,6 +18,7 @@ from deeptutor.core.capability_protocol import BaseCapability, CapabilityManifes
 from deeptutor.core.context import UnifiedContext
 from deeptutor.core.stream_bus import StreamBus
 from deeptutor.core.trace import merge_trace_metadata
+from deeptutor.services.runtime_policy import ensure_runtime_policy, format_assessment_context
 
 
 class DeepQuestionCapability(BaseCapability):
@@ -34,6 +35,16 @@ class DeepQuestionCapability(BaseCapability):
         from deeptutor.agents.question.coordinator import AgentCoordinator
         from deeptutor.services.llm.config import get_llm_config
         from deeptutor.services.path_service import get_path_service
+
+        policy = ensure_runtime_policy(context, self.name)
+        assessment_policy_context = format_assessment_context(policy)
+        runtime_debug = context.metadata.get("runtime_policy", {}).get("debug", {})
+        await stream.progress(
+            message="Runtime policy slices assembled.",
+            source=self.name,
+            stage="ideation",
+            metadata=runtime_debug,
+        )
 
         llm_config = get_llm_config()
         kb_name = context.knowledge_bases[0] if context.knowledge_bases else None
@@ -58,7 +69,11 @@ class DeepQuestionCapability(BaseCapability):
             agent.set_trace_callback(self._build_trace_bridge(stream))
             async with stream.stage("generation", source=self.name):
                 answer = await agent.process(
-                    user_message=context.user_message,
+                    user_message=(
+                        f"{assessment_policy_context}\n\nUser request:\n{context.user_message}"
+                        if assessment_policy_context
+                        else context.user_message
+                    ),
                     question_context=followup_question_context,
                     history_context=str(
                         context.metadata.get("conversation_context_text", "") or ""
@@ -86,6 +101,10 @@ class DeepQuestionCapability(BaseCapability):
         preference = str(overrides.get("preference", "") or "")
         if subject:
             preference = "\n".join(part for part in [f"Subject: {subject}", preference] if part).strip()
+        if assessment_policy_context:
+            preference = "\n\n".join(
+                part for part in [assessment_policy_context, preference] if part
+            ).strip()
         history_context = str(
             context.metadata.get("conversation_context_text", "") or ""
         ).strip()

--- a/deeptutor/runtime/orchestrator.py
+++ b/deeptutor/runtime/orchestrator.py
@@ -19,6 +19,7 @@ from deeptutor.core.stream_bus import StreamBus
 from deeptutor.events.event_bus import Event, EventType, get_event_bus
 from deeptutor.runtime.registry.capability_registry import get_capability_registry
 from deeptutor.runtime.registry.tool_registry import get_tool_registry
+from deeptutor.services.runtime_policy import ensure_runtime_policy
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,7 @@ class ChatOrchestrator:
 
         async def _run() -> None:
             try:
+                ensure_runtime_policy(context, cap_name)
                 await capability.run(context, bus)
             except Exception as exc:
                 logger.error("Capability %s failed: %s", cap_name, exc, exc_info=True)

--- a/deeptutor/services/runtime_policy/__init__.py
+++ b/deeptutor/services/runtime_policy/__init__.py
@@ -1,0 +1,17 @@
+"""Runtime policy assembly for teacher-spec driven capabilities."""
+
+from .compiler import (
+    SOURCE_PRIORITY,
+    RuntimePolicy,
+    ensure_runtime_policy,
+    format_assessment_context,
+    format_chat_system_context,
+)
+
+__all__ = [
+    "SOURCE_PRIORITY",
+    "RuntimePolicy",
+    "ensure_runtime_policy",
+    "format_assessment_context",
+    "format_chat_system_context",
+]

--- a/deeptutor/services/runtime_policy/compiler.py
+++ b/deeptutor/services/runtime_policy/compiler.py
@@ -1,0 +1,161 @@
+"""Compile teacher-authored spec slices into a runtime policy contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from deeptutor.core.context import UnifiedContext
+
+SLICE_NAMES = ["SOUL", "RULES", "WORKFLOW", "ASSESSMENT", "KNOWLEDGE", "CURRICULUM"]
+SOURCE_PRIORITY = [
+    "teacher_kb",
+    "curriculum_excerpt",
+    "teacher_rules",
+    "llm_prior_knowledge",
+]
+DEFAULT_KNOWLEDGE_POLICY = "kb_preferred"
+
+
+@dataclass
+class RuntimePolicy:
+    """Serializable policy object injected into runtime context."""
+
+    capability: str
+    slices: dict[str, str]
+    sources: dict[str, str]
+    knowledge_policy: str
+    source_priority: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        applied = [name for name, value in self.slices.items() if value.strip()]
+        missing = [name for name in SLICE_NAMES if name not in applied]
+        return {
+            "capability": self.capability,
+            "slices": dict(self.slices),
+            "sources": dict(self.sources),
+            "knowledge_policy": self.knowledge_policy,
+            "source_priority": list(self.source_priority),
+            "debug": {
+                "applied_slices": applied,
+                "missing_slices": missing,
+            },
+        }
+
+
+def ensure_runtime_policy(context: UnifiedContext, capability: str) -> RuntimePolicy:
+    """Return existing compiled policy from context metadata or compile one."""
+    existing = context.metadata.get("runtime_policy")
+    if isinstance(existing, dict):
+        return RuntimePolicy(
+            capability=str(existing.get("capability") or capability),
+            slices={k: str(v or "") for k, v in dict(existing.get("slices") or {}).items()},
+            sources={k: str(v or "") for k, v in dict(existing.get("sources") or {}).items()},
+            knowledge_policy=str(existing.get("knowledge_policy") or DEFAULT_KNOWLEDGE_POLICY),
+            source_priority=list(existing.get("source_priority") or SOURCE_PRIORITY),
+        )
+
+    policy = _compile_runtime_policy(context=context, capability=capability)
+    context.metadata["runtime_policy"] = policy.to_dict()
+    return policy
+
+
+def format_chat_system_context(policy: RuntimePolicy) -> str:
+    """Build tutoring-oriented system guidance from assembled slices."""
+    blocks: list[str] = [
+        "Teacher Runtime Policy:",
+        _slice_block("SOUL", policy.slices.get("SOUL", "")),
+        _slice_block("RULES", policy.slices.get("RULES", "")),
+        _slice_block("WORKFLOW", policy.slices.get("WORKFLOW", "")),
+        _slice_block("KNOWLEDGE", policy.slices.get("KNOWLEDGE", "")),
+        "Knowledge source priority:",
+        " > ".join(policy.source_priority),
+        "Scope guardrail: Stay within teacher-defined scope and clarify uncertainty when evidence is missing.",
+    ]
+    return "\n\n".join(block for block in blocks if block.strip())
+
+
+def format_assessment_context(policy: RuntimePolicy) -> str:
+    """Build assessment-oriented guidance from assembled slices."""
+    blocks: list[str] = [
+        "Teacher Assessment Runtime Policy:",
+        _slice_block("ASSESSMENT", policy.slices.get("ASSESSMENT", "")),
+        _slice_block("RULES", policy.slices.get("RULES", "")),
+        _slice_block("WORKFLOW", policy.slices.get("WORKFLOW", "")),
+        _slice_block("KNOWLEDGE", policy.slices.get("KNOWLEDGE", "")),
+        "Knowledge source priority:",
+        " > ".join(policy.source_priority),
+        "Scope guardrail: Keep generated questions and feedback aligned with teacher policy and curriculum context.",
+    ]
+    return "\n\n".join(block for block in blocks if block.strip())
+
+
+def _compile_runtime_policy(context: UnifiedContext, capability: str) -> RuntimePolicy:
+    teacher_spec = _get_teacher_spec(context)
+    slices: dict[str, str] = {}
+    sources: dict[str, str] = {}
+    for slice_name in SLICE_NAMES:
+        value, source = _resolve_slice(slice_name, teacher_spec, context)
+        if value:
+            slices[slice_name] = value
+            sources[slice_name] = source
+
+    knowledge_policy = _resolve_knowledge_policy(teacher_spec, slices)
+    return RuntimePolicy(
+        capability=capability,
+        slices=slices,
+        sources=sources,
+        knowledge_policy=knowledge_policy,
+        source_priority=list(SOURCE_PRIORITY),
+    )
+
+
+def _get_teacher_spec(context: UnifiedContext) -> dict[str, Any]:
+    candidates = [
+        context.metadata.get("teacher_spec_compiled"),
+        context.metadata.get("teacher_spec"),
+        context.config_overrides.get("teacher_spec"),
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            return candidate
+    return {}
+
+
+def _resolve_slice(
+    slice_name: str,
+    teacher_spec: dict[str, Any],
+    context: UnifiedContext,
+) -> tuple[str, str]:
+    keys = [slice_name, slice_name.lower()]
+    for key in keys:
+        value = teacher_spec.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip(), f"teacher_spec.{key}"
+
+    if slice_name == "CURRICULUM":
+        raw = context.metadata.get("curriculum_excerpt")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip(), "metadata.curriculum_excerpt"
+
+    if slice_name == "RULES":
+        raw = context.metadata.get("teacher_rules")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip(), "metadata.teacher_rules"
+
+    return "", ""
+
+
+def _resolve_knowledge_policy(teacher_spec: dict[str, Any], slices: dict[str, str]) -> str:
+    raw = teacher_spec.get("knowledge_policy")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    knowledge_slice = slices.get("KNOWLEDGE", "")
+    if "kb_preferred" in knowledge_slice.lower():
+        return "kb_preferred"
+    return DEFAULT_KNOWLEDGE_POLICY
+
+
+def _slice_block(name: str, content: str) -> str:
+    text = content.strip() or "(not provided)"
+    return f"[{name}]\n{text}"

--- a/docs/superpowers/pr-notes/2026-04-26-lane-2-spec-runtime-assembly.md
+++ b/docs/superpowers/pr-notes/2026-04-26-lane-2-spec-runtime-assembly.md
@@ -1,0 +1,38 @@
+# PR Architecture Note: Lane 2 Spec Runtime Assembly
+
+## Summary
+
+This PR introduces a shared runtime policy assembly contract so tutoring and assessment flows consume the same teacher-spec policy slices at runtime.
+
+## Architectural changes
+
+- Add shared runtime policy compiler under `deeptutor/services/runtime_policy/`.
+- Compile explicit policy slices (`SOUL`, `RULES`, `WORKFLOW`, `ASSESSMENT`, `KNOWLEDGE`) with deterministic source priority.
+- Inject compiled runtime policy in orchestrator before capability execution.
+- Apply assembled policy context in both `chat` and `deep_question` capabilities.
+- Emit runtime debug metadata for assembled slice visibility.
+
+```mermaid
+flowchart TD
+  TeacherSpec["Teacher Spec Pack"] --> Compiler["Runtime Policy Compiler"]
+  SessionState["Session State"] --> Compiler
+  StudentState["Student State"] --> Compiler
+
+  Compiler --> Contract["Compiled Runtime Policy Contract"]
+  Contract --> ChatCap["chat capability"]
+  Contract --> QuestionCap["deep_question capability"]
+
+  Contract --> Debug["Debug slices: applied/missing"]
+  Contract --> Priority["Source priority enforcement"]
+```
+
+## Main system map status
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated in this PR.
+
+## Validation
+
+- `pytest tests/services/runtime_policy/test_compiler.py -vv`
+- `pytest tests/core/test_capabilities_runtime.py::test_chat_capability_streams_content_and_geogebra_context -vv -s`
+- `pytest tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_user_message_as_topic -vv`
+- `git diff --check`

--- a/tests/core/test_capabilities_runtime.py
+++ b/tests/core/test_capabilities_runtime.py
@@ -20,7 +20,10 @@ from deeptutor.core.stream_bus import StreamBus
 
 
 def _install_module(monkeypatch: pytest.MonkeyPatch, fullname: str, **attrs: Any) -> types.ModuleType:
-    __import__("src")
+    try:
+        __import__("src")
+    except ModuleNotFoundError:
+        pass
     parts = fullname.split(".")
     for idx in range(1, len(parts)):
         pkg_name = ".".join(parts[:idx])
@@ -73,6 +76,7 @@ async def test_chat_capability_streams_content_and_geogebra_context(
             captured["process"] = {
                 "message": f"{context.user_message}\nGGB commands",
                 "enabled_tools": list(context.enabled_tools or []),
+                "memory_context": context.memory_context,
             }
             await stream.tool_call(
                 "geogebra_analysis",
@@ -98,6 +102,14 @@ async def test_chat_capability_streams_content_and_geogebra_context(
         knowledge_bases=["demo-kb"],
         language="en",
         attachments=[Attachment(type="image", base64="ZmFrZQ==", filename="img.png")],
+        metadata={
+            "teacher_spec": {
+                "SOUL": "Coach with encouragement.",
+                "RULES": "Keep explanations concise.",
+                "WORKFLOW": "Explain then practice.",
+                "KNOWLEDGE": "Use kb_preferred retrieval first.",
+            }
+        },
     )
 
     capability = ChatCapability()
@@ -107,6 +119,8 @@ async def test_chat_capability_streams_content_and_geogebra_context(
     assert any(event.type == StreamEventType.SOURCES for event in events)
     assert any(event.type == StreamEventType.CONTENT and "assistant output" in event.content for event in events)
     assert "GGB commands" in captured["process"]["message"]
+    assert "Teacher Runtime Policy:" in captured["process"]["memory_context"]
+    assert "teacher_kb > curriculum_excerpt > teacher_rules > llm_prior_knowledge" in captured["process"]["memory_context"]
 
 
 @pytest.mark.asyncio
@@ -294,11 +308,19 @@ async def test_deep_question_capability_uses_user_message_as_topic(
         user_message="linear algebra fundamentals",
         config_overrides={},
         language="en",
+        metadata={
+            "teacher_spec": {
+                "ASSESSMENT": "Focus each item on one concept.",
+                "RULES": "Avoid trick wording.",
+                "WORKFLOW": "Progress from basic to applied questions.",
+            }
+        },
     )
     capability = DeepQuestionCapability()
     events = await _collect_events(lambda bus: capability.run(context, bus))
 
     assert captured["topic_call"]["user_topic"] == "linear algebra fundamentals"
+    assert "Teacher Assessment Runtime Policy:" in captured["topic_call"]["preference"]
     assert any(event.type == StreamEventType.PROGRESS and event.stage == "ideation" for event in events)
     result_event = next(event for event in events if event.type == StreamEventType.RESULT)
     assert "Question 1" in result_event.metadata["response"]

--- a/tests/services/runtime_policy/test_compiler.py
+++ b/tests/services/runtime_policy/test_compiler.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from deeptutor.core.context import UnifiedContext
+from deeptutor.services.runtime_policy import SOURCE_PRIORITY, ensure_runtime_policy
+
+
+def test_runtime_policy_compiles_teacher_slices_and_priority() -> None:
+    context = UnifiedContext(
+        metadata={
+            "teacher_spec": {
+                "SOUL": "Be calm and encouraging.",
+                "RULES": "Stay inside algebra scope.",
+                "WORKFLOW": "Explain then practice then check.",
+                "ASSESSMENT": "Ask one concept per question.",
+                "KNOWLEDGE": "Use kb_preferred when possible.",
+            },
+            "curriculum_excerpt": "Linear equations and inequalities.",
+        }
+    )
+
+    policy = ensure_runtime_policy(context, "chat")
+    payload = policy.to_dict()
+
+    assert payload["slices"]["SOUL"] == "Be calm and encouraging."
+    assert payload["slices"]["CURRICULUM"] == "Linear equations and inequalities."
+    assert payload["knowledge_policy"] == "kb_preferred"
+    assert payload["source_priority"] == SOURCE_PRIORITY
+    assert "SOUL" in payload["debug"]["applied_slices"]
+    assert "MARKETPLACE" not in payload["debug"]["applied_slices"]
+
+
+def test_runtime_policy_uses_metadata_fallback_for_rules() -> None:
+    context = UnifiedContext(metadata={"teacher_rules": "Always request justification."})
+
+    policy = ensure_runtime_policy(context, "deep_question")
+    payload = policy.to_dict()
+
+    assert payload["slices"]["RULES"] == "Always request justification."
+    assert payload["sources"]["RULES"] == "metadata.teacher_rules"
+    assert payload["knowledge_policy"] == "kb_preferred"


### PR DESCRIPTION
## Summary\n- add a shared runtime policy assembly service for teacher spec slices\n- attach compiled runtime policy in orchestrator before capability execution\n- apply the same runtime policy contract in both chat and deep_question flows\n- expose runtime debug metadata for assembled slices\n- add focused tests for runtime policy compiler and capability integration\n\n## Architecture note\n- added: docs/superpowers/pr-notes/2026-04-26-lane-2-spec-runtime-assembly.md\n- contains required Mermaid diagram\n\n## Main system map\n- updated ai_first/architecture/MAIN_SYSTEM_MAP.md to include runtime policy assembly boundaries and shared contract edges\n\n## Validation\n- pytest tests/services/runtime_policy/test_compiler.py -q\n- pytest tests/core/test_capabilities_runtime.py::test_chat_capability_streams_content_and_geogebra_context -vv -s\n- pytest tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_user_message_as_topic -q\n- git diff --check\n