### PR TITLE
feat(agent-spec): add markdown spec-pack authoring flow [L1]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,20 +28,17 @@ Rules:
 
 ## Active
 
-- No active AI-owned lane is open right now.
-- Use the six lane packets under `docs/superpowers/tasks/2026-04-26-lane-*.md` before starting any new session.
-
 ### Assignment
 
 - Owner: Codex
 - Machine: `MacBook-Air-cua-Loc.local`
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: `SIX_LANE_SESSION_PACKETS`
+- Task: `L1_AGENT_SPEC_AUTHORING`
 - Status: In progress
-- Branch: `docs/six-lane-session-packets`
-- Task packet: None
-- Owned files: `ai_first/AI_OPERATING_PROMPT.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/tasks/2026-04-26-lane-*.md`, `docs/superpowers/pr-notes/*`
+- Branch: `pod-a/agent-spec-authoring`
+- Task packet: `docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md`
+- Owned files: `web/app/(workspace)/agents/`, `web/components/agents/`, `web/lib/agent-spec-api.ts`, `deeptutor/api/routers/agent_specs.py`, `deeptutor/services/agent_spec/`, `tests/api/test_agent_specs_router.py`, `tests/services/agent_spec/`, `docs/superpowers/pr-notes/*`
 - PR: Not opened
 - Last update: 2026-04-26
-- Next action: Create six session-ready lane packets and refresh the AI-first control plane so workers can route themselves safely.
+- Next action: Finish the teacher-facing Agent Spec Pack authoring slice, validate it, then open a draft PR.
 - Blocker: None

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -34,6 +34,10 @@ flowchart TD
 
   Project --> Product["Contest MVP Product Layer"]
   Product --> TeacherWorkspace["Teacher Workspace"]
+  TeacherWorkspace --> AgentSpecAuthoring["Agent Spec Authoring"]
+  AgentSpecAuthoring --> AgentSpecUI["/agents authoring tab"]
+  AgentSpecAuthoring --> AgentSpecAPI["/api/v1/agent-specs"]
+  AgentSpecAuthoring --> AgentSpecStorage["Versioned Markdown spec packs"]
   Product --> KnowledgePack["Knowledge Pack"]
   KnowledgePack --> KPMetaFlow["Metadata Create/Edit/Update Flow"]
   KnowledgePack --> KPVersions["Versioned teacher-pack metadata: current_version + version_history"]
@@ -123,6 +127,7 @@ flowchart TD
   Data --> Memory["data/memory"]
   Data --> Settings["data/user/settings"]
   Data --> Workspace["data/user/workspace"]
+  Workspace --> AgentSpecWorkspace["agent_specs/<agent_id>/ + versions/"]
 
   Project --> AIFirst["AI-first Operating Layer"]
   AIFirst --> OperatingPrompt["ai_first/AI_OPERATING_PROMPT.md"]

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -31,6 +31,15 @@
 - Blockers: None.
 - Next: Open and merge the docs/workflow PR so all future sessions inherit the same commit standard from `main`.
 
+## Lane 1
+
+- Branch: `pod-a/agent-spec-authoring`
+- Task: `L1_AGENT_SPEC_AUTHORING`
+- Done: Added `AgentSpecService` and `/api/v1/agent-specs` for versioned Markdown spec packs, created a teacher-facing authoring tab on `/agents` with structured editing for `IDENTITY`, `SOUL`, and `RULES`, preserved the remaining files as markdown-first text areas, and added zip export plus focused API/service tests.
+- Tests: `pytest tests/services/agent_spec/test_service.py tests/api/test_agent_specs_router.py -q`; `./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/agents/page.tsx components/agents/SpecPackAuthoringTab.tsx lib/agent-spec-api.ts` from `web/`; `git diff --check`
+- Blockers: None.
+- Next: Run a final smoke pass on the new authoring flow, then open a draft PR for Lane 1.
+
 ## Architecture Map Updates
 
-- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the structured evidence spine and teacher insight panel.
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the structured evidence spine, teacher insight panel, and the new Agent Spec authoring surface/API/storage path.

--- a/deeptutor/api/main.py
+++ b/deeptutor/api/main.py
@@ -253,6 +253,7 @@ app.mount(
 # Some router modules load YAML settings at import time.
 from deeptutor.api.routers import (
     assessment,
+    agent_specs,
     agent_config,
     chat,
     co_writer,
@@ -290,6 +291,7 @@ app.include_router(settings.router, prefix="/api/v1/settings", tags=["settings"]
 app.include_router(system.router, prefix="/api/v1/system", tags=["system"])
 app.include_router(plugins_api.router, prefix="/api/v1/plugins", tags=["plugins"])
 app.include_router(agent_config.router, prefix="/api/v1/agent-config", tags=["agent-config"])
+app.include_router(agent_specs.router, prefix="/api/v1/agent-specs", tags=["agent-specs"])
 app.include_router(vision_solver.router, prefix="/api/v1", tags=["vision-solver"])
 app.include_router(tutorbot.router, prefix="/api/v1/tutorbot", tags=["tutorbot"])
 

--- a/deeptutor/api/routers/agent_specs.py
+++ b/deeptutor/api/routers/agent_specs.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from deeptutor.services.agent_spec import get_agent_spec_service
+
+router = APIRouter()
+
+
+class IdentityPayload(BaseModel):
+    agent_name: str = ""
+    subject: str = ""
+    grade_band: str = ""
+    tone: str = ""
+    primary_language: str = ""
+    persona_summary: str = ""
+
+
+class SoulPayload(BaseModel):
+    teaching_philosophy: str = ""
+    when_student_wrong: str = ""
+    when_student_stuck: str = ""
+    encouragement_style: str = ""
+
+
+class RulesPayload(BaseModel):
+    do_not_solve_directly: str = "yes"
+    max_session_minutes: str = ""
+    hint_policy: str = ""
+    escalation_rule: str = ""
+    guardrails: str = ""
+
+
+class StructuredPayload(BaseModel):
+    identity: IdentityPayload = Field(default_factory=IdentityPayload)
+    soul: SoulPayload = Field(default_factory=SoulPayload)
+    rules: RulesPayload = Field(default_factory=RulesPayload)
+
+
+class AgentSpecUpsertRequest(BaseModel):
+    agent_id: str
+    display_name: str
+    description: str = ""
+    structured: StructuredPayload = Field(default_factory=StructuredPayload)
+    files: dict[str, str] = Field(default_factory=dict)
+
+
+@router.get("")
+async def list_agent_specs():
+    return {"items": get_agent_spec_service().list_packs()}
+
+
+@router.post("")
+async def create_agent_spec(payload: AgentSpecUpsertRequest):
+    service = get_agent_spec_service()
+    try:
+        return service.create_pack(
+            agent_id=payload.agent_id,
+            display_name=payload.display_name,
+            description=payload.description,
+            structured=payload.structured.model_dump(),
+            files=payload.files,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/{agent_id}")
+async def get_agent_spec(agent_id: str):
+    service = get_agent_spec_service()
+    try:
+        return service.get_pack(agent_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Agent spec not found") from exc
+
+
+@router.put("/{agent_id}")
+async def update_agent_spec(agent_id: str, payload: AgentSpecUpsertRequest):
+    service = get_agent_spec_service()
+    try:
+        return service.save_pack(
+            agent_id=agent_id,
+            display_name=payload.display_name,
+            description=payload.description,
+            structured=payload.structured.model_dump(),
+            files=payload.files,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Agent spec not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/{agent_id}/export")
+async def export_agent_spec(agent_id: str):
+    service = get_agent_spec_service()
+    try:
+        content = service.export_pack_archive(agent_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Agent spec not found") from exc
+    return Response(
+        content=content,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{agent_id}-spec-pack.zip"'},
+    )

--- a/deeptutor/services/agent_spec/__init__.py
+++ b/deeptutor/services/agent_spec/__init__.py
@@ -1,0 +1,3 @@
+from .service import AgentSpecService, get_agent_spec_service
+
+__all__ = ["AgentSpecService", "get_agent_spec_service"]

--- a/deeptutor/services/agent_spec/service.py
+++ b/deeptutor/services/agent_spec/service.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import io
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from deeptutor.services.path_service import get_path_service
+
+SPEC_FILES: tuple[str, ...] = (
+    "IDENTITY.md",
+    "SOUL.md",
+    "CURRICULUM.md",
+    "RULES.md",
+    "ASSESSMENT.md",
+    "WORKFLOW.md",
+    "KNOWLEDGE.md",
+    "MARKETPLACE.md",
+)
+
+STRUCTURED_FILES = {"IDENTITY.md", "SOUL.md", "RULES.md"}
+
+
+DEFAULT_RAW_FILES: dict[str, str] = {
+    "CURRICULUM.md": "# Curriculum\n\n## Core Topics\n\n- Add the priority topics for this agent.\n",
+    "ASSESSMENT.md": "# Assessment\n\n## Evidence Signals\n\n- Define what the agent should watch for.\n",
+    "WORKFLOW.md": "# Workflow\n\n## Session Flow\n\n1. Teach\n2. Practice\n3. Check\n4. Remediate\n",
+    "KNOWLEDGE.md": "# Knowledge\n\n## Retrieval Policy\n\n- Prefer teacher-authored materials first.\n",
+    "MARKETPLACE.md": "# Marketplace\n\n## Metadata\n\n- Audience:\n- Difficulty:\n- Share status: private\n",
+}
+
+IDENTITY_FIELDS = (
+    ("agent_name", "Agent Name"),
+    ("subject", "Subject"),
+    ("grade_band", "Grade Band"),
+    ("tone", "Tone"),
+    ("primary_language", "Primary Language"),
+)
+
+RULE_FIELDS = (
+    ("do_not_solve_directly", "Do Not Solve Directly"),
+    ("max_session_minutes", "Max Session Minutes"),
+    ("hint_policy", "Hint Policy"),
+    ("escalation_rule", "Escalation Rule"),
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+    return slug
+
+
+def _parse_bullet_fields(markdown: str, fields: tuple[tuple[str, str], ...]) -> dict[str, str]:
+    result = {key: "" for key, _ in fields}
+    labels = {label: key for key, label in fields}
+    pattern = re.compile(r"^- ([^:]+):\s*(.*)$", re.MULTILINE)
+    for label, value in pattern.findall(markdown):
+        key = labels.get(label.strip())
+        if key:
+            result[key] = value.strip()
+    return result
+
+
+def _extract_section(markdown: str, heading: str) -> str:
+    pattern = re.compile(rf"^## {re.escape(heading)}\n(.*?)(?=^## |\Z)", re.MULTILINE | re.DOTALL)
+    match = pattern.search(markdown)
+    return match.group(1).strip() if match else ""
+
+
+def _normalize_bool_text(value: str | bool) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    lowered = value.strip().lower()
+    if lowered in {"true", "yes", "y", "1"}:
+        return "yes"
+    if lowered in {"false", "no", "n", "0"}:
+        return "no"
+    return value.strip()
+
+
+def render_identity_markdown(data: dict[str, str]) -> str:
+    lines = ["# Identity", ""]
+    for key, label in IDENTITY_FIELDS:
+        lines.append(f"- {label}: {data.get(key, '').strip()}")
+    lines.extend(
+        [
+            "",
+            "## Persona Summary",
+            data.get("persona_summary", "").strip() or "Describe the role, subject focus, and classroom presence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_identity_markdown(markdown: str) -> dict[str, str]:
+    data = _parse_bullet_fields(markdown, IDENTITY_FIELDS)
+    data["persona_summary"] = _extract_section(markdown, "Persona Summary")
+    return data
+
+
+def render_soul_markdown(data: dict[str, str]) -> str:
+    sections = (
+        ("Teaching Philosophy", data.get("teaching_philosophy", "")),
+        ("When The Student Is Wrong", data.get("when_student_wrong", "")),
+        ("When The Student Is Stuck", data.get("when_student_stuck", "")),
+        ("Encouragement Style", data.get("encouragement_style", "")),
+    )
+    lines = ["# Soul", ""]
+    for heading, content in sections:
+        lines.extend(
+            [
+                f"## {heading}",
+                content.strip() or "Fill in this section.",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_soul_markdown(markdown: str) -> dict[str, str]:
+    return {
+        "teaching_philosophy": _extract_section(markdown, "Teaching Philosophy"),
+        "when_student_wrong": _extract_section(markdown, "When The Student Is Wrong"),
+        "when_student_stuck": _extract_section(markdown, "When The Student Is Stuck"),
+        "encouragement_style": _extract_section(markdown, "Encouragement Style"),
+    }
+
+
+def render_rules_markdown(data: dict[str, str | bool]) -> str:
+    lines = ["# Rules", ""]
+    for key, label in RULE_FIELDS:
+        value = data.get(key, "")
+        if key == "do_not_solve_directly":
+            value = _normalize_bool_text(value)
+        lines.append(f"- {label}: {str(value).strip()}")
+    lines.extend(
+        [
+            "",
+            "## Guardrails",
+            str(data.get("guardrails", "")).strip() or "List the operating guardrails for this teaching agent.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_rules_markdown(markdown: str) -> dict[str, str]:
+    data = _parse_bullet_fields(markdown, RULE_FIELDS)
+    data["guardrails"] = _extract_section(markdown, "Guardrails")
+    return data
+
+
+@dataclass
+class AgentSpecPaths:
+    root: Path
+    versions_dir: Path
+    metadata_file: Path
+
+
+class AgentSpecService:
+    def __init__(self, base_dir: Path | None = None) -> None:
+        root = base_dir or (get_path_service().get_workspace_dir() / "agent_specs")
+        self._base_dir = Path(root)
+
+    @property
+    def base_dir(self) -> Path:
+        return self._base_dir
+
+    def list_packs(self) -> list[dict[str, object]]:
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+        packs: list[dict[str, object]] = []
+        for entry in sorted(self._base_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            metadata_path = entry / "metadata.json"
+            if not metadata_path.exists():
+                continue
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            packs.append(self._build_summary(entry.name, metadata))
+        packs.sort(key=lambda item: str(item["updated_at"]), reverse=True)
+        return packs
+
+    def get_pack(self, agent_id: str) -> dict[str, object]:
+        paths = self._get_paths(agent_id)
+        if not paths.root.exists():
+            raise FileNotFoundError(agent_id)
+        metadata = self._read_metadata(paths)
+        files = self._read_current_files(paths.root)
+        return self._build_payload(agent_id, metadata, files)
+
+    def create_pack(
+        self,
+        *,
+        agent_id: str,
+        display_name: str,
+        description: str = "",
+        structured: dict[str, dict[str, str | bool]] | None = None,
+        files: dict[str, str] | None = None,
+    ) -> dict[str, object]:
+        normalized_agent_id = self._validate_agent_id(agent_id)
+        paths = self._get_paths(normalized_agent_id)
+        if paths.root.exists():
+            raise ValueError(f"Agent spec '{normalized_agent_id}' already exists")
+
+        now = _now_iso()
+        metadata = {
+            "agent_id": normalized_agent_id,
+            "display_name": display_name.strip() or normalized_agent_id,
+            "description": description.strip(),
+            "created_at": now,
+            "updated_at": now,
+            "version": 1,
+        }
+        combined_files = self._assemble_files(structured or {}, files or {})
+        self._write_pack(paths, metadata, combined_files)
+        return self._build_payload(normalized_agent_id, metadata, combined_files)
+
+    def save_pack(
+        self,
+        *,
+        agent_id: str,
+        display_name: str,
+        description: str = "",
+        structured: dict[str, dict[str, str | bool]] | None = None,
+        files: dict[str, str] | None = None,
+    ) -> dict[str, object]:
+        normalized_agent_id = self._validate_agent_id(agent_id)
+        paths = self._get_paths(normalized_agent_id)
+        if not paths.root.exists():
+            raise FileNotFoundError(normalized_agent_id)
+
+        metadata = self._read_metadata(paths)
+        metadata["display_name"] = display_name.strip() or normalized_agent_id
+        metadata["description"] = description.strip()
+        metadata["updated_at"] = _now_iso()
+        metadata["version"] = int(metadata.get("version", 0)) + 1
+        current_files = self._read_current_files(paths.root)
+        combined_files = self._assemble_files(structured or {}, files or {}, current_files=current_files)
+        self._write_pack(paths, metadata, combined_files)
+        return self._build_payload(normalized_agent_id, metadata, combined_files)
+
+    def export_pack_archive(self, agent_id: str) -> bytes:
+        payload = self.get_pack(agent_id)
+        files = payload["files"]
+        assert isinstance(files, dict)
+
+        buffer = io.BytesIO()
+        with ZipFile(buffer, "w", ZIP_DEFLATED) as archive:
+            for filename in SPEC_FILES:
+                archive.writestr(f"{agent_id}/{filename}", str(files[filename]))
+        return buffer.getvalue()
+
+    def _validate_agent_id(self, agent_id: str) -> str:
+        normalized = _slugify(agent_id)
+        if not normalized:
+            raise ValueError("Agent ID must contain at least one letter or number")
+        return normalized
+
+    def _get_paths(self, agent_id: str) -> AgentSpecPaths:
+        root = self._base_dir / agent_id
+        return AgentSpecPaths(
+            root=root,
+            versions_dir=root / "versions",
+            metadata_file=root / "metadata.json",
+        )
+
+    def _assemble_files(
+        self,
+        structured: dict[str, dict[str, str | bool]],
+        files: dict[str, str],
+        *,
+        current_files: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        current_files = current_files or {}
+        merged = {name: current_files.get(name, DEFAULT_RAW_FILES.get(name, "")) for name in SPEC_FILES}
+
+        identity = {key: str(value) for key, value in structured.get("identity", {}).items()}
+        soul = {key: str(value) for key, value in structured.get("soul", {}).items()}
+        rules = {
+            key: (_normalize_bool_text(value) if key == "do_not_solve_directly" else str(value))
+            for key, value in structured.get("rules", {}).items()
+        }
+
+        merged["IDENTITY.md"] = render_identity_markdown(identity)
+        merged["SOUL.md"] = render_soul_markdown(soul)
+        merged["RULES.md"] = render_rules_markdown(rules)
+
+        for name in SPEC_FILES:
+            if name in STRUCTURED_FILES:
+                continue
+            if name in files:
+                merged[name] = files[name].strip() + ("\n" if not files[name].endswith("\n") else "")
+
+        for name in SPEC_FILES:
+            if not merged[name].strip():
+                if name in DEFAULT_RAW_FILES:
+                    merged[name] = DEFAULT_RAW_FILES[name]
+                else:
+                    raise ValueError(f"{name} cannot be empty")
+
+        return merged
+
+    def _write_pack(self, paths: AgentSpecPaths, metadata: dict[str, object], files: dict[str, str]) -> None:
+        paths.root.mkdir(parents=True, exist_ok=True)
+        paths.versions_dir.mkdir(parents=True, exist_ok=True)
+        version_dir = paths.versions_dir / f"v{int(metadata['version']):04d}"
+        version_dir.mkdir(parents=True, exist_ok=True)
+
+        for filename, content in files.items():
+            (paths.root / filename).write_text(content, encoding="utf-8")
+            (version_dir / filename).write_text(content, encoding="utf-8")
+
+        paths.metadata_file.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+        (version_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+    def _read_metadata(self, paths: AgentSpecPaths) -> dict[str, object]:
+        return json.loads(paths.metadata_file.read_text(encoding="utf-8"))
+
+    def _read_current_files(self, root: Path) -> dict[str, str]:
+        return {filename: (root / filename).read_text(encoding="utf-8") for filename in SPEC_FILES}
+
+    def _build_summary(self, agent_id: str, metadata: dict[str, object]) -> dict[str, object]:
+        return {
+            "agent_id": agent_id,
+            "display_name": metadata.get("display_name") or agent_id,
+            "description": metadata.get("description") or "",
+            "version": int(metadata.get("version", 1)),
+            "updated_at": metadata.get("updated_at"),
+        }
+
+    def _build_payload(
+        self,
+        agent_id: str,
+        metadata: dict[str, object],
+        files: dict[str, str],
+    ) -> dict[str, object]:
+        return {
+            "agent_id": agent_id,
+            "display_name": metadata.get("display_name") or agent_id,
+            "description": metadata.get("description") or "",
+            "version": int(metadata.get("version", 1)),
+            "created_at": metadata.get("created_at"),
+            "updated_at": metadata.get("updated_at"),
+            "files": files,
+            "structured": {
+                "identity": parse_identity_markdown(files["IDENTITY.md"]),
+                "soul": parse_soul_markdown(files["SOUL.md"]),
+                "rules": parse_rules_markdown(files["RULES.md"]),
+            },
+            "summary": {
+                "subject": parse_identity_markdown(files["IDENTITY.md"]).get("subject", ""),
+                "language": parse_identity_markdown(files["IDENTITY.md"]).get("primary_language", ""),
+                "teaching_philosophy": parse_soul_markdown(files["SOUL.md"]).get("teaching_philosophy", ""),
+                "guardrails": parse_rules_markdown(files["RULES.md"]).get("guardrails", ""),
+            },
+        }
+
+
+_service_instance: AgentSpecService | None = None
+
+
+def get_agent_spec_service() -> AgentSpecService:
+    global _service_instance
+    if _service_instance is None:
+        _service_instance = AgentSpecService()
+    return _service_instance

--- a/docs/superpowers/pr-notes/2026-04-26-lane-1-agent-spec-authoring.md
+++ b/docs/superpowers/pr-notes/2026-04-26-lane-1-agent-spec-authoring.md
@@ -1,0 +1,28 @@
+# PR Note: Lane 1 Agent Spec Authoring
+
+## Summary
+
+- add a new `agent_specs` backend service and API for teacher-defined markdown spec packs
+- add a teacher-facing authoring tab on `/agents` with structured editing for `IDENTITY`, `SOUL`, and `RULES`
+- keep the remaining spec files markdown-first, version them on save, and support zip export
+
+## Architecture
+
+```mermaid
+flowchart LR
+  UI["/agents spec authoring tab"] --> API["/api/v1/agent-specs"]
+  API --> Service["AgentSpecService"]
+  Service --> Current["agent_specs/<agent_id>/*.md"]
+  Service --> Versions["agent_specs/<agent_id>/versions/vNNNN/"]
+  Service --> Export["zip export"]
+```
+
+## Validation
+
+- `pytest tests/services/agent_spec/test_service.py tests/api/test_agent_specs_router.py -q`
+- `./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/agents/page.tsx components/agents/SpecPackAuthoringTab.tsx lib/agent-spec-api.ts`
+- `git diff --check`
+
+## Main System Map
+
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the new authoring surface, API, and storage path.

--- a/docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md
@@ -81,3 +81,5 @@ Create the teacher-facing authoring layer for the Markdown Agent Spec Pack witho
 - This is Session = Lane 1.
 - Read `docs/superpowers/specs/2026-04-26-contest-mvp-hybrid-lanes-design.md` before implementation.
 - Coordinate with Lane 2 only through explicit file/API contracts, not by shared unstated assumptions.
+- Current implementation path: `web/app/(workspace)/agents/page.tsx` now hosts a dedicated spec-pack authoring tab backed by `/api/v1/agent-specs`.
+- Storage contract: save current Markdown files under `data/user/workspace/agent_specs/<agent_id>/` and snapshot each save into `versions/vNNNN/`.

--- a/tests/api/test_agent_specs_router.py
+++ b/tests/api/test_agent_specs_router.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover
+    FastAPI = None
+    TestClient = None
+
+from deeptutor.services.agent_spec.service import AgentSpecService
+
+pytestmark = pytest.mark.skipif(FastAPI is None or TestClient is None, reason="fastapi not installed")
+
+
+def _build_app(service: AgentSpecService, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from deeptutor.api.routers import agent_specs
+
+    app = FastAPI()
+    app.include_router(agent_specs.router, prefix="/api/v1/agent-specs")
+    monkeypatch.setattr(agent_specs, "get_agent_spec_service", lambda: service)
+    return app
+
+
+def _payload(agent_id: str = "fraction-coach") -> dict:
+    return {
+        "agent_id": agent_id,
+        "display_name": "Fraction Coach",
+        "description": "Teacher-authored fraction tutor",
+        "structured": {
+            "identity": {
+                "agent_name": "Fraction Coach",
+                "subject": "Mathematics",
+                "grade_band": "Grade 6",
+                "tone": "Warm and direct",
+                "primary_language": "Vietnamese",
+                "persona_summary": "A tutor for fraction remediation.",
+            },
+            "soul": {
+                "teaching_philosophy": "Use evidence first.",
+                "when_student_wrong": "Diagnose before correcting.",
+                "when_student_stuck": "Use a single scaffold.",
+                "encouragement_style": "Specific and calm.",
+            },
+            "rules": {
+                "do_not_solve_directly": "yes",
+                "max_session_minutes": "25",
+                "hint_policy": "One hint at a time.",
+                "escalation_rule": "Escalate after repeated confusion.",
+                "guardrails": "Never finish the full answer.",
+            },
+        },
+        "files": {
+            "CURRICULUM.md": "# Curriculum\n\n- Fractions first.\n",
+        },
+    }
+
+
+def test_agent_specs_router_supports_create_list_update_and_export(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+
+    with TestClient(_build_app(service, monkeypatch)) as client:
+        created = client.post("/api/v1/agent-specs", json=_payload())
+        assert created.status_code == 200
+        assert created.json()["agent_id"] == "fraction-coach"
+
+        listing = client.get("/api/v1/agent-specs")
+        assert listing.status_code == 200
+        assert listing.json()["items"][0]["agent_id"] == "fraction-coach"
+
+        detail = client.get("/api/v1/agent-specs/fraction-coach")
+        assert detail.status_code == 200
+        assert detail.json()["structured"]["identity"]["subject"] == "Mathematics"
+
+        payload = _payload()
+        payload["display_name"] = "Fraction Coach Revised"
+        payload["files"]["WORKFLOW.md"] = "# Workflow\n\n1. Teach\n2. Practice\n"
+        updated = client.put("/api/v1/agent-specs/fraction-coach", json=payload)
+        assert updated.status_code == 200
+        assert updated.json()["version"] == 2
+
+        exported = client.get("/api/v1/agent-specs/fraction-coach/export")
+        assert exported.status_code == 200
+        assert exported.headers["content-type"] == "application/zip"
+
+
+def test_agent_specs_router_returns_404_for_missing_pack(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+
+    with TestClient(_build_app(service, monkeypatch)) as client:
+        response = client.get("/api/v1/agent-specs/missing-pack")
+
+    assert response.status_code == 404

--- a/tests/services/agent_spec/test_service.py
+++ b/tests/services/agent_spec/test_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from io import BytesIO
+from zipfile import ZipFile
+
+from deeptutor.services.agent_spec.service import AgentSpecService
+
+
+def _sample_structured() -> dict[str, dict[str, str]]:
+    return {
+        "identity": {
+            "agent_name": "Fraction Coach",
+            "subject": "Mathematics",
+            "grade_band": "Grade 6",
+            "tone": "Warm and direct",
+            "primary_language": "Vietnamese",
+            "persona_summary": "A teacher-defined tutor for fraction practice.",
+        },
+        "soul": {
+            "teaching_philosophy": "Use evidence before intervention.",
+            "when_student_wrong": "Acknowledge the attempt, then diagnose the misconception.",
+            "when_student_stuck": "Offer one scaffold at a time.",
+            "encouragement_style": "Calm, specific praise.",
+        },
+        "rules": {
+            "do_not_solve_directly": "yes",
+            "max_session_minutes": "25",
+            "hint_policy": "Give one hint before revealing the next step.",
+            "escalation_rule": "Pause and recommend teacher support after repeated confusion.",
+            "guardrails": "Never complete the full answer for the student.",
+        },
+    }
+
+
+def test_create_pack_writes_markdown_and_versions(tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+
+    payload = service.create_pack(
+        agent_id="Fraction Coach",
+        display_name="Fraction Coach",
+        description="Middle-school fraction remediation",
+        structured=_sample_structured(),
+        files={"CURRICULUM.md": "# Curriculum\n\n- Fractions first.\n"},
+    )
+
+    assert payload["agent_id"] == "fraction-coach"
+    assert payload["version"] == 1
+    assert (tmp_path / "agent_specs" / "fraction-coach" / "IDENTITY.md").exists()
+    assert (tmp_path / "agent_specs" / "fraction-coach" / "versions" / "v0001" / "SOUL.md").exists()
+    assert "Agent Name: Fraction Coach" in payload["files"]["IDENTITY.md"]
+    assert "## Teaching Philosophy" in payload["files"]["SOUL.md"]
+
+
+def test_save_pack_increments_version_and_preserves_raw_files(tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured=_sample_structured(),
+        files={"CURRICULUM.md": "# Curriculum\n\n- Fractions first.\n"},
+    )
+
+    updated = service.save_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach v2",
+        description="Updated authoring pack",
+        structured={
+            **_sample_structured(),
+            "identity": {**_sample_structured()["identity"], "tone": "Socratic and encouraging"},
+        },
+        files={"CURRICULUM.md": "# Curriculum\n\n- Fractions\n- Ratios\n"},
+    )
+
+    assert updated["version"] == 2
+    assert updated["display_name"] == "Fraction Coach v2"
+    assert "Tone: Socratic and encouraging" in updated["files"]["IDENTITY.md"]
+    assert updated["files"]["CURRICULUM.md"].startswith("# Curriculum")
+    assert (tmp_path / "agent_specs" / "fraction-coach" / "versions" / "v0002" / "CURRICULUM.md").exists()
+
+
+def test_export_pack_archive_contains_all_markdown_files(tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured=_sample_structured(),
+    )
+
+    blob = service.export_pack_archive("fraction-coach")
+
+    with ZipFile(BytesIO(blob)) as archive:
+        names = set(archive.namelist())
+
+    assert "fraction-coach/IDENTITY.md" in names
+    assert "fraction-coach/SOUL.md" in names
+    assert "fraction-coach/MARKETPLACE.md" in names

--- a/web/app/(workspace)/agents/page.tsx
+++ b/web/app/(workspace)/agents/page.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import dynamic from "next/dynamic";
 import { apiUrl } from "@/lib/api";
+import SpecPackAuthoringTab from "@/components/agents/SpecPackAuthoringTab";
 
 const MarkdownRenderer = dynamic(() => import("@/components/common/MarkdownRenderer"), {
   ssr: false,
@@ -43,7 +44,7 @@ interface SoulTemplate {
   content: string;
 }
 
-type Tab = "bots" | "profiles" | "souls";
+type Tab = "specs" | "bots" | "profiles" | "souls";
 
 const BOT_FILES = ["SOUL.md", "USER.md", "TOOLS.md", "AGENTS.md", "HEARTBEAT.md"] as const;
 type BotFile = (typeof BOT_FILES)[number];
@@ -56,7 +57,7 @@ export default function AgentsPage() {
   const [bots, setBots] = useState<BotInfo[]>([]);
   const [souls, setSouls] = useState<SoulTemplate[]>([]);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState<Tab>("bots");
+  const [activeTab, setActiveTab] = useState<Tab>("specs");
   const [toast, setToast] = useState("");
 
   useEffect(() => {
@@ -96,7 +97,7 @@ export default function AgentsPage() {
             <p className="mt-1 text-[13px] text-[var(--primary)] animate-fade-in">{toast}</p>
           ) : (
             <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
-              {t("Manage your in-process TutorBot instances")}
+              {t("Author teacher-defined spec packs, then manage in-process TutorBot instances when needed")}
             </p>
           )}
         </div>
@@ -104,6 +105,7 @@ export default function AgentsPage() {
         {/* Tabs */}
         <div className="mb-6 flex items-center gap-1 border-b border-[var(--border)]/50 pb-3">
           {([
+            { key: "specs" as Tab, label: t("Spec Packs"), icon: FileText },
             { key: "bots" as Tab, label: t("Bots"), icon: Bot },
             { key: "profiles" as Tab, label: t("Profiles"), icon: FileText },
             { key: "souls" as Tab, label: t("Souls"), icon: Heart },
@@ -127,7 +129,9 @@ export default function AgentsPage() {
           })}
         </div>
 
-        {activeTab === "bots" ? (
+        {activeTab === "specs" ? (
+          <SpecPackAuthoringTab onToast={setToast} />
+        ) : activeTab === "bots" ? (
           <BotsTab
             bots={bots}
             souls={souls}
@@ -269,7 +273,9 @@ function BotsTab({
                 className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-[13px] text-[var(--foreground)] outline-none focus:border-[var(--ring)] placeholder:text-[var(--muted-foreground)]/40"
               />
               {botId && (
-                <p className="mt-1 text-[11px] text-[var(--muted-foreground)]">ID: {botId}</p>
+                <p className="mt-1 text-[11px] text-[var(--muted-foreground)]">
+                  {t("ID")}: {botId}
+                </p>
               )}
             </div>
             <div>
@@ -763,7 +769,7 @@ function SoulsTab({
               />
               {newName.trim() && (
                 <p className="mt-1 text-[11px] text-[var(--muted-foreground)]">
-                  ID: {newName.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}
+                  {t("ID")}: {newName.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}
                 </p>
               )}
             </div>

--- a/web/components/agents/SpecPackAuthoringTab.tsx
+++ b/web/components/agents/SpecPackAuthoringTab.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { Download, Loader2, Plus, Save } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import MarkdownRenderer from "@/components/common/MarkdownRenderer";
+import {
+  createAgentSpec,
+  exportAgentSpec,
+  getAgentSpec,
+  listAgentSpecs,
+  type AgentSpecDetail,
+  type AgentSpecUpsertPayload,
+  updateAgentSpec,
+} from "@/lib/agent-spec-api";
+
+const MANUAL_FILES = ["CURRICULUM.md", "ASSESSMENT.md", "WORKFLOW.md", "KNOWLEDGE.md", "MARKETPLACE.md"] as const;
+type ManualFile = (typeof MANUAL_FILES)[number];
+
+function emptyDraft(): AgentSpecDetail {
+  return {
+    agent_id: "",
+    display_name: "",
+    description: "",
+    version: 0,
+    files: {
+      "IDENTITY.md": "# Identity\n",
+      "SOUL.md": "# Soul\n",
+      "CURRICULUM.md": "# Curriculum\n\n## Core Topics\n\n- Add the priority topics for this agent.\n",
+      "RULES.md": "# Rules\n",
+      "ASSESSMENT.md": "# Assessment\n\n## Evidence Signals\n\n- Define what the agent should watch for.\n",
+      "WORKFLOW.md": "# Workflow\n\n## Session Flow\n\n1. Teach\n2. Practice\n3. Check\n4. Remediate\n",
+      "KNOWLEDGE.md": "# Knowledge\n\n## Retrieval Policy\n\n- Prefer teacher-authored materials first.\n",
+      "MARKETPLACE.md": "# Marketplace\n\n## Metadata\n\n- Audience:\n- Difficulty:\n- Share status: private\n",
+    },
+    structured: {
+      identity: {
+        agent_name: "",
+        subject: "",
+        grade_band: "",
+        tone: "",
+        primary_language: "",
+        persona_summary: "",
+      },
+      soul: {
+        teaching_philosophy: "",
+        when_student_wrong: "",
+        when_student_stuck: "",
+        encouragement_style: "",
+      },
+      rules: {
+        do_not_solve_directly: "yes",
+        max_session_minutes: "",
+        hint_policy: "",
+        escalation_rule: "",
+        guardrails: "",
+      },
+    },
+    summary: {
+      subject: "",
+      language: "",
+      teaching_philosophy: "",
+      guardrails: "",
+    },
+  };
+}
+
+function slugify(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: string) => void }) {
+  const { t } = useTranslation();
+  const [packs, setPacks] = useState<AgentSpecDetail[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [draft, setDraft] = useState<AgentSpecDetail>(emptyDraft());
+  const [activeManualFile, setActiveManualFile] = useState<ManualFile>("CURRICULUM.md");
+  const [saving, setSaving] = useState(false);
+  const [exporting, setExporting] = useState(false);
+
+  async function reloadList(preferredId?: string) {
+    const items = await listAgentSpecs();
+    const details = await Promise.all(items.map((item) => getAgentSpec(item.agent_id)));
+    setPacks(details);
+    if (!details.length) {
+      setSelectedId("");
+      setDraft(emptyDraft());
+      return;
+    }
+    const nextId = preferredId && details.some((item) => item.agent_id === preferredId)
+      ? preferredId
+      : details[0].agent_id;
+    setSelectedId(nextId);
+    const selected = details.find((item) => item.agent_id === nextId);
+    if (selected) {
+      setDraft(selected);
+    }
+  }
+
+  useEffect(() => {
+    void (async () => {
+      setLoading(true);
+      try {
+        await reloadList();
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const runtimeSummary = useMemo(
+    () => [
+      draft.structured.identity.subject || t("No subject yet"),
+      draft.structured.identity.primary_language || t("No language yet"),
+      draft.structured.rules.do_not_solve_directly || t("No direct-answer rule yet"),
+    ],
+    [draft, t],
+  );
+
+  const currentPreview = draft.files[activeManualFile] || "";
+
+  function beginNewPack() {
+    setSelectedId("");
+    setDraft(emptyDraft());
+    setActiveManualFile("CURRICULUM.md");
+  }
+
+  async function selectPack(agentId: string) {
+    setSelectedId(agentId);
+    const detail = await getAgentSpec(agentId);
+    setDraft(detail);
+  }
+
+  async function saveDraft() {
+    const resolvedAgentId = draft.version > 0 ? draft.agent_id : slugify(draft.agent_id || draft.display_name);
+    if (!resolvedAgentId) {
+      onToast(t("Enter a name or agent ID before saving."));
+      return;
+    }
+    const payload: AgentSpecUpsertPayload = {
+      agent_id: resolvedAgentId,
+      display_name: draft.display_name.trim() || resolvedAgentId,
+      description: draft.description,
+      structured: draft.structured,
+      files: Object.fromEntries(MANUAL_FILES.map((filename) => [filename, draft.files[filename] ?? ""])),
+    };
+
+    setSaving(true);
+    try {
+      const saved = draft.version > 0
+        ? await updateAgentSpec(resolvedAgentId, payload)
+        : await createAgentSpec(payload);
+      setDraft(saved);
+      setSelectedId(saved.agent_id);
+      await reloadList(saved.agent_id);
+      onToast(
+        draft.version > 0
+          ? t("Spec pack saved.")
+          : t("Spec pack created."),
+      );
+    } catch (error) {
+      onToast(error instanceof Error ? error.message : t("Failed to save spec pack."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function exportDraft() {
+    if (!draft.agent_id) {
+      onToast(t("Save the pack before exporting."));
+      return;
+    }
+    setExporting(true);
+    try {
+      const blob = await exportAgentSpec(draft.agent_id);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `${draft.agent_id}-spec-pack.zip`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      onToast(t("Spec pack exported."));
+    } catch (error) {
+      onToast(error instanceof Error ? error.message : t("Failed to export spec pack."));
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
+      <aside className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+              {t("Spec Packs")}
+            </p>
+            <h2 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
+              {t("Teacher-defined agents")}
+            </h2>
+          </div>
+          <button
+            onClick={beginNewPack}
+            className="inline-flex items-center gap-1 rounded-lg border border-[var(--border)] px-2.5 py-1.5 text-[12px] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("New")}
+          </button>
+        </div>
+        {loading ? (
+          <div className="flex min-h-[120px] items-center justify-center">
+            <Loader2 className="h-4 w-4 animate-spin text-[var(--muted-foreground)]" />
+          </div>
+        ) : packs.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-[var(--border)] p-4 text-[13px] text-[var(--muted-foreground)]">
+            {t("No spec packs yet. Start with a new teacher-defined agent.")}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {packs.map((pack) => {
+              const isActive = selectedId === pack.agent_id;
+              return (
+                <button
+                  key={pack.agent_id}
+                  onClick={() => void selectPack(pack.agent_id)}
+                  className={`w-full rounded-xl border px-3 py-3 text-left transition-colors ${
+                    isActive
+                      ? "border-[var(--primary)] bg-[var(--primary)]/6"
+                      : "border-[var(--border)] hover:border-[var(--foreground)]/20"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-[13px] font-medium text-[var(--foreground)]">{pack.display_name}</p>
+                    <span className="rounded-full bg-[var(--muted)] px-2 py-0.5 text-[10px] text-[var(--muted-foreground)]">
+                      v{pack.version}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-[11px] text-[var(--muted-foreground)]">{pack.agent_id}</p>
+                  <p className="mt-2 line-clamp-2 text-[12px] text-[var(--muted-foreground)]">
+                    {pack.description || t("No description yet.")}
+                  </p>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </aside>
+
+      <section className="space-y-5">
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-5">
+          <div className="mb-4 flex items-center justify-between gap-4">
+            <div>
+              <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                {t("Hybrid narrow")}
+              </p>
+              <h2 className="mt-1 text-[18px] font-semibold text-[var(--foreground)]">
+                {t("Structured authoring for IDENTITY, SOUL, and RULES")}
+              </h2>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => void exportDraft()}
+                disabled={exporting || !draft.agent_id}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-2 text-[12px] text-[var(--muted-foreground)] disabled:opacity-40"
+              >
+                {exporting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+                {t("Export")}
+              </button>
+              <button
+                onClick={() => void saveDraft()}
+                disabled={saving}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-[12px] font-medium text-[var(--primary-foreground)] disabled:opacity-40"
+              >
+                {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                {draft.version > 0 ? t("Save") : t("Create")}
+              </button>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <LabeledInput label={t("Display name")} value={draft.display_name} onChange={(value) => setDraft((current) => ({ ...current, display_name: value }))} />
+            <LabeledInput
+              label={t("Agent ID")}
+              value={draft.version > 0 ? draft.agent_id : draft.agent_id}
+              disabled={draft.version > 0}
+              onChange={(value) => setDraft((current) => ({ ...current, agent_id: slugify(value) }))}
+            />
+          </div>
+          <LabeledTextarea
+            label={t("Description")}
+            rows={3}
+            value={draft.description}
+            onChange={(value) => setDraft((current) => ({ ...current, description: value }))}
+          />
+        </div>
+
+        <StructuredSection
+          title={t("IDENTITY.md")}
+          description={t("Define the role, subject, and language of the teaching agent.")}
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <LabeledInput label={t("Agent name")} value={draft.structured.identity.agent_name} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, identity: { ...current.structured.identity, agent_name: value } } }))} />
+            <LabeledInput label={t("Subject")} value={draft.structured.identity.subject} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, identity: { ...current.structured.identity, subject: value } } }))} />
+            <LabeledInput label={t("Grade band")} value={draft.structured.identity.grade_band} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, identity: { ...current.structured.identity, grade_band: value } } }))} />
+            <LabeledInput label={t("Primary language")} value={draft.structured.identity.primary_language} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, identity: { ...current.structured.identity, primary_language: value } } }))} />
+          </div>
+          <LabeledInput label={t("Tone")} value={draft.structured.identity.tone} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, identity: { ...current.structured.identity, tone: value } } }))} />
+          <LabeledTextarea label={t("Persona summary")} rows={3} value={draft.structured.identity.persona_summary} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, identity: { ...current.structured.identity, persona_summary: value } } }))} />
+        </StructuredSection>
+
+        <StructuredSection
+          title={t("SOUL.md")}
+          description={t("Capture the teaching philosophy and failure-response style.")}
+        >
+          <LabeledTextarea label={t("Teaching philosophy")} rows={4} value={draft.structured.soul.teaching_philosophy} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, soul: { ...current.structured.soul, teaching_philosophy: value } } }))} />
+          <LabeledTextarea label={t("When the student is wrong")} rows={4} value={draft.structured.soul.when_student_wrong} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, soul: { ...current.structured.soul, when_student_wrong: value } } }))} />
+          <LabeledTextarea label={t("When the student is stuck")} rows={4} value={draft.structured.soul.when_student_stuck} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, soul: { ...current.structured.soul, when_student_stuck: value } } }))} />
+          <LabeledTextarea label={t("Encouragement style")} rows={3} value={draft.structured.soul.encouragement_style} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, soul: { ...current.structured.soul, encouragement_style: value } } }))} />
+        </StructuredSection>
+
+        <StructuredSection
+          title={t("RULES.md")}
+          description={t("Add operating guardrails without baking runtime logic into the UI.")}
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <LabeledInput label={t("Do not solve directly")} value={draft.structured.rules.do_not_solve_directly} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, rules: { ...current.structured.rules, do_not_solve_directly: value } } }))} />
+            <LabeledInput label={t("Max session minutes")} value={draft.structured.rules.max_session_minutes} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, rules: { ...current.structured.rules, max_session_minutes: value } } }))} />
+            <LabeledInput label={t("Hint policy")} value={draft.structured.rules.hint_policy} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, rules: { ...current.structured.rules, hint_policy: value } } }))} />
+            <LabeledInput label={t("Escalation rule")} value={draft.structured.rules.escalation_rule} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, rules: { ...current.structured.rules, escalation_rule: value } } }))} />
+          </div>
+          <LabeledTextarea label={t("Guardrails")} rows={4} value={draft.structured.rules.guardrails} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, rules: { ...current.structured.rules, guardrails: value } } }))} />
+        </StructuredSection>
+
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-5">
+          <div className="mb-4">
+            <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+              {t("Markdown source of truth")}
+            </p>
+            <h3 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
+              {t("Manual editing for the remaining files")}
+            </h3>
+          </div>
+          <div className="mb-3 flex flex-wrap gap-2">
+            {MANUAL_FILES.map((filename) => (
+              <button
+                key={filename}
+                onClick={() => setActiveManualFile(filename)}
+                className={`rounded-lg px-3 py-1.5 text-[12px] transition-colors ${
+                  activeManualFile === filename
+                    ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                    : "bg-[var(--muted)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                }`}
+              >
+                {filename}
+              </button>
+            ))}
+          </div>
+          <textarea
+            value={draft.files[activeManualFile] ?? ""}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                files: {
+                  ...current.files,
+                  [activeManualFile]: event.target.value,
+                },
+              }))
+            }
+            rows={18}
+            className="w-full rounded-xl border border-[var(--border)] bg-transparent px-3 py-3 font-mono text-[13px] text-[var(--foreground)] outline-none focus:border-[var(--ring)]"
+          />
+        </div>
+      </section>
+
+      <aside className="space-y-4">
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
+          <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+            {t("Runtime summary")}
+          </p>
+          <h3 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
+            {draft.display_name || t("Unsaved spec pack")}
+          </h3>
+          <div className="mt-4 space-y-3 text-[13px]">
+            <SummaryRow label={t("Subject")} value={draft.structured.identity.subject} />
+            <SummaryRow label={t("Language")} value={draft.structured.identity.primary_language} />
+            <SummaryRow label={t("Tone")} value={draft.structured.identity.tone} />
+            <SummaryRow label={t("Session rule")} value={runtimeSummary.join(" • ")} />
+            <SummaryRow label={t("Version")} value={draft.version > 0 ? `v${draft.version}` : t("New")} />
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
+          <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+            {t("Markdown preview")}
+          </p>
+          <h3 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">{activeManualFile}</h3>
+          <div className="mt-4 max-h-[520px] overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--background)]/60 p-3">
+            <MarkdownRenderer content={currentPreview || "_No content yet._"} variant="prose" />
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function StructuredSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-5">
+      <div className="mb-4">
+        <h3 className="text-[16px] font-semibold text-[var(--foreground)]">{title}</h3>
+        <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">{description}</p>
+      </div>
+      <div className="space-y-4">{children}</div>
+    </div>
+  );
+}
+
+function LabeledInput({
+  label,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-[12px] font-medium text-[var(--muted-foreground)]">{label}</span>
+      <input
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-xl border border-[var(--border)] bg-transparent px-3 py-2 text-[13px] text-[var(--foreground)] outline-none focus:border-[var(--ring)] disabled:opacity-60"
+      />
+    </label>
+  );
+}
+
+function LabeledTextarea({
+  label,
+  value,
+  onChange,
+  rows,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  rows: number;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-[12px] font-medium text-[var(--muted-foreground)]">{label}</span>
+      <textarea
+        value={value}
+        rows={rows}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-xl border border-[var(--border)] bg-transparent px-3 py-2 text-[13px] leading-6 text-[var(--foreground)] outline-none focus:border-[var(--ring)]"
+      />
+    </label>
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.16em] text-[var(--muted-foreground)]">{label}</p>
+      <p className="mt-1 text-[13px] text-[var(--foreground)]">{value || "—"}</p>
+    </div>
+  );
+}

--- a/web/lib/agent-spec-api.ts
+++ b/web/lib/agent-spec-api.ts
@@ -1,0 +1,107 @@
+import { apiUrl } from "@/lib/api";
+
+export interface AgentSpecSummary {
+  agent_id: string;
+  display_name: string;
+  description: string;
+  version: number;
+  updated_at: string;
+}
+
+export interface AgentSpecStructuredIdentity {
+  agent_name: string;
+  subject: string;
+  grade_band: string;
+  tone: string;
+  primary_language: string;
+  persona_summary: string;
+}
+
+export interface AgentSpecStructuredSoul {
+  teaching_philosophy: string;
+  when_student_wrong: string;
+  when_student_stuck: string;
+  encouragement_style: string;
+}
+
+export interface AgentSpecStructuredRules {
+  do_not_solve_directly: string;
+  max_session_minutes: string;
+  hint_policy: string;
+  escalation_rule: string;
+  guardrails: string;
+}
+
+export interface AgentSpecDetail {
+  agent_id: string;
+  display_name: string;
+  description: string;
+  version: number;
+  created_at?: string;
+  updated_at?: string;
+  files: Record<string, string>;
+  structured: {
+    identity: AgentSpecStructuredIdentity;
+    soul: AgentSpecStructuredSoul;
+    rules: AgentSpecStructuredRules;
+  };
+  summary: {
+    subject: string;
+    language: string;
+    teaching_philosophy: string;
+    guardrails: string;
+  };
+}
+
+export interface AgentSpecUpsertPayload {
+  agent_id: string;
+  display_name: string;
+  description: string;
+  structured: AgentSpecDetail["structured"];
+  files: Record<string, string>;
+}
+
+async function expectJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function listAgentSpecs(): Promise<AgentSpecSummary[]> {
+  const response = await fetch(apiUrl("/api/v1/agent-specs"), { cache: "no-store" });
+  const payload = await expectJson<{ items: AgentSpecSummary[] }>(response);
+  return payload.items;
+}
+
+export async function getAgentSpec(agentId: string): Promise<AgentSpecDetail> {
+  const response = await fetch(apiUrl(`/api/v1/agent-specs/${agentId}`), { cache: "no-store" });
+  return expectJson<AgentSpecDetail>(response);
+}
+
+export async function createAgentSpec(payload: AgentSpecUpsertPayload): Promise<AgentSpecDetail> {
+  const response = await fetch(apiUrl("/api/v1/agent-specs"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return expectJson<AgentSpecDetail>(response);
+}
+
+export async function updateAgentSpec(agentId: string, payload: AgentSpecUpsertPayload): Promise<AgentSpecDetail> {
+  const response = await fetch(apiUrl(`/api/v1/agent-specs/${agentId}`), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return expectJson<AgentSpecDetail>(response);
+}
+
+export async function exportAgentSpec(agentId: string): Promise<Blob> {
+  const response = await fetch(apiUrl(`/api/v1/agent-specs/${agentId}/export`), { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Export failed: ${response.status}`);
+  }
+  return response.blob();
+}


### PR DESCRIPTION
## Summary
- add a new `agent_specs` backend service and API for teacher-defined markdown spec packs
- add a teacher-facing authoring tab on `/agents` with structured editing for `IDENTITY`, `SOUL`, and `RULES`
- keep the remaining spec files markdown-first, version them on save, and support zip export

## Validation
- `pytest tests/services/agent_spec/test_service.py tests/api/test_agent_specs_router.py -q`
- `./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/agents/page.tsx components/agents/SpecPackAuthoringTab.tsx lib/agent-spec-api.ts` (run from `web/`)
- `git diff --check`

## Main System Map
- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the new authoring surface, API, and storage path.
