### PR TITLE
docs(ai-first): sync assignments and queue after lane1 merge [OPS-COMMIT]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,7 @@ Rules:
 
 ## Active
 
-### Assignment
-
-- Owner: Codex
-- Machine: `MacBook-Air-cua-Loc.local`
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: `L1_AGENT_SPEC_AUTHORING`
-- Status: In progress
-- Branch: `pod-a/agent-spec-authoring`
-- Task packet: `docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md`
-- Owned files: `web/app/(workspace)/agents/`, `web/components/agents/`, `web/lib/agent-spec-api.ts`, `deeptutor/api/routers/agent_specs.py`, `deeptutor/services/agent_spec/`, `tests/api/test_agent_specs_router.py`, `tests/services/agent_spec/`, `docs/superpowers/pr-notes/*`
-- PR: Not opened
-- Last update: 2026-04-26
-- Next action: Finish the teacher-facing Agent Spec Pack authoring slice, validate it, then open a draft PR.
-- Blocker: None
+- No active AI-owned lane is open right now.
+- Lane 1 (`L1_AGENT_SPEC_AUTHORING`) merged through PR `#136`.
+- Lane 2 (`L2_SPEC_RUNTIME_ASSEMBLY`) merged through PR `#135`.
+- Use the remaining lane packets (`lane-3` to `lane-6`) before starting new implementation sessions.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,8 +7,9 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#135 feat(runtime): assemble teacher spec runtime policy contract [L2]`
-- Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) is now merged to `main`.
+- Latest merged PR: `#137 docs(ai-first): sync control-plane state after lane2 merge [OPS-COMMIT]`
+- Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
+- Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Latest smoke result: the 2026-04-25 scripted-reset smoke pass succeeded against current `main`.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -23,11 +24,10 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 Create or use one session per lane from `main` with these packets:
 
-1. `docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md`
-2. `docs/superpowers/tasks/2026-04-26-lane-3-observation-student-state.md`
-3. `docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md`
-4. `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md`
-5. `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
+1. `docs/superpowers/tasks/2026-04-26-lane-3-observation-student-state.md`
+2. `docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md`
+3. `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md`
+4. `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
 
 If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
 

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -44,10 +44,10 @@
 
 - Branch: `pod-a/agent-spec-authoring`
 - Task: `L1_AGENT_SPEC_AUTHORING`
-- Done: Added `AgentSpecService` and `/api/v1/agent-specs` for versioned Markdown spec packs, created a teacher-facing authoring tab on `/agents` with structured editing for `IDENTITY`, `SOUL`, and `RULES`, preserved the remaining files as markdown-first text areas, and added zip export plus focused API/service tests.
+- Done: Added `AgentSpecService` and `/api/v1/agent-specs` for versioned Markdown spec packs, created a teacher-facing authoring tab on `/agents` with structured editing for `IDENTITY`, `SOUL`, and `RULES`, preserved the remaining files as markdown-first text areas, added zip export plus focused API/service tests, and merged via PR `#136`.
 - Tests: `pytest tests/services/agent_spec/test_service.py tests/api/test_agent_specs_router.py -q`; `./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/agents/page.tsx components/agents/SpecPackAuthoringTab.tsx lib/agent-spec-api.ts` from `web/`; `git diff --check`
 - Blockers: None.
-- Next: Run a final smoke pass on the new authoring flow, then open a draft PR for Lane 1.
+- Next: Continue with the remaining session lanes (`lane-3` to `lane-6`) from `main`.
 
 ## Architecture Map Updates
 


### PR DESCRIPTION
## Summary
- update ACTIVE_ASSIGNMENTS to mark no active AI-owned lane and record lane1/lane2 as merged
- refresh EXECUTION_QUEUE latest merged section and remaining lane order (lane-3..lane-6)
- update 2026-04-26 daily log lane1 section to reflect merged PR #136

## Scope notes
- intentionally leaves existing out-of-scope local edit in ai_first/daily/2026-04-25.md untouched

## Validation
- git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/EXECUTION_QUEUE.md ai_first/daily/2026-04-26.md
