### PR TITLE
feat(runtime-policy): compile shared teacher policy contract [L2]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -33,12 +33,12 @@ Rules:
 - Owner: Codex
 - Machine: `MacBook-Air-cua-Loc.local`
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: `L1_AGENT_SPEC_AUTHORING`
+- Task: `L2_SPEC_RUNTIME_ASSEMBLY`
 - Status: In progress
-- Branch: `pod-a/agent-spec-authoring`
-- Task packet: `docs/superpowers/tasks/2026-04-26-lane-1-agent-spec-authoring.md`
-- Owned files: `web/app/(workspace)/agents/`, `web/components/agents/`, `web/lib/agent-spec-api.ts`, `deeptutor/api/routers/agent_specs.py`, `deeptutor/services/agent_spec/`, `tests/api/test_agent_specs_router.py`, `tests/services/agent_spec/`, `docs/superpowers/pr-notes/*`
+- Branch: `pod-a/spec-runtime-assembly`
+- Task packet: `docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md`
+- Owned files: `deeptutor/services/runtime_policy/`, `deeptutor/services/prompt/`, `deeptutor/runtime/orchestrator.py`, `deeptutor/capabilities/chat.py`, `deeptutor/capabilities/deep_question.py`, `tests/services/runtime_policy/`, `tests/core/test_capabilities_runtime.py`, `tests/services/test_prompt_manager.py`, `docs/superpowers/pr-notes/*`
 - PR: Not opened
 - Last update: 2026-04-26
-- Next action: Finish the teacher-facing Agent Spec Pack authoring slice, validate it, then open a draft PR.
+- Next action: Compile teacher-defined spec packs into a shared runtime policy contract for tutoring and assessment flows.
 - Blocker: None

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -19,6 +19,7 @@ flowchart TD
   Runtime --> ToolRegistry["ToolRegistry"]
   Runtime --> CapabilityRegistry["CapabilityRegistry"]
   Runtime --> StreamBus["StreamBus"]
+  Runtime --> RuntimePolicy["Runtime Policy Compiler"]
   Runtime --> RuntimePolicy["Runtime Policy Assembly"]
   RuntimePolicy --> PolicyCompiler["services/runtime_policy/compiler.py"]
   RuntimePolicy --> PolicySlices["SOUL/RULES/WORKFLOW/ASSESSMENT/KNOWLEDGE"]
@@ -37,6 +38,9 @@ flowchart TD
   Capabilities --> DeepQuestion["deep_question"]
   RuntimePolicy --> Chat
   RuntimePolicy --> DeepQuestion
+  RuntimePolicy --> PolicyBoundary["Teacher Spec / Student State / Session State"]
+  RuntimePolicy --> Chat
+  RuntimePolicy --> DeepQuestion
 
   Project --> Product["Contest MVP Product Layer"]
   Product --> TeacherWorkspace["Teacher Workspace"]
@@ -44,6 +48,7 @@ flowchart TD
   AgentSpecAuthoring --> AgentSpecUI["/agents authoring tab"]
   AgentSpecAuthoring --> AgentSpecAPI["/api/v1/agent-specs"]
   AgentSpecAuthoring --> AgentSpecStorage["Versioned Markdown spec packs"]
+  AgentSpecStorage --> RuntimePolicy
   Product --> KnowledgePack["Knowledge Pack"]
   KnowledgePack --> KPMetaFlow["Metadata Create/Edit/Update Flow"]
   KnowledgePack --> KPVersions["Versioned teacher-pack metadata: current_version + version_history"]

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -40,6 +40,15 @@
 - Blockers: None.
 - Next: Run a final smoke pass on the new authoring flow, then open a draft PR for Lane 1.
 
+## Lane 2
+
+- Branch: `pod-a/spec-runtime-assembly`
+- Task: `L2_SPEC_RUNTIME_ASSEMBLY`
+- Done: Extended the shared runtime-policy compiler so chat and deep-question can resolve a teacher-defined spec pack by `agent_spec_id`, normalize explicit slices from compiled teacher policy, include knowledge-pack metadata context, and format deterministic policy blocks through `PromptManager` while preserving old behavior when no policy is present.
+- Tests: `pytest tests/services/runtime_policy/test_compiler.py tests/services/test_prompt_manager.py tests/core/test_capabilities_runtime.py::test_chat_capability_streams_content_and_geogebra_context tests/core/test_capabilities_runtime.py::test_chat_capability_resolves_runtime_policy_from_agent_spec_pack tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_user_message_as_topic tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_single_call_followup_agent -q`; `git diff --check`
+- Blockers: Passing `agent_spec_id` through the session-turn request path is still not wired in this lane because `turn_runtime` is outside the owned-file contract.
+- Next: Open a draft PR for Lane 2, then decide whether that request-path wiring belongs in a follow-up packet or a scope-approved extension.
+
 ## Architecture Map Updates
 
 - Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the structured evidence spine, teacher insight panel, and the new Agent Spec authoring surface/API/storage path.

--- a/deeptutor/services/prompt/manager.py
+++ b/deeptutor/services/prompt/manager.py
@@ -176,6 +176,34 @@ class PromptManager:
 
         return fallback
 
+    def build_runtime_policy_prompt(
+        self,
+        *,
+        title: str,
+        sections: list[tuple[str, str]],
+        source_priority: list[str] | None = None,
+        guardrail: str = "",
+        extra_blocks: list[str] | None = None,
+    ) -> str:
+        """Render explicit runtime policy sections into a predictable prompt block."""
+        blocks: list[str] = [title.strip()]
+        for label, content in sections:
+            cleaned = content.strip()
+            if not cleaned:
+                continue
+            blocks.append(f"[{label}]\n{cleaned}")
+
+        if source_priority:
+            blocks.append("Knowledge source priority:\n" + " > ".join(source_priority))
+
+        if extra_blocks:
+            blocks.extend(block.strip() for block in extra_blocks if block.strip())
+
+        if guardrail.strip():
+            blocks.append(f"Scope guardrail: {guardrail.strip()}")
+
+        return "\n\n".join(block for block in blocks if block.strip())
+
     def clear_cache(self, module_name: str | None = None) -> None:
         """
         Clear cached prompts.

--- a/deeptutor/services/runtime_policy/compiler.py
+++ b/deeptutor/services/runtime_policy/compiler.py
@@ -6,8 +6,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from deeptutor.core.context import UnifiedContext
+from deeptutor.knowledge.manager import KnowledgeBaseManager
+from deeptutor.services.agent_spec import get_agent_spec_service
+from deeptutor.services.path_service import get_path_service
+from deeptutor.services.prompt import get_prompt_manager
 
-SLICE_NAMES = ["SOUL", "RULES", "WORKFLOW", "ASSESSMENT", "KNOWLEDGE", "CURRICULUM"]
+SLICE_NAMES = ["IDENTITY", "SOUL", "RULES", "WORKFLOW", "ASSESSMENT", "KNOWLEDGE", "CURRICULUM"]
 SOURCE_PRIORITY = [
     "teacher_kb",
     "curriculum_excerpt",
@@ -15,6 +19,15 @@ SOURCE_PRIORITY = [
     "llm_prior_knowledge",
 ]
 DEFAULT_KNOWLEDGE_POLICY = "kb_preferred"
+SPEC_FILE_TO_SLICE = {
+    "IDENTITY.md": "IDENTITY",
+    "SOUL.md": "SOUL",
+    "CURRICULUM.md": "CURRICULUM",
+    "RULES.md": "RULES",
+    "ASSESSMENT.md": "ASSESSMENT",
+    "WORKFLOW.md": "WORKFLOW",
+    "KNOWLEDGE.md": "KNOWLEDGE",
+}
 
 
 @dataclass
@@ -22,23 +35,34 @@ class RuntimePolicy:
     """Serializable policy object injected into runtime context."""
 
     capability: str
+    agent_spec_id: str
     slices: dict[str, str]
     sources: dict[str, str]
     knowledge_policy: str
     source_priority: list[str]
+    teacher_kb_context: str = ""
+    student_state: dict[str, Any] | None = None
+    session_state: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         applied = [name for name, value in self.slices.items() if value.strip()]
         missing = [name for name in SLICE_NAMES if name not in applied]
         return {
             "capability": self.capability,
+            "agent_spec_id": self.agent_spec_id,
             "slices": dict(self.slices),
             "sources": dict(self.sources),
             "knowledge_policy": self.knowledge_policy,
             "source_priority": list(self.source_priority),
+            "teacher_kb_context": self.teacher_kb_context,
+            "student_state": dict(self.student_state or {}),
+            "session_state": dict(self.session_state or {}),
             "debug": {
                 "applied_slices": applied,
                 "missing_slices": missing,
+                "slice_sources": dict(self.sources),
+                "agent_spec_id": self.agent_spec_id,
+                "has_teacher_kb_context": bool(self.teacher_kb_context.strip()),
             },
         }
 
@@ -49,45 +73,66 @@ def ensure_runtime_policy(context: UnifiedContext, capability: str) -> RuntimePo
     if isinstance(existing, dict):
         return RuntimePolicy(
             capability=str(existing.get("capability") or capability),
+            agent_spec_id=str(existing.get("agent_spec_id") or ""),
             slices={k: str(v or "") for k, v in dict(existing.get("slices") or {}).items()},
             sources={k: str(v or "") for k, v in dict(existing.get("sources") or {}).items()},
             knowledge_policy=str(existing.get("knowledge_policy") or DEFAULT_KNOWLEDGE_POLICY),
             source_priority=list(existing.get("source_priority") or SOURCE_PRIORITY),
+            teacher_kb_context=str(existing.get("teacher_kb_context") or ""),
+            student_state=dict(existing.get("student_state") or {}),
+            session_state=dict(existing.get("session_state") or {}),
         )
 
     policy = _compile_runtime_policy(context=context, capability=capability)
+    context.metadata.setdefault("teacher_spec_compiled", _export_teacher_spec(policy))
     context.metadata["runtime_policy"] = policy.to_dict()
     return policy
 
 
 def format_chat_system_context(policy: RuntimePolicy) -> str:
     """Build tutoring-oriented system guidance from assembled slices."""
-    blocks: list[str] = [
-        "Teacher Runtime Policy:",
-        _slice_block("SOUL", policy.slices.get("SOUL", "")),
-        _slice_block("RULES", policy.slices.get("RULES", "")),
-        _slice_block("WORKFLOW", policy.slices.get("WORKFLOW", "")),
-        _slice_block("KNOWLEDGE", policy.slices.get("KNOWLEDGE", "")),
-        "Knowledge source priority:",
-        " > ".join(policy.source_priority),
-        "Scope guardrail: Stay within teacher-defined scope and clarify uncertainty when evidence is missing.",
+    sections = [
+        ("KNOWLEDGE BASE", policy.teacher_kb_context),
+        ("IDENTITY", policy.slices.get("IDENTITY", "")),
+        ("SOUL", policy.slices.get("SOUL", "")),
+        ("RULES", policy.slices.get("RULES", "")),
+        ("WORKFLOW", policy.slices.get("WORKFLOW", "")),
+        ("KNOWLEDGE", policy.slices.get("KNOWLEDGE", "")),
+        ("CURRICULUM", policy.slices.get("CURRICULUM", "")),
     ]
-    return "\n\n".join(block for block in blocks if block.strip())
+    if not _has_runtime_guidance(policy, sections):
+        return ""
+    manager = get_prompt_manager()
+    return manager.build_runtime_policy_prompt(
+        title="Teacher Runtime Policy:",
+        sections=sections,
+        source_priority=policy.source_priority,
+        extra_blocks=_boundary_blocks(policy),
+        guardrail="Stay within teacher-defined scope and clarify uncertainty when evidence is missing.",
+    )
 
 
 def format_assessment_context(policy: RuntimePolicy) -> str:
     """Build assessment-oriented guidance from assembled slices."""
-    blocks: list[str] = [
-        "Teacher Assessment Runtime Policy:",
-        _slice_block("ASSESSMENT", policy.slices.get("ASSESSMENT", "")),
-        _slice_block("RULES", policy.slices.get("RULES", "")),
-        _slice_block("WORKFLOW", policy.slices.get("WORKFLOW", "")),
-        _slice_block("KNOWLEDGE", policy.slices.get("KNOWLEDGE", "")),
-        "Knowledge source priority:",
-        " > ".join(policy.source_priority),
-        "Scope guardrail: Keep generated questions and feedback aligned with teacher policy and curriculum context.",
+    sections = [
+        ("KNOWLEDGE BASE", policy.teacher_kb_context),
+        ("IDENTITY", policy.slices.get("IDENTITY", "")),
+        ("ASSESSMENT", policy.slices.get("ASSESSMENT", "")),
+        ("RULES", policy.slices.get("RULES", "")),
+        ("WORKFLOW", policy.slices.get("WORKFLOW", "")),
+        ("KNOWLEDGE", policy.slices.get("KNOWLEDGE", "")),
+        ("CURRICULUM", policy.slices.get("CURRICULUM", "")),
     ]
-    return "\n\n".join(block for block in blocks if block.strip())
+    if not _has_runtime_guidance(policy, sections):
+        return ""
+    manager = get_prompt_manager()
+    return manager.build_runtime_policy_prompt(
+        title="Teacher Assessment Runtime Policy:",
+        sections=sections,
+        source_priority=policy.source_priority,
+        extra_blocks=_boundary_blocks(policy),
+        guardrail="Keep generated questions and feedback aligned with teacher policy and curriculum context.",
+    )
 
 
 def _compile_runtime_policy(context: UnifiedContext, capability: str) -> RuntimePolicy:
@@ -101,12 +146,20 @@ def _compile_runtime_policy(context: UnifiedContext, capability: str) -> Runtime
             sources[slice_name] = source
 
     knowledge_policy = _resolve_knowledge_policy(teacher_spec, slices)
+    agent_spec_id = str(teacher_spec.get("agent_spec_id") or "")
+    teacher_kb_context, teacher_kb_source = _build_teacher_kb_context(context)
+    if teacher_kb_source:
+        sources.setdefault("KNOWLEDGE_BASE", teacher_kb_source)
     return RuntimePolicy(
         capability=capability,
+        agent_spec_id=agent_spec_id,
         slices=slices,
         sources=sources,
         knowledge_policy=knowledge_policy,
         source_priority=list(SOURCE_PRIORITY),
+        teacher_kb_context=teacher_kb_context,
+        student_state=_extract_mapping(context, "student_state"),
+        session_state=_extract_mapping(context, "session_state"),
     )
 
 
@@ -115,10 +168,22 @@ def _get_teacher_spec(context: UnifiedContext) -> dict[str, Any]:
         context.metadata.get("teacher_spec_compiled"),
         context.metadata.get("teacher_spec"),
         context.config_overrides.get("teacher_spec"),
+        context.metadata.get("agent_spec_compiled"),
+        context.config_overrides.get("agent_spec_compiled"),
     ]
     for candidate in candidates:
         if isinstance(candidate, dict):
-            return candidate
+            normalized = _normalize_teacher_spec(candidate)
+            if normalized:
+                return normalized
+
+    agent_spec_id = _resolve_agent_spec_id(context)
+    if agent_spec_id:
+        try:
+            pack = get_agent_spec_service().get_pack(agent_spec_id)
+        except FileNotFoundError:
+            return {}
+        return _normalize_teacher_spec(_pack_to_teacher_spec(pack))
     return {}
 
 
@@ -137,6 +202,9 @@ def _resolve_slice(
         raw = context.metadata.get("curriculum_excerpt")
         if isinstance(raw, str) and raw.strip():
             return raw.strip(), "metadata.curriculum_excerpt"
+        kb_excerpt, source = _build_curriculum_excerpt_from_kb(context)
+        if kb_excerpt:
+            return kb_excerpt, source
 
     if slice_name == "RULES":
         raw = context.metadata.get("teacher_rules")
@@ -156,6 +224,121 @@ def _resolve_knowledge_policy(teacher_spec: dict[str, Any], slices: dict[str, st
     return DEFAULT_KNOWLEDGE_POLICY
 
 
-def _slice_block(name: str, content: str) -> str:
-    text = content.strip() or "(not provided)"
-    return f"[{name}]\n{text}"
+def _resolve_agent_spec_id(context: UnifiedContext) -> str:
+    candidates = [
+        context.metadata.get("agent_spec_id"),
+        context.config_overrides.get("agent_spec_id"),
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return ""
+
+
+def _pack_to_teacher_spec(pack: dict[str, Any]) -> dict[str, Any]:
+    files = dict(pack.get("files") or {})
+    compiled: dict[str, Any] = {
+        "agent_spec_id": str(pack.get("agent_id") or ""),
+        "knowledge_policy": str((pack.get("summary") or {}).get("knowledge_policy") or ""),
+    }
+    for filename, slice_name in SPEC_FILE_TO_SLICE.items():
+        value = files.get(filename)
+        if isinstance(value, str) and value.strip():
+            compiled[slice_name] = value.strip()
+
+    summary = pack.get("summary") or {}
+    if isinstance(summary, dict) and isinstance(summary.get("teaching_philosophy"), str):
+        compiled.setdefault("SOUL", str(compiled.get("SOUL") or summary.get("teaching_philosophy") or ""))
+    return compiled
+
+
+def _normalize_teacher_spec(candidate: dict[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    for key, value in candidate.items():
+        if isinstance(value, str):
+            if value.strip():
+                normalized[str(key)] = value.strip()
+        elif isinstance(value, dict):
+            continue
+        elif value is not None:
+            normalized[str(key)] = value
+    return normalized
+
+
+def _build_teacher_kb_context(context: UnifiedContext) -> tuple[str, str]:
+    kb_name = context.knowledge_bases[0] if context.knowledge_bases else ""
+    if not kb_name:
+        return "", ""
+    try:
+        manager = KnowledgeBaseManager(base_dir=str(get_path_service().project_root / "data" / "knowledge_bases"))
+        info = manager.get_info(kb_name)
+    except Exception:
+        return "", ""
+
+    metadata = info.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return "", ""
+
+    lines = [f"Knowledge Pack: {kb_name}"]
+    for label, key in (
+        ("Subject", "subject"),
+        ("Grade", "grade"),
+        ("Curriculum", "curriculum"),
+        ("Language", "language"),
+    ):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            lines.append(f"{label}: {value.strip()}")
+
+    objectives = metadata.get("learning_objectives")
+    if isinstance(objectives, list) and objectives:
+        objective_lines = [str(item).strip() for item in objectives if str(item).strip()]
+        if objective_lines:
+            lines.append("Learning objectives:")
+            lines.extend(f"- {item}" for item in objective_lines)
+
+    if len(lines) == 1:
+        return "", ""
+    return "\n".join(lines), f"knowledge_base.{kb_name}.metadata"
+
+
+def _build_curriculum_excerpt_from_kb(context: UnifiedContext) -> tuple[str, str]:
+    teacher_kb_context, source = _build_teacher_kb_context(context)
+    return teacher_kb_context, source
+
+
+def _extract_mapping(context: UnifiedContext, key: str) -> dict[str, Any]:
+    for candidate in (context.metadata.get(key), context.config_overrides.get(key)):
+        if isinstance(candidate, dict):
+            return dict(candidate)
+    return {}
+
+
+def _boundary_blocks(policy: RuntimePolicy) -> list[str]:
+    blocks: list[str] = []
+    if policy.agent_spec_id:
+        blocks.append(f"Teacher Spec Reference:\n{policy.agent_spec_id}")
+    if policy.student_state:
+        blocks.append("Student State Available:\nUse the provided student state as dynamic context, not immutable policy.")
+    if policy.session_state:
+        blocks.append("Session State Available:\nUse the provided session state for current-turn context only.")
+    return blocks
+
+
+def _export_teacher_spec(policy: RuntimePolicy) -> dict[str, Any]:
+    payload = {
+        "agent_spec_id": policy.agent_spec_id,
+        "knowledge_policy": policy.knowledge_policy,
+    }
+    payload.update(policy.slices)
+    return payload
+
+
+def _has_runtime_guidance(policy: RuntimePolicy, sections: list[tuple[str, str]]) -> bool:
+    if any(content.strip() for _, content in sections):
+        return True
+    if policy.agent_spec_id:
+        return True
+    if policy.student_state or policy.session_state:
+        return True
+    return False

--- a/docs/superpowers/pr-notes/2026-04-26-lane-2-spec-runtime-assembly.md
+++ b/docs/superpowers/pr-notes/2026-04-26-lane-2-spec-runtime-assembly.md
@@ -1,38 +1,28 @@
-# PR Architecture Note: Lane 2 Spec Runtime Assembly
+# PR Note: Lane 2 Spec Runtime Assembly
 
 ## Summary
 
-This PR introduces a shared runtime policy assembly contract so tutoring and assessment flows consume the same teacher-spec policy slices at runtime.
+- extend `runtime_policy` so runtime can resolve an authored spec pack by `agent_spec_id` and normalize it into explicit policy slices
+- add a prompt-manager helper for deterministic runtime policy prompt assembly instead of ad hoc string concatenation
+- keep tutoring and assessment on the same runtime contract while preserving legacy behavior when no teacher policy is present
 
-## Architectural changes
-
-- Add shared runtime policy compiler under `deeptutor/services/runtime_policy/`.
-- Compile explicit policy slices (`SOUL`, `RULES`, `WORKFLOW`, `ASSESSMENT`, `KNOWLEDGE`) with deterministic source priority.
-- Inject compiled runtime policy in orchestrator before capability execution.
-- Apply assembled policy context in both `chat` and `deep_question` capabilities.
-- Emit runtime debug metadata for assembled slice visibility.
+## Architecture
 
 ```mermaid
-flowchart TD
-  TeacherSpec["Teacher Spec Pack"] --> Compiler["Runtime Policy Compiler"]
-  SessionState["Session State"] --> Compiler
-  StudentState["Student State"] --> Compiler
-
-  Compiler --> Contract["Compiled Runtime Policy Contract"]
-  Contract --> ChatCap["chat capability"]
-  Contract --> QuestionCap["deep_question capability"]
-
-  Contract --> Debug["Debug slices: applied/missing"]
-  Contract --> Priority["Source priority enforcement"]
+flowchart LR
+  Spec["Agent Spec Pack"] --> Compiler["runtime_policy compiler"]
+  KB["Knowledge Pack metadata"] --> Compiler
+  Compiler --> Contract["Compiled runtime policy"]
+  Contract --> Chat["chat capability"]
+  Contract --> Quiz["deep_question capability"]
+  Contract --> Debug["runtime debug metadata"]
 ```
-
-## Main system map status
-
-- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated in this PR.
 
 ## Validation
 
-- `pytest tests/services/runtime_policy/test_compiler.py -vv`
-- `pytest tests/core/test_capabilities_runtime.py::test_chat_capability_streams_content_and_geogebra_context -vv -s`
-- `pytest tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_user_message_as_topic -vv`
+- `pytest tests/services/runtime_policy/test_compiler.py tests/services/test_prompt_manager.py tests/core/test_capabilities_runtime.py::test_chat_capability_streams_content_and_geogebra_context tests/core/test_capabilities_runtime.py::test_chat_capability_resolves_runtime_policy_from_agent_spec_pack tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_user_message_as_topic tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_single_call_followup_agent -q`
 - `git diff --check`
+
+## Main System Map
+
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the shared runtime-policy compiler boundary.

--- a/docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md
@@ -80,3 +80,5 @@ Compile teacher policy into a predictable runtime contract shared by tutoring an
 - This is Session = Lane 2.
 - Coordinate with Lane 1 through documented compiled-pack format only.
 - Coordinate with Lanes 3-5 through explicit `Teacher Spec / Student State / Session State` boundaries.
+- Implemented runtime entry points now accept teacher policy through `teacher_spec`, `teacher_spec_compiled`, or `agent_spec_id` when those values are already present on the runtime context.
+- Runtime prompt assembly now uses explicit named sections and keeps legacy behavior unchanged when no teacher policy is present.

--- a/tests/core/test_capabilities_runtime.py
+++ b/tests/core/test_capabilities_runtime.py
@@ -17,6 +17,8 @@ from deeptutor.capabilities.deep_solve import DeepSolveCapability
 from deeptutor.core.context import Attachment, UnifiedContext
 from deeptutor.core.stream import StreamEvent, StreamEventType
 from deeptutor.core.stream_bus import StreamBus
+from deeptutor.services.agent_spec.service import AgentSpecService
+from deeptutor.services.runtime_policy import compiler as runtime_policy_compiler
 
 
 def _install_module(monkeypatch: pytest.MonkeyPatch, fullname: str, **attrs: Any) -> types.ModuleType:
@@ -121,6 +123,65 @@ async def test_chat_capability_streams_content_and_geogebra_context(
     assert "GGB commands" in captured["process"]["message"]
     assert "Teacher Runtime Policy:" in captured["process"]["memory_context"]
     assert "teacher_kb > curriculum_excerpt > teacher_rules > llm_prior_knowledge" in captured["process"]["memory_context"]
+
+
+@pytest.mark.asyncio
+async def test_chat_capability_resolves_runtime_policy_from_agent_spec_pack(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    captured: dict[str, Any] = {}
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {
+                "agent_name": "Fraction Coach",
+                "subject": "Mathematics",
+                "grade_band": "Grade 6",
+                "tone": "Warm and direct",
+                "primary_language": "Vietnamese",
+                "persona_summary": "A teacher-defined tutor for fraction practice.",
+            },
+            "soul": {
+                "teaching_philosophy": "Use evidence before intervention.",
+                "when_student_wrong": "Diagnose the misconception before correcting.",
+                "when_student_stuck": "Offer one scaffold at a time.",
+                "encouragement_style": "Calm and specific.",
+            },
+            "rules": {
+                "do_not_solve_directly": "yes",
+                "max_session_minutes": "25",
+                "hint_policy": "One hint at a time.",
+                "escalation_rule": "Escalate after repeated confusion.",
+                "guardrails": "Never finish the answer for the student.",
+            },
+        },
+    )
+
+    class FakePipeline:
+        def __init__(self, language: str = "en") -> None:
+            captured["language"] = language
+
+        async def run(self, context: UnifiedContext, stream: StreamBus) -> None:
+            captured["memory_context"] = context.memory_context
+            await stream.content("assistant output", source="chat", stage="responding")
+
+    monkeypatch.setattr("deeptutor.capabilities.chat.AgenticChatPipeline", FakePipeline)
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    context = UnifiedContext(
+        user_message="help me compare fractions",
+        language="en",
+        metadata={"agent_spec_id": "fraction-coach"},
+    )
+    events = await _collect_events(lambda bus: ChatCapability().run(context, bus))
+
+    assert any(event.type == StreamEventType.CONTENT for event in events)
+    assert "[IDENTITY]" in captured["memory_context"]
+    assert "Fraction Coach" in captured["memory_context"]
+    assert "Teacher Spec Reference:\nfraction-coach" in captured["memory_context"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/runtime_policy/test_compiler.py
+++ b/tests/services/runtime_policy/test_compiler.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from deeptutor.services.agent_spec.service import AgentSpecService
 from deeptutor.core.context import UnifiedContext
 from deeptutor.services.runtime_policy import SOURCE_PRIORITY, ensure_runtime_policy
+from deeptutor.services.runtime_policy import compiler as runtime_policy_compiler
 
 
 def test_runtime_policy_compiles_teacher_slices_and_priority() -> None:
@@ -38,3 +40,76 @@ def test_runtime_policy_uses_metadata_fallback_for_rules() -> None:
     assert payload["slices"]["RULES"] == "Always request justification."
     assert payload["sources"]["RULES"] == "metadata.teacher_rules"
     assert payload["knowledge_policy"] == "kb_preferred"
+
+
+def test_runtime_policy_resolves_agent_spec_pack(monkeypatch, tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {
+                "agent_name": "Fraction Coach",
+                "subject": "Mathematics",
+                "grade_band": "Grade 6",
+                "tone": "Warm and direct",
+                "primary_language": "Vietnamese",
+                "persona_summary": "A teacher-defined tutor for fraction practice.",
+            },
+            "soul": {
+                "teaching_philosophy": "Use evidence before intervention.",
+                "when_student_wrong": "Diagnose the misconception.",
+                "when_student_stuck": "Offer one scaffold at a time.",
+                "encouragement_style": "Calm and specific.",
+            },
+            "rules": {
+                "do_not_solve_directly": "yes",
+                "max_session_minutes": "25",
+                "hint_policy": "One hint at a time.",
+                "escalation_rule": "Escalate after repeated confusion.",
+                "guardrails": "Never finish the answer for the student.",
+            },
+        },
+        files={
+            "ASSESSMENT.md": "# Assessment\n\n## Evidence Signals\n\n- Ask one concept per question.\n",
+            "WORKFLOW.md": "# Workflow\n\n## Session Flow\n\n1. Teach\n2. Practice\n3. Check\n",
+            "KNOWLEDGE.md": "# Knowledge\n\n## Retrieval Policy\n\n- Prefer teacher-authored materials first.\n- Use kb_preferred retrieval.\n",
+        },
+    )
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    context = UnifiedContext(metadata={"agent_spec_id": "fraction-coach"})
+    policy = ensure_runtime_policy(context, "chat")
+    payload = policy.to_dict()
+
+    assert payload["agent_spec_id"] == "fraction-coach"
+    assert payload["slices"]["IDENTITY"].startswith("# Identity")
+    assert payload["slices"]["SOUL"].startswith("# Soul")
+    assert payload["slices"]["WORKFLOW"].startswith("# Workflow")
+    assert payload["debug"]["agent_spec_id"] == "fraction-coach"
+
+
+def test_runtime_policy_reads_teacher_kb_context_from_metadata(monkeypatch) -> None:
+    class FakeKBManager:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def get_info(self, _name: str) -> dict:
+            return {
+                "metadata": {
+                    "subject": "Mathematics",
+                    "grade": "10",
+                    "curriculum": "Vietnam National Curriculum",
+                    "learning_objectives": ["Quadratic equations", "Graph reading"],
+                }
+            }
+
+    monkeypatch.setattr(runtime_policy_compiler, "KnowledgeBaseManager", FakeKBManager)
+
+    context = UnifiedContext(knowledge_bases=["algebra-pack"])
+    policy = ensure_runtime_policy(context, "deep_question")
+    payload = policy.to_dict()
+
+    assert "Knowledge Pack: algebra-pack" in payload["teacher_kb_context"]
+    assert payload["sources"]["KNOWLEDGE_BASE"] == "knowledge_base.algebra-pack.metadata"
+    assert payload["slices"]["CURRICULUM"].startswith("Knowledge Pack: algebra-pack")

--- a/tests/services/test_prompt_manager.py
+++ b/tests/services/test_prompt_manager.py
@@ -16,3 +16,27 @@ def test_prompt_manager_loads_prompts_from_deeptutor_tree() -> None:
     )
 
     assert "generate_ideas" in prompts
+
+
+def test_prompt_manager_builds_runtime_policy_prompt_with_explicit_sections() -> None:
+    manager = get_prompt_manager()
+
+    prompt = manager.build_runtime_policy_prompt(
+        title="Teacher Runtime Policy:",
+        sections=[
+            ("IDENTITY", "Math tutor for grade 6."),
+            ("SOUL", "Stay calm and encouraging."),
+            ("RULES", ""),
+        ],
+        source_priority=["teacher_kb", "curriculum_excerpt", "teacher_rules"],
+        guardrail="Stay within teacher-defined scope.",
+        extra_blocks=["Teacher Spec Reference:\nfraction-coach"],
+    )
+
+    assert "Teacher Runtime Policy:" in prompt
+    assert "[IDENTITY]\nMath tutor for grade 6." in prompt
+    assert "[SOUL]\nStay calm and encouraging." in prompt
+    assert "[RULES]" not in prompt
+    assert "teacher_kb > curriculum_excerpt > teacher_rules" in prompt
+    assert "Teacher Spec Reference:\nfraction-coach" in prompt
+    assert "Scope guardrail: Stay within teacher-defined scope." in prompt


### PR DESCRIPTION
## Summary
- extend `runtime_policy` so runtime can resolve an authored spec pack by `agent_spec_id` and normalize it into explicit policy slices
- add a prompt-manager helper for deterministic runtime policy prompt assembly instead of ad hoc string concatenation
- keep tutoring and assessment on the same runtime contract while preserving legacy behavior when no teacher policy is present

## Validation
- `pytest tests/services/runtime_policy/test_compiler.py tests/services/test_prompt_manager.py tests/core/test_capabilities_runtime.py::test_chat_capability_streams_content_and_geogebra_context tests/core/test_capabilities_runtime.py::test_chat_capability_resolves_runtime_policy_from_agent_spec_pack tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_user_message_as_topic tests/core/test_capabilities_runtime.py::test_deep_question_capability_uses_single_call_followup_agent -q`
- `git diff --check`

## Known limitation
- Passing `agent_spec_id` through the session-turn request path is not wired in this lane because `deeptutor/services/session/turn_runtime.py` is outside the owned-file contract.

## Main System Map
- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` for the shared runtime-policy compiler boundary.
