### PR TITLE
[L4] feat(evidence): strengthen diagnosis recommendation engine

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,8 +28,17 @@ Rules:
 
 ## Active
 
-- No active AI-owned lane is open right now.
-- Lane 1 (`L1_AGENT_SPEC_AUTHORING`) merged through PR `#136`.
-- Lane 2 (`L2_SPEC_RUNTIME_ASSEMBLY`) merged through PR `#135`.
-- Lane 3 (`L3_OBSERVATION_STUDENT_STATE`) merged through PR `#140`.
-- Use the remaining lane packets (`lane-4` to `lane-6`) before starting new implementation sessions.
+### Assignment
+
+- Owner: GitHub Copilot (GPT-5.3-Codex)
+- Machine: macOS
+- Worktree: .worktrees/lane2
+- Task: L4_DIAGNOSIS_RECOMMENDATION
+- Status: in-progress
+- Branch: pod-a/diagnosis-recommendation
+- Task packet: docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md
+- Owned files: deeptutor/services/evidence/diagnosis.py; deeptutor/services/evidence/teacher_insights.py; deeptutor/api/routers/assessment.py; deeptutor/api/routers/dashboard.py; tests/services/evidence/test_diagnosis.py; tests/api/test_assessment_router.py; tests/api/test_dashboard_router.py
+- PR: (draft, not opened yet)
+- Last update: 2026-04-26
+- Next action: Implement expanded diagnosis taxonomy, deterministic action ranking, and abstain behavior; then update router tests.
+- Blocker: none

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -62,3 +62,12 @@
 - Tests: `pytest tests/services/evidence/test_extractor.py tests/services/session/test_sqlite_store.py tests/core/test_capabilities_runtime.py -q`; scoped `git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md deeptutor/services/evidence/extractor.py deeptutor/services/session/context_builder.py deeptutor/services/session/sqlite_store.py deeptutor/services/session/turn_runtime.py tests/core/test_capabilities_runtime.py tests/services/evidence/test_extractor.py tests/services/session/test_sqlite_store.py`
 - Blockers: Full-repo `git diff --check` reports an existing out-of-scope blank-line issue in `ai_first/daily/2026-04-25.md`.
 - Next: Start Lane 4 (`L4_DIAGNOSIS_RECOMMENDATION`) from updated `main`.
+
+## Lane 4
+
+- Branch: `pod-a/diagnosis-recommendation`
+- Task: `L4_DIAGNOSIS_RECOMMENDATION`
+- Done: Upgraded diagnosis scoring/taxonomy selection, added deterministic per-student action ranking, introduced abstain behavior for weak/contradictory evidence, and improved teacher-insight small-group grouping with deterministic topic+diagnosis+action cohorts.
+- Tests: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
+- Blockers: None.
+- Next: Open Draft PR with `[L4]` tag and move to Ready after self-review.

--- a/deeptutor/api/routers/assessment.py
+++ b/deeptutor/api/routers/assessment.py
@@ -75,13 +75,9 @@ async def get_assessment_diagnosis(session_id: str):
     await store.save_observations(observations)
 
     student_id = review["student_id"]
-    state = {
-        "student_id": student_id,
-        "repeated_mistakes": sorted({row["topic"] for row in observations if not row["is_correct"]}),
-        "support_level": "guided" if any(not row["is_correct"] for row in observations) else "independent",
-        "confidence_trend": "down" if any(not row["is_correct"] for row in observations) else "flat",
-    }
-    await store.upsert_student_state(student_id, state)
+    rollup = await store.build_student_state_rollup(student_id)
+    if rollup is not None:
+        await store.upsert_student_state(student_id, rollup)
 
     return build_student_diagnosis(
         student_id=student_id,

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -499,15 +499,10 @@ async def get_dashboard_insights(
         observations = extract_observations_from_review(review)
         await store.save_observations(observations)
 
+        rollup = await store.build_student_state_rollup(student_id)
+        if rollup is not None:
+            await store.upsert_student_state(student_id, rollup)
         state = await store.get_student_state(student_id)
-        if state is None:
-            state = {
-                "student_id": student_id,
-                "repeated_mistakes": sorted({row["topic"] for row in observations if not row["is_correct"]}),
-                "support_level": "guided" if any(not row["is_correct"] for row in observations) else "independent",
-                "confidence_trend": "down" if any(not row["is_correct"] for row in observations) else "flat",
-            }
-            await store.upsert_student_state(student_id, state)
 
         student_payloads.append(
             build_student_diagnosis(

--- a/deeptutor/services/evidence/diagnosis.py
+++ b/deeptutor/services/evidence/diagnosis.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
 
-from collections import Counter
 from typing import Any
 
 
-def _confidence_tag(observations: list[dict[str, Any]]) -> str:
-    if len(observations) >= 3:
+ACTION_BY_DIAGNOSIS = {
+    "concept_gap": "review_prerequisite",
+    "needs_scaffold": "increase_scaffold",
+    "careless_error": "retry_easier",
+    "low_confidence": "small_group_support",
+}
+
+ACTION_PRIORITY = {
+    "review_prerequisite": 0,
+    "increase_scaffold": 1,
+    "retry_easier": 2,
+    "small_group_support": 3,
+}
+
+
+def _confidence_tag(
+    *,
+    evidence_count: int,
+    contradiction_ratio: float,
+) -> str:
+    if evidence_count >= 4 and contradiction_ratio <= 0.25:
         return "high"
-    if len(observations) == 2:
+    if evidence_count >= 2 and contradiction_ratio <= 0.45:
         return "medium"
     return "low"
 
@@ -18,6 +36,138 @@ def _support_level(observations: list[dict[str, Any]]) -> str:
     if any(not row.get("is_correct") for row in observations):
         return "guided"
     return "independent"
+
+
+def _topic_rows(observations: list[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+    by_topic: dict[str, list[dict[str, Any]]] = {}
+    for row in observations:
+        topic = str(row.get("topic") or "general")
+        by_topic.setdefault(topic, []).append(row)
+
+    best_topic = "general"
+    best_rows: list[dict[str, Any]] = observations
+    best_score = float("-inf")
+    for topic, rows in by_topic.items():
+        miss_count = sum(1 for row in rows if not row.get("is_correct"))
+        support_load = sum(
+            int(row.get("hint_count") or 0) + int(row.get("retry_count") or 0)
+            for row in rows
+        )
+        score = miss_count * 3 + support_load
+        if score > best_score or (score == best_score and topic < best_topic):
+            best_topic = topic
+            best_rows = rows
+            best_score = score
+    return best_topic, best_rows
+
+
+def _diagnosis_scores(rows: list[dict[str, Any]]) -> tuple[dict[str, int], int, float]:
+    scores = {
+        "concept_gap": 0,
+        "needs_scaffold": 0,
+        "careless_error": 0,
+        "low_confidence": 0,
+    }
+    contradictions = 0
+    evidence_count = 0
+
+    for row in rows:
+        is_correct = bool(row.get("is_correct"))
+        hint_count = int(row.get("hint_count") or 0)
+        retry_count = int(row.get("retry_count") or 0)
+        latency = row.get("latency_seconds")
+        latency_value = int(latency) if latency is not None else None
+        dominant_error = str(row.get("dominant_error") or "").strip()
+
+        if not is_correct:
+            evidence_count += 1
+            scores["needs_scaffold"] += 1
+            if hint_count >= 2 or retry_count >= 2:
+                scores["needs_scaffold"] += 2
+            if retry_count >= 1 and hint_count >= 1:
+                scores["concept_gap"] += 1
+            if latency_value is not None and latency_value <= 15:
+                scores["careless_error"] += 3
+            elif latency_value is not None and latency_value >= 45:
+                scores["concept_gap"] += 2
+            else:
+                scores["low_confidence"] += 1
+        else:
+            # Correct-but-heavy-support patterns can still indicate low confidence.
+            if hint_count >= 2 or retry_count >= 2:
+                scores["low_confidence"] += 2
+                contradictions += 1
+
+        if dominant_error in scores:
+            scores[dominant_error] += 2
+
+    # Contradiction means mixed signals where dominant hypothesis is weaker.
+    contradiction_ratio = float(contradictions) / float(max(1, len(rows)))
+    return scores, evidence_count, contradiction_ratio
+
+
+def _select_diagnosis(scores: dict[str, int]) -> tuple[str, int, int]:
+    ordered = sorted(scores.items(), key=lambda item: (-item[1], item[0]))
+    top_type, top_score = ordered[0]
+    second_score = ordered[1][1] if len(ordered) > 1 else 0
+    return top_type, top_score, second_score
+
+
+def _build_ranked_actions(
+    *,
+    student_id: str,
+    topic: str,
+    diagnosis_type: str,
+    confidence_tag: str,
+    miss_count: int,
+) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    primary_action = ACTION_BY_DIAGNOSIS.get(diagnosis_type, "increase_scaffold")
+    candidates.append(
+        {
+            "action_type": primary_action,
+            "score": 4 if confidence_tag == "high" else 3 if confidence_tag == "medium" else 2,
+            "rationale": f"Primary support for {topic} based on {diagnosis_type} pattern.",
+        }
+    )
+    if miss_count >= 2 and diagnosis_type != "review_prerequisite":
+        candidates.append(
+            {
+                "action_type": "review_prerequisite",
+                "score": 2,
+                "rationale": f"Multiple misses suggest prerequisite review for {topic}.",
+            }
+        )
+    if diagnosis_type == "careless_error":
+        candidates.append(
+            {
+                "action_type": "retry_easier",
+                "score": 2,
+                "rationale": f"Quick retry cycle can stabilize accuracy on {topic}.",
+            }
+        )
+
+    ranked = sorted(
+        candidates,
+        key=lambda item: (-item["score"], ACTION_PRIORITY.get(item["action_type"], 99), item["action_type"]),
+    )
+    deduped: list[dict[str, Any]] = []
+    seen_types: set[str] = set()
+    for item in ranked:
+        action_type = item["action_type"]
+        if action_type in seen_types:
+            continue
+        seen_types.add(action_type)
+        deduped.append(
+            {
+                "action_id": f"{student_id}:{topic}:{action_type}",
+                "action_type": action_type,
+                "target_student_ids": [student_id],
+                "topic": topic,
+                "rationale": item["rationale"],
+            }
+        )
+    return deduped
 
 
 def build_student_diagnosis(
@@ -35,58 +185,69 @@ def build_student_diagnosis(
             "recommended_actions": [],
         }
 
-    topic_counter = Counter(row["topic"] for row in observations if not row.get("is_correct"))
-    if topic_counter:
-        dominant_topic, _ = topic_counter.most_common(1)[0]
-        dominant_rows = [row for row in observations if row["topic"] == dominant_topic]
-    else:
-        dominant_rows = observations
-        dominant_topic = observations[0]["topic"]
-
-    error_counter = Counter(row["dominant_error"] for row in dominant_rows if row.get("dominant_error"))
-    dominant_error = error_counter.most_common(1)[0][0] if error_counter else "low_confidence"
-    confidence = _confidence_tag(dominant_rows)
+    dominant_topic, dominant_rows = _topic_rows(observations)
+    scores, evidence_count, contradiction_ratio = _diagnosis_scores(dominant_rows)
+    dominant_error, top_score, second_score = _select_diagnosis(scores)
+    confidence = _confidence_tag(
+        evidence_count=evidence_count,
+        contradiction_ratio=contradiction_ratio,
+    )
     avg_latency_values = [
         int(row.get("latency_seconds") or 0)
         for row in dominant_rows
         if row.get("latency_seconds") is not None
     ]
+    miss_count = sum(1 for row in dominant_rows if not row.get("is_correct"))
+    abstain = miss_count == 0 or (
+        miss_count <= 1
+        and top_score <= 1
+        and (top_score - second_score) <= 0
+        and confidence == "low"
+        and contradiction_ratio >= 0.5
+    )
+
     derived_state = student_state or {
         "student_id": student_id,
         "repeated_mistakes": [dominant_topic],
         "support_level": _support_level(dominant_rows),
         "confidence_trend": "down",
     }
-    recommendation_type = "review_prerequisite" if dominant_error == "concept_gap" else "increase_scaffold"
 
-    return {
-        "student_id": student_id,
-        "observed": {
-            "topic": dominant_topic,
-            "miss_count": sum(1 for row in dominant_rows if not row.get("is_correct")),
-            "avg_latency_seconds": round(sum(avg_latency_values) / len(avg_latency_values))
-            if avg_latency_values
-            else 0,
-        },
-        "student_state": derived_state,
-        "inferred": [
+    inferred: list[dict[str, Any]] = []
+    actions: list[dict[str, Any]] = []
+    if not abstain:
+        inferred = [
             {
                 "diagnosis_type": dominant_error,
                 "confidence_tag": confidence,
                 "topic": dominant_topic,
                 "evidence": [
-                    f"{len(dominant_rows)} missed question(s) in {dominant_topic}",
+                    f"miss_count={miss_count} on {dominant_topic}",
                     f"support_level={_support_level(dominant_rows)}",
+                    f"contradiction_ratio={round(contradiction_ratio, 2)}",
                 ],
             }
-        ],
-        "recommended_actions": [
-            {
-                "action_id": f"{student_id}:{dominant_topic}:{recommendation_type}",
-                "action_type": recommendation_type,
-                "target_student_ids": [student_id],
-                "topic": dominant_topic,
-                "rationale": f"Revisit {dominant_topic} before moving to mixed practice.",
-            }
-        ],
+        ]
+        actions = _build_ranked_actions(
+            student_id=student_id,
+            topic=dominant_topic,
+            diagnosis_type=dominant_error,
+            confidence_tag=confidence,
+            miss_count=miss_count,
+        )
+
+    return {
+        "student_id": student_id,
+        "observed": {
+            "topic": dominant_topic,
+            "miss_count": miss_count,
+            "evidence_count": evidence_count,
+            "abstained": abstain,
+            "avg_latency_seconds": round(sum(avg_latency_values) / len(avg_latency_values))
+            if avg_latency_values
+            else 0,
+        },
+        "student_state": derived_state,
+        "inferred": inferred,
+        "recommended_actions": actions,
     }

--- a/deeptutor/services/evidence/teacher_insights.py
+++ b/deeptutor/services/evidence/teacher_insights.py
@@ -4,28 +4,68 @@ from collections import defaultdict
 from typing import Any
 
 
+_CONFIDENCE_SCORE = {"high": 3, "medium": 2, "low": 1}
+
+
+def _top_inferred(payload: dict[str, Any]) -> dict[str, Any] | None:
+    inferred = payload.get("inferred") or []
+    if not inferred:
+        return None
+    return inferred[0]
+
+
+def _top_action(payload: dict[str, Any]) -> dict[str, Any] | None:
+    actions = payload.get("recommended_actions") or []
+    if not actions:
+        return None
+    return actions[0]
+
+
 def build_teacher_insights_payload(
     *,
     student_payloads: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    grouped: dict[tuple[str, str], list[str]] = defaultdict(list)
+    grouped: dict[tuple[str, str, str], list[tuple[str, int]]] = defaultdict(list)
     for payload in student_payloads:
-        inferred = payload.get("inferred") or []
-        if not inferred:
+        inferred = _top_inferred(payload)
+        action = _top_action(payload)
+        if not inferred or not action:
             continue
-        key = (inferred[0]["topic"], inferred[0]["diagnosis_type"])
-        grouped[key].append(payload["student_id"])
+        key = (
+            str(inferred.get("topic") or "general"),
+            str(inferred.get("diagnosis_type") or "low_confidence"),
+            str(action.get("action_type") or "small_group_support"),
+        )
+        grouped[key].append(
+            (
+                str(payload.get("student_id") or "unknown"),
+                _CONFIDENCE_SCORE.get(str(inferred.get("confidence_tag") or "low"), 1),
+            )
+        )
 
-    small_groups = [
-        {
-            "topic": topic,
-            "diagnosis_type": diagnosis_type,
-            "student_ids": sorted(student_ids),
-            "recommended_action": "small_group_support",
-        }
-        for (topic, diagnosis_type), student_ids in grouped.items()
-        if len(student_ids) >= 2
-    ]
+    small_groups: list[dict[str, Any]] = []
+    for (topic, diagnosis_type, action_type), rows in grouped.items():
+        if len(rows) < 2:
+            continue
+        confidence_sum = sum(score for _sid, score in rows)
+        avg_confidence = confidence_sum / float(len(rows))
+        if avg_confidence < 1.0:
+            continue
+        student_ids = sorted({sid for sid, _score in rows})
+        small_groups.append(
+            {
+                "topic": topic,
+                "diagnosis_type": diagnosis_type,
+                "student_ids": student_ids,
+                "recommended_action": "small_group_support",
+                "source_action_type": action_type,
+                "confidence_tag": "high" if avg_confidence >= 2.5 else "medium",
+            }
+        )
+
+    small_groups.sort(
+        key=lambda row: (-len(row["student_ids"]), row["topic"], row["diagnosis_type"], row["source_action_type"])
+    )
 
     return {
         "students": student_payloads,

--- a/docs/superpowers/pr-notes/2026-04-26-lane-4-diagnosis-recommendation.md
+++ b/docs/superpowers/pr-notes/2026-04-26-lane-4-diagnosis-recommendation.md
@@ -1,0 +1,43 @@
+# PR Note: Lane 4 Diagnosis and Recommendation Engine [L4]
+
+## Summary
+
+This lane upgrades diagnosis and recommendation logic from a placeholder rule set to a deterministic hybrid engine with abstain behavior, confidence policy, and ranked actions.
+
+## Scope
+
+- Expanded diagnosis scoring and taxonomy selection in `deeptutor/services/evidence/diagnosis.py`.
+- Added deterministic per-student action ranking mapped from diagnosis types.
+- Added abstain behavior for weak/contradictory evidence.
+- Improved teacher insight grouping to deterministic topic+diagnosis+action cohorts in `deeptutor/services/evidence/teacher_insights.py`.
+- Updated assessment/dashboard routers to refresh student-state rollups before diagnosis.
+- Added tests for taxonomy routing, confidence tags, abstain behavior, and insights payload structure.
+
+## Architecture
+
+```mermaid
+flowchart TD
+  Obs[Observed evidence rows] --> Rollup[Student state rollup]
+  Rollup --> Dx[Diagnosis engine]
+  Dx --> Infer[Inferred hypotheses\n(engine-owned confidence)]
+  Infer --> Rank[Deterministic action ranking]
+  Rank --> StudentOut[Per-student recommendations]
+  StudentOut --> Group[Teacher insight grouper\ntopic+diagnosis+action]
+  Group --> SmallGroup[Small-group recommendations]
+```
+
+## Contract Notes
+
+- `Observed` remains the source of truth.
+- `Inferred` is derived only from observed evidence.
+- Confidence tags remain engine-owned (no LLM dependency).
+- Action types are mapped explicitly before rationale text.
+
+## Validation
+
+- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
+- `git diff --check` on lane-owned files.
+
+## Main System Map
+
+- Updated: no (logic refinement within existing diagnosis/recommendation pathway).

--- a/tests/api/test_assessment_router.py
+++ b/tests/api/test_assessment_router.py
@@ -181,4 +181,38 @@ async def test_assessment_diagnosis_endpoint_returns_structured_payload(
     payload = response.json()
     assert payload["student_id"] == "assessment-recent"
     assert payload["inferred"][0]["diagnosis_type"] == "concept_gap"
+    assert payload["inferred"][0]["confidence_tag"] in {"medium", "high"}
+    assert payload["observed"]["abstained"] is False
     assert payload["recommended_actions"][0]["topic"] == "fractions subtraction"
+
+
+@pytest.mark.asyncio
+async def test_assessment_diagnosis_endpoint_can_abstain_on_strong_correct_signal(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="assessment-perfect",
+        capability="deep_question",
+        message="Generate a quiz on algebra",
+        knowledge_bases=["algebra-pack"],
+    )
+    await store.add_message(
+        "assessment-perfect",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve algebra equation x + 2 = 5 -> Answered: 3 (Correct, time: 12s)\n"
+        "Score: 1/1 (100%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/assessment/diagnosis/assessment-perfect")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["observed"]["abstained"] is True
+    assert payload["inferred"] == []
+    assert payload["recommended_actions"] == []

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -494,6 +494,8 @@ async def test_dashboard_insights_returns_students_and_small_groups(
     assert payload["students"][0]["student_id"] in {"student-a", "student-b"}
     assert payload["small_groups"][0]["topic"] == "fractions subtraction"
     assert sorted(payload["small_groups"][0]["student_ids"]) == ["student-a", "student-b"]
+    assert payload["small_groups"][0]["recommended_action"] == "small_group_support"
+    assert payload["small_groups"][0]["confidence_tag"] in {"medium", "high"}
 
 
 @pytest.mark.asyncio

--- a/tests/services/evidence/test_diagnosis.py
+++ b/tests/services/evidence/test_diagnosis.py
@@ -47,5 +47,75 @@ def test_build_student_diagnosis_returns_structured_hypotheses_and_actions() -> 
 
     assert payload["student_id"] == "student-a"
     assert payload["observed"]["topic"] == "fractions subtraction"
+    assert payload["observed"]["abstained"] is False
     assert payload["inferred"][0]["diagnosis_type"] == "concept_gap"
+    assert payload["inferred"][0]["confidence_tag"] in {"medium", "high"}
     assert payload["recommended_actions"][0]["action_type"] == "review_prerequisite"
+
+
+def test_build_student_diagnosis_routes_careless_error_to_retry_action() -> None:
+    observations = [
+        {
+            "observation_id": "obs_c1",
+            "session_id": "quiz-2",
+            "student_id": "student-c",
+            "source": "assessment",
+            "topic": "arithmetic",
+            "question_id": "q1",
+            "is_correct": False,
+            "latency_seconds": 8,
+            "hint_count": 0,
+            "retry_count": 0,
+            "dominant_error": "careless_error",
+        },
+        {
+            "observation_id": "obs_c2",
+            "session_id": "quiz-2",
+            "student_id": "student-c",
+            "source": "assessment",
+            "topic": "arithmetic",
+            "question_id": "q2",
+            "is_correct": False,
+            "latency_seconds": 10,
+            "hint_count": 0,
+            "retry_count": 0,
+            "dominant_error": "careless_error",
+        },
+    ]
+
+    payload = build_student_diagnosis(
+        student_id="student-c",
+        observations=observations,
+        student_state=None,
+    )
+
+    assert payload["inferred"][0]["diagnosis_type"] == "careless_error"
+    assert payload["recommended_actions"][0]["action_type"] == "retry_easier"
+
+
+def test_build_student_diagnosis_abstains_on_weak_or_non_error_signal() -> None:
+    observations = [
+        {
+            "observation_id": "obs_ok",
+            "session_id": "quiz-3",
+            "student_id": "student-d",
+            "source": "assessment",
+            "topic": "geometry",
+            "question_id": "q1",
+            "is_correct": True,
+            "latency_seconds": 20,
+            "hint_count": 0,
+            "retry_count": 0,
+            "dominant_error": None,
+        }
+    ]
+
+    payload = build_student_diagnosis(
+        student_id="student-d",
+        observations=observations,
+        student_state=None,
+    )
+
+    assert payload["observed"]["abstained"] is True
+    assert payload["inferred"] == []
+    assert payload["recommended_actions"] == []


### PR DESCRIPTION
## Summary
- upgrade diagnosis scoring/taxonomy selection beyond Wave 1 placeholder behavior
- add deterministic per-student action ranking mapped from diagnosis types
- add abstain behavior for weak/contradictory evidence
- make teacher small-group recommendations deterministic via topic+diagnosis+action grouping
- refresh assessment/dashboard diagnosis flows with student-state rollup refresh

## Scope and Constraints
- lane packet: docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md
- storage schema unchanged
- session runtime and UI ownership untouched

## Validation
- /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q
- scoped git diff --check on lane-owned files

## Architecture
- PR note: docs/superpowers/pr-notes/2026-04-26-lane-4-diagnosis-recommendation.md
- MAIN_SYSTEM_MAP.md updated: no (pipeline path unchanged; engine logic refined)
