### PR TITLE
docs(ai-first): sync control-plane after lane4 merge [OPS-COMMIT]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,9 @@ Rules:
 
 ## Active
 
-### Assignment
-
-- Owner: GitHub Copilot (GPT-5.3-Codex)
-- Machine: macOS
-- Worktree: .worktrees/lane2
-- Task: L4_DIAGNOSIS_RECOMMENDATION
-- Status: in-progress
-- Branch: pod-a/diagnosis-recommendation
-- Task packet: docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md
-- Owned files: deeptutor/services/evidence/diagnosis.py; deeptutor/services/evidence/teacher_insights.py; deeptutor/api/routers/assessment.py; deeptutor/api/routers/dashboard.py; tests/services/evidence/test_diagnosis.py; tests/api/test_assessment_router.py; tests/api/test_dashboard_router.py
-- PR: (draft, not opened yet)
-- Last update: 2026-04-26
-- Next action: Implement expanded diagnosis taxonomy, deterministic action ranking, and abstain behavior; then update router tests.
-- Blocker: none
+- No active AI-owned lane is open right now.
+- Lane 1 (`L1_AGENT_SPEC_AUTHORING`) merged through PR `#136`.
+- Lane 2 (`L2_SPEC_RUNTIME_ASSEMBLY`) merged through PR `#135`.
+- Lane 3 (`L3_OBSERVATION_STUDENT_STATE`) merged through PR `#140`.
+- Lane 4 (`L4_DIAGNOSIS_RECOMMENDATION`) merged through PR `#142`.
+- Use the remaining lane packets (`lane-5` to `lane-6`) before starting new implementation sessions.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,10 +7,11 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#140 [L3] feat(evidence): tutoring observations + recency student-state rollups`
+- Latest merged PR: `#142 [L4] feat(evidence): strengthen diagnosis recommendation engine`
 - Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
+- Lane 4 (`2026-04-26-lane-4-diagnosis-recommendation`) merged to `main` through PR `#142`.
 - Latest smoke result: the 2026-04-25 scripted-reset smoke pass succeeded against current `main`.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -25,9 +26,8 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 Create or use one session per lane from `main` with these packets:
 
-1. `docs/superpowers/tasks/2026-04-26-lane-4-diagnosis-recommendation.md`
-2. `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md`
-3. `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
+1. `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md`
+2. `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
 
 If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
 

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -68,6 +68,7 @@
 - Branch: `pod-a/diagnosis-recommendation`
 - Task: `L4_DIAGNOSIS_RECOMMENDATION`
 - Done: Upgraded diagnosis scoring/taxonomy selection, added deterministic per-student action ranking, introduced abstain behavior for weak/contradictory evidence, and improved teacher-insight small-group grouping with deterministic topic+diagnosis+action cohorts.
+- Merge: PR `#142` merged to `main` after CI checks (`Backend`, `Frontend`, `Docs`, `Summary`) passed.
 - Tests: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
 - Blockers: None.
-- Next: Open Draft PR with `[L4]` tag and move to Ready after self-review.
+- Next: Start Lane 5 (`L5_TEACHER_INSIGHT_UI`) from updated `main`.


### PR DESCRIPTION
## Summary
- update ACTIVE_ASSIGNMENTS to mark Lane 4 merged via PR #142
- update EXECUTION_QUEUE latest merged result and next remaining lanes (5-6)
- update daily log with Lane 4 merge status and next lane

## Scope
- docs/control-plane only
- no runtime or UI code changes

## Main System Map
- updated: no