### PR TITLE
feat(dashboard): add evidence-first teacher insight workflow [L5]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,9 +28,17 @@ Rules:
 
 ## Active
 
-- No active AI-owned lane is open right now.
-- Lane 1 (`L1_AGENT_SPEC_AUTHORING`) merged through PR `#136`.
-- Lane 2 (`L2_SPEC_RUNTIME_ASSEMBLY`) merged through PR `#135`.
-- Lane 3 (`L3_OBSERVATION_STUDENT_STATE`) merged through PR `#140`.
-- Lane 4 (`L4_DIAGNOSIS_RECOMMENDATION`) merged through PR `#142`.
-- Use the remaining lane packets (`lane-5` to `lane-6`) before starting new implementation sessions.
+### Assignment
+
+- Owner: GitHub Copilot (GPT-5.3-Codex)
+- Machine: macOS
+- Worktree: .worktrees/lane2
+- Task: L5_TEACHER_INSIGHT_UI
+- Status: in-progress
+- Branch: pod-a/teacher-insight-ui
+- Task packet: docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md
+- Owned files: web/app/(workspace)/dashboard/page.tsx; web/app/(workspace)/dashboard/student/page.tsx; web/components/dashboard/TeacherInsightPanel.tsx; web/components/dashboard/*; web/lib/dashboard-api.ts
+- PR: (draft, not opened yet)
+- Last update: 2026-04-26
+- Next action: Finish lane docs/handoff, open the Draft PR, and verify the new dashboard flow on CI.
+- Blocker: none

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -72,3 +72,12 @@
 - Tests: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
 - Blockers: None.
 - Next: Start Lane 5 (`L5_TEACHER_INSIGHT_UI`) from updated `main`.
+
+## Lane 5
+
+- Branch: `pod-a/teacher-insight-ui`
+- Task: `L5_TEACHER_INSIGHT_UI`
+- Done: Reworked the teacher dashboard into an evidence-first workflow, split overview rendering into focused student and small-group cards, and added a student drill-down path using `/dashboard/student?student=<id>` with explicit `Observed`, `Inferred`, and `Recommended Action` sections.
+- Tests: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2/web/node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx app/'(workspace)'/dashboard/student/page.tsx components/dashboard/TeacherInsightPanel.tsx components/dashboard/InsightSectionLabel.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts`; `git diff --check -- web/app/'(workspace)'/dashboard/page.tsx web/app/'(workspace)'/dashboard/student/page.tsx web/components/dashboard/TeacherInsightPanel.tsx web/components/dashboard/InsightSectionLabel.tsx web/components/dashboard/StudentInsightCard.tsx web/components/dashboard/SmallGroupInsightCard.tsx web/components/dashboard/StudentInsightDetail.tsx docs/superpowers/pr-notes/2026-04-26-lane-5-teacher-insight-ui.md docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md ai_first/daily/2026-04-26.md`
+- Blockers: None.
+- Next: Open Draft PR for Lane 5 and validate the new dashboard flow on CI.

--- a/docs/superpowers/plans/2026-04-26-lane-5-teacher-insight-ui.md
+++ b/docs/superpowers/plans/2026-04-26-lane-5-teacher-insight-ui.md
@@ -1,0 +1,593 @@
+# Lane 5 Teacher Insight UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the current teacher dashboard into an evidence-first workflow that clearly separates observed facts, inferred diagnosis, and recommended actions at both overview and student-detail levels.
+
+**Architecture:** Keep the existing dashboard data contract intact and focus this lane on presentation structure. Extract small display components from the current teacher insight panel, tighten dashboard hierarchy around `Observed -> Inferred -> Recommended Action`, and repurpose the student detail page into a drill-down surface that uses the already merged payloads without inventing frontend diagnosis logic.
+
+**Tech Stack:** Next.js App Router, React client components, TypeScript, Tailwind utility classes, `react-i18next`, existing dashboard REST client in `web/lib/dashboard-api.ts`
+
+---
+
+## File Structure
+
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+  - Keep page-level data fetching and filter state.
+  - Reframe the page so the hero copy, summary cards, and teacher insight section follow the evidence-first workflow.
+- Modify: `web/app/(workspace)/dashboard/student/page.tsx`
+  - Convert the current student progress page into a teacher-facing student detail drill-down.
+  - Reuse existing student progress data where useful, but prioritize evidence/diagnosis/action presentation.
+- Modify: `web/components/dashboard/TeacherInsightPanel.tsx`
+  - Shrink into a composition surface instead of a single large rendering file.
+- Create: `web/components/dashboard/InsightSectionLabel.tsx`
+  - Shared section heading for `Observed`, `Inferred`, and `Recommended Action`.
+- Create: `web/components/dashboard/StudentInsightCard.tsx`
+  - Overview card for one student, evidence-first and mobile-safe.
+- Create: `web/components/dashboard/SmallGroupInsightCard.tsx`
+  - Overview card for one small-group recommendation.
+- Create: `web/components/dashboard/StudentInsightDetail.tsx`
+  - Detail layout for a single student’s evidence, diagnosis, and action stack.
+- Modify: `web/lib/dashboard-api.ts`
+  - Add small helper types or selectors only if needed to keep components simple and typed.
+- Modify: `docs/superpowers/pr-notes/2026-04-26-lane-5-teacher-insight-ui.md`
+  - Record architecture note with Mermaid diagram for the PR.
+
+### Task 1: Freeze the Lane 5 UI contract in focused presentational components
+
+**Files:**
+- Create: `web/components/dashboard/InsightSectionLabel.tsx`
+- Create: `web/components/dashboard/StudentInsightCard.tsx`
+- Create: `web/components/dashboard/SmallGroupInsightCard.tsx`
+- Modify: `web/components/dashboard/TeacherInsightPanel.tsx`
+- Test: `web/components/dashboard/TeacherInsightPanel.tsx`
+
+- [ ] **Step 1: Write the failing lint target expectation by introducing imports that do not exist yet**
+
+```tsx
+import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
+import { SmallGroupInsightCard } from "@/components/dashboard/SmallGroupInsightCard";
+import { StudentInsightCard } from "@/components/dashboard/StudentInsightCard";
+```
+
+Expected failure after wiring:
+- `Module not found` for the three new components until they are created.
+
+- [ ] **Step 2: Run lint on the panel file to verify the missing-component failure**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2/web
+./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherInsightPanel.tsx
+```
+
+Expected:
+- FAIL with unresolved imports for the new dashboard components.
+
+- [ ] **Step 3: Create the shared section label component**
+
+```tsx
+import type { ReactNode } from "react";
+
+export function InsightSectionLabel({
+  eyebrow,
+  title,
+  toneClassName = "text-[var(--muted-foreground)]",
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  toneClassName?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className={`text-[11px] font-semibold uppercase tracking-[0.12em] ${toneClassName}`}>
+        {eyebrow}
+      </div>
+      <div className="text-[14px] font-medium text-[var(--foreground)]">{title}</div>
+      {children ? <div className="text-[12px] text-[var(--muted-foreground)]">{children}</div> : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Create the student insight card component**
+
+```tsx
+import Link from "next/link";
+import type { TeacherInsightStudent } from "@/lib/dashboard-api";
+import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
+
+export function StudentInsightCard({
+  student,
+  detailHref,
+  t,
+}: {
+  student: TeacherInsightStudent;
+  detailHref: string;
+  t: (value: string, options?: Record<string, string | number>) => string;
+}) {
+  const diagnosis = student.inferred[0];
+  const recommendation = student.recommended_actions[0];
+
+  return (
+    <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-[12px] font-semibold uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+            {student.student_id}
+          </div>
+          <div className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
+            {student.observed?.topic ?? t("No dominant topic")}
+          </div>
+        </div>
+        <Link href={detailHref} className="text-[12px] font-medium text-[var(--foreground)] underline-offset-4 hover:underline">
+          {t("Open detail")}
+        </Link>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        <section className="rounded-2xl bg-[var(--muted)]/45 p-3">
+          <InsightSectionLabel eyebrow={t("Observed")} title={student.observed?.topic ?? t("No recent evidence")} />
+          <ul className="mt-3 space-y-1 text-[12px] text-[var(--foreground)]">
+            <li>{t("Misses: {{count}}", { count: student.observed?.miss_count ?? 0 })}</li>
+            <li>{t("Latency: {{value}}", { value: student.observed?.avg_latency_seconds ?? 0 })}</li>
+          </ul>
+        </section>
+
+        <section className="rounded-2xl bg-amber-50 p-3">
+          <InsightSectionLabel
+            eyebrow={t("Inferred")}
+            title={diagnosis?.diagnosis_type ?? t("No diagnosis")}
+            toneClassName="text-amber-700"
+          >
+            {t("Confidence: {{value}}", { value: diagnosis?.confidence_tag ?? "N/A" })}
+          </InsightSectionLabel>
+        </section>
+
+        <section className="rounded-2xl bg-emerald-50 p-3">
+          <InsightSectionLabel
+            eyebrow={t("Recommended Action")}
+            title={recommendation?.action_type ?? t("No action yet")}
+            toneClassName="text-emerald-700"
+          >
+            {recommendation?.rationale ?? t("No recommendation available")}
+          </InsightSectionLabel>
+        </section>
+      </div>
+    </article>
+  );
+}
+```
+
+- [ ] **Step 5: Create the small-group card component**
+
+```tsx
+import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
+import type { DashboardInsights } from "@/lib/dashboard-api";
+
+type SmallGroup = DashboardInsights["small_groups"][number];
+
+export function SmallGroupInsightCard({
+  group,
+  t,
+}: {
+  group: SmallGroup;
+  t: (value: string, options?: Record<string, string | number>) => string;
+}) {
+  return (
+    <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4">
+      <InsightSectionLabel eyebrow={t("Small Group")} title={group.topic} />
+      <div className="mt-3 text-[12px] text-[var(--muted-foreground)]">{group.diagnosis_type}</div>
+      <div className="mt-4 rounded-2xl bg-[var(--muted)]/45 p-3">
+        <InsightSectionLabel eyebrow={t("Recommended Action")} title={group.recommended_action} toneClassName="text-emerald-700" />
+        <div className="mt-2 text-[12px] text-[var(--muted-foreground)]">
+          {t("Students: {{students}}", { students: group.student_ids.join(", ") })}
+        </div>
+      </div>
+    </article>
+  );
+}
+```
+
+- [ ] **Step 6: Refactor the panel to compose the new card components**
+
+```tsx
+import { SmallGroupInsightCard } from "@/components/dashboard/SmallGroupInsightCard";
+import { StudentInsightCard } from "@/components/dashboard/StudentInsightCard";
+
+// inside the render
+<div className="space-y-4">
+  {insights.students.map((student) => (
+    <StudentInsightCard
+      key={student.student_id}
+      student={student}
+      detailHref={`/dashboard/student?student=${encodeURIComponent(student.student_id)}`}
+      t={t}
+    />
+  ))}
+</div>
+
+<div className="space-y-4">
+  {insights.small_groups.map((group) => (
+    <SmallGroupInsightCard key={`${group.topic}:${group.diagnosis_type}`} group={group} t={t} />
+  ))}
+</div>
+```
+
+- [ ] **Step 7: Run lint to verify the panel and new components pass**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2/web
+./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherInsightPanel.tsx components/dashboard/InsightSectionLabel.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx
+```
+
+Expected:
+- PASS with no lint errors in the owned component files.
+
+- [ ] **Step 8: Commit the component extraction**
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2
+git add web/components/dashboard/TeacherInsightPanel.tsx web/components/dashboard/InsightSectionLabel.tsx web/components/dashboard/StudentInsightCard.tsx web/components/dashboard/SmallGroupInsightCard.tsx
+git commit -m "feat(dashboard): split teacher insight cards by evidence layer [L5]"
+```
+
+### Task 2: Reframe the dashboard overview around teacher workflow instead of activity summary
+
+**Files:**
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+- Modify: `web/components/dashboard/TeacherInsightPanel.tsx`
+- Modify: `web/lib/dashboard-api.ts`
+- Test: `web/app/(workspace)/dashboard/page.tsx`
+
+- [ ] **Step 1: Write the failing view-level expectation by wiring the new hero copy and section order**
+
+```tsx
+<p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+  {t("Teacher Workflow")}
+</p>
+<h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
+  {t("Observed, diagnosed, and ready for action")}
+</h1>
+```
+
+Expected failure:
+- The page renders old class-activity framing until the file is updated.
+
+- [ ] **Step 2: Run targeted lint to confirm the page still builds after the first markup change**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2/web
+./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx
+```
+
+Expected:
+- PASS or actionable lint output only in the page file being edited.
+
+- [ ] **Step 3: Replace the current hero summary with evidence-first teacher workflow copy**
+
+```tsx
+const nextActionLabel =
+  insights?.students?.[0]?.recommended_actions?.[0]?.rationale ??
+  t("Review evidence-backed recommendations and confirm the next intervention.");
+
+// inside header
+<p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+  {t("Teacher Workflow")}
+</p>
+<h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
+  {t("Observed, diagnosed, and ready for action")}
+</h1>
+<p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
+  {t("Review observed facts first, then inspect diagnosis and next-step recommendations for each student or group.")}
+</p>
+```
+
+- [ ] **Step 4: Move the teacher insight panel higher in the overview layout**
+
+```tsx
+{insights ? <TeacherInsightPanel insights={insights} /> : null}
+
+<section className="grid gap-4 xl:grid-cols-[1.3fr_0.7fr]">
+  {/* recent activity and knowledge-pack activity stay below the insight surface */}
+</section>
+```
+
+- [ ] **Step 5: Reduce summary cards that do not help the teacher workflow**
+
+```tsx
+const cards = useMemo(
+  () => [
+    { label: t("Students with signals"), value: insights?.students.length ?? 0, icon: Users },
+    { label: t("Small-group actions"), value: insights?.small_groups.length ?? 0, icon: BookOpen },
+    { label: t("Recent assessments"), value: totals?.assessments ?? 0, icon: PenLine },
+    { label: t("Active sessions"), value: totals?.running ?? 0, icon: Activity },
+  ],
+  [insights, t, totals],
+);
+```
+
+- [ ] **Step 6: Keep the existing history filters but visually demote them below the insight hero**
+
+```tsx
+<section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
+  <div className="mb-3 flex items-center justify-between gap-3">
+    <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--muted-foreground)]">
+      <Filter size={14} />
+      {t("History filters")}
+    </div>
+  </div>
+</section>
+```
+
+- [ ] **Step 7: Run lint for the overview page and panel together**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2/web
+./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx components/dashboard/TeacherInsightPanel.tsx
+```
+
+Expected:
+- PASS with no new lint errors in the owned files.
+
+- [ ] **Step 8: Commit the overview workflow reshape**
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2
+git add web/app/'(workspace)'/dashboard/page.tsx web/components/dashboard/TeacherInsightPanel.tsx web/lib/dashboard-api.ts
+git commit -m "feat(dashboard): reframe teacher overview around evidence workflow [L5]"
+```
+
+### Task 3: Turn the student page into an evidence-first teacher drill-down
+
+**Files:**
+- Create: `web/components/dashboard/StudentInsightDetail.tsx`
+- Modify: `web/app/(workspace)/dashboard/student/page.tsx`
+- Modify: `web/lib/dashboard-api.ts`
+- Test: `web/app/(workspace)/dashboard/student/page.tsx`
+
+- [ ] **Step 1: Write the failing drill-down contract by reading the `student` query param**
+
+```tsx
+import { useSearchParams } from "next/navigation";
+
+const searchParams = useSearchParams();
+const studentId = searchParams.get("student") ?? "";
+```
+
+Expected failure:
+- The current page ignores the selected student and still behaves like a generic student progress dashboard.
+
+- [ ] **Step 2: Run lint to verify the page can parse the new route state**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2/web
+./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/student/page.tsx
+```
+
+Expected:
+- PASS or actionable lint feedback only in the student page.
+
+- [ ] **Step 3: Add a detail component that stacks evidence, diagnosis, and action**
+
+```tsx
+import type { TeacherInsightStudent } from "@/lib/dashboard-api";
+import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
+
+export function StudentInsightDetail({
+  student,
+  t,
+}: {
+  student: TeacherInsightStudent | null;
+  t: (value: string, options?: Record<string, string | number>) => string;
+}) {
+  const diagnosis = student?.inferred[0];
+  const recommendation = student?.recommended_actions[0];
+
+  if (!student) {
+    return (
+      <section className="rounded-[28px] border border-dashed border-[var(--border)] bg-[var(--card)] px-5 py-8 text-center text-[13px] text-[var(--muted-foreground)]">
+        {t("Choose a student from the dashboard to inspect evidence and next steps.")}
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5">
+        <InsightSectionLabel eyebrow={t("Observed")} title={student.observed?.topic ?? t("No recent evidence")} />
+      </div>
+      <div className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5">
+        <InsightSectionLabel eyebrow={t("Inferred")} title={diagnosis?.diagnosis_type ?? t("No diagnosis")} toneClassName="text-amber-700" />
+      </div>
+      <div className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5">
+        <InsightSectionLabel eyebrow={t("Recommended Action")} title={recommendation?.action_type ?? t("No action")} toneClassName="text-emerald-700" />
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Fetch the same dashboard insights payload and select the active student**
+
+```tsx
+import { getDashboardInsights, getStudentProgress } from "@/lib/dashboard-api";
+
+const [insights, setInsights] = useState<DashboardInsights | null>(null);
+
+useEffect(() => {
+  let cancelled = false;
+  Promise.all([getStudentProgress(), getDashboardInsights(100)])
+    .then(([progressData, insightData]) => {
+      if (!cancelled) {
+        setOverview(progressData);
+        setInsights(insightData);
+      }
+    })
+    .finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+  return () => {
+    cancelled = true;
+  };
+}, []);
+
+const activeStudent = insights?.students.find((row) => row.student_id === studentId) ?? null;
+```
+
+- [ ] **Step 5: Replace the page hero and body with teacher drill-down structure**
+
+```tsx
+<header className="rounded-[32px] border border-[var(--border)] bg-[var(--card)] p-6">
+  <Link href="/dashboard" className="inline-flex items-center gap-2 text-[13px] text-[var(--muted-foreground)]">
+    <ArrowLeft size={14} />
+    {t("Back to dashboard")}
+  </Link>
+  <h1 className="mt-4 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
+    {activeStudent?.student_id ?? t("Student detail")}
+  </h1>
+  <p className="mt-2 max-w-[640px] text-[14px] leading-6 text-[var(--muted-foreground)]">
+    {t("Review observed evidence first, then inspect diagnosis and the recommended next move.")}
+  </p>
+</header>
+
+<StudentInsightDetail student={activeStudent} t={t} />
+```
+
+- [ ] **Step 6: Keep the existing progress sections below the new detail block as supporting context**
+
+```tsx
+<div className="grid gap-4 xl:grid-cols-2">
+  <TopicList ... />
+  <LearningPathCard ... />
+</div>
+```
+
+- [ ] **Step 7: Run lint on the student page and new detail component**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2/web
+./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/student/page.tsx components/dashboard/StudentInsightDetail.tsx components/dashboard/InsightSectionLabel.tsx
+```
+
+Expected:
+- PASS with no lint errors in the student detail surface.
+
+- [ ] **Step 8: Commit the student drill-down**
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2
+git add web/app/'(workspace)'/dashboard/student/page.tsx web/components/dashboard/StudentInsightDetail.tsx web/lib/dashboard-api.ts
+git commit -m "feat(dashboard): add evidence-first student insight detail [L5]"
+```
+
+### Task 4: Add lane documentation, validation notes, and final verification
+
+**Files:**
+- Modify: `docs/superpowers/pr-notes/2026-04-26-lane-5-teacher-insight-ui.md`
+- Modify: `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md`
+- Modify: `ai_first/daily/2026-04-26.md`
+- Test: owned dashboard files plus docs updates
+
+- [ ] **Step 1: Write the PR architecture note with the final UI flow**
+
+```md
+# Lane 5 Teacher Insight UI
+
+## Summary
+- reshaped `/dashboard` around teacher insight workflow
+- split student and group insight rendering into focused components
+- added evidence-first student drill-down on `/dashboard/student`
+
+## Main System Map
+- not updated; workflow surface changed within the existing teacher dashboard boundary
+
+```mermaid
+flowchart TD
+  Dashboard["/dashboard"] --> StudentCards["Student insight cards"]
+  Dashboard --> GroupCards["Small-group cards"]
+  StudentCards --> StudentDetail["/dashboard/student?student=<id>"]
+  StudentDetail --> Observed["Observed"]
+  StudentDetail --> Inferred["Inferred"]
+  StudentDetail --> Action["Recommended Action"]
+```
+```
+
+- [ ] **Step 2: Update the task packet handoff notes with any payload gaps or explicit non-goals**
+
+```md
+## Handoff notes
+
+- Implemented the evidence-first layout without changing backend diagnosis semantics.
+- Student detail reuses existing dashboard insight payload plus student-progress context.
+- If future UX needs richer evidence traces, extend the backend contract in a new lane instead of growing frontend inference logic.
+```
+
+- [ ] **Step 3: Record the lane in the daily log**
+
+```md
+## Lane 5
+
+- Branch: `pod-a/teacher-insight-ui`
+- Task: `L5_TEACHER_INSIGHT_UI`
+- Done: Reworked the teacher dashboard into an evidence-first workflow with per-student and small-group cards plus a drill-down detail page.
+- Tests: `./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx app/'(workspace)'/dashboard/student/page.tsx components/dashboard/TeacherInsightPanel.tsx components/dashboard/InsightSectionLabel.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx`; `git diff --check`
+- Blockers: None.
+- Next: Open Draft PR, wait for CI, then move to Ready if green.
+```
+
+- [ ] **Step 4: Run final scoped lint and diff checks**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2/web
+./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx app/'(workspace)'/dashboard/student/page.tsx components/dashboard/TeacherInsightPanel.tsx components/dashboard/InsightSectionLabel.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts
+
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2
+git diff --check -- web/app/'(workspace)'/dashboard/page.tsx web/app/'(workspace)'/dashboard/student/page.tsx web/components/dashboard/TeacherInsightPanel.tsx web/components/dashboard/InsightSectionLabel.tsx web/components/dashboard/StudentInsightCard.tsx web/components/dashboard/SmallGroupInsightCard.tsx web/components/dashboard/StudentInsightDetail.tsx web/lib/dashboard-api.ts docs/superpowers/pr-notes/2026-04-26-lane-5-teacher-insight-ui.md docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md ai_first/daily/2026-04-26.md
+```
+
+Expected:
+- PASS with no lint or diff-format errors in owned Lane 5 files.
+
+- [ ] **Step 5: Commit docs and verification notes**
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane2
+git add docs/superpowers/pr-notes/2026-04-26-lane-5-teacher-insight-ui.md docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md ai_first/daily/2026-04-26.md
+git commit -m "docs(dashboard): record lane 5 insight workflow handoff [L5]"
+```
+
+## Self-Review
+
+### Spec coverage
+
+- Evidence-first hierarchy: covered in Tasks 1, 2, and 3.
+- Overview-to-detail flow: covered in Tasks 2 and 3.
+- Grouped-card small-group surface: covered in Task 1.
+- Mobile-safe stacked layout: covered in Tasks 1 and 3 through card-based rendering and no table layout.
+- No backend diagnosis logic in frontend: enforced in Tasks 1, 2, and 4 by reusing existing payload fields only.
+
+### Placeholder scan
+
+- No `TODO`, `TBD`, or “implement later” placeholders remain.
+- Each task includes exact files, commands, and code anchors.
+
+### Type consistency
+
+- Shared payload types consistently use `DashboardInsights`, `TeacherInsightStudent`, and existing dashboard REST helpers from `web/lib/dashboard-api.ts`.
+- All new components depend on the same evidence-first labels and avoid introducing parallel frontend-only diagnosis types.

--- a/docs/superpowers/pr-notes/2026-04-26-lane-5-teacher-insight-ui.md
+++ b/docs/superpowers/pr-notes/2026-04-26-lane-5-teacher-insight-ui.md
@@ -1,0 +1,21 @@
+# Lane 5 Teacher Insight UI
+
+## Summary
+
+- reshaped `/dashboard` around the teacher evidence workflow instead of a generic class-activity summary
+- split teacher insight rendering into focused student and small-group cards
+- added a student drill-down view at `/dashboard/student?student=<id>` that keeps `Observed`, `Inferred`, and `Recommended Action` visibly separate
+
+## Main System Map
+
+- not updated; this lane changes the teacher-facing dashboard workflow within the existing top-level dashboard boundary
+
+```mermaid
+flowchart TD
+  Dashboard["/dashboard"] --> StudentCards["Student insight cards"]
+  Dashboard --> GroupCards["Small-group cards"]
+  StudentCards --> StudentDetail["/dashboard/student?student=<id>"]
+  StudentDetail --> Observed["Observed"]
+  StudentDetail --> Inferred["Inferred"]
+  StudentDetail --> Action["Recommended Action"]
+```

--- a/docs/superpowers/specs/2026-04-26-lane-5-teacher-insight-ui-design.md
+++ b/docs/superpowers/specs/2026-04-26-lane-5-teacher-insight-ui-design.md
@@ -1,0 +1,239 @@
+# Lane 5 Teacher Insight UI Design
+
+Date: 2026-04-26
+Status: Drafted for user review
+Scope: Contest MVP+ Lane 5 teacher-facing workflow on top of merged evidence, diagnosis, and recommendation payloads
+
+## Purpose
+
+This design defines the UI layer for the Contest MVP+ hybrid proof after the evidence spine, runtime policy, observation/state, and diagnosis/recommendation lanes are in place. The goal is to present teacher insight as an evidence-backed workflow rather than a decorative analytics dashboard.
+
+The design stays intentionally narrow:
+
+- `/dashboard` is the primary entry point.
+- Per-student and small-group insight surfaces share the same evidence-first hierarchy.
+- `/dashboard/student` is the drill-down surface for a single learner.
+- The frontend does not invent or reinterpret diagnosis semantics beyond the structured payload already produced by the backend.
+
+## Problem Statement
+
+The current teacher insight surface proves that the platform can emit observations and recommendations, but the teacher workflow still risks collapsing facts, diagnosis, and actions into one blended card. That weakens the thesis of the product.
+
+For the contest MVP+, the UI should prove three claims clearly:
+
+1. The system separates `Observed`, `Inferred`, and `Recommended Action`.
+2. Teachers can scan class-level signals quickly and then drill into a student when needed.
+3. Small-group suggestions are visible as actionable teaching moves rather than hidden metadata.
+
+## Core Decision
+
+The UI should be `Evidence-first`.
+
+That means every primary teacher-facing insight surface follows the same order:
+
+1. `Observed`
+2. `Inferred`
+3. `Recommended Action`
+
+This is preferred over action-first or blended cards because the contest MVP still needs to earn trust. Showing the evidence before the AI interpretation makes the system easier to defend and easier to understand.
+
+## Hero Flow
+
+The hero flow for Lane 5 is `Overview -> detail`.
+
+1. The teacher lands on `/dashboard`.
+2. The teacher scans per-student insight cards and small-group recommendation cards.
+3. The teacher selects a student to inspect more closely.
+4. The teacher lands on `/dashboard/student`.
+5. The teacher sees the evidence trace first, the diagnosis second, and the intervention suggestion third.
+
+This flow balances breadth and depth. It gives the contest demo an immediately understandable overview while still proving that the system can support deeper teacher judgment.
+
+## Information Architecture
+
+### Dashboard Overview
+
+The overview should contain two clearly separated sections:
+
+1. `Student insight cards`
+2. `Small-group recommendation cards`
+
+The overview is not a generic KPI page. It is a teacher workflow page.
+
+Each section should use the same conceptual structure but tuned to its scope.
+
+### Student Detail
+
+The student detail page should expand a single learner's evidence trace and recommendation context. It exists to answer:
+
+- what actually happened;
+- what the system thinks it means;
+- what the teacher should do next.
+
+## Student Insight Cards
+
+Each student card should be easy to scan in under a few seconds. The card should expose:
+
+- student name or identifier;
+- dominant topic or misconception;
+- 2-3 short observed signals such as repeated error, hint count, or confidence change;
+- a diagnosis badge with confidence tag;
+- a short next-action summary;
+- a direct link or CTA to the student detail page.
+
+The visual order should be:
+
+1. `Observed`
+2. `Inferred`
+3. `Action`
+
+The card must not blur evidence and diagnosis into a single paragraph.
+
+## Small-Group Recommendation Cards
+
+Small-group surfaces should use `grouped cards`, not tables and not inline fragments below student cards.
+
+Each group card should show:
+
+- the shared misconception or shared support need;
+- the students in the group;
+- the common evidence basis for grouping;
+- the recommended teacher move for the group.
+
+The group card should explain why the students belong together without pretending that grouping is more precise than the payload supports.
+
+## Student Detail View
+
+The student detail page should use an evidence-first stacked layout:
+
+1. `Observed signals`
+2. `Diagnosis`
+3. `Recommended action`
+
+The top section should show the most relevant factual trace:
+
+- recent error patterns;
+- hint or retry behavior;
+- confidence or support indicators;
+- any recent session summary the payload already exposes.
+
+The diagnosis section should show:
+
+- the primary inferred issue;
+- confidence tag;
+- rationale phrased as interpretation, not as fact.
+
+The action section should show:
+
+- what the teacher should do next;
+- whether the action is individual or part of a group strategy;
+- any linked follow-up path that the current UI already supports.
+
+## Visual Semantics
+
+The three layers need stable visual separation:
+
+- `Observed` should look factual and neutral.
+- `Inferred` should look analytical, with visible confidence framing.
+- `Recommended Action` should look operational and next-step oriented.
+
+Recommended tactics:
+
+- use section labels directly in the UI;
+- use distinct badges or tonal containers for evidence, inference, and action;
+- avoid color semantics that imply a diagnosis is a hard fact;
+- avoid presenting confidence as more precise than the backend payload.
+
+## Interaction Rules
+
+The overview should support lightweight teacher filters, limited to what the payload already supports cleanly:
+
+- topic;
+- misconception or diagnosis type;
+- confidence level;
+- support need.
+
+The overview should allow a fast path into detail without modal-heavy interaction.
+
+The student detail page should not require the teacher to reconstruct context from multiple tabs. The most important evidence and action should remain on one page.
+
+## Mobile and Demo Constraints
+
+The layout must remain mobile-safe and contest-demo friendly.
+
+That means:
+
+- prefer stacked cards over dense tables;
+- keep the most important line visible without expansion;
+- ensure the section order remains readable on narrow screens;
+- avoid interaction patterns that rely on hover or wide-screen comparison.
+
+## Boundaries and Non-Goals
+
+Lane 5 owns presentation and workflow, not diagnosis semantics.
+
+Therefore:
+
+- do not embed diagnosis logic in the frontend;
+- do not fabricate evidence summaries not present in the payload;
+- do not widen backend scope unless a true payload contract gap prevents the core UX;
+- if a payload gap is discovered, document the exact field or contract issue rather than silently compensating in UI code.
+
+## Implementation Shape
+
+Expected owned surfaces:
+
+- `/web/app/(workspace)/dashboard/page.tsx`
+- `/web/app/(workspace)/dashboard/student/page.tsx`
+- `/web/components/dashboard/TeacherInsightPanel.tsx`
+- additional scoped components under `/web/components/dashboard/`
+- `/web/lib/dashboard-api.ts` only if presentation needs a small compatible client-side mapping
+
+The implementation should prefer extracting focused display components over growing one large dashboard file.
+
+## Acceptance Criteria
+
+The design is successful when:
+
+1. `/dashboard` clearly shows both student-level and group-level insight.
+2. Every primary insight surface visibly separates `Observed`, `Inferred`, and `Recommended Action`.
+3. A teacher can move from overview to student detail without losing evidence context.
+4. The UI does not imply certainty beyond the confidence and evidence already in the payload.
+5. The layout remains usable on both desktop and mobile.
+
+## Risks
+
+### Risk 1: Payload shape is too thin for the intended detail page
+
+Mitigation:
+- keep the first pass conservative;
+- surface only the evidence already available;
+- escalate a precise contract gap to the human if required.
+
+### Risk 2: Cards become visually dense
+
+Mitigation:
+- constrain each card to a short evidence summary;
+- move longer rationale or traces into the detail view.
+
+### Risk 3: UI appears smarter than the backend really is
+
+Mitigation:
+- preserve evidence-first ordering;
+- label diagnosis as interpretation;
+- show confidence and action as bounded suggestions, not absolute truth.
+
+## Architecture Note
+
+```mermaid
+flowchart TD
+  Overview["/dashboard Overview"] --> StudentCards["Student Insight Cards"]
+  Overview --> GroupCards["Small-Group Cards"]
+  StudentCards --> Detail["/dashboard/student"]
+  GroupCards --> Detail
+  Detail --> Observed["Observed Section"]
+  Detail --> Inferred["Inferred Section"]
+  Detail --> Action["Recommended Action Section"]
+```
+
+This lane changes the teacher workflow surface, but not the underlying diagnosis engine. The frontend reflects the pipeline boundaries rather than redefining them.

--- a/docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md
+++ b/docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md
@@ -76,3 +76,6 @@ Turn the merged Wave 1 teacher insight surface into a clearer teacher workflow t
 - This is Session = Lane 5.
 - Keep visual language aligned with existing dashboard patterns unless the human explicitly asks for redesign.
 - Treat backend payloads as contracts, not suggestions.
+- Implemented the evidence-first workflow without changing backend diagnosis semantics or router contracts.
+- `/dashboard/student` now uses the dashboard insight payload plus existing progress context; deeper evidence traces should be added in a future backend lane if needed.
+- Do not compensate for missing payload fields with frontend-only inference.

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -88,33 +88,34 @@ export default function DashboardPage() {
   const cards = useMemo(
     () => [
       {
-        label: t("Sessions"),
-        value: totals?.total_sessions ?? 0,
-        icon: Activity,
+        label: t("Students with signals"),
+        value: insights?.students.length ?? 0,
+        icon: Users,
       },
       {
-        label: t("Assessments"),
+        label: t("Small-group actions"),
+        value: insights?.small_groups.length ?? 0,
+        icon: BookOpen,
+      },
+      {
+        label: t("Recent assessments"),
         value: totals?.assessments ?? 0,
         icon: PenLine,
       },
       {
-        label: t("Tutoring"),
-        value: totals?.tutoring_sessions ?? 0,
-        icon: Users,
-      },
-      {
-        label: t("Running"),
+        label: t("Active sessions"),
         value: totals?.running ?? 0,
-        icon: Loader2,
+        icon: Activity,
       },
     ],
-    [t, totals],
+    [insights, t, totals],
   );
   const activeFilterCount = [searchTerm, activityType, knowledgeBase, minScore].filter(Boolean).length;
   const nextActionLabel =
-    focusTopics.length > 0
+    insights?.students?.[0]?.recommended_actions?.[0]?.rationale ??
+    (focusTopics.length > 0
       ? t("Review the weakest topics first")
-      : t("Open the latest session and confirm the student is ready for the next pack");
+      : t("Open the latest session and confirm the student is ready for the next pack"));
   const recentActivity = overview?.recent_activity ?? [];
   const knowledgePackActivity = overview?.knowledge_packs ?? [];
 
@@ -125,13 +126,13 @@ export default function DashboardPage() {
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
               <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
-                {t("Teacher Dashboard")}
+                {t("Teacher Workflow")}
               </p>
               <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
-                {t("Class activity")}
+                {t("Observed, diagnosed, and ready for action")}
               </h1>
               <p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
-                {t("Review recent assessments, tutoring sessions, and Knowledge Pack usage.")}
+                {t("Review observed facts first, then inspect diagnosis and next-step recommendations for each student or group.")}
               </p>
             </div>
             <Link
@@ -169,6 +170,8 @@ export default function DashboardPage() {
             </div>
           </div>
         </header>
+
+        <TeacherInsightPanel insights={insights} />
 
         <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">
           <div className="mb-3 flex items-center justify-between gap-3">
@@ -397,8 +400,6 @@ export default function DashboardPage() {
             </div>
           </div>
         </section>
-
-        <TeacherInsightPanel insights={insights} />
 
         <section className="grid gap-5 lg:grid-cols-[1fr_320px]">
           <div>

--- a/web/app/(workspace)/dashboard/student/page.tsx
+++ b/web/app/(workspace)/dashboard/student/page.tsx
@@ -2,10 +2,14 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { ArrowLeft, ArrowRight, BookOpen, Flame, LineChart, Loader2, Target } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { StudentInsightDetail } from "@/components/dashboard/StudentInsightDetail";
 import {
+  getDashboardInsights,
   getStudentProgress,
+  type DashboardInsights,
   type StudentProgressAssessment,
   type StudentProgressOverview,
   type StudentProgressPathStep,
@@ -219,17 +223,20 @@ function LearningPathCard({
 
 export default function StudentDashboardPage() {
   const { t } = useTranslation();
+  const searchParams = useSearchParams();
+  const studentId = searchParams.get("student") ?? "";
   const [overview, setOverview] = useState<StudentProgressOverview | null>(null);
+  const [insights, setInsights] = useState<DashboardInsights | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    getStudentProgress()
-      .then((data) => {
+    Promise.all([getStudentProgress(), getDashboardInsights(100)])
+      .then(([progressData, insightData]) => {
         if (!cancelled) {
-          setOverview(data);
+          setOverview(progressData);
+          setInsights(insightData);
           setError(null);
         }
       })
@@ -248,6 +255,7 @@ export default function StudentDashboardPage() {
   const focusTopics = overview?.focus_topics ?? [];
   const masteredTopics = overview?.mastered_topics ?? [];
   const suggestedPath = overview?.suggested_learning_path ?? [];
+  const activeStudent = insights?.students.find((row) => row.student_id === studentId) ?? null;
   const statCards = useMemo(
     () => [
       {
@@ -290,21 +298,21 @@ export default function StudentDashboardPage() {
             {t("Back to teacher dashboard")}
           </Link>
           <span className="rounded-full border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-[12px] font-medium text-[var(--muted-foreground)]">
-            {t("Student Dashboard")}
+            {t("Student Detail")}
           </span>
         </div>
 
         <section className="rounded-[32px] border border-[var(--border)] bg-[var(--card)]/90 px-6 py-6 shadow-sm">
           <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-[var(--muted-foreground)]">
-            {t("Learning progress")}
+            {t("Teacher Drill-down")}
           </p>
           <div className="mt-3 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div>
               <h1 className="text-[30px] font-semibold tracking-tight text-[var(--foreground)]">
-                {t("See the full learning arc, not just the latest quiz")}
+                {activeStudent?.student_id || t("Inspect evidence before deciding the next move")}
               </h1>
               <p className="mt-2 max-w-[720px] text-[14px] leading-6 text-[var(--muted-foreground)]">
-                {t("Track recent assessments, revisit weak topics, and spot where the student is building confidence.")}
+                {t("Review observed evidence first, then inspect diagnosis and the recommended next move.")}
               </p>
             </div>
             {loading && (
@@ -317,32 +325,36 @@ export default function StudentDashboardPage() {
           <div className="mt-4 grid gap-3 md:grid-cols-3">
             <div className="rounded-2xl bg-[var(--muted)]/50 px-4 py-3">
               <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
-                {t("Next Steps")}
+                {t("Recommended action")}
               </div>
               <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
-                {focusTopics.length > 0
-                  ? t("Review the weakest topic before assigning a harder pack")
-                  : t("No weak topics detected yet. The student is ready for a stretch goal.")}
+                {activeStudent?.recommended_actions[0]?.rationale ??
+                  (focusTopics.length > 0
+                    ? t("Review the weakest topic before assigning a harder pack")
+                    : t("No weak topics detected yet. The student is ready for a stretch goal."))}
               </div>
             </div>
             <div className="rounded-2xl bg-[var(--muted)]/50 px-4 py-3">
               <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
-                {t("Focus next")}
+                {t("Observed topic")}
               </div>
               <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
-                {focusTopics[0]?.topic || t("No weak topics detected yet.")}
+                {activeStudent?.observed?.topic || focusTopics[0]?.topic || t("No weak topics detected yet.")}
               </div>
             </div>
             <div className="rounded-2xl bg-[var(--muted)]/50 px-4 py-3">
               <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
-                {t("Suggested learning path")}
+                {t("Diagnosis")}
               </div>
               <div className="mt-1 text-[13px] font-medium text-[var(--foreground)]">
-                {suggestedPath[0]?.topic || t("No learning path suggestions yet. Complete an assessment or add pack objectives to unlock the next-step sequence.")}
+                {activeStudent?.inferred[0]?.diagnosis_type ||
+                  t("No diagnosis available. Complete an assessment or tutoring session to generate evidence.")}
               </div>
             </div>
           </div>
         </section>
+
+        <StudentInsightDetail student={activeStudent} t={t} />
 
         {error && (
           <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">

--- a/web/app/(workspace)/dashboard/student/page.tsx
+++ b/web/app/(workspace)/dashboard/student/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { ArrowLeft, ArrowRight, BookOpen, Flame, LineChart, Loader2, Target } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -221,7 +221,7 @@ function LearningPathCard({
   );
 }
 
-export default function StudentDashboardPage() {
+function StudentDashboardContent() {
   const { t } = useTranslation();
   const searchParams = useSearchParams();
   const studentId = searchParams.get("student") ?? "";
@@ -428,5 +428,26 @@ export default function StudentDashboardPage() {
         </section>
       </div>
     </main>
+  );
+}
+
+export default function StudentDashboardPage() {
+  const { t } = useTranslation();
+
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-full bg-[radial-gradient(circle_at_top_left,_rgba(247,208,96,0.18),_transparent_32%),linear-gradient(180deg,_var(--background),_color-mix(in_oklab,_var(--background)_78%,_white))]">
+          <div className="mx-auto flex w-full max-w-[1120px] items-center justify-center px-6 py-16">
+            <div className="inline-flex items-center gap-2 text-[13px] text-[var(--muted-foreground)]">
+              <Loader2 size={14} className="animate-spin" />
+              {t("Loading student detail")}
+            </div>
+          </div>
+        </main>
+      }
+    >
+      <StudentDashboardContent />
+    </Suspense>
   );
 }

--- a/web/components/dashboard/InsightSectionLabel.tsx
+++ b/web/components/dashboard/InsightSectionLabel.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+export function InsightSectionLabel({
+  eyebrow,
+  title,
+  toneClassName = "text-[var(--muted-foreground)]",
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  toneClassName?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className={`text-[11px] font-semibold uppercase tracking-[0.12em] ${toneClassName}`}>
+        {eyebrow}
+      </div>
+      <div className="text-[14px] font-medium text-[var(--foreground)]">{title}</div>
+      {children ? <div className="text-[12px] text-[var(--muted-foreground)]">{children}</div> : null}
+    </div>
+  );
+}

--- a/web/components/dashboard/SmallGroupInsightCard.tsx
+++ b/web/components/dashboard/SmallGroupInsightCard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
+import type { DashboardInsights } from "@/lib/dashboard-api";
+
+type SmallGroupInsight = DashboardInsights["small_groups"][number];
+
+export function SmallGroupInsightCard({
+  group,
+  t,
+}: {
+  group: SmallGroupInsight;
+  t: (value: string, options?: Record<string, string | number>) => string;
+}) {
+  return (
+    <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <InsightSectionLabel eyebrow={t("Small Group")} title={group.topic}>
+          {group.diagnosis_type}
+        </InsightSectionLabel>
+        <span className="rounded-full bg-[var(--muted)] px-2.5 py-1 text-[11px] text-[var(--muted-foreground)]">
+          {t("{{count}} students", { count: group.student_ids.length })}
+        </span>
+      </div>
+
+      <div className="mt-4 rounded-2xl bg-emerald-50 p-3">
+        <InsightSectionLabel
+          eyebrow={t("Recommended Action")}
+          title={group.recommended_action}
+          toneClassName="text-emerald-700"
+        />
+        <div className="mt-3 text-[12px] text-[var(--muted-foreground)]">
+          {t("Students: {{students}}", { students: group.student_ids.join(", ") })}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/web/components/dashboard/StudentInsightCard.tsx
+++ b/web/components/dashboard/StudentInsightCard.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
+import type { TeacherInsightStudent } from "@/lib/dashboard-api";
+
+function formatLatency(seconds: number | undefined): string | null {
+  if (seconds == null) return null;
+  if (seconds < 1) return `≈${Math.round(seconds * 1000)} ms`;
+  return `${Math.round(seconds)} s`;
+}
+
+export function StudentInsightCard({
+  student,
+  t,
+}: {
+  student: TeacherInsightStudent;
+  t: (value: string, options?: Record<string, string | number>) => string;
+}) {
+  const diagnosis = student.inferred[0];
+  const recommendation = student.recommended_actions[0];
+
+  return (
+    <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="text-[12px] font-semibold uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
+            {student.student_id}
+          </div>
+          <div className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
+            {student.observed?.topic ?? t("No dominant topic")}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-[var(--muted)] px-2.5 py-1 text-[11px] text-[var(--muted-foreground)]">
+            {t("{{confidence}} confidence", { confidence: diagnosis?.confidence_tag ?? "N/A" })}
+          </span>
+          <Link
+            href={`/dashboard/student?student=${encodeURIComponent(student.student_id)}`}
+            className="inline-flex items-center gap-1 rounded-full border border-[var(--border)] px-3 py-1 text-[11px] font-medium text-[var(--foreground)] transition hover:border-[var(--foreground)]"
+          >
+            {t("Open detail")}
+            <ArrowRight size={12} />
+          </Link>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <section className="rounded-2xl bg-[var(--muted)]/45 p-3">
+          <InsightSectionLabel eyebrow={t("Observed")} title={student.observed?.topic ?? t("No recent evidence")} />
+          <div className="mt-3 space-y-2 text-[12px] text-[var(--foreground)]">
+            <div>{t("Misses: {{count}}", { count: student.observed?.miss_count ?? 0 })}</div>
+            <div>{t("Latency: {{value}}", { value: formatLatency(student.observed?.avg_latency_seconds) ?? t("Unknown") })}</div>
+            {student.student_state?.support_level ? (
+              <div>{t("Support: {{value}}", { value: student.student_state.support_level })}</div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="rounded-2xl bg-amber-50 p-3">
+          <InsightSectionLabel
+            eyebrow={t("Inferred")}
+            title={diagnosis?.diagnosis_type ?? t("No diagnosis")}
+            toneClassName="text-amber-700"
+          >
+            {diagnosis?.topic ? t("Topic: {{topic}}", { topic: diagnosis.topic }) : t("No inferred topic")}
+          </InsightSectionLabel>
+          {diagnosis?.evidence?.length ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {diagnosis.evidence.slice(0, 3).map((fact) => (
+                <span
+                  key={`${student.student_id}-${fact}`}
+                  className="rounded-full bg-white/70 px-2.5 py-1 text-[11px] text-amber-900/80"
+                >
+                  {fact}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </section>
+
+        <section className="rounded-2xl bg-emerald-50 p-3">
+          <InsightSectionLabel
+            eyebrow={t("Recommended Action")}
+            title={recommendation?.action_type ?? t("No action yet")}
+            toneClassName="text-emerald-700"
+          >
+            {recommendation?.rationale ?? t("No recommendation available")}
+          </InsightSectionLabel>
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/web/components/dashboard/StudentInsightDetail.tsx
+++ b/web/components/dashboard/StudentInsightDetail.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
+import type { TeacherInsightStudent } from "@/lib/dashboard-api";
+
+function formatLatency(seconds: number | undefined): string | null {
+  if (seconds == null) return null;
+  if (seconds < 1) return `≈${Math.round(seconds * 1000)} ms`;
+  return `${Math.round(seconds)} s`;
+}
+
+export function StudentInsightDetail({
+  student,
+  t,
+}: {
+  student: TeacherInsightStudent | null;
+  t: (value: string, options?: Record<string, string | number>) => string;
+}) {
+  const diagnosis = student?.inferred[0];
+  const recommendation = student?.recommended_actions[0];
+
+  if (!student) {
+    return (
+      <section className="rounded-[28px] border border-dashed border-[var(--border)] bg-[var(--card)] px-5 py-8 text-center text-[13px] text-[var(--muted-foreground)]">
+        {t("Choose a student from the dashboard to inspect evidence and next steps.")}
+      </section>
+    );
+  }
+
+  return (
+    <section className="grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+      <div className="space-y-4">
+        <section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
+          <InsightSectionLabel eyebrow={t("Observed")} title={student.observed?.topic ?? t("No recent evidence")} />
+          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl bg-[var(--muted)]/50 p-3 text-[12px] text-[var(--foreground)]">
+              <div className="font-semibold text-[var(--muted-foreground)]">{t("Miss count")}</div>
+              <div className="mt-2 text-[18px] font-semibold text-[var(--foreground)]">
+                {student.observed?.miss_count ?? 0}
+              </div>
+            </div>
+            <div className="rounded-2xl bg-[var(--muted)]/50 p-3 text-[12px] text-[var(--foreground)]">
+              <div className="font-semibold text-[var(--muted-foreground)]">{t("Average latency")}</div>
+              <div className="mt-2 text-[18px] font-semibold text-[var(--foreground)]">
+                {formatLatency(student.observed?.avg_latency_seconds) ?? t("Unknown")}
+              </div>
+            </div>
+            <div className="rounded-2xl bg-[var(--muted)]/50 p-3 text-[12px] text-[var(--foreground)]">
+              <div className="font-semibold text-[var(--muted-foreground)]">{t("Confidence trend")}</div>
+              <div className="mt-2 text-[18px] font-semibold text-[var(--foreground)]">
+                {student.student_state?.confidence_trend ?? t("Unknown")}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
+          <InsightSectionLabel
+            eyebrow={t("Inferred")}
+            title={diagnosis?.diagnosis_type ?? t("No diagnosis")}
+            toneClassName="text-amber-700"
+          >
+            {t("Confidence: {{value}}", { value: diagnosis?.confidence_tag ?? "N/A" })}
+          </InsightSectionLabel>
+          <div className="mt-4 rounded-2xl bg-amber-50 p-4">
+            <div className="text-[13px] font-medium text-[var(--foreground)]">
+              {diagnosis?.topic ? t("Likely topic gap: {{topic}}", { topic: diagnosis.topic }) : t("No inferred topic")}
+            </div>
+            {diagnosis?.evidence?.length ? (
+              <ul className="mt-3 space-y-2 text-[12px] text-[var(--muted-foreground)]">
+                {diagnosis.evidence.map((fact) => (
+                  <li key={`${student.student_id}-${fact}`}>• {fact}</li>
+                ))}
+              </ul>
+            ) : (
+              <div className="mt-3 text-[12px] text-[var(--muted-foreground)]">
+                {t("No structured rationale was provided in the payload.")}
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
+        <InsightSectionLabel
+          eyebrow={t("Recommended Action")}
+          title={recommendation?.action_type ?? t("No action")}
+          toneClassName="text-emerald-700"
+        >
+          {t("Use this as the next teacher move, not as an automatic intervention.")}
+        </InsightSectionLabel>
+
+        <div className="mt-4 rounded-2xl bg-emerald-50 p-4">
+          <div className="text-[14px] font-medium text-[var(--foreground)]">
+            {recommendation?.rationale ?? t("No recommendation available")}
+          </div>
+          <div className="mt-4 space-y-2 text-[12px] text-[var(--muted-foreground)]">
+            <div>{t("Topic: {{topic}}", { topic: recommendation?.topic ?? diagnosis?.topic ?? t("Unknown") })}</div>
+            <div>
+              {t("Targets: {{count}} student(s)", {
+                count: recommendation?.target_student_ids.length ?? 0,
+              })}
+            </div>
+            {student.student_state?.support_level ? (
+              <div>{t("Support level: {{value}}", { value: student.student_state.support_level })}</div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/web/components/dashboard/TeacherInsightPanel.tsx
+++ b/web/components/dashboard/TeacherInsightPanel.tsx
@@ -1,3 +1,5 @@
+import { SmallGroupInsightCard } from "@/components/dashboard/SmallGroupInsightCard";
+import { StudentInsightCard } from "@/components/dashboard/StudentInsightCard";
 import type { DashboardInsights } from "@/lib/dashboard-api";
 import { useTranslation } from "react-i18next";
 
@@ -21,81 +23,43 @@ export function TeacherInsightPanel({
 
   return (
     <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
           <h2 className="text-[16px] font-semibold text-[var(--foreground)]">{t("Teacher insights")}</h2>
           <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
-            {t("Evidence-backed diagnosis for individual students and small groups.")}
+            {t("Clear evidence, diagnosis, and next-step actions for students and small groups.")}
           </p>
         </div>
-        <div className="rounded-full bg-[var(--muted)] px-3 py-1 text-[12px] text-[var(--muted-foreground)]">
-          {t("{{count}} students", { count: insights.students.length })}
+        <div className="flex flex-wrap gap-2">
+          <span className="rounded-full bg-[var(--muted)] px-3 py-1 text-[12px] text-[var(--muted-foreground)]">
+            {t("{{count}} students", { count: insights.students.length })}
+          </span>
+          <span className="rounded-full bg-[var(--muted)] px-3 py-1 text-[12px] text-[var(--muted-foreground)]">
+            {t("{{count}} small-group recommendations", { count: insights.small_groups.length })}
+          </span>
         </div>
       </div>
 
-      <div className="mt-4 grid gap-4 xl:grid-cols-[1.4fr_1fr]">
-        <div className="space-y-3">
-          {insights.students.map((student) => {
-            const diagnosis = student.inferred[0];
-            const recommendation = student.recommended_actions[0];
-            return (
-              <article key={student.student_id} className="rounded-2xl bg-[var(--muted)]/50 p-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <div className="text-[12px] font-semibold uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
-                      {student.student_id}
-                    </div>
-                    <div className="mt-1 text-[15px] font-medium text-[var(--foreground)]">
-                      {student.observed?.topic ?? t("No dominant topic")}
-                    </div>
-                  </div>
-                  <span className="rounded-full bg-[var(--card)] px-2.5 py-1 text-[11px] text-[var(--muted-foreground)]">
-                    {t("{{confidence}} confidence", { confidence: diagnosis?.confidence_tag ?? "n/a" })}
-                  </span>
-                </div>
-                <div className="mt-3 text-[13px] text-[var(--muted-foreground)]">
-                  {t("Diagnosis")}: <span className="text-[var(--foreground)]">{diagnosis?.diagnosis_type ?? t("None")}</span>
-                </div>
-                <div className="mt-2 text-[13px] leading-6 text-[var(--foreground)]">
-                  {recommendation?.rationale ?? t("No recommendation")}
-                </div>
-                {diagnosis?.evidence?.length ? (
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {diagnosis.evidence.map((item) => (
-                      <span
-                        key={`${student.student_id}-${item}`}
-                        className="rounded-full bg-[var(--card)] px-2.5 py-1 text-[11px] text-[var(--muted-foreground)]"
-                      >
-                        {item}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-              </article>
-            );
-          })}
+      <div className="mt-4 grid gap-4 xl:grid-cols-[1.8fr_1fr]">
+        <div className="space-y-4">
+          {insights.students.map((student) => (
+            <StudentInsightCard key={student.student_id} student={student} t={t} />
+          ))}
         </div>
 
-        <div className="space-y-3">
-          <div className="rounded-2xl bg-[var(--muted)]/40 p-4">
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-[var(--border)] bg-[var(--muted)]/40 p-4">
             <div className="text-[12px] font-semibold uppercase tracking-[0.08em] text-[var(--muted-foreground)]">
               {t("Small-group recommendations")}
             </div>
+            <p className="mt-2 text-[13px] text-[var(--muted-foreground)]">
+              {t("Use shared teaching actions to support multiple students with the same learning signal.")}
+            </p>
           </div>
+
           {insights.small_groups.length > 0 ? (
             insights.small_groups.map((group) => (
-              <article
-                key={`${group.topic}:${group.diagnosis_type}`}
-                className="rounded-2xl bg-[var(--muted)]/50 p-4"
-              >
-                <div className="text-[14px] font-medium text-[var(--foreground)]">{group.topic}</div>
-                <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">
-                  {group.diagnosis_type} · {group.student_ids.join(", ")}
-                </div>
-                <div className="mt-3 text-[13px] text-[var(--foreground)]">
-                  {t("Recommended action")}: {group.recommended_action}
-                </div>
-              </article>
+              <SmallGroupInsightCard key={`${group.topic}:${group.diagnosis_type}`} group={group} t={t} />
             ))
           ) : (
             <div className="rounded-2xl bg-[var(--muted)]/50 p-4 text-[13px] text-[var(--muted-foreground)]">


### PR DESCRIPTION
## Summary
- reshape `/dashboard` around student and small-group teacher insight cards
- add evidence-first drill-down on `/dashboard/student?student=<id>`
- document the Lane 5 dashboard workflow and handoff boundaries

## Validation
- `./node_modules/.bin/eslint --config eslint.config.mjs app/'(workspace)'/dashboard/page.tsx app/'(workspace)'/dashboard/student/page.tsx components/dashboard/TeacherInsightPanel.tsx components/dashboard/InsightSectionLabel.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts`\n- `git diff --check -- web/app/'(workspace)'/dashboard/page.tsx web/app/'(workspace)'/dashboard/student/page.tsx web/components/dashboard/TeacherInsightPanel.tsx web/components/dashboard/InsightSectionLabel.tsx web/components/dashboard/StudentInsightCard.tsx web/components/dashboard/SmallGroupInsightCard.tsx web/components/dashboard/StudentInsightDetail.tsx docs/superpowers/pr-notes/2026-04-26-lane-5-teacher-insight-ui.md docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md ai_first/daily/2026-04-26.md ai_first/ACTIVE_ASSIGNMENTS.md`\n\n## Main System Map\n- Not updated; this lane changes the teacher-facing dashboard workflow within the existing top-level dashboard boundary.