### PR TITLE
docs(evidence): refresh lane-6 smoke readiness [L6]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -32,13 +32,13 @@ Rules:
 
 - Owner: Codex
 - Machine: `MacBook-Air-cua-Loc.local`
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: `L2_SPEC_RUNTIME_ASSEMBLY`
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane6`
+- Task: `L6_EVALUATION_EVIDENCE_READINESS`
 - Status: In progress
-- Branch: `pod-a/spec-runtime-assembly`
-- Task packet: `docs/superpowers/tasks/2026-04-26-lane-2-spec-runtime-assembly.md`
-- Owned files: `deeptutor/services/runtime_policy/`, `deeptutor/services/prompt/`, `deeptutor/runtime/orchestrator.py`, `deeptutor/capabilities/chat.py`, `deeptutor/capabilities/deep_question.py`, `tests/services/runtime_policy/`, `tests/core/test_capabilities_runtime.py`, `tests/services/test_prompt_manager.py`, `docs/superpowers/pr-notes/*`
-- PR: `#139` (Ready)
+- Branch: `docs/evaluation-evidence-readiness`
+- Task packet: `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
+- Owned files: `docs/contest/`, `ai_first/evidence/`, `docs/superpowers/pr-notes/`, `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/daily/2026-04-26.md`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`
+- PR: Not opened
 - Last update: 2026-04-26
-- Next action: Resolve the latest `origin/main` sync, push the branch, then merge PR `#139` once GitHub recalculates mergeability.
+- Next action: Refresh contest evidence docs for the hybrid authoring plus evidence-loop demo and calibrate known limitations.
 - Blocker: None

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: `MacBook-Air-cua-Loc.local`
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane6`
 - Task: `L6_EVALUATION_EVIDENCE_READINESS`
-- Status: In progress
+- Status: In review (Draft PR)
 - Branch: `docs/evaluation-evidence-readiness`
 - Task packet: `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
 - Owned files: `docs/contest/`, `ai_first/evidence/`, `docs/superpowers/pr-notes/`, `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/daily/2026-04-26.md`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`
-- PR: Not opened
+- PR: `#145` (Draft)
 - Last update: 2026-04-26
-- Next action: Refresh contest evidence docs for the hybrid authoring plus evidence-loop demo and calibrate known limitations.
+- Next action: Wait for review feedback and optionally capture hybrid `/agents` screenshots to upgrade remaining `Stale` rows.
 - Blocker: None

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current State
 
-Last updated: 2026-04-25
+Last updated: 2026-04-26
 
 This file is a compatibility snapshot. The authoritative operating instructions live in `ai_first/AI_OPERATING_PROMPT.md`.
 
@@ -28,10 +28,10 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Latest merged docs/control-plane PR: `#129 docs: clean up control plane after smoke refresh`
-- Current branch for this sync: `docs/post-130-screenshot-sync`
-- Product MVP path status: Knowledge Pack, assessment, tutor, dashboard, marketplace, offline, analytics, contest evidence, submission docs, optional video runbook, two-person collaboration workflow, and the full two-lane contest MVP polish experiment are merged to `main`.
-- Current purpose: clear the stale post-merge lane status and keep the merged evidence state visible.
+- Latest merged docs/control-plane PR: `#139 [L2] feat(runtime): compile teacher policy blocks into prompt assembly`
+- Current branch for this sync: `docs/evaluation-evidence-readiness`
+- Product MVP path status: core contest flow plus Wave 1 evidence spine and lane 1-4 contracts are merged to `main`; lane 6 is documenting hybrid-proof readiness and evidence calibration.
+- Current purpose: keep contest evidence docs aligned with the merged hybrid teacher-authoring plus evidence-loop story without claiming unverified runtime behavior.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -59,16 +59,16 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-25-post-130-screenshot-sync.md`
+- Current open task packet: `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
 - Current open GitHub issue:
-- Latest completed smoke run result: the 2026-04-25 scripted-reset smoke pass succeeded with backend online through the CLI server path, frontend build passed after `npm ci`, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
+- Latest completed smoke run result: the 2026-04-26 scripted-reset smoke pass succeeded with backend online through the CLI server path, frontend build passed after `npm ci`, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
 - Recently completed merged work: the screenshot bundle refresh re-run merged on 2026-04-25 through PR `#130`, and evidence docs now mark screenshots `Current`.
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Keep the merged screenshot evidence state reflected in the compact mirrors and contest entry docs.
+Complete lane 6 docs/evidence updates and record calibrated hybrid-proof limitations in the contest artifacts.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -12,22 +12,22 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
 - Lane 4 (`2026-04-26-lane-4-diagnosis-recommendation`) merged to `main` through PR `#142`.
-- Latest smoke result: the 2026-04-25 scripted-reset smoke pass succeeded against current `main`.
+- Latest smoke result: the 2026-04-26 scripted-reset smoke pass succeeded in lane 6 (`docs/evaluation-evidence-readiness`) against current `main` behavior.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
 - Core MVP path in `main` now also includes the Wave 1 evidence spine: structured observations, student-state persistence, assessment diagnosis, and teacher insight payloads on top of the earlier marketplace, assessment, tutor, dashboard, offline, analytics, evidence, and submission flows.
 
 ## Active queue
 
-- No active AI-owned implementation lane is open right now.
-- Current purpose: prepare clean multi-session execution from `main` using one lane packet per session.
+- Lane 6 (`docs/evaluation-evidence-readiness`) is in progress for docs/evidence alignment.
+- Current purpose: keep contest evidence and readiness docs aligned with the merged hybrid flow while avoiding overclaims.
 
 ## Next recommended task
 
-Create or use one session per lane from `main` with these packets:
+Complete the active lane and then continue with remaining packetized work from `main`:
 
-1. `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md`
-2. `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
+1. `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md` (current session)
+2. `docs/superpowers/tasks/2026-04-26-lane-5-teacher-insight-ui.md` (if still open after lane 6 handoff)
 
 If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -1,13 +1,13 @@
 # Next Actions
 
-Last updated: 2026-04-25
+Last updated: 2026-04-26
 
 This file is a compatibility snapshot. The authoritative action list lives in `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Immediate
 
-1. Keep the merged screenshot bundle and evidence-doc updates from PR `#130` as the current contest evidence baseline.
-2. Refresh the compact mirrors after the merged screenshot lane so they no longer describe that lane as active.
+1. Complete lane 6 (`L6_EVALUATION_EVIDENCE_READINESS`) docs updates for hybrid-proof demo flow and evidence calibration.
+2. Keep `docs/contest/VALIDATION_REPORT.md` and `docs/contest/EVIDENCE_CHECKLIST.md` aligned on what is `Current` versus what is still pending recapture.
 3. Treat any future smoke failure as the next product task before opening another polish slice.
 4. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new lane or docs sync.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, smoke passes, screenshot refreshes, lane changes, and blocker changes.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -72,3 +72,14 @@
 - Tests: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
 - Blockers: None.
 - Next: Start Lane 5 (`L5_TEACHER_INSIGHT_UI`) from updated `main`.
+
+## Lane 6
+
+- Branch: `docs/evaluation-evidence-readiness`
+- Task: `L6_EVALUATION_EVIDENCE_READINESS`
+- Done: Re-aligned contest docs and compact AI-first mirrors for the hybrid proof narrative (teacher Agent Spec authoring + evidence loop) with explicit claim calibration to avoid overstating runtime binding.
+- Docs updated: `docs/contest/README.md`, `docs/contest/DEMO_SCRIPT.md`, `docs/contest/EVIDENCE_CHECKLIST.md`, `docs/contest/VALIDATION_REPORT.md`, `docs/contest/SUBMISSION_PACKAGE.md`, `docs/contest/HUMAN_REVIEW_HANDOFF.md`, `ai_first/evidence/demo-script.md`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`.
+- Smoke refresh run: 2026-04-26 scripted reset + backend/API + frontend build all passed in `.worktrees/lane6`.
+- Tests: `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`; `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`; `curl -s http://127.0.0.1:8001/api/v1/system/status`; `curl -s http://127.0.0.1:8001/api/v1/knowledge/list`; `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview`; `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent`; `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo`; `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo`; `cd web && npm ci && npm run build`; `git diff --check`
+- Blockers: None.
+- Next: Capture hybrid `/agents` screenshots in a dedicated browser run, then move corresponding checklist rows from `Stale` to `Current`.

--- a/ai_first/evidence/demo-script.md
+++ b/ai_first/evidence/demo-script.md
@@ -6,6 +6,14 @@ Show one reliable end-to-end learning loop:
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher views dashboard.
 
+Optional hybrid add-on before Scene 1:
+
+- open `/agents` to show teacher Agent Spec authoring;
+- show structured `IDENTITY`, `SOUL`, and `RULES` sections;
+- export a spec pack.
+
+Keep this claim scoped to authoring proof unless the current smoke run verifies full turn-time runtime binding.
+
 ## Scene 1: Teacher creates Knowledge Pack
 
 - Open Teacher or Knowledge page.

--- a/docs/contest/DEMO_SCRIPT.md
+++ b/docs/contest/DEMO_SCRIPT.md
@@ -10,6 +10,16 @@ Use this script to present the MVP in the same order as the project goal.
 4. Open the web workspace in a browser.
 5. Use demo-safe sample content. Do not use private student data.
 
+## Hybrid Presenter Check
+
+Before the learning loop, optionally show a short teacher-authoring proof on `/agents`:
+
+1. Open Agent Specs authoring.
+2. Show structured sections (`IDENTITY`, `SOUL`, `RULES`) and free-form markdown sections.
+3. Export the spec pack.
+
+Do not claim that every live turn is already bound to a selected `agent_spec_id` unless that exact path is re-verified in the current smoke run.
+
 ## Demo Path
 
 ### 1. Teacher Creates A Knowledge Pack
@@ -91,3 +101,4 @@ Evidence to capture:
 - Use one consistent sample topic across all screens.
 - If an external LLM provider is unavailable, explain the unavailable credential and show the local validation report instead of inventing evidence.
 - After the demo, open `VALIDATION_REPORT.md` to show exact commands and known limitations.
+- If you include the hybrid authoring check, keep it under one minute and treat it as authoring proof unless runtime binding is re-verified in this environment.

--- a/docs/contest/EVIDENCE_CHECKLIST.md
+++ b/docs/contest/EVIDENCE_CHECKLIST.md
@@ -18,20 +18,29 @@ Refresh these only when the UI changed or when the latest smoke-backed validatio
 | Dashboard | Summary cards visible | Browser capture | Current | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass`; see `05-dashboard-summary-and-activity.png`. |
 | Dashboard | Recent activity includes assessment/tutoring distinction and Knowledge Pack reference | Browser capture | Current | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass`; see `05-dashboard-summary-and-activity.png`. |
 
+## Hybrid Proof Screenshots
+
+Use this section to calibrate claims when showing teacher authoring plus evidence loop in one demo.
+
+| Area | Evidence | Refresh mode | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Agent Specs authoring | Structured `IDENTITY`, `SOUL`, and `RULES` sections visible on `/agents` | Browser capture | Stale | Route and feature are merged, but this screenshot is not yet part of the contest bundle. Capture only after a successful smoke-backed refresh cycle. |
+| Agent Specs authoring | Export action visible from authoring tab | Browser capture | Stale | Keep claim scoped to authoring/export proof unless runtime binding is re-verified. |
+
 ## Required Command Evidence
 
 Refresh these automatically after every successful smoke pass.
 
 | Command | Refresh mode | Status | Source |
 | --- | --- | --- | --- |
-| `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Auto before smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
-| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed on 2026-04-25; see `VALIDATION_REPORT.md`. |
-| `cd web && npm ci && npm run build` | Auto after smoke | Current | Passed on 2026-04-25 in the fresh smoke worktree, with the existing lockfile warning. |
+| `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Auto before smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/system/status` | Auto after smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Auto after smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Auto after smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Auto after smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
+| `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
+| `cd web && npm ci && npm run build` | Auto after smoke | Current | Passed on 2026-04-26 in lane 6, with the existing lockfile warning. |
 
 ## Optional Video
 
@@ -60,7 +69,8 @@ Video status follows the same freshness states:
 | Criterion | Status | Notes |
 | --- | --- | --- |
 | Full MVP story can be followed from docs | Passed | Start with `docs/contest/README.md`. |
+| Hybrid authoring plus evidence-loop claim is calibrated | Passed | Hybrid authoring is documented with explicit pending-capture and runtime-binding caveats. |
 | Product commands have smoke-backed validation evidence | Passed | See `VALIDATION_REPORT.md`. |
-| Screenshots are captured and linked | Passed | The screenshot bundle was refreshed on 2026-04-25 against the current merged UI. |
+| Screenshots are captured and linked | Passed with pending hybrid capture | Core screenshot bundle is current from 2026-04-25; `/agents` hybrid screenshots remain `Stale` until recaptured. |
 | Video is captured or explicitly deferred | Deferred | Optional unless submission requires it. |
 | No secrets or private data in evidence | Passed | Screenshots use demo-safe Knowledge Pack and session data. |

--- a/docs/contest/HUMAN_REVIEW_HANDOFF.md
+++ b/docs/contest/HUMAN_REVIEW_HANDOFF.md
@@ -37,6 +37,7 @@ Before submission, quickly verify:
 
 - screenshots are clear and contain no private data
 - `docs/contest/VALIDATION_REPORT.md` still matches the intended demo environment
+- hybrid authoring claims stay calibrated: `/agents` authoring can be shown, but live `agent_spec_id` runtime binding is only claimed when freshly verified
 - optional video is either not required or has been recorded separately using `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`
 
 ### 4. Final package sign-off

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -6,6 +6,15 @@ This folder is the entry point for VnExpress Sang kien Khoa hoc 2026 demo eviden
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
 
+## Hybrid Proof Scope
+
+This evidence bundle now supports a hybrid contest narrative:
+
+- Teacher authoring proof: the teacher can structure Agent Specs on `/agents` and export a spec pack.
+- Learning evidence-loop proof: Knowledge Pack -> assessment -> tutoring follow-up -> dashboard activity.
+
+Runtime wiring between a selected `agent_spec_id` and every live turn request is still treated as a known limitation unless explicitly re-verified by smoke.
+
 ## Evidence Files
 
 - [`SUBMISSION_PACKAGE.md`](./SUBMISSION_PACKAGE.md): compact final review path for contest submission.
@@ -18,8 +27,10 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Current Status
 
 - Product MVP path is implemented through merged PRs for Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard.
-- The latest scripted-reset smoke-backed MVP verification passed on 2026-04-25 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
+- Teacher Agent Spec authoring UI/API and runtime policy assembly contracts are merged on `main` and documented as hybrid-proof context.
+- The latest scripted-reset smoke-backed MVP verification passed on 2026-04-26 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
 - Screenshot evidence is captured in [`screenshots/`](./screenshots/) and is current again after the refreshed `T037` re-run merged on 2026-04-25.
+- Hybrid `/agents` screenshots are intentionally marked `Stale` until a dedicated recapture run is completed.
 - Video capture is optional and deferred to avoid storing large media in the repository.
 
 ## Evidence Refresh Rules

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -10,6 +10,12 @@ One-line pitch:
 
 An AI-first learning platform where Vietnamese teachers create Knowledge Packs and teaching skills, then AI Tutor Agents help students learn, practice, and improve from teacher-approved materials.
 
+Hybrid proof calibration:
+
+- Teacher authoring capability on `/agents` is part of the merged product story.
+- Contest evidence-loop proof remains anchored to smoke-backed Knowledge Pack -> assessment -> tutor -> dashboard artifacts.
+- Do not claim universal live turn-time binding of `agent_spec_id` unless that path is re-verified in the target demo environment.
+
 Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/competition/pitch-notes.md).
 
 ## Ready Evidence
@@ -32,12 +38,12 @@ Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/com
 
 ## Latest Validation
 
-The latest smoke-backed refresh passed on 2026-04-25 after running the scripted local reset. It verified:
+The latest smoke-backed refresh passed on 2026-04-26 after running the scripted local reset. It verified:
 
 - demo-safe Knowledge Pack `contest-demo-quadratics`;
 - assessment session `contest-assessment-demo`;
 - tutor session `contest-tutor-demo`;
-- dashboard overview and recent activity;
+- dashboard overview and recent activity including the contest sessions;
 - frontend production build with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
 
 Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` and `#128` for smoke-backed evidence, and `#99` plus `#130` for the screenshot bundle.
@@ -61,9 +67,10 @@ If the submission requires video, use [`VIDEO_CAPTURE_RUNBOOK.md`](./VIDEO_CAPTU
 
 - Optional video is deferred to avoid storing large media in the repository.
 - Provider-backed AI quality depends on configured model credentials.
+- Hybrid authoring evidence for `/agents` is documented but still pending dedicated screenshot capture in the contest bundle.
 - The backend `deeptutor.api.run_server` path has a reload/absolute-pattern incompatibility with the installed `uvicorn`; latest smoke used the CLI server path with reload disabled.
 - Frontend build may need network access to fetch Google Fonts.
-- Screenshots are current as of the 2026-04-25 `T037` re-run and should be recaptured only if the UI meaningfully changes again.
+- Core-loop screenshots are current as of the 2026-04-25 `T037` re-run; hybrid `/agents` screenshots remain pending dedicated recapture.
 
 ## Review Flow
 

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -1,6 +1,6 @@
 # Validation Report
 
-Last updated: 2026-04-25
+Last updated: 2026-04-26
 
 ## Scope
 
@@ -10,13 +10,14 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Evidence Freshness Status
 
-Latest smoke-backed refresh: 2026-04-25
+Latest smoke-backed refresh: 2026-04-26
 
 | Evidence group | Refresh mode | Status | Latest source |
 | --- | --- | --- | --- |
-| Backend and API reachability | Auto after smoke | Current | Scripted-reset smoke run recorded in `ai_first/daily/2026-04-25.md`. |
-| Frontend production build | Auto after smoke | Current | `npm ci && npm run build` passed on 2026-04-25 with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` in the fresh smoke worktree. |
+| Backend and API reachability | Auto after smoke | Current | Scripted-reset smoke run recorded in `ai_first/daily/2026-04-26.md`. |
+| Frontend production build | Auto after smoke | Current | `npm ci && npm run build` passed on 2026-04-26 with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` in the lane-6 worktree. |
 | Screenshot bundle | Browser capture after smoke when the UI changes | Current | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass` against the current merged UI. |
+| Hybrid authoring screenshots (`/agents`) | Browser capture after smoke when hybrid story is presented | Stale | Lane 6 documented the hybrid proof path, but the contest screenshot bundle has not yet captured `/agents` authoring evidence. |
 | Optional video | Human capture only | Deferred | No external video is required yet. |
 
 Use these status values consistently:
@@ -30,27 +31,28 @@ Use these status values consistently:
 
 | Area | Command | Result |
 | --- | --- | --- |
-| Scripted demo reset | `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Passed on 2026-04-25; it recreated `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo` in the fresh worktree. |
-| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed on 2026-04-25 with backend `online`, configured `gpt-4o-mini`, and local fallback search. |
-| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed on 2026-04-25; `contest-demo-quadratics` was present with demo-safe metadata and `sharing_status=demo`. |
-| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed on 2026-04-25 with one assessment, one tutoring session, and recent activity grounded in `contest-demo-quadratics`. |
-| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed on 2026-04-25 with assessment and tutor activity grounded in `contest-demo-quadratics`. |
-| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed on 2026-04-25 and returned `context_support` plus demo-safe Knowledge Pack references. |
-| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed on 2026-04-25 and returned `context_support` plus demo-safe Knowledge Pack references. |
-| Frontend production build | `cd web && npm ci && npm run build` | Passed on 2026-04-25 in the fresh smoke worktree, with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing multiple-lockfile warning. |
+| Scripted demo reset | `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Passed on 2026-04-26; it recreated `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo` in the lane-6 worktree. |
+| Backend health | `curl -s http://127.0.0.1:8001/api/v1/system/status` | Passed on 2026-04-26 with backend `online`, configured `gpt-4.1`, embeddings not configured, and fallback search provider `duckduckgo`. |
+| Knowledge Pack presence | `curl -s http://127.0.0.1:8001/api/v1/knowledge/list` | Passed on 2026-04-26; `contest-demo-quadratics` was present with demo-safe metadata and team-safe sharing status. |
+| Dashboard overview | `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview` | Passed on 2026-04-26 with recent activity including the contest assessment and tutor sessions grounded in `contest-demo-quadratics`. |
+| Dashboard recent activity | `curl -s http://127.0.0.1:8001/api/v1/dashboard/recent` | Passed on 2026-04-26 with assessment and tutor activity grounded in `contest-demo-quadratics`. |
+| Assessment evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Passed on 2026-04-26 and returned `context_support` plus demo-safe Knowledge Pack references. |
+| Tutor evidence session | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Passed on 2026-04-26 and returned `context_support` plus demo-safe Knowledge Pack references. |
+| Frontend production build | `cd web && npm ci && npm run build` | Passed on 2026-04-26 in lane 6, with `NEXT_PUBLIC_API_BASE=http://localhost:8001` from `web/.env.local` and the existing multiple-lockfile warning. |
 
 ## Current Known Limitations
 
 - Video evidence is deferred unless the final contest submission requires it.
 - The frontend build emits a Next.js warning about multiple lockfiles and inferred workspace root. The build still completes successfully.
 - Browser-backed screenshot refresh now works in a local worktree, but it still depends on a running backend and frontend plus demo-safe local data.
+- Runtime handoff from selected `agent_spec_id` through every live session-turn request path is not yet claimed as universally wired in this report. Treat `/agents` authoring as demonstrated UI/API capability unless a fresh smoke pass verifies full request-path binding.
 - Local provider-backed assessment generation was unavailable during the 2026-04-25 screenshot refresh because the configured model key was still a placeholder. The refreshed `07` and `08` screenshots therefore use demo-safe local session content in the worktree data store instead of a live provider response.
 - Provider-backed AI quality depends on configured model credentials. If credentials are unavailable during a demo, use the command validation and recorded UI flow as fallback evidence.
 - This report uses demo-safe descriptions only. Do not add real student data.
 
 ## Local Demo Run
 
-The latest smoke-backed evidence refresh used local demo data only:
+The latest smoke-backed evidence refresh used local demo data only (2026-04-26):
 
 - Reset: `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
 - Backend: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001`
@@ -60,9 +62,9 @@ The latest smoke-backed evidence refresh used local demo data only:
   - `contest-assessment-demo`
   - `contest-tutor-demo`
 - Screenshot refresh follow-up:
-  - browser capture run from `docs/t037-contest-screenshot-refresh-pass`
-  - refreshed files under `docs/contest/screenshots/`
-  - local demo-safe assistant content was seeded into `contest-assessment-demo` inside the worktree `data/` directory only
+  - no new screenshot recapture was performed in this smoke pass;
+  - existing screenshot bundle remains valid for the current core loop;
+  - hybrid `/agents` screenshot rows remain `Stale` until dedicated capture.
 
 Before future smoke or evidence refresh runs, use `DEMO_DATA_RESET.md` when local demo state may be missing or stale.
 
@@ -74,17 +76,17 @@ python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://lo
 
 The first backend attempt with `.venv/bin/python -m deeptutor.api.run_server` failed before binding because the reload configuration passed absolute `reload_excludes` paths to the installed `uvicorn`, which rejects non-relative glob patterns. The smoke run used the existing CLI server path with reload disabled instead.
 
-The first frontend build attempt failed in sandbox because Next.js could not fetch Google Fonts. Re-running the same build with network permission passed. The build still emits the existing multiple-lockfile warning.
+The frontend build in this smoke pass completed successfully. It still emits the existing multiple-lockfile warning.
 
 ## Smoke-backed Verification Record
 
-The 2026-04-25 scripted-reset smoke run verified the MVP path in the current merged state:
+The 2026-04-26 scripted-reset smoke run verified the MVP path in the current merged state:
 
 1. scripted reset recreated the demo-safe Knowledge Pack and assessment/tutor sessions in the fresh worktree;
 2. backend started successfully with the repository-local virtual environment through the CLI server path;
 3. system status, knowledge list, dashboard overview, dashboard recent, assessment session, and tutor session endpoints all returned the expected demo-safe data;
-4. the frontend production build passed against `http://localhost:8001` after `npm ci` in the new worktree;
-5. screenshot evidence was refreshed on 2026-04-25 after the merged UI changes from `T044`, `T045`, and `T046`.
+4. the frontend production build passed against `http://localhost:8001` after `npm ci` in the lane-6 worktree;
+5. screenshot bundle status stayed `Current` for the core loop, while hybrid `/agents` screenshots stayed `Stale` pending dedicated capture.
 
 ## Manual Verification Template
 
@@ -126,3 +128,5 @@ Complete this section when the local app is running.
 rg -n "evidence refresh|smoke|validation|screenshot|video|Current|Stale|Blocked" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
 git diff --check
 ```
+
+6. When the hybrid authoring story is presented to reviewers, capture `/agents` authoring screenshots after a successful smoke cycle and move the hybrid rows from `Stale` to `Current`.

--- a/docs/superpowers/pr-notes/2026-04-26-lane-6-evaluation-evidence-readiness.md
+++ b/docs/superpowers/pr-notes/2026-04-26-lane-6-evaluation-evidence-readiness.md
@@ -1,0 +1,43 @@
+# PR Note: Lane 6 Evaluation, Evidence, and Contest Readiness
+
+Date: 2026-04-26
+Task ID: `L6_EVALUATION_EVIDENCE_READINESS`
+Commit tag: `L6`
+Branch: `docs/evaluation-evidence-readiness`
+
+## Summary
+
+This lane updates contest-facing and AI-first mirror docs to keep the hybrid proof narrative accurate:
+
+- teacher authoring proof on `/agents` is documented;
+- evidence-loop proof remains anchored to smoke-backed artifacts;
+- runtime binding claims are explicitly calibrated to avoid overstatement.
+
+## Architecture Impact
+
+- Runtime/product code: unchanged.
+- Documentation contracts: updated in `docs/contest/` and compact mirrors under `ai_first/`.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`: not updated in this lane (no system-structure change introduced).
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Authoring[Teacher Agent Spec Authoring /agents]
+  Loop[Knowledge -> Assessment -> Tutor -> Dashboard]
+  Smoke[Smoke + Reset Validation]
+  Checklist[Evidence Checklist]
+  Report[Validation Report]
+  Submission[Submission Package]
+
+  Authoring --> Checklist
+  Loop --> Smoke
+  Smoke --> Report
+  Report --> Checklist
+  Checklist --> Submission
+```
+
+## Risk Notes
+
+- Hybrid proof screenshots for `/agents` are marked pending (`Stale`) until a future smoke-backed capture run.
+- Existing smoke-backed evidence for the core loop remains `Current` as of 2026-04-26.


### PR DESCRIPTION
## Summary
- refresh lane-6 contest evidence docs with 2026-04-26 smoke-backed verification
- calibrate Current/Stale status across checklist, validation report, and submission mirrors
- keep hybrid `/agents` screenshots explicitly marked `Stale` pending dedicated browser recapture

## Verification
- python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
- /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m deeptutor_cli.main serve --host 127.0.0.1 --port 8001
- curl -s http://127.0.0.1:8001/api/v1/system/status
- curl -s http://127.0.0.1:8001/api/v1/knowledge/list
- curl -s http://127.0.0.1:8001/api/v1/dashboard/overview
- curl -s http://127.0.0.1:8001/api/v1/dashboard/recent
- curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo
- curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo
- cd web && npm ci && npm run build
- rg -n "evidence refresh|smoke|validation|screenshot|video|Current|Stale|Blocked" docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first -S
- git diff --check

## Architecture
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unchanged (docs/evidence-only lane)
- architecture note: `docs/superpowers/pr-notes/2026-04-26-lane-6-evaluation-evidence-readiness.md`
