### PR TITLE
docs(ai-first): sync queue after evidence merge [OPS-SYNC]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -33,12 +33,12 @@ Rules:
 - Owner: Codex
 - Machine: `MacBook-Air-cua-Loc.local`
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane6`
-- Task: `OPS_EVIDENCE_RECAPTURE_DASHBOARD_AGENTS`
-- Status: Ready for review
-- Branch: `docs/evidence-dashboard-agents-recapture`
-- Task packet: `docs/superpowers/tasks/2026-04-26-dashboard-agents-evidence-recapture.md`
-- Owned files: `docs/contest/screenshots/*`, `docs/contest/EVIDENCE_CHECKLIST.md`, `docs/contest/VALIDATION_REPORT.md`, `docs/contest/DEMO_SCRIPT.md`, `docs/contest/README.md`, `docs/contest/SUBMISSION_PACKAGE.md`, `docs/superpowers/tasks/2026-04-26-dashboard-agents-evidence-recapture.md`, `docs/superpowers/pr-notes/*`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/EXECUTION_QUEUE.md`, `ai_first/daily/2026-04-26.md`
-- PR: `#147` (Draft)
+- Task: `OPS_POST_147_EVIDENCE_SYNC`
+- Status: In progress
+- Branch: `docs/post-147-evidence-merge-sync`
+- Task packet: `docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md`
+- Owned files: `ai_first/EXECUTION_QUEUE.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md`, `docs/superpowers/pr-notes/*`
+- PR: not opened yet
 - Last update: 2026-04-26
-- Next action: Wait for CI on PR `#147`, then merge if green under the docs auto-merge policy.
+- Next action: Sync the compact mirrors after merged PR `#147`, then open a tiny docs PR to leave `main` pointing at the remaining human-only steps.
 - Blocker: None

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,13 +7,14 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#145 [L6] docs(evidence): refresh lane-6 smoke readiness`
+- Latest merged PR: `#147 [OPS-EVIDENCE] docs(evidence): add dashboard and agents recapture packet`
 - Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
 - Lane 4 (`2026-04-26-lane-4-diagnosis-recommendation`) merged to `main` through PR `#142`.
 - Lane 5 (`2026-04-26-lane-5-teacher-insight-ui`) merged to `main` through PR `#144`.
 - Lane 6 (`2026-04-26-lane-6-evaluation-evidence-readiness`) merged to `main` through PR `#145`.
+- Dashboard and `/agents` evidence recapture merged to `main` through PR `#147`.
 - Latest smoke result: the 2026-04-26 scripted-reset smoke pass succeeded in lane 6 (`docs/evaluation-evidence-readiness`) against current `main` behavior.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -21,14 +22,13 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Active queue
 
-- Docs recapture packet `2026-04-26-dashboard-agents-evidence-recapture` is next.
-- Current purpose: recapture stale dashboard and `/agents` screenshots so contest evidence can move those rows from `Stale` to `Current`.
+- No screenshot recapture lane remains open.
+- Current purpose: keep the repo aligned for final human review, optional video, and submission sign-off.
 
 ## Next recommended task
 
-Run the dedicated recapture packet from `main`:
-
-1. `docs/superpowers/tasks/2026-04-26-dashboard-agents-evidence-recapture.md`
+- Human review of the submission package, IP commitment, and optional video decision is now the shortest remaining path.
+- If another AI-only task is needed, create a new packet from `main` instead of reusing the merged screenshot lane.
 
 If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
 
@@ -47,8 +47,8 @@ If a requested task appears to span multiple packets, stop and ask the human to 
 
 ## Human-review blockers
 
-- Human-only submission items still remain for the contest package, including IP commitment review, optional video decision, and final package sign-off.
-- Those human blockers no longer prevent the repo from running a separate contest MVP polish backlog.
+- Human-only submission items remain for the contest package, including IP commitment review, optional video decision, and final package sign-off.
+- Screenshot evidence is current; the remaining blockers are no longer browser-refresh tasks.
 
 ## Read path
 

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -99,3 +99,12 @@
 - Tests: `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`; `curl -s http://127.0.0.1:8001/api/v1/dashboard/overview`; `curl -s http://127.0.0.1:8001/api/v1/dashboard/insights`; `curl -s -X POST http://127.0.0.1:8001/api/v1/agent-specs ...`; `node /tmp/recapture-evidence.cjs`; `rg -n "Stale|Current|dashboard|/agents|screenshots|recapture" docs/contest ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
 - Blockers: None on local recapture; remaining work is PR push, CI, and merge.
 - Next: Push the refreshed docs/screenshots, move PR `#147` to Ready, wait for CI, then merge if green under the docs auto-merge policy.
+
+## Post-147 Sync
+
+- Branch: `docs/post-147-evidence-merge-sync`
+- Task: `OPS_POST_147_EVIDENCE_SYNC`
+- Done: Started the compact control-plane sync after PR `#147` merged so `main` no longer points workers at the completed screenshot recapture lane.
+- Tests: `rg -n "#147|screenshot|human review|optional video|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
+- Blockers: None.
+- Next: Open the tiny post-merge sync PR, merge it if CI is green, then stop the AI loop at the remaining human-only submission steps.

--- a/docs/superpowers/pr-notes/2026-04-26-post-147-evidence-merge-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-26-post-147-evidence-merge-sync.md
@@ -1,0 +1,31 @@
+# PR Note: Post-147 Evidence Merge Sync
+
+## Summary
+
+- Syncs the compact AI-first mirrors after PR `#147` merged.
+- Removes the completed screenshot recapture lane from the active queue.
+- Reframes the remaining work as human review, optional video, and submission sign-off.
+
+## Architecture impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR only refreshes control-plane mirrors after a docs/evidence merge.
+
+```mermaid
+flowchart LR
+  A["PR #147 merged"] --> B["Screenshot evidence current on main"]
+  B --> C["Execution queue no longer points to recapture lane"]
+  C --> D["Remaining path: human review + optional video"]
+```
+
+## Files changed
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md`
+- `docs/superpowers/pr-notes/2026-04-26-post-147-evidence-merge-sync.md`
+
+## Validation
+
+- `rg -n "#147|screenshot|human review|optional video|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/EXECUTION_QUEUE.md ai_first/daily/2026-04-26.md docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md docs/superpowers/pr-notes/2026-04-26-post-147-evidence-merge-sync.md`

--- a/docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md
+++ b/docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md
@@ -1,0 +1,50 @@
+# Feature Pod Task: Post-147 Evidence Merge Sync
+
+Task ID: `OPS_POST_147_EVIDENCE_SYNC`
+Commit tag: `OPS-SYNC`
+Owner: Session-specific
+Branch: `docs/post-147-evidence-merge-sync`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Sync the compact AI-first control-plane mirrors after PR `#147` merged so the repository no longer points workers at the already-completed dashboard and `/agents` screenshot recapture lane.
+
+## User-visible outcome
+
+- `ai_first/EXECUTION_QUEUE.md` reflects that contest screenshot evidence is current.
+- `ai_first/ACTIVE_ASSIGNMENTS.md` no longer advertises the merged recapture lane as the next pending task.
+- The next operational step is clearly framed as human review and optional video, not stale screenshot work.
+
+## Owned files/modules
+
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `docs/contest/screenshots/*`
+- `docs/contest/*.md`
+- `deeptutor/`
+- `web/`
+- `ai_first/AI_OPERATING_PROMPT.md` unless the operating rules themselves changed
+
+## Acceptance criteria
+
+- Latest merged result points to PR `#147`.
+- Queue no longer instructs workers to rerun the screenshot recapture packet.
+- Remaining blockers are described as human-review or optional-video tasks only.
+
+## Required tests
+
+- `rg -n "#147|screenshot|human review|optional video|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged.


### PR DESCRIPTION
## Summary
- sync the compact AI-first mirrors after PR #147 merged
- remove the completed screenshot recapture lane from the active queue
- reframe the remaining work as human review, optional video, and submission sign-off

## Testing
- rg -n "#147|screenshot|human review|optional video|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S
- git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/EXECUTION_QUEUE.md ai_first/daily/2026-04-26.md docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md docs/superpowers/pr-notes/2026-04-26-post-147-evidence-merge-sync.md

## Notes
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR only refreshes control-plane mirrors.
