### PR TITLE
docs(ai-first): enter terminal human-review wait state [OPS-WAIT]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,6 @@ Rules:
 
 ## Active
 
-### Assignment
+No active AI implementation task.
 
-- Owner: Codex
-- Machine: `MacBook-Air-cua-Loc.local`
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/lane6`
-- Task: `OPS_POST_147_EVIDENCE_SYNC`
-- Status: In progress
-- Branch: `docs/post-147-evidence-merge-sync`
-- Task packet: `docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md`
-- Owned files: `ai_first/EXECUTION_QUEUE.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`, `docs/superpowers/tasks/2026-04-26-post-147-evidence-merge-sync.md`, `docs/superpowers/pr-notes/*`
-- PR: not opened yet
-- Last update: 2026-04-26
-- Next action: Sync the compact mirrors after merged PR `#147`, then open a tiny docs PR to leave `main` pointing at the remaining human-only steps.
-- Blocker: None
+Remaining work is human review, optional video decision, and final submission sign-off unless a new task packet is opened.

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -28,10 +28,10 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 ## Active Branches and PRs
 
-- Latest merged docs/control-plane PR: `#139 [L2] feat(runtime): compile teacher policy blocks into prompt assembly`
-- Current branch for this sync: `docs/evaluation-evidence-readiness`
-- Product MVP path status: core contest flow plus Wave 1 evidence spine and lane 1-4 contracts are merged to `main`; lane 6 is documenting hybrid-proof readiness and evidence calibration.
-- Current purpose: keep contest evidence docs aligned with the merged hybrid teacher-authoring plus evidence-loop story without claiming unverified runtime behavior.
+- Latest merged docs/control-plane PR: `#148 [OPS-SYNC] docs(ai-first): sync queue after evidence merge`
+- Current branch for this sync: none required on `main`
+- Product MVP path status: the core contest flow, the Wave 1 evidence spine, lane 1-6 roadmap slices, and the refreshed dashboard plus `/agents` screenshot evidence are all merged to `main`.
+- Current purpose: hold a correct terminal wait state while the remaining submission work is human review, optional video, and final sign-off.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -59,16 +59,16 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: `docs/superpowers/tasks/2026-04-26-lane-6-evaluation-evidence-readiness.md`
+- Current open task packet: none
 - Current open GitHub issue:
 - Latest completed smoke run result: the 2026-04-26 scripted-reset smoke pass succeeded with backend online through the CLI server path, frontend build passed after `npm ci`, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
-- Recently completed merged work: the screenshot bundle refresh re-run merged on 2026-04-25 through PR `#130`, and evidence docs now mark screenshots `Current`.
+- Recently completed merged work: dashboard and `/agents` screenshot evidence merged through PR `#147`, followed by queue/control-plane sync in PR `#148`.
 - Autonomous loop design: `docs/superpowers/specs/2026-04-18-autonomous-ai-loop-design.md`
 - Autonomous loop roadmap: `ai_first/AI_FIRST_ROADMAP.md`
 
 ## Current Next Task
 
-Complete lane 6 docs/evidence updates and record calibrated hybrid-proof limitations in the contest artifacts.
+Wait for human review of the submission package, IP commitment, optional video decision, and final sign-off. Start a new AI task only if a fresh packet is opened from `main`.
 
 ## Autonomous Merge Policy
 
@@ -84,3 +84,4 @@ Use this file only as a compact status mirror. Do not rely on it for the full op
 - `main` now includes the Wave 1 evidence spine from PR `#132`.
 - The Contest MVP+ roadmap is now decomposed into six session-ready lane packets under `docs/superpowers/tasks/2026-04-26-lane-*.md`.
 - In multi-session mode, `ai_first/AI_OPERATING_PROMPT.md` is expected to route AI workers through those packets and ask the human to resolve conflicts or ambiguity.
+- Contest screenshot evidence is current after PR `#147`, and the control-plane wait-state sync merged in PR `#148`.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#147 [OPS-EVIDENCE] docs(evidence): add dashboard and agents recapture packet`
+- Latest merged PR: `#148 [OPS-SYNC] docs(ai-first): sync queue after evidence merge`
 - Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
@@ -15,6 +15,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 - Lane 5 (`2026-04-26-lane-5-teacher-insight-ui`) merged to `main` through PR `#144`.
 - Lane 6 (`2026-04-26-lane-6-evaluation-evidence-readiness`) merged to `main` through PR `#145`.
 - Dashboard and `/agents` evidence recapture merged to `main` through PR `#147`.
+- Post-147 evidence merge sync merged to `main` through PR `#148`.
 - Latest smoke result: the 2026-04-26 scripted-reset smoke pass succeeded in lane 6 (`docs/evaluation-evidence-readiness`) against current `main` behavior.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -22,13 +23,13 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Active queue
 
-- No screenshot recapture lane remains open.
-- Current purpose: keep the repo aligned for final human review, optional video, and submission sign-off.
+- No active AI implementation task remains.
+- Current purpose: keep the repository in a correct wait state for final human review, optional video, and submission sign-off.
 
 ## Next recommended task
 
 - Human review of the submission package, IP commitment, and optional video decision is now the shortest remaining path.
-- If another AI-only task is needed, create a new packet from `main` instead of reusing the merged screenshot lane.
+- If a new AI-only task is needed, create a fresh packet from `main` instead of reusing a merged lane or stale branch.
 
 If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
 
@@ -43,7 +44,7 @@ If a requested task appears to span multiple packets, stop and ask the human to 
 
 ## AI-owned blockers
 
-- None currently for command-backed validation or screenshot evidence.
+- None currently. The repository is waiting on human-only submission work.
 
 ## Human-review blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -6,12 +6,12 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Immediate
 
-1. Complete lane 6 (`L6_EVALUATION_EVIDENCE_READINESS`) docs updates for hybrid-proof demo flow and evidence calibration.
-2. Keep `docs/contest/VALIDATION_REPORT.md` and `docs/contest/EVIDENCE_CHECKLIST.md` aligned on what is `Current` versus what is still pending recapture.
+1. Complete human review of the submission package, IP commitment, and final product-description wording.
+2. Decide whether an optional contest video artifact is required.
 3. Treat any future smoke failure as the next product task before opening another polish slice.
-4. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new lane or docs sync.
-5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, smoke passes, screenshot refreshes, lane changes, and blocker changes.
-6. Review IP commitment, final product description wording, and optional video requirements in parallel with the remaining human-only submission work.
+4. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new AI lane or docs sync.
+5. Keep `ai_first/EXECUTION_QUEUE.md` current only if a new AI-owned task is opened.
+6. If more AI work is requested, create a fresh task packet from `main` instead of reviving merged lanes.
 
 ## After Milestone 0
 
@@ -22,13 +22,13 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 
 ## Human Review Needed
 
-- Review product scope changes, credential/deployment decisions, or PRs marked blocked by the AI worker.
+- Review IP commitment, product-description wording, optional video requirement, and final submission sign-off.
 
 ## Mirror Policy
 
 Use this file only as a compact queue mirror. Do not rely on it for the full operating contract. For a human-friendly quick start, read `ai_first/USAGE_GUIDE.md`.
 ## 2026-04-26
 
-1. Start new AI sessions from `main`, one lane per session.
-2. Use the matching `docs/superpowers/tasks/2026-04-26-lane-*.md` packet before code edits.
-3. If a task appears to touch multiple lanes, stop and ask the human to clarify ownership first.
+1. Start new AI sessions from `main` only if a new task packet is explicitly opened.
+2. Use the matching packet before code edits.
+3. If no packet exists and the remaining work is human-only, stop instead of inventing a new AI lane.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -108,3 +108,12 @@
 - Tests: `rg -n "#147|screenshot|human review|optional video|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
 - Blockers: None.
 - Next: Open the tiny post-merge sync PR, merge it if CI is green, then stop the AI loop at the remaining human-only submission steps.
+
+## Post-148 Terminal Sync
+
+- Branch: `docs/post-148-terminal-sync`
+- Task: `OPS_POST_148_TERMINAL_SYNC`
+- Done: Started the terminal wait-state sync after PR `#148` so `ACTIVE_ASSIGNMENTS`, `EXECUTION_QUEUE`, and compatibility snapshots agree there is no active AI implementation task left.
+- Tests: `rg -n "#148|human review|optional video|no active AI|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE|CURRENT_STATE|NEXT_ACTIONS" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
+- Blockers: None.
+- Next: Open the final tiny sync PR, merge it if CI is green, and stop at the remaining human-only submission work.

--- a/docs/superpowers/pr-notes/2026-04-26-post-148-terminal-wait-state-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-26-post-148-terminal-wait-state-sync.md
@@ -1,0 +1,34 @@
+# PR Note: Post-148 Terminal Wait-State Sync
+
+## Summary
+
+- Syncs the control-plane after PR `#148` so the repository no longer advertises any active AI implementation task.
+- Aligns the compact queue and compatibility snapshots on a human-review wait state.
+- Keeps the next AI entry point explicit: only start again when a fresh packet is opened from `main`.
+
+## Architecture impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR only refreshes operating mirrors and wait-state docs.
+
+```mermaid
+flowchart LR
+  A["PR #148 merged"] --> B["Evidence queue already synced"]
+  B --> C["Terminal wait-state sync"]
+  C --> D["No active AI implementation task"]
+  D --> E["Remaining path: human review + optional video + sign-off"]
+```
+
+## Files changed
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/tasks/2026-04-26-post-148-terminal-wait-state-sync.md`
+- `docs/superpowers/pr-notes/2026-04-26-post-148-terminal-wait-state-sync.md`
+
+## Validation
+
+- `rg -n "#148|human review|optional video|no active AI|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE|CURRENT_STATE|NEXT_ACTIONS" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/EXECUTION_QUEUE.md ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md ai_first/daily/2026-04-26.md docs/superpowers/tasks/2026-04-26-post-148-terminal-wait-state-sync.md docs/superpowers/pr-notes/2026-04-26-post-148-terminal-wait-state-sync.md`

--- a/docs/superpowers/tasks/2026-04-26-post-148-terminal-wait-state-sync.md
+++ b/docs/superpowers/tasks/2026-04-26-post-148-terminal-wait-state-sync.md
@@ -1,0 +1,52 @@
+# Feature Pod Task: Post-148 Terminal Wait-State Sync
+
+Task ID: `OPS_POST_148_TERMINAL_SYNC`
+Commit tag: `OPS-WAIT`
+Owner: Session-specific
+Branch: `docs/post-148-terminal-sync`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Sync the control-plane after PR `#148` merged so the repository lands in a correct terminal state for the contest package: no active AI implementation task, with the remaining work explicitly framed as human review and optional video only.
+
+## User-visible outcome
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md` no longer advertises a stale AI task.
+- `ai_first/EXECUTION_QUEUE.md`, `CURRENT_STATE.md`, and `NEXT_ACTIONS.md` agree that screenshot evidence is current and the next path is human review.
+- Future AI workers can immediately see that they should stop unless a new packet is opened.
+
+## Owned files/modules
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/tasks/2026-04-26-post-148-terminal-wait-state-sync.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- Product/runtime source files
+- `docs/contest/`
+- `ai_first/AI_OPERATING_PROMPT.md` unless the operating rules themselves changed
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## Acceptance criteria
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md` shows no active AI implementation task.
+- `ai_first/EXECUTION_QUEUE.md` names PR `#148` as the latest merged control-plane result.
+- Compatibility snapshots match the current human-review wait state.
+
+## Required tests
+
+- `rg -n "#148|human review|optional video|no active AI|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE|CURRENT_STATE|NEXT_ACTIONS" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged.


### PR DESCRIPTION
## Summary
- sync the control-plane after PR #148 so the repo no longer advertises an active AI implementation task
- align EXECUTION_QUEUE, ACTIVE_ASSIGNMENTS, CURRENT_STATE, and NEXT_ACTIONS on a human-review wait state
- keep the next AI entry point explicit: only restart when a fresh task packet is opened from main

## Testing
- rg -n "#148|human review|optional video|no active AI|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE|CURRENT_STATE|NEXT_ACTIONS" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S
- git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/EXECUTION_QUEUE.md ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md ai_first/daily/2026-04-26.md docs/superpowers/tasks/2026-04-26-post-148-terminal-wait-state-sync.md docs/superpowers/pr-notes/2026-04-26-post-148-terminal-wait-state-sync.md

## Notes
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR only refreshes wait-state mirrors.
