### PR TITLE
docs(tasks): add judge-risk hardening lane packets [OPS-COMMIT]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,6 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task.
+### Assignment
 
-Remaining work is human review, optional video decision, and final submission sign-off unless a new task packet is opened.
+- Owner: Codex
+- Machine: `MacBook-Air-cua-Loc.local`
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
+- Task: `RISK_HARDENING_LANE_PACKETS`
+- Status: In progress
+- Branch: `docs/judge-risk-hardening-lanes`
+- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-1-runtime-binding-proof.md` through `docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md`
+- Owned files: `docs/superpowers/tasks/2026-04-26-risk-lane-*.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`
+- PR:
+- Last update: 2026-04-26
+- Next action: Finish the six risk-hardening lane packets, then hand them off for one-session-per-lane execution.
+- Blocker: None

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -117,3 +117,12 @@
 - Tests: `rg -n "#148|human review|optional video|no active AI|ACTIVE_ASSIGNMENTS|EXECUTION_QUEUE|CURRENT_STATE|NEXT_ACTIONS" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
 - Blockers: None.
 - Next: Open the final tiny sync PR, merge it if CI is green, and stop at the remaining human-only submission work.
+
+## Judge-Risk Lane Packets
+
+- Branch: `docs/judge-risk-hardening-lanes`
+- Task: `RISK_HARDENING_LANE_PACKETS`
+- Done: Converted the contest judge-risk attack surface into six execution-ready risk-hardening lane packets: runtime binding proof, diagnosis credibility, assessment safety/review, teacher value proposition, dashboard actionability, and claim calibration/pilot evidence.
+- Tests: `rg -n "R1_RUNTIME_BINDING_PROOF|R2_DIAGNOSIS_CREDIBILITY|R3_ASSESSMENT_SAFETY|R4_TEACHER_VALUE_PROP|R5_DASHBOARD_ACTIONABILITY|R6_CLAIM_CALIBRATION_PILOT" docs/superpowers/tasks ai_first -S`; `git diff --check`
+- Blockers: None.
+- Next: Review the packet set, then open future AI sessions one lane at a time depending on which judge-risk the team wants to harden first.

--- a/docs/superpowers/pr-notes/2026-04-26-judge-risk-hardening-lanes.md
+++ b/docs/superpowers/pr-notes/2026-04-26-judge-risk-hardening-lanes.md
@@ -1,0 +1,38 @@
+# PR Note: Judge-Risk Hardening Lane Packets
+
+## Summary
+
+- Converts likely judge and voter attack surfaces into six execution-ready lane packets.
+- Keeps the work aligned with the current product instead of inventing speculative new features.
+- Makes it possible to run one AI session per risk lane with bounded ownership and clearer proof goals.
+
+## Architecture impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR creates planning/execution packets, not new runtime structure.
+
+```mermaid
+flowchart LR
+  A["Judge / voter attack surface"] --> B["Runtime binding proof lane"]
+  A --> C["Diagnosis credibility lane"]
+  A --> D["Assessment safety lane"]
+  A --> E["Teacher value-prop lane"]
+  A --> F["Dashboard actionability lane"]
+  A --> G["Claim calibration / pilot lane"]
+```
+
+## Files changed
+
+- `docs/superpowers/tasks/2026-04-26-risk-lane-1-runtime-binding-proof.md`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/pr-notes/2026-04-26-judge-risk-hardening-lanes.md`
+
+## Validation
+
+- `rg -n "R1_RUNTIME_BINDING_PROOF|R2_DIAGNOSIS_CREDIBILITY|R3_ASSESSMENT_SAFETY|R4_TEACHER_VALUE_PROP|R5_DASHBOARD_ACTIONABILITY|R6_CLAIM_CALIBRATION_PILOT" docs/superpowers/tasks ai_first -S`
+- `git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-26.md docs/superpowers/tasks/2026-04-26-risk-lane-1-runtime-binding-proof.md docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md docs/superpowers/pr-notes/2026-04-26-judge-risk-hardening-lanes.md`

--- a/docs/superpowers/tasks/2026-04-26-risk-lane-1-runtime-binding-proof.md
+++ b/docs/superpowers/tasks/2026-04-26-risk-lane-1-runtime-binding-proof.md
@@ -1,0 +1,90 @@
+# Feature Pod Task: Risk Lane 1 Runtime Binding Proof
+
+Task ID: `R1_RUNTIME_BINDING_PROOF`
+Commit tag: `R1`
+Owner: Session-specific
+Branch: `docs-or-pod/runtime-binding-proof`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Produce bounded, convincing proof that teacher-authored spec packs affect live Tutor Agent behavior through the current runtime policy path.
+
+## User-visible outcome
+
+- Reviewers can see that `/agents` authoring is not just a static UI.
+- The team has a repeatable demo or artifact showing behavior changes between at least two spec packs.
+- Claims about runtime binding become specific and defensible instead of vague.
+
+## Owned files/modules
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/prompt/`
+- `deeptutor/core/capabilities/`
+- `deeptutor/services/session/turn_runtime.py` only if the selected proof slice truly needs request-path wiring
+- `tests/services/runtime_policy/`
+- `tests/core/`
+- `docs/contest/`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-1-runtime-binding-proof.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/evidence/`
+- `deeptutor/api/routers/dashboard.py`
+- `web/app/(workspace)/dashboard/`
+- `web/components/dashboard/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless runtime boundaries materially change
+
+## API/data contract
+
+- The proof must distinguish between:
+  - compiled policy contract
+  - request-path binding
+  - user-visible behavior difference
+- Do not claim universal end-to-end support unless the selected live request path is directly verified.
+- Any debug trace added for proof must remain bounded and not leak unrelated session data.
+
+## Acceptance criteria
+
+- Two contrasting spec packs are defined for a single demo question or session.
+- The team can show a stable behavior diff grounded in `SOUL`, `RULES`, or another teacher-authored policy slice.
+- At least one explicit artifact exists:
+  - runtime trace
+  - test
+  - screenshot/log bundle
+  - repeatable demo script
+- Final wording distinguishes “behavioral proof” from “full request-path coverage”.
+
+## Required tests
+
+- Focused runtime-policy or capability tests proving behavior differs under two compiled specs
+- `git diff --check`
+
+## Manual verification
+
+- Run the same student prompt against two different spec packs.
+- Confirm the output differs in a way the teacher can recognize:
+  - tone
+  - scaffolding
+  - directness
+  - guardrail behavior
+- Verify any trace or debug output points back to the selected `agent_spec_id` or compiled policy slice.
+
+## Parallel-work notes
+
+- This lane exists to close a judge-risk, not to redesign the runtime stack.
+- If full request-path wiring is still incomplete, ship bounded proof and explicit wording rather than expanding into a multi-week runtime refactor.
+- Coordinate with the claim-calibration lane so demo wording matches the exact level of proof achieved.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if the selected proof work changes live runtime boundaries.
+
+## Handoff notes
+
+- Primary attack being addressed: “Does `agent_spec_id` actually affect Tutor Agent runtime behavior?”
+- Preferred demo shape: two spec packs with one identical student question and a visible behavior difference.
+- If full live binding cannot be completed safely in scope, the fallback is a narrower but honest behavioral proof.

--- a/docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md
+++ b/docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md
@@ -1,0 +1,82 @@
+# Feature Pod Task: Risk Lane 2 Diagnosis Credibility
+
+Task ID: `R2_DIAGNOSIS_CREDIBILITY`
+Commit tag: `R2`
+Owner: Session-specific
+Branch: `docs-or-pod/diagnosis-credibility`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Strengthen the credibility of diagnosis and recommendation outputs by making their logic, examples, and teacher-review framing explicit.
+
+## User-visible outcome
+
+- The team can explain how diagnosis works without bluffing benchmark accuracy.
+- Reviewers see examples where observation, diagnosis, and recommendation line up clearly.
+- The project can defend “teacher-in-the-loop” as a deliberate safety and pedagogy choice.
+
+## Owned files/modules
+
+- `deeptutor/services/evidence/`
+- `tests/services/evidence/`
+- `docs/contest/`
+- `ai_first/competition/`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/session/`
+- `web/app/(workspace)/agents/`
+- `web/components/agents/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless diagnosis boundaries materially change
+
+## API/data contract
+
+- Diagnosis outputs must remain framed as:
+  - evidence-backed
+  - confidence-tagged
+  - teacher-reviewable
+- Do not introduce fabricated numeric accuracy claims.
+- Example packs, cases, or comparison tables must stay demo-safe and non-private.
+
+## Acceptance criteria
+
+- At least 2-3 diagnosis case studies are documented or test-backed.
+- Each case shows:
+  - observed inputs
+  - inferred diagnosis
+  - recommended action
+  - teacher-review framing or commentary
+- Final project wording explicitly states that the system is rule-assisted plus teacher-reviewed, not a benchmarked autonomous assessor.
+
+## Required tests
+
+- Focused diagnosis/recommendation tests for the selected case patterns
+- `git diff --check`
+
+## Manual verification
+
+- Walk through the prepared cases as if answering a judge.
+- Confirm that every diagnosis can be traced back to observations.
+- Confirm that weak or ambiguous evidence is either downgraded or abstained on rather than overstated.
+
+## Parallel-work notes
+
+- This lane can ship purely as examples, docs, and framing improvements if engine behavior is already adequate.
+- If engine behavior itself is weak, keep the change bounded to the smallest slice that materially improves credibility.
+- Coordinate with the dashboard-actionability lane so case studies can double as story cards.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if the diagnosis pipeline structure changes materially.
+
+## Handoff notes
+
+- Primary attack being addressed: “How accurate or trustworthy is your diagnosis layer?”
+- Preferred defense: transparent reasoning, bounded confidence, teacher-in-the-loop.
+- Do not overcorrect by inventing fake evaluation metrics.

--- a/docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md
+++ b/docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md
@@ -1,0 +1,78 @@
+# Feature Pod Task: Risk Lane 3 Assessment Safety And Review
+
+Task ID: `R3_ASSESSMENT_SAFETY`
+Commit tag: `R3`
+Owner: Session-specific
+Branch: `docs-or-pod/assessment-safety`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Make the teacher-review and quality-control layer around assessment generation obvious, concrete, and demo-ready.
+
+## User-visible outcome
+
+- Reviewers see that AI-generated assessments are not blindly published.
+- The demo flow clearly shows teacher review, approval, or editing before use.
+- The project has a concrete answer for hallucination and pedagogy quality concerns.
+
+## Owned files/modules
+
+- `web/app/(workspace)/assessment/`
+- `web/app/(workspace)/dashboard/assessments/`
+- `web/lib/assessment-api.ts`
+- `docs/contest/`
+- `ai_first/competition/`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/evidence/`
+- `web/app/(workspace)/agents/`
+- `web/app/(workspace)/dashboard/student/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless the assessment-review flow changes materially
+
+## API/data contract
+
+- The selected proof slice must preserve teacher control between generation and publication.
+- Do not claim automated assessment quality assurance beyond what the review flow actually supports.
+- Safety positioning should rely on human review, not hidden assumptions about model quality.
+
+## Acceptance criteria
+
+- The demo path clearly shows:
+  - generated assessment
+  - teacher review or edit step
+  - publish or accept step
+- At least one reusable example exists showing how teacher intervention improves or validates the generated assessment.
+- Contest wording is aligned with “human-in-the-loop safety layer”.
+
+## Required tests
+
+- Focused frontend or API checks for the selected review/edit slice if code changes are made
+- `git diff --check`
+
+## Manual verification
+
+- Walk one Knowledge Pack through generation, review, and approval.
+- Confirm the teacher can intervene before the assessment becomes part of the student flow.
+- Confirm the demo can explain how hallucination risk is bounded in practice.
+
+## Parallel-work notes
+
+- This lane may be docs-and-demo heavy if the current UI already supports teacher review sufficiently.
+- Avoid expanding into a new authoring system unless the current review step is genuinely invisible or missing.
+- Coordinate with the evidence lane so screenshots or demo notes reflect the same review flow.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if the assessment publication flow changes materially.
+
+## Handoff notes
+
+- Primary attack being addressed: “How do you control quality when AI generates assessments?”
+- Preferred defense: teacher review is the primary safety gate, not model infallibility.

--- a/docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md
+++ b/docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md
@@ -1,0 +1,77 @@
+# Feature Pod Task: Risk Lane 4 Teacher Value Proposition
+
+Task ID: `R4_TEACHER_VALUE_PROP`
+Commit tag: `R4`
+Owner: Session-specific
+Branch: `docs-or-pod/teacher-value-prop`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Translate the technical architecture into concrete teacher-facing value so non-technical judges and voters understand why the product matters.
+
+## User-visible outcome
+
+- `/agents` and the evidence loop are explained in teacher-benefit language rather than internal architecture language.
+- The team can answer “why does a teacher need this?” without talking about compiler layers first.
+- Demo materials foreground classroom value before engineering sophistication.
+
+## Owned files/modules
+
+- `docs/contest/`
+- `ai_first/competition/`
+- `web/app/(workspace)/agents/` only if copy-level clarification is needed
+- `web/components/agents/` only if copy-level clarification is needed
+- `docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/`
+- `deeptutor/api/`
+- `web/app/(workspace)/dashboard/`
+- `web/components/dashboard/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless shipped surface areas materially change
+
+## API/data contract
+
+- Do not change runtime or storage semantics just to improve positioning.
+- If UI copy changes are made, they must stay truthful to the implemented behavior.
+- Teacher-facing language should distinguish:
+  - teacher-defined style/policy
+  - evidence-backed insight
+  - student-facing tutoring behavior
+
+## Acceptance criteria
+
+- At least 2-3 teacher use cases are documented in clear, non-technical language.
+- The project has a short explanation for what `IDENTITY`, `SOUL`, and `RULES` let a teacher control.
+- A behavior-diff example exists that a judge can understand without reading code.
+
+## Required tests
+
+- If copy changes touch UI files, run the smallest relevant lint/build check
+- `git diff --check`
+
+## Manual verification
+
+- Rehearse the `/agents` demo without using terms like “compiler”, “contract”, or “runtime assembly” first.
+- Confirm a non-technical listener can understand what changes when a teacher edits the spec.
+- Confirm the demo still stays honest about current product limits.
+
+## Parallel-work notes
+
+- This lane is primarily narrative, evidence, and demo hardening.
+- Avoid turning it into a broad marketing rewrite of the whole repo.
+- Coordinate with runtime-binding and claim-calibration lanes so wording stays technically accurate.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged unless shipped user flows materially change.
+
+## Handoff notes
+
+- Primary attack being addressed: “Why would a normal teacher care about `/agents` or spec authoring?”
+- Preferred defense: simple teacher outcomes, not agent-system jargon.

--- a/docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md
+++ b/docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md
@@ -1,0 +1,77 @@
+# Feature Pod Task: Risk Lane 5 Dashboard Actionability
+
+Task ID: `R5_DASHBOARD_ACTIONABILITY`
+Commit tag: `R5`
+Owner: Session-specific
+Branch: `docs-or-pod/dashboard-actionability`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Make the teacher dashboard’s recommendations feel concrete, specific, and classroom-actionable rather than generic or decorative.
+
+## User-visible outcome
+
+- Reviewers can follow at least 2-3 student stories from signal to teacher action.
+- The dashboard can be defended as a decision aid, not just an analytics page.
+- Recommendation examples feel specific enough to justify the product’s evidence-loop thesis.
+
+## Owned files/modules
+
+- `web/app/(workspace)/dashboard/`
+- `web/components/dashboard/`
+- `web/lib/dashboard-api.ts`
+- `docs/contest/`
+- `ai_first/competition/`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/agent_spec/`
+- `web/app/(workspace)/agents/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless the shipped dashboard workflow changes materially
+
+## API/data contract
+
+- Preserve the existing hierarchy:
+  - `Observed`
+  - `Inferred`
+  - `Recommended Action`
+- Do not smuggle new diagnosis claims into the UI layer.
+- If examples are seeded or curated for demo use, label them as demo-safe and non-private.
+
+## Acceptance criteria
+
+- At least 2-3 dashboard story cards or equivalent artifacts exist.
+- Each story shows a concrete teacher move, not just a generic recommendation label.
+- Small-group action examples are available if the grouped-signal path is part of the contest narrative.
+
+## Required tests
+
+- Focused frontend lint/build checks for any touched dashboard files
+- `git diff --check`
+
+## Manual verification
+
+- Walk through each prepared student story from observation to action.
+- Confirm a teacher could say what they would do next without extra explanation from the team.
+- Confirm the examples remain aligned with current diagnosis and insight payloads.
+
+## Parallel-work notes
+
+- This lane may be delivered through UI tightening, seeded examples, or docs/story artifacts depending on the real gap.
+- Avoid turning it into a full redesign of the dashboard.
+- Coordinate with the diagnosis-credibility lane so story cards reuse the same examples.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if dashboard flow boundaries materially change.
+
+## Handoff notes
+
+- Primary attack being addressed: “The dashboard looks smart, but what should a teacher actually do?”
+- Preferred defense: student stories and teacher actions, not abstract labels alone.

--- a/docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md
+++ b/docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md
@@ -1,0 +1,85 @@
+# Feature Pod Task: Risk Lane 6 Claim Calibration And Pilot Evidence
+
+Task ID: `R6_CLAIM_CALIBRATION_PILOT`
+Commit tag: `R6`
+Owner: Session-specific
+Branch: `docs-or-pod/claim-calibration-pilot`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Reduce vulnerability to judge skepticism by tightening product claims, clarifying prototype status, and adding the smallest credible pilot or human-feedback evidence available.
+
+## User-visible outcome
+
+- Project wording no longer overclaims “multi-agent” or production readiness.
+- Reviewers can see what is validated, what is prototype, and what remains future work.
+- Even limited external feedback or pilot evidence is packaged honestly if available.
+
+## Owned files/modules
+
+- `docs/contest/`
+- `ai_first/competition/`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/`
+- `deeptutor/api/`
+- `web/app/`
+- `web/components/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` unless shipped architecture language materially changes
+
+## API/data contract
+
+- All wording must distinguish:
+  - validated prototype
+  - current merged capability
+  - future multi-agent design direction
+- Do not fabricate pilot data, teacher quotes, or user counts.
+- If no real pilot evidence exists, say so plainly and frame the current evidence as structured walkthrough validation instead.
+
+## Acceptance criteria
+
+- Contest-facing wording is calibrated around current proof, not intended future architecture.
+- Any “multi-agent” language is either tightened or explicitly scoped.
+- A minimal pilot-feedback artifact or an explicit no-pilot-yet note is included.
+- The submission package can defend itself against “staged demo” skepticism with honest framing.
+
+## Required tests
+
+- `rg` checks across contest and competition docs for overclaim terms or stale wording
+- `git diff --check`
+
+## Manual verification
+
+- Re-read the main contest docs as a skeptical judge.
+- Check that every strong claim has either:
+  - an artifact
+  - a test
+  - a screenshot
+  - a careful limitation note
+- Confirm no wording implies classroom deployment or inter-agent autonomy beyond current proof.
+
+## Parallel-work notes
+
+- This lane is docs-and-positioning heavy.
+- If a real teacher pilot becomes available, fold it in carefully without expanding into a research-study claim.
+- Coordinate with every other risk lane so the final wording reflects the actual proof level achieved.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged unless architecture-facing language in shipped docs changes materially.
+
+## Handoff notes
+
+- Primary attacks being addressed:
+  - “This looks staged.”
+  - “This is overclaiming multi-agent.”
+  - “Where is the real user evidence?”
+- Preferred defense: honest calibration plus the strongest real artifact currently available.


### PR DESCRIPTION
## Summary
- convert the likely contest judge and voter attack surface into six execution-ready risk-hardening lane packets
- keep the packets anchored to the current product instead of inventing speculative new features
- add a compact AI-first assignment and daily-log entry so future sessions can pick one risk lane at a time

## Testing
- rg -n "R1_RUNTIME_BINDING_PROOF|R2_DIAGNOSIS_CREDIBILITY|R3_ASSESSMENT_SAFETY|R4_TEACHER_VALUE_PROP|R5_DASHBOARD_ACTIONABILITY|R6_CLAIM_CALIBRATION_PILOT" docs/superpowers/tasks ai_first -S
- git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-26.md docs/superpowers/tasks/2026-04-26-risk-lane-1-runtime-binding-proof.md docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md docs/superpowers/pr-notes/2026-04-26-judge-risk-hardening-lanes.md

## Notes
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR creates execution packets only.
