### PR TITLE
docs: sync AI-first queue after risk lane 1 merge

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,6 @@ Rules:
 
 ## Active
 
-### Assignment
+No active AI implementation task.
 
-- Owner: Codex
-- Machine: `MacBook-Air-cua-Loc.local`
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/runtime-binding-proof`
-- Task: `R1_RUNTIME_BINDING_PROOF`
-- Status: Ready for draft PR
-- Branch: `pod-a/runtime-binding-proof`
-- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-1-runtime-binding-proof.md`
-- Owned files: `deeptutor/services/runtime_policy/`, `deeptutor/services/prompt/`, `deeptutor/core/capabilities/`, `deeptutor/services/session/turn_runtime.py` if needed, `tests/services/runtime_policy/`, `tests/core/`, `docs/contest/`, `docs/superpowers/pr-notes/*`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`
-- PR:
-- Last update: 2026-04-26
-- Next action: Commit, push, and open the draft PR for bounded runtime-binding proof review.
-- Blocker: None
+Recommended next AI-owned task: open `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md` from a fresh branch/worktree if the team wants to keep hardening judge-risk defenses.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest merged PR: `#148 [OPS-SYNC] docs(ai-first): sync queue after evidence merge`
+- Latest feature-risk merge: `#151 [R1] feat(runtime-policy): add bounded tutor spec binding proof`
 - Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
@@ -16,6 +16,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 - Lane 6 (`2026-04-26-lane-6-evaluation-evidence-readiness`) merged to `main` through PR `#145`.
 - Dashboard and `/agents` evidence recapture merged to `main` through PR `#147`.
 - Post-147 evidence merge sync merged to `main` through PR `#148`.
+- Risk Lane 1 runtime binding proof merged to `main` through PR `#151`.
 - Latest smoke result: the 2026-04-26 scripted-reset smoke pass succeeded in lane 6 (`docs/evaluation-evidence-readiness`) against current `main` behavior.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -23,13 +24,14 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Active queue
 
-- No active AI implementation task remains.
-- Current purpose: keep the repository in a correct wait state for final human review, optional video, and submission sign-off.
+- No active AI implementation task remains on `main`.
+- The contest repo now also has six merged risk-hardening lane packets for judge/voter attack-surface defense.
 
 ## Next recommended task
 
-- Human review of the submission package, IP commitment, and optional video decision is now the shortest remaining path.
-- If a new AI-only task is needed, create a fresh packet from `main` instead of reusing a merged lane or stale branch.
+- If the team wants to continue AI-owned product hardening, start `R2_DIAGNOSIS_CREDIBILITY` from `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md`.
+- If not, the shortest remaining non-code path is still human review of the submission package, IP commitment, and optional video decision.
+- Any new AI task should start from a fresh branch/worktree off `main`, not from a merged lane branch.
 
 If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
 
@@ -44,7 +46,7 @@ If a requested task appears to span multiple packets, stop and ask the human to 
 
 ## AI-owned blockers
 
-- None currently. The repository is waiting on human-only submission work.
+- None currently. The next AI-owned work is optional risk-hardening, not a blocker for the already-validated MVP path.
 
 ## Human-review blockers
 

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -135,3 +135,12 @@
 - Tests: `pytest tests/services/runtime_policy/test_compiler.py tests/core/test_capabilities_runtime.py tests/api/test_unified_ws_turn_runtime.py -q`
 - Blockers: None.
 - Next: Run `git diff --check`, write the PR architecture note, then open the Draft PR for lane review.
+
+## Post-151 Sync
+
+- Branch: `docs/post-151-risk-sync`
+- Task: `OPS_POST_151_RISK_SYNC`
+- Done: Reset the AI-first control plane after Risk Lane 1 merged so `main` no longer advertises the merged lane as active and the compact queue now points future AI workers to `R2_DIAGNOSIS_CREDIBILITY` as the next optional risk-hardening slice.
+- Tests: `git diff --check`
+- Blockers: None.
+- Next: Commit the sync or roll it into the next lane branch before any further AI implementation starts.

--- a/docs/superpowers/pr-notes/2026-04-26-post-151-risk-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-26-post-151-risk-sync.md
@@ -1,0 +1,29 @@
+# PR Note: Post-151 Risk Sync
+
+## Summary
+
+- clear the stale `R1_RUNTIME_BINDING_PROOF` assignment from `main`
+- update the compact execution queue so future AI workers see `R2_DIAGNOSIS_CREDIBILITY` as the next optional risk-hardening lane
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Merge["PR #151 merged"]
+  Active["ACTIVE_ASSIGNMENTS.md"]
+  Queue["EXECUTION_QUEUE.md"]
+  Next["Next lane: R2 diagnosis credibility"]
+
+  Merge --> Active
+  Merge --> Queue
+  Active --> Next
+  Queue --> Next
+```
+
+## Main System Map
+
+- Not updated. This PR only synchronizes AI-first control-plane docs after a merge.
+
+## Validation
+
+- `git diff --check`


### PR DESCRIPTION
## Summary
- clear the stale Risk Lane 1 active assignment from `main`
- update the compact execution queue after PR #151 merged
- point future AI workers to `R2_DIAGNOSIS_CREDIBILITY` as the next optional risk-hardening lane

## Validation
- `git diff --check`

## Main System Map
- Not updated; this PR only synchronizes AI-first control-plane docs after a merge.