### PR TITLE
feat: strengthen diagnosis credibility framing

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,6 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task.
+### Assignment
 
-Recommended next AI-owned task: open `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md` from a fresh branch/worktree if the team wants to keep hardening judge-risk defenses.
+- Owner: Codex
+- Machine: `MacBook-Air-cua-Loc.local`
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/diagnosis-credibility`
+- Task: `R2_DIAGNOSIS_CREDIBILITY`
+- Status: Ready for draft PR
+- Branch: `pod-a/diagnosis-credibility`
+- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md`
+- Owned files: `deeptutor/services/evidence/`, `tests/services/evidence/`, `docs/contest/`, `ai_first/competition/`, `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md`, `docs/superpowers/pr-notes/*`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`
+- PR:
+- Last update: 2026-04-26
+- Next action: Commit, push, and open the draft PR for diagnosis credibility review.
+- Blocker: None

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,14 +1,14 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T12:30:00Z",
+    "last_updated": "2026-04-26T14:40:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
-    "total_tasks": 43
+    "total_tasks": 49
   },
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 43,
+      "count": 44,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -52,13 +52,16 @@
         "T048_PARALLEL_LANE_TASK_PACKET_SET",
         "T049_METADATA_DEPTH_PASS",
         "T050_DASHBOARD_INSIGHT_DEPTH",
-        "T051_SESSION_CONTEXT_QUALITY_PASS"
+        "T051_SESSION_CONTEXT_QUALITY_PASS",
+        "R1_RUNTIME_BINDING_PROOF"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "R2_DIAGNOSIS_CREDIBILITY"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -67,8 +70,13 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 0,
-      "tasks": []
+      "count": 4,
+      "tasks": [
+        "R3_ASSESSMENT_SAFETY",
+        "R4_TEACHER_VALUE_PROP",
+        "R5_DASHBOARD_ACTIONABILITY",
+        "R6_CLAIM_CALIBRATION_PILOT"
+      ]
     }
   },
   "tasks": [
@@ -1025,6 +1033,153 @@
       ],
       "status": "completed",
       "notes": "Merged on origin/main (branch pod-b/t051-session-context-quality). Lane 2 does not need to claim this work; registry updated to reflect remote merge."
+    },
+    {
+      "id": "R1_RUNTIME_BINDING_PROOF",
+      "category": "Risk Hardening",
+      "priority": 44,
+      "title": "Bounded Runtime Binding Proof For Tutor Specs",
+      "description": "Prove that teacher-authored Agent Specs affect live Tutor behavior through the unified turn path without overclaiming universal entry-point coverage.",
+      "scope": {
+        "backend": "deeptutor/capabilities/request_contracts.py, deeptutor/services/runtime_policy/, deeptutor/services/session/turn_runtime.py",
+        "tests": "tests/core/test_capabilities_runtime.py, tests/api/test_unified_ws_turn_runtime.py, tests/services/runtime_policy/test_compiler.py",
+        "docs": "docs/contest/*.md, docs/superpowers/pr-notes/"
+      },
+      "affected_features": [
+        "Tutor Runtime Policy",
+        "Agent Specs",
+        "Contest Claim Calibration"
+      ],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": [
+        "L1_AGENT_SPEC_AUTHORING",
+        "L2_SPEC_RUNTIME_ASSEMBLY"
+      ],
+      "status": "completed",
+      "notes": "Merged to main through PR #151. Added bounded proof that config.agent_spec_id can drive unified Tutor runtime behavior across contrasting spec packs."
+    },
+    {
+      "id": "R2_DIAGNOSIS_CREDIBILITY",
+      "category": "Risk Hardening",
+      "priority": 45,
+      "title": "Diagnosis Credibility And Teacher Review Framing",
+      "description": "Strengthen diagnosis trustworthiness by making outputs explicitly rule-assisted, confidence-tagged, abstain-capable, and teacher-reviewed, backed by demo-safe case studies.",
+      "scope": {
+        "backend": "deeptutor/services/evidence/",
+        "tests": "tests/services/evidence/test_diagnosis.py, tests/api/test_assessment_router.py, tests/api/test_dashboard_router.py",
+        "docs": "docs/contest/*.md, ai_first/competition/*.md, docs/superpowers/pr-notes/"
+      },
+      "affected_features": [
+        "Diagnosis Engine",
+        "Teacher Dashboard",
+        "Contest Defense Materials"
+      ],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": [
+        "L3_OBSERVATION_STUDENT_STATE",
+        "L4_DIAGNOSIS_RECOMMENDATION"
+      ],
+      "status": "in-progress",
+      "notes": "Active on branch pod-a/diagnosis-credibility. Draft PR #153 adds teacher-review notes, abstain reasoning, and diagnosis case studies."
+    },
+    {
+      "id": "R3_ASSESSMENT_SAFETY",
+      "category": "Risk Hardening",
+      "priority": 46,
+      "title": "Assessment Safety And Teacher Approval Proof",
+      "description": "Make the teacher review step and assessment quality-control framing explicit so generated assessments are presented as supervised rather than autonomous classroom output.",
+      "scope": {
+        "backend": "deeptutor/api/routers/assessment.py, related assessment services as needed",
+        "tests": "tests/api/test_assessment_router.py and bounded assessment slices",
+        "docs": "docs/contest/*.md, ai_first/competition/*.md"
+      },
+      "affected_features": [
+        "Assessment Generation",
+        "Assessment Review",
+        "Contest Demo Story"
+      ],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": [
+        "T010_ASSESSMENT_FEEDBACK_DETAILS",
+        "T015_ASSESSMENT_RECOMMENDATIONS"
+      ],
+      "status": "not-started",
+      "notes": "Session-ready risk lane packet exists under docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md."
+    },
+    {
+      "id": "R4_TEACHER_VALUE_PROP",
+      "category": "Risk Hardening",
+      "priority": 47,
+      "title": "Teacher Value Proposition Hardening",
+      "description": "Clarify why Agent Specs and the teacher dashboard matter to real teachers, with benefit-first wording and bounded demos rather than architecture-heavy explanations.",
+      "scope": {
+        "docs": "docs/contest/*.md, ai_first/competition/*.md, docs/superpowers/pr-notes/",
+        "ui_copy": "teacher-facing wording only if a bounded update is needed"
+      },
+      "affected_features": [
+        "Agent Specs",
+        "Teacher Dashboard",
+        "Contest Pitch"
+      ],
+      "complexity": "Low",
+      "estimated_hours": 2,
+      "dependencies": [
+        "L1_AGENT_SPEC_AUTHORING",
+        "L5_TEACHER_INSIGHT_UI"
+      ],
+      "status": "not-started",
+      "notes": "Session-ready risk lane packet exists under docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md."
+    },
+    {
+      "id": "R5_DASHBOARD_ACTIONABILITY",
+      "category": "Risk Hardening",
+      "priority": 48,
+      "title": "Dashboard Actionability Story Cards",
+      "description": "Turn the teacher dashboard into clearer intervention narratives by preparing student and small-group story cards tied directly to observed and inferred signals.",
+      "scope": {
+        "backend": "deeptutor/services/evidence/ and dashboard payloads only if needed",
+        "tests": "dashboard-focused evidence tests if payloads change",
+        "docs": "docs/contest/*.md, ai_first/competition/*.md"
+      },
+      "affected_features": [
+        "Teacher Dashboard",
+        "Teacher Insights",
+        "Contest Demo Story"
+      ],
+      "complexity": "Medium",
+      "estimated_hours": 3,
+      "dependencies": [
+        "L5_TEACHER_INSIGHT_UI",
+        "R2_DIAGNOSIS_CREDIBILITY"
+      ],
+      "status": "not-started",
+      "notes": "Session-ready risk lane packet exists under docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md."
+    },
+    {
+      "id": "R6_CLAIM_CALIBRATION_PILOT",
+      "category": "Risk Hardening",
+      "priority": 49,
+      "title": "Claim Calibration And Pilot Evidence",
+      "description": "Keep contest claims honest and defensible by aligning product wording, evidence language, and any pilot-style validation notes with the repository's actual proof level.",
+      "scope": {
+        "docs": "docs/contest/*.md, ai_first/competition/*.md, ai_first/EXECUTION_QUEUE.md, ai_first/ACTIVE_ASSIGNMENTS.md"
+      },
+      "affected_features": [
+        "Contest Submission Package",
+        "Human Review Handoff",
+        "Pitch Materials"
+      ],
+      "complexity": "Low",
+      "estimated_hours": 2,
+      "dependencies": [
+        "R1_RUNTIME_BINDING_PROOF",
+        "R2_DIAGNOSIS_CREDIBILITY"
+      ],
+      "status": "not-started",
+      "notes": "Session-ready risk lane packet exists under docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md."
     }
   ],
   "github_issues_template": {

--- a/ai_first/competition/pitch-notes.md
+++ b/ai_first/competition/pitch-notes.md
@@ -10,7 +10,7 @@ Teachers have learning materials but limited time to convert them into personali
 
 ## Solution
 
-The platform turns teacher-owned materials into Knowledge Packs, generates assessments, supports student tutoring, and gives teachers a simple dashboard.
+The platform turns teacher-owned materials into Knowledge Packs, generates assessments, supports student tutoring, and gives teachers a simple dashboard. Its diagnosis and recommendation layer is designed as rule-assisted and teacher-reviewed, so the teacher stays responsible for intervention decisions.
 
 ## Why now
 
@@ -21,4 +21,4 @@ LLM agents, RAG, and AI-assisted content generation make it possible to reduce l
 1. Teacher creates a Knowledge Pack.
 2. Teacher generates questions from the pack.
 3. Student studies with Tutor Agent grounded in the pack.
-4. Teacher views dashboard evidence.
+4. Teacher views dashboard evidence and teacher-reviewable diagnosis suggestions.

--- a/ai_first/competition/product-description.md
+++ b/ai_first/competition/product-description.md
@@ -22,13 +22,15 @@ The platform keeps teachers in control of the source knowledge. A teacher create
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
 
+Within that loop, diagnosis and recommendation outputs are positioned as evidence-backed, confidence-tagged, teacher-reviewed hypotheses rather than autonomous final judgments.
+
 ## Main Capabilities in the Current MVP
 
 1. Knowledge Pack management for teacher-owned learning materials and metadata.
 2. Marketplace import and batch import for reusable packs.
 3. AI-generated assessments with review insights, timing metrics, and export support.
 4. Tutor Agent sessions with context badges, follow-up prompts, and replay support.
-5. Teacher dashboard analytics for recent activity and student-facing learning progress.
+5. Teacher dashboard analytics for recent activity, student-facing learning progress, and teacher-reviewable diagnosis/recommendation signals.
 6. Contest-ready evidence bundle with smoke-backed validation, screenshots, and demo-safe reset workflow.
 
 ## Why It Is Useful in Vietnam

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -144,3 +144,12 @@
 - Tests: `git diff --check`
 - Blockers: None.
 - Next: Commit the sync or roll it into the next lane branch before any further AI implementation starts.
+
+## Risk Lane 2
+
+- Branch: `pod-a/diagnosis-credibility`
+- Task: `R2_DIAGNOSIS_CREDIBILITY`
+- Done: Tightened diagnosis credibility by making payloads explicitly `rule_assisted_teacher_review`, adding abstain reasoning and teacher-review notes, and documenting three judge-facing diagnosis case studies without inventing accuracy metrics.
+- Tests: `pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
+- Blockers: None.
+- Next: Write the PR architecture note, run `git diff --check`, and open the Draft PR for review.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -149,7 +149,7 @@
 
 - Branch: `pod-a/diagnosis-credibility`
 - Task: `R2_DIAGNOSIS_CREDIBILITY`
-- Done: Tightened diagnosis credibility by making payloads explicitly `rule_assisted_teacher_review`, adding abstain reasoning and teacher-review notes, and documenting three judge-facing diagnosis case studies without inventing accuracy metrics.
-- Tests: `pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
+- Done: Tightened diagnosis credibility by making payloads explicitly `rule_assisted_teacher_review`, adding abstain reasoning and teacher-review notes, documenting three judge-facing diagnosis case studies without inventing accuracy metrics, and syncing `ai_first/TASK_REGISTRY.json` so `R1` through `R6` now exist as first-class AI-first tracked tasks.
+- Tests: `pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`; `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
 - Blockers: None.
 - Next: Write the PR architecture note, run `git diff --check`, and open the Draft PR for review.

--- a/deeptutor/services/evidence/contracts.py
+++ b/deeptutor/services/evidence/contracts.py
@@ -36,6 +36,7 @@ class DiagnosisRecord(TypedDict):
     confidence_tag: ConfidenceTag
     topic: str
     evidence: list[str]
+    teacher_review_note: str
 
 
 class RecommendationRecord(TypedDict):
@@ -49,3 +50,4 @@ class RecommendationRecord(TypedDict):
     target_student_ids: list[str]
     topic: str
     rationale: str
+    teacher_review_note: str

--- a/deeptutor/services/evidence/diagnosis.py
+++ b/deeptutor/services/evidence/diagnosis.py
@@ -17,6 +17,8 @@ ACTION_PRIORITY = {
     "small_group_support": 3,
 }
 
+DIAGNOSIS_POLICY = "rule_assisted_teacher_review"
+
 
 def _confidence_tag(
     *,
@@ -165,6 +167,9 @@ def _build_ranked_actions(
                 "target_student_ids": [student_id],
                 "topic": topic,
                 "rationale": item["rationale"],
+                "teacher_review_note": (
+                    f"Teacher should confirm that {action_type} matches the student's actual misconception before intervention."
+                ),
             }
         )
     return deduped
@@ -179,6 +184,8 @@ def build_student_diagnosis(
     if not observations:
         return {
             "student_id": student_id,
+            "diagnosis_policy": DIAGNOSIS_POLICY,
+            "teacher_review_required": True,
             "observed": None,
             "student_state": student_state,
             "inferred": [],
@@ -226,6 +233,9 @@ def build_student_diagnosis(
                     f"support_level={_support_level(dominant_rows)}",
                     f"contradiction_ratio={round(contradiction_ratio, 2)}",
                 ],
+                "teacher_review_note": (
+                    "Use this diagnosis as a teacher-reviewable hypothesis grounded in observed signals, not as an autonomous final judgment."
+                ),
             }
         ]
         actions = _build_ranked_actions(
@@ -238,11 +248,18 @@ def build_student_diagnosis(
 
     return {
         "student_id": student_id,
+        "diagnosis_policy": DIAGNOSIS_POLICY,
+        "teacher_review_required": True,
         "observed": {
             "topic": dominant_topic,
             "miss_count": miss_count,
             "evidence_count": evidence_count,
             "abstained": abstain,
+            "abstain_reason": (
+                "Evidence is too weak or too mixed for a confident diagnosis."
+                if abstain
+                else ""
+            ),
             "avg_latency_seconds": round(sum(avg_latency_values) / len(avg_latency_values))
             if avg_latency_values
             else 0,

--- a/docs/contest/DIAGNOSIS_CASE_STUDIES.md
+++ b/docs/contest/DIAGNOSIS_CASE_STUDIES.md
@@ -1,0 +1,92 @@
+# Diagnosis Credibility Case Studies
+
+Use these cases when a reviewer asks how the diagnosis layer works or how much trust to place in it.
+
+## Framing
+
+- The diagnosis layer is `rule_assisted_teacher_review`, not a benchmarked autonomous assessor.
+- Each diagnosis is a teacher-reviewable hypothesis built from observed signals.
+- When evidence is too weak or mixed, the system abstains instead of overstating certainty.
+
+## Case 1: Concept Gap In Fraction Subtraction
+
+**Observed**
+
+- Topic: `fractions subtraction`
+- Two incorrect answers in the same topic
+- Long response times: `48s`, `61s`
+- Retry behavior present
+
+**Inferred**
+
+- Diagnosis: `concept_gap`
+- Confidence: `medium` to `high`
+- Why:
+  - repeated misses on one topic
+  - slow responses
+  - retry pattern suggests misunderstanding, not just carelessness
+
+**Recommended action**
+
+- `review_prerequisite`
+
+**Teacher review framing**
+
+- Safe claim: the system is highlighting a likely prerequisite gap worth checking.
+- Unsafe claim: the system has proven the student's exact misconception without teacher review.
+
+## Case 2: Careless Error In Basic Arithmetic
+
+**Observed**
+
+- Topic: `arithmetic`
+- Two incorrect answers
+- Very short response times: `8s`, `10s`
+- No strong hint or retry pattern
+
+**Inferred**
+
+- Diagnosis: `careless_error`
+- Confidence: bounded by the rule pattern, not by external benchmark accuracy
+- Why:
+  - errors happen quickly
+  - low support load
+  - pattern looks more like haste than a deep conceptual gap
+
+**Recommended action**
+
+- `retry_easier`
+
+**Teacher review framing**
+
+- Safe claim: the student may need a quick accuracy-reset loop.
+- Unsafe claim: the system has ruled out all conceptual confusion.
+
+## Case 3: Abstain On Strong Correct Signal
+
+**Observed**
+
+- Topic: `geometry`
+- Correct answer
+- No hint burden
+- No retry burden
+
+**Inferred**
+
+- No diagnosis returned
+- `abstain_reason`: evidence is too weak or too mixed for a confident diagnosis
+
+**Recommended action**
+
+- None
+
+**Teacher review framing**
+
+- This is a credibility feature, not a weakness.
+- The system avoids fabricating intervention when the observation layer does not justify it.
+
+## Judge-Facing Answer
+
+If asked about diagnosis accuracy, use this wording:
+
+> We do not present this as a benchmarked autonomous assessor. It is a rule-assisted, confidence-tagged, teacher-reviewed hypothesis layer. Each recommendation is traceable to observed signals, and weak evidence leads to abstention rather than overclaiming.

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -21,6 +21,7 @@ The repository now includes bounded proof that the unified live turn path can ca
 - [`DEMO_SCRIPT.md`](./DEMO_SCRIPT.md): step-by-step demo path for a reviewer or presenter.
 - [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md): required screenshots, optional video, and pass/fail evidence fields.
 - [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md): local validation commands, results, limitations, and remaining capture work.
+- [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md): judge-facing diagnosis examples and teacher-review framing.
 - [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md): smoke lane used to verify the MVP path before any evidence refresh.
 - [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md): demo-safe data inventory and reset runbook before smoke/evidence refresh.
 
@@ -28,6 +29,7 @@ The repository now includes bounded proof that the unified live turn path can ca
 
 - Product MVP path is implemented through merged PRs for Knowledge Pack, Assessment Builder, Student Tutor context, and Teacher Dashboard.
 - Teacher Agent Spec authoring UI/API and runtime policy assembly contracts are merged on `main` and documented as hybrid-proof context.
+- Diagnosis and recommendation outputs are framed as rule-assisted, confidence-tagged, teacher-reviewed hypotheses rather than benchmarked autonomous judgments.
 - The latest scripted-reset smoke-backed MVP verification passed on 2026-04-26 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
 - Screenshot evidence is captured in [`screenshots/`](./screenshots/), including the 2026-04-26 dashboard evidence-first refresh and the `/agents` authoring proof refresh.
 - Hybrid `/agents` screenshots are current, and the codebase now also carries automated bounded runtime-binding proof for the unified Tutor turn path. Keep the claim narrower than universal entry-point coverage.

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -15,6 +15,7 @@ Hybrid proof calibration:
 - Teacher authoring capability on `/agents` is part of the merged product story.
 - Contest evidence-loop proof remains anchored to smoke-backed Knowledge Pack -> assessment -> tutor -> dashboard artifacts.
 - You may claim bounded automated proof that the unified Tutor turn path accepts `config.agent_spec_id` and changes behavior across two contrasting spec packs. Do not expand that into universal live turn-time binding unless broader paths are re-verified in the target demo environment.
+- Diagnosis claims should stay at: rule-assisted, confidence-tagged, teacher-reviewed hypothesis layer. Do not present the diagnosis engine as a benchmarked autonomous assessor.
 
 Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/competition/pitch-notes.md).
 
@@ -25,6 +26,7 @@ Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/com
 | Demo script | Ready | [`DEMO_SCRIPT.md`](./DEMO_SCRIPT.md) |
 | Smoke-backed validation | Ready | [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) |
 | Evidence checklist | Ready | [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md) |
+| Diagnosis credibility cases | Ready | [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md) |
 | Screenshot bundle | Ready | [`screenshots/`](./screenshots/) |
 | Demo-safe reset command | Ready | [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) |
 | Smoke procedure | Ready | [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md) |

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -46,6 +46,7 @@ Use these status values consistently:
 - The frontend build emits a Next.js warning about multiple lockfiles and inferred workspace root. The build still completes successfully.
 - Browser-backed screenshot refresh now works in a local worktree, but it still depends on a running backend and frontend plus demo-safe local data.
 - Runtime handoff from `config.agent_spec_id` through the unified live Tutor turn path now has bounded automated proof in repository tests, including a visible behavior difference between two spec packs. This report still does not claim universal wiring across every possible entry point.
+- Diagnosis credibility is grounded in deterministic rules plus teacher review framing. This report does not claim benchmark accuracy numbers for diagnosis or recommendation quality.
 - Local provider-backed assessment generation was unavailable during the 2026-04-25 screenshot refresh because the configured model key was still a placeholder. The refreshed `07` and `08` screenshots therefore use demo-safe local session content in the worktree data store instead of a live provider response.
 - Provider-backed AI quality depends on configured model credentials. If credentials are unavailable during a demo, use the command validation and recorded UI flow as fallback evidence.
 - This report uses demo-safe descriptions only. Do not add real student data.
@@ -89,6 +90,7 @@ The 2026-04-26 scripted-reset smoke run verified the MVP path in the current mer
 4. the frontend production build passed against `http://localhost:8001` after `npm ci` in the lane-6 worktree;
 5. smoke-backed command evidence stayed `Current`, and browser-captured dashboard plus hybrid `/agents` rows were refreshed on 2026-04-26 against the current merged UI;
 6. focused automated tests now prove the unified Tutor turn path can accept `config.agent_spec_id`, assemble the matching runtime policy, and produce a deterministic behavior difference between two contrasting spec packs without claiming full entry-point coverage.
+7. diagnosis credibility is supported by focused rule-based cases in repository tests and a reviewer-facing case-study packet in `DIAGNOSIS_CASE_STUDIES.md`, not by fabricated accuracy metrics.
 
 ## Manual Verification Template
 

--- a/docs/superpowers/pr-notes/2026-04-26-risk-lane-2-diagnosis-credibility.md
+++ b/docs/superpowers/pr-notes/2026-04-26-risk-lane-2-diagnosis-credibility.md
@@ -1,0 +1,32 @@
+# PR Note: Risk Lane 2 Diagnosis Credibility
+
+## Summary
+
+- make diagnosis payloads explicitly teacher-reviewed and rule-assisted
+- add abstain reasoning and teacher-review notes to diagnosis and recommendation outputs
+- document three judge-facing diagnosis case studies without inventing benchmark accuracy claims
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Obs["Observed signals"]
+  Rules["Rule-assisted diagnosis scoring"]
+  Hyp["Teacher-reviewable hypothesis"]
+  Act["Recommended action"]
+  Cases["Diagnosis case studies"]
+
+  Obs --> Rules
+  Rules --> Hyp
+  Hyp --> Act
+  Hyp --> Cases
+```
+
+## Main System Map
+
+- Not updated. This lane strengthens framing and payload semantics inside the existing evidence pipeline without changing architectural boundaries.
+
+## Validation
+
+- `pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
+- `git diff --check`

--- a/tests/services/evidence/test_diagnosis.py
+++ b/tests/services/evidence/test_diagnosis.py
@@ -46,11 +46,15 @@ def test_build_student_diagnosis_returns_structured_hypotheses_and_actions() -> 
     )
 
     assert payload["student_id"] == "student-a"
+    assert payload["diagnosis_policy"] == "rule_assisted_teacher_review"
+    assert payload["teacher_review_required"] is True
     assert payload["observed"]["topic"] == "fractions subtraction"
     assert payload["observed"]["abstained"] is False
     assert payload["inferred"][0]["diagnosis_type"] == "concept_gap"
     assert payload["inferred"][0]["confidence_tag"] in {"medium", "high"}
+    assert "teacher-reviewable hypothesis" in payload["inferred"][0]["teacher_review_note"]
     assert payload["recommended_actions"][0]["action_type"] == "review_prerequisite"
+    assert "Teacher should confirm" in payload["recommended_actions"][0]["teacher_review_note"]
 
 
 def test_build_student_diagnosis_routes_careless_error_to_retry_action() -> None:
@@ -91,6 +95,7 @@ def test_build_student_diagnosis_routes_careless_error_to_retry_action() -> None
 
     assert payload["inferred"][0]["diagnosis_type"] == "careless_error"
     assert payload["recommended_actions"][0]["action_type"] == "retry_easier"
+    assert payload["observed"]["abstain_reason"] == ""
 
 
 def test_build_student_diagnosis_abstains_on_weak_or_non_error_signal() -> None:
@@ -117,5 +122,6 @@ def test_build_student_diagnosis_abstains_on_weak_or_non_error_signal() -> None:
     )
 
     assert payload["observed"]["abstained"] is True
+    assert payload["observed"]["abstain_reason"] == "Evidence is too weak or too mixed for a confident diagnosis."
     assert payload["inferred"] == []
     assert payload["recommended_actions"] == []


### PR DESCRIPTION
## Summary
- make diagnosis payloads explicitly rule-assisted and teacher-reviewed
- add abstain reasoning and teacher-review notes to evidence outputs
- add judge-facing diagnosis case studies and calibrate contest wording without inventing accuracy metrics

## Validation
- `pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`
- `git diff --check`

## Main System Map
- Not updated; this lane strengthens framing and payload semantics inside the existing evidence pipeline without changing architectural boundaries.