### PR TITLE
docs: sync AI-first queue after risk lane 2 merge

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,6 @@ Rules:
 
 ## Active
 
-### Assignment
+No active AI implementation task.
 
-- Owner: Codex
-- Machine: `MacBook-Air-cua-Loc.local`
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/diagnosis-credibility`
-- Task: `R2_DIAGNOSIS_CREDIBILITY`
-- Status: Ready for draft PR
-- Branch: `pod-a/diagnosis-credibility`
-- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md`
-- Owned files: `deeptutor/services/evidence/`, `tests/services/evidence/`, `docs/contest/`, `ai_first/competition/`, `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md`, `docs/superpowers/pr-notes/*`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`
-- PR:
-- Last update: 2026-04-26
-- Next action: Commit, push, and open the draft PR for diagnosis credibility review.
-- Blocker: None
+Recommended next AI-owned task: open `docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md` from a fresh branch/worktree if the team wants to keep hardening judge-risk defenses.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest feature-risk merge: `#151 [R1] feat(runtime-policy): add bounded tutor spec binding proof`
+- Latest feature-risk merge: `#153 [R2] feat(evidence): strengthen diagnosis credibility framing`
 - Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
@@ -17,6 +17,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 - Dashboard and `/agents` evidence recapture merged to `main` through PR `#147`.
 - Post-147 evidence merge sync merged to `main` through PR `#148`.
 - Risk Lane 1 runtime binding proof merged to `main` through PR `#151`.
+- Risk Lane 2 diagnosis credibility merged to `main` through PR `#153`.
 - Latest smoke result: the 2026-04-26 scripted-reset smoke pass succeeded in lane 6 (`docs/evaluation-evidence-readiness`) against current `main` behavior.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -29,7 +30,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Next recommended task
 
-- If the team wants to continue AI-owned product hardening, start `R2_DIAGNOSIS_CREDIBILITY` from `docs/superpowers/tasks/2026-04-26-risk-lane-2-diagnosis-credibility.md`.
+- If the team wants to continue AI-owned product hardening, start `R3_ASSESSMENT_SAFETY` from `docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md`.
 - If not, the shortest remaining non-code path is still human review of the submission package, IP commitment, and optional video decision.
 - Any new AI task should start from a fresh branch/worktree off `main`, not from a merged lane branch.
 

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -153,3 +153,12 @@
 - Tests: `pytest tests/services/evidence/test_diagnosis.py tests/api/test_assessment_router.py tests/api/test_dashboard_router.py -q`; `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
 - Blockers: None.
 - Next: Write the PR architecture note, run `git diff --check`, and open the Draft PR for review.
+
+## Post-153 Sync
+
+- Branch: `docs/post-153-risk-sync`
+- Task: `OPS_POST_153_RISK_SYNC`
+- Done: Reset the AI-first control plane after Risk Lane 2 merged so `main` no longer advertises the merged lane as active and the compact queue now points future AI workers to `R3_ASSESSMENT_SAFETY` as the next optional risk-hardening slice.
+- Tests: `git diff --check`
+- Blockers: None.
+- Next: Commit the sync and open the tiny docs PR before any R3 implementation starts.

--- a/docs/superpowers/pr-notes/2026-04-26-post-153-risk-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-26-post-153-risk-sync.md
@@ -1,0 +1,29 @@
+# PR Note: Post-153 Risk Sync
+
+## Summary
+
+- clear the stale `R2_DIAGNOSIS_CREDIBILITY` assignment from `main`
+- update the compact execution queue so future AI workers see `R3_ASSESSMENT_SAFETY` as the next optional risk-hardening lane
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Merge["PR #153 merged"]
+  Active["ACTIVE_ASSIGNMENTS.md"]
+  Queue["EXECUTION_QUEUE.md"]
+  Next["Next lane: R3 assessment safety"]
+
+  Merge --> Active
+  Merge --> Queue
+  Active --> Next
+  Queue --> Next
+```
+
+## Main System Map
+
+- Not updated. This PR only synchronizes AI-first control-plane docs after a merge.
+
+## Validation
+
+- `git diff --check`


### PR DESCRIPTION
## Summary
- clear the stale Risk Lane 2 active assignment from `main`
- update the compact execution queue after PR #153 merged
- point future AI workers to `R3_ASSESSMENT_SAFETY` as the next optional risk-hardening lane

## Validation
- `git diff --check`

## Main System Map
- Not updated; this PR only synchronizes AI-first control-plane docs after a merge.