### PR TITLE
feat: make assessment review safety gate explicit

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,6 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task.
+### Assignment
 
-Recommended next AI-owned task: open `docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md` from a fresh branch/worktree if the team wants to keep hardening judge-risk defenses.
+- Owner: Codex
+- Machine: `MacBook-Air-cua-Loc.local`
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/risk-lane3`
+- Task: `R3_ASSESSMENT_SAFETY`
+- Status: Ready for draft PR
+- Branch: `pod-a/assessment-safety`
+- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md`
+- Owned files: `web/app/(workspace)/guide/`, `web/components/quiz/`, `web/app/(workspace)/dashboard/assessments/`, `docs/contest/`, `ai_first/competition/`, `docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md`, `docs/superpowers/pr-notes/*`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-26.md`
+- PR:
+- Last update: 2026-04-26
+- Next action: Commit, push, and open the draft PR for assessment safety review.
+- Blocker: None

--- a/ai_first/competition/pitch-notes.md
+++ b/ai_first/competition/pitch-notes.md
@@ -10,7 +10,7 @@ Teachers have learning materials but limited time to convert them into personali
 
 ## Solution
 
-The platform turns teacher-owned materials into Knowledge Packs, generates assessments, supports student tutoring, and gives teachers a simple dashboard. Its diagnosis and recommendation layer is designed as rule-assisted and teacher-reviewed, so the teacher stays responsible for intervention decisions.
+The platform turns teacher-owned materials into Knowledge Packs, generates assessments, supports student tutoring, and gives teachers a simple dashboard. Assessment generation is framed as a draft-plus-review workflow, and the diagnosis layer is rule-assisted and teacher-reviewed, so the teacher stays responsible for both content quality and intervention decisions.
 
 ## Why now
 

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -162,3 +162,12 @@
 - Tests: `git diff --check`
 - Blockers: None.
 - Next: Commit the sync and open the tiny docs PR before any R3 implementation starts.
+
+## Risk Lane 3
+
+- Branch: `pod-a/assessment-safety`
+- Task: `R3_ASSESSMENT_SAFETY`
+- Done: Made the assessment flow explicitly draft-and-review oriented by adding teacher-review safety-gate messaging to generated quiz output and assessment review, tightening contest wording so the safe claim is human-in-the-loop quality control rather than hidden model reliability, and correcting the lane packet to match the real assessment UI files in the repo.
+- Tests: `./node_modules/.bin/eslint --config eslint.config.mjs components/quiz/QuizViewer.tsx app/'(workspace)'/dashboard/assessments/'[sessionId]'/page.tsx` from `web/`; `git diff --check`
+- Blockers: None.
+- Next: Write the PR architecture note, then open the Draft PR once the focused frontend validation passes.

--- a/docs/contest/DEMO_SCRIPT.md
+++ b/docs/contest/DEMO_SCRIPT.md
@@ -55,7 +55,9 @@ Steps:
 2. Select or reference the demo Knowledge Pack.
 3. Set subject and quiz parameters.
 4. Generate the assessment.
-5. Review generated questions and common-mistake feedback.
+5. Show that the generated assessment is treated as a draft requiring teacher review.
+6. Review generated questions and common-mistake feedback.
+7. Explain that a teacher can approve, edit, or reject before student-facing reuse.
 
 Evidence to capture:
 
@@ -105,3 +107,4 @@ Evidence to capture:
 - If an external LLM provider is unavailable, explain the unavailable credential and show the local validation report instead of inventing evidence.
 - After the demo, open `VALIDATION_REPORT.md` to show exact commands and known limitations.
 - If you include the hybrid authoring check, keep it under one minute. The safe claim is: authoring is visible in UI, and the current repository also contains bounded automated proof that the unified Tutor turn path changes behavior across two contrasting spec packs.
+- For assessment safety, the safe claim is: teacher review is the primary quality gate, not hidden model infallibility.

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -16,6 +16,7 @@ Hybrid proof calibration:
 - Contest evidence-loop proof remains anchored to smoke-backed Knowledge Pack -> assessment -> tutor -> dashboard artifacts.
 - You may claim bounded automated proof that the unified Tutor turn path accepts `config.agent_spec_id` and changes behavior across two contrasting spec packs. Do not expand that into universal live turn-time binding unless broader paths are re-verified in the target demo environment.
 - Diagnosis claims should stay at: rule-assisted, confidence-tagged, teacher-reviewed hypothesis layer. Do not present the diagnosis engine as a benchmarked autonomous assessor.
+- Assessment claims should stay at: AI can draft questions and feedback, but teacher review is the primary safety gate before student-facing reuse.
 
 Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/competition/pitch-notes.md).
 

--- a/docs/superpowers/pr-notes/2026-04-26-risk-lane-3-assessment-safety.md
+++ b/docs/superpowers/pr-notes/2026-04-26-risk-lane-3-assessment-safety.md
@@ -1,0 +1,30 @@
+# PR Note: Risk Lane 3 Assessment Safety
+
+## Summary
+
+- add visible teacher-review safety-gate messaging to the generated assessment and assessment-review surfaces
+- calibrate contest wording so assessment quality claims rely on human review, not hidden model infallibility
+- correct the lane packet to match the real assessment UI files used in this repository
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Generate["AI generates assessment draft"]
+  Review["Teacher review surface"]
+  Gate["Approve, edit, or reject"]
+  Student["Student-facing reuse"]
+
+  Generate --> Review
+  Review --> Gate
+  Gate --> Student
+```
+
+## Main System Map
+
+- Not updated. This lane clarifies an existing assessment review gate without changing architectural boundaries.
+
+## Validation
+
+- `./node_modules/.bin/eslint --config eslint.config.mjs components/quiz/QuizViewer.tsx app/'(workspace)'/dashboard/assessments/'[sessionId]'/page.tsx`
+- `git diff --check`

--- a/docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md
+++ b/docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md
@@ -19,9 +19,9 @@ Make the teacher-review and quality-control layer around assessment generation o
 
 ## Owned files/modules
 
-- `web/app/(workspace)/assessment/`
+- `web/app/(workspace)/guide/`
+- `web/components/quiz/`
 - `web/app/(workspace)/dashboard/assessments/`
-- `web/lib/assessment-api.ts`
 - `docs/contest/`
 - `ai_first/competition/`
 - `docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md`

--- a/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
+++ b/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
@@ -190,6 +190,28 @@ export default function AssessmentReviewPage() {
           </div>
         </section>
 
+        <section className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4 shadow-sm dark:border-amber-900/40 dark:bg-amber-950/20">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-amber-800 dark:text-amber-300">
+            {t("Teacher Review Safety Gate")}
+          </div>
+          <p className="mt-2 text-[14px] leading-6 text-amber-900 dark:text-amber-100">
+            {t(
+              "This assessment should be teacher-reviewed before student-facing reuse. Use this screen to confirm question wording, distractor quality, and explanation clarity rather than assuming the AI output is ready to publish unchanged.",
+            )}
+          </p>
+          <div className="mt-3 grid gap-2 text-[13px] text-amber-900 dark:text-amber-200 md:grid-cols-3">
+            <div className="rounded-xl border border-amber-200/70 bg-white/60 px-3 py-2 dark:border-amber-900/40 dark:bg-amber-950/20">
+              {t("1. Review question wording")}
+            </div>
+            <div className="rounded-xl border border-amber-200/70 bg-white/60 px-3 py-2 dark:border-amber-900/40 dark:bg-amber-950/20">
+              {t("2. Check answer and distractor quality")}
+            </div>
+            <div className="rounded-xl border border-amber-200/70 bg-white/60 px-3 py-2 dark:border-amber-900/40 dark:bg-amber-950/20">
+              {t("3. Approve, edit, or reject before reuse")}
+            </div>
+          </div>
+        </section>
+
         <ProgressIndicator
           totalQuestions={review.summary.total_questions}
           correctCount={review.summary.correct_count}

--- a/web/components/quiz/QuizViewer.tsx
+++ b/web/components/quiz/QuizViewer.tsx
@@ -461,6 +461,17 @@ export default function QuizViewer({
         </div>
       </div>
 
+      <div className="border-b border-amber-200/70 bg-amber-50/80 px-4 py-3 text-[12px] text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-200">
+        <div className="font-semibold uppercase tracking-[0.08em]">
+          {t("Teacher Review Safety Gate")}
+        </div>
+        <p className="mt-1 leading-relaxed">
+          {t(
+            "This generated assessment should be reviewed or edited by a teacher before it is reused in a student-facing flow.",
+          )}
+        </p>
+      </div>
+
       <div className="px-4 py-3">
         <div className="mb-2 flex flex-wrap items-center gap-1.5">
           <span className="rounded-md bg-[var(--muted)] px-1.5 py-0.5 text-[10px] font-medium uppercase text-[var(--muted-foreground)]">
@@ -589,6 +600,15 @@ export default function QuizViewer({
                 {t("Retry")}
               </button>
             </>
+          )}
+        </div>
+
+        <div className="mt-3 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[12px] text-[var(--muted-foreground)]">
+          <span className="font-medium text-[var(--foreground)]">
+            {t("Review cue")}:
+          </span>{" "}
+          {t(
+            "Check answer wording, distractor quality, and explanation clarity before sharing this assessment with students.",
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- add explicit teacher-review safety messaging to generated assessment and assessment review surfaces
- calibrate contest wording so assessment quality claims rely on human review before student-facing reuse
- correct the risk lane packet to match the real assessment UI files in the repo

## Validation
- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/eslint.config.mjs /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/risk-lane3/web/components/quiz/QuizViewer.tsx "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/risk-lane3/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx"`
- `git diff --check`

## Main System Map
- Not updated; this lane clarifies an existing assessment review gate without changing architectural boundaries.