### PR TITLE
docs(teacher-value): clarify teacher outcomes and agent copy [R4]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,6 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task.
+### Assignment
 
-Recommended next AI-owned task: open `docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md` from a fresh branch/worktree if the team wants to keep hardening judge-risk defenses.
+- Owner: Codex
+- Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/teacher-value-prop`
+- Task: `R4_TEACHER_VALUE_PROP`
+- Status: in progress
+- Branch: `pod-a/teacher-value-prop`
+- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md`
+- Owned files: `docs/contest/`, `ai_first/competition/`, `/web/app/(workspace)/agents/` copy only, `/web/components/agents/` copy only, task packet, PR note
+- PR:
+- Last update: 2026-04-26
+- Next action: rewrite `/agents` and contest copy in teacher-benefit language, then validate and open Draft PR
+- Blocker: none

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T14:40:00Z",
+    "last_updated": "2026-04-26T16:35:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 49
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 44,
+      "count": 46,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -53,14 +53,16 @@
         "T049_METADATA_DEPTH_PASS",
         "T050_DASHBOARD_INSIGHT_DEPTH",
         "T051_SESSION_CONTEXT_QUALITY_PASS",
-        "R1_RUNTIME_BINDING_PROOF"
+        "R1_RUNTIME_BINDING_PROOF",
+        "R2_DIAGNOSIS_CREDIBILITY",
+        "R3_ASSESSMENT_SAFETY"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
       "count": 1,
       "tasks": [
-        "R2_DIAGNOSIS_CREDIBILITY"
+        "R4_TEACHER_VALUE_PROP"
       ]
     },
     "blocked": {
@@ -70,10 +72,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 4,
+      "count": 2,
       "tasks": [
-        "R3_ASSESSMENT_SAFETY",
-        "R4_TEACHER_VALUE_PROP",
         "R5_DASHBOARD_ACTIONABILITY",
         "R6_CLAIM_CALIBRATION_PILOT"
       ]
@@ -1081,8 +1081,8 @@
         "L3_OBSERVATION_STUDENT_STATE",
         "L4_DIAGNOSIS_RECOMMENDATION"
       ],
-      "status": "in-progress",
-      "notes": "Active on branch pod-a/diagnosis-credibility. Draft PR #153 adds teacher-review notes, abstain reasoning, and diagnosis case studies."
+      "status": "completed",
+      "notes": "Merged to main through PR #153. Diagnosis outputs now carry teacher-review notes, abstain reasoning, and judge-facing case studies."
     },
     {
       "id": "R3_ASSESSMENT_SAFETY",
@@ -1106,8 +1106,8 @@
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
         "T015_ASSESSMENT_RECOMMENDATIONS"
       ],
-      "status": "not-started",
-      "notes": "Session-ready risk lane packet exists under docs/superpowers/tasks/2026-04-26-risk-lane-3-assessment-safety.md."
+      "status": "completed",
+      "notes": "Merged to main through PR #155. Assessment flows and contest docs now make teacher review the explicit safety gate before student-facing reuse."
     },
     {
       "id": "R4_TEACHER_VALUE_PROP",
@@ -1130,8 +1130,8 @@
         "L1_AGENT_SPEC_AUTHORING",
         "L5_TEACHER_INSIGHT_UI"
       ],
-      "status": "not-started",
-      "notes": "Session-ready risk lane packet exists under docs/superpowers/tasks/2026-04-26-risk-lane-4-teacher-value-prop.md."
+      "status": "in-progress",
+      "notes": "Active on branch pod-a/teacher-value-prop. This lane reframes `/agents`, pitch copy, and contest docs around teacher outcomes rather than architecture jargon."
     },
     {
       "id": "R5_DASHBOARD_ACTIONABILITY",

--- a/ai_first/competition/pitch-notes.md
+++ b/ai_first/competition/pitch-notes.md
@@ -2,15 +2,21 @@
 
 ## One-line pitch
 
-An AI-first learning platform where Vietnamese teachers create Knowledge Packs and teaching skills, then AI Tutor Agents help students learn, practice, and improve from those teacher-approved materials.
+An AI-first learning platform where Vietnamese teachers turn their own materials into classroom-ready tutoring, practice, and follow-up insight without giving up control over how the AI teaches.
 
 ## Problem
 
-Teachers have learning materials but limited time to convert them into personalized practice, tutoring, and progress tracking.
+Teachers already have lesson materials and teaching instincts, but they do not have enough time to turn them into personalized practice, tutoring support, and follow-up decisions for each learner.
 
 ## Solution
 
-The platform turns teacher-owned materials into Knowledge Packs, generates assessments, supports student tutoring, and gives teachers a simple dashboard. Assessment generation is framed as a draft-plus-review workflow, and the diagnosis layer is rule-assisted and teacher-reviewed, so the teacher stays responsible for both content quality and intervention decisions.
+The platform turns teacher-owned materials into Knowledge Packs, drafts assessments for teacher review, supports student tutoring, and gives teachers an evidence-first dashboard. Teachers can also set the tutor's class fit, support style, and guardrails on `/agents`, so the system adapts to how they want students to be helped, not just what content is covered.
+
+Teacher-facing use cases:
+
+1. A grade 6 teacher can make the tutor explain more gently, use simpler language, and avoid giving final answers too quickly.
+2. A grade 10 teacher can make the tutor more Socratic, push for reasoning steps, and escalate when students keep repeating the same mistake.
+3. A teacher reviewing the dashboard can spot which students need remediation now and which small group should revisit the same misconception together.
 
 ## Why now
 
@@ -22,3 +28,10 @@ LLM agents, RAG, and AI-assisted content generation make it possible to reduce l
 2. Teacher generates questions from the pack.
 3. Student studies with Tutor Agent grounded in the pack.
 4. Teacher views dashboard evidence and teacher-reviewable diagnosis suggestions.
+
+Behavior-diff story for judges:
+
+- `IDENTITY` changes who the tutor is serving: subject, grade band, tone, and language.
+- `SOUL` changes how the tutor reacts when a student is wrong, stuck, or discouraged.
+- `RULES` changes the classroom boundaries: for example, whether the tutor should withhold direct answers, how much hinting is allowed, and when to stop or escalate.
+- The same student question can therefore receive a more encouraging scaffolded response in one class setup and a more Socratic push-back in another, without changing the underlying source material.

--- a/ai_first/competition/product-description.md
+++ b/ai_first/competition/product-description.md
@@ -10,7 +10,7 @@ Education
 
 ## Short Description
 
-Multiagent Learning Platform is an AI-first learning platform that helps Vietnamese teachers turn their own teaching materials into reusable Knowledge Packs, generate assessments, support student tutoring, and review learning progress through one connected workflow.
+Multiagent Learning Platform is an AI-first learning platform that helps Vietnamese teachers turn their own teaching materials into reusable Knowledge Packs, draft assessments, support student tutoring, and review learning progress through one connected workflow while still deciding how the AI should teach.
 
 ## Problem
 
@@ -22,7 +22,13 @@ The platform keeps teachers in control of the source knowledge. A teacher create
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
 
-Within that loop, diagnosis and recommendation outputs are positioned as evidence-backed, confidence-tagged, teacher-reviewed hypotheses rather than autonomous final judgments.
+Within that loop, diagnosis and recommendation outputs are positioned as evidence-backed, confidence-tagged, teacher-reviewed hypotheses rather than autonomous final judgments. The `/agents` flow adds one more teacher-control layer: the teacher can decide who the tutor is for, how it should respond when students are wrong or stuck, and which classroom guardrails it must respect.
+
+## Concrete Teacher Use Cases
+
+1. A lower-secondary math teacher can set a calmer tone, simpler language, and stronger hint scaffolding for students who lose confidence quickly.
+2. An exam-prep teacher can set a more demanding style that asks students to justify each step before the tutor gives another hint.
+3. After class, a teacher can review the dashboard to see which students need individual follow-up and which small group should revisit the same misconception together.
 
 ## Main Capabilities in the Current MVP
 
@@ -42,7 +48,7 @@ Within that loop, diagnosis and recommendation outputs are positioned as evidenc
 
 ## Innovation
 
-The platform combines agent workflows, retrieval grounded in teacher-approved materials, assessment generation, tutoring, and dashboard review into one connected product path instead of isolated tools. Its practical novelty is not only “using AI,” but using AI while preserving teacher control over source content and evidence.
+The platform combines agent workflows, retrieval grounded in teacher-approved materials, assessment generation, tutoring, and dashboard review into one connected product path instead of isolated tools. Its practical novelty is not only “using AI,” but using AI while preserving teacher control over source content, teaching style, and evidence review.
 
 ## Practical Applicability
 
@@ -52,7 +58,7 @@ The current MVP already demonstrates the end-to-end classroom loop locally with 
 
 - Reduces manual work needed to turn teaching materials into assessments.
 - Gives students immediate tutoring support based on the same approved knowledge source.
-- Gives teachers a faster feedback loop through dashboard activity and assessment review.
+- Gives teachers a faster feedback loop through dashboard activity, assessment review, and next-step intervention suggestions.
 
 ## Development Potential
 

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -180,3 +180,8 @@
 - Tests: `git diff --check`
 - Blockers: None.
 - Next: Commit the sync and open the tiny docs PR before any R4 implementation starts.
+# R4_TEACHER_VALUE_PROP
+
+- Started risk-lane 4 in worktree `.worktrees/teacher-value-prop` on branch `pod-a/teacher-value-prop`.
+- Reframed `/agents`, contest README, demo script, submission package, pitch notes, and product description in teacher-benefit language.
+- Added explicit explanations for `IDENTITY`, `SOUL`, and `RULES`, plus concrete teacher use cases and a behavior-diff judge story.

--- a/docs/contest/DEMO_SCRIPT.md
+++ b/docs/contest/DEMO_SCRIPT.md
@@ -15,8 +15,14 @@ Use this script to present the MVP in the same order as the project goal.
 Before the learning loop, optionally show a short teacher-authoring proof on `/agents`:
 
 1. Open Agent Specs authoring.
-2. Show structured sections (`IDENTITY`, `SOUL`, `RULES`) and free-form markdown sections.
-3. Export the spec pack.
+2. Explain the sections in teacher language:
+   - `IDENTITY`: who this tutor is for;
+   - `SOUL`: how it reacts when students are wrong or stuck;
+   - `RULES`: what classroom boundaries it must respect.
+3. Show one behavior-diff example:
+   - a supportive class setup gives more encouragement and scaffolding;
+   - an exam-prep setup pushes the student to justify steps before another hint.
+4. Export the spec pack.
 
 You may claim bounded proof that the unified Tutor turn path can bind `config.agent_spec_id` and change runtime behavior between two contrasting spec packs. Do not expand that into a claim about every entry point unless the broader path is re-verified in the current smoke run.
 
@@ -92,6 +98,7 @@ Steps:
 3. Confirm small-group recommendation cards are visible when grouped signals exist.
 4. Confirm recent activity still distinguishes assessment and tutoring sessions.
 5. Confirm Knowledge Pack references appear when sessions used a selected pack.
+6. Explain one concrete teacher move, such as reteaching one concept to a small group or giving a gentler scaffold to one student next session.
 
 Evidence to capture:
 
@@ -104,6 +111,7 @@ Evidence to capture:
 
 - Keep the demo short and linear.
 - Use one consistent sample topic across all screens.
+- When explaining `/agents`, start with classroom outcomes before architecture words.
 - If an external LLM provider is unavailable, explain the unavailable credential and show the local validation report instead of inventing evidence.
 - After the demo, open `VALIDATION_REPORT.md` to show exact commands and known limitations.
 - If you include the hybrid authoring check, keep it under one minute. The safe claim is: authoring is visible in UI, and the current repository also contains bounded automated proof that the unified Tutor turn path changes behavior across two contrasting spec packs.

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -13,6 +13,13 @@ This evidence bundle now supports a hybrid contest narrative:
 - Teacher authoring proof: the teacher can structure Agent Specs on `/agents` and export a spec pack.
 - Learning evidence-loop proof: Knowledge Pack -> assessment -> tutoring follow-up -> dashboard activity.
 
+Teacher-value framing for presenters:
+
+- `IDENTITY` lets a teacher choose who the tutor is for: subject, grade band, tone, and language.
+- `SOUL` lets a teacher decide how the tutor reacts when a student is wrong, stuck, or discouraged.
+- `RULES` lets a teacher keep classroom boundaries such as no direct answers, hint limits, or escalation expectations.
+- The dashboard is not only reporting activity; it helps the teacher decide what to reteach, who needs follow-up, and which students can be grouped around the same misconception.
+
 The repository now includes bounded proof that the unified live turn path can carry `config.agent_spec_id` into Tutor runtime policy assembly and produce a visible behavior difference between two spec packs. Do not expand that claim into universal coverage across every entry point unless a fresh smoke run verifies those additional paths.
 
 ## Evidence Files
@@ -34,6 +41,12 @@ The repository now includes bounded proof that the unified live turn path can ca
 - Screenshot evidence is captured in [`screenshots/`](./screenshots/), including the 2026-04-26 dashboard evidence-first refresh and the `/agents` authoring proof refresh.
 - Hybrid `/agents` screenshots are current, and the codebase now also carries automated bounded runtime-binding proof for the unified Tutor turn path. Keep the claim narrower than universal entry-point coverage.
 - Video capture is optional and deferred to avoid storing large media in the repository.
+
+## Judge-Friendly Use Cases
+
+1. A teacher can create one tutoring style for a lower-confidence class and another for an exam-prep class without changing the underlying lesson materials.
+2. A teacher can draft an assessment from a Knowledge Pack, review it, then reuse the same knowledge source during tutoring.
+3. A teacher can move from observed errors to a recommended next action instead of reading raw activity logs alone.
 
 ## Evidence Refresh Rules
 

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -8,7 +8,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 One-line pitch:
 
-An AI-first learning platform where Vietnamese teachers create Knowledge Packs and teaching skills, then AI Tutor Agents help students learn, practice, and improve from teacher-approved materials.
+An AI-first learning platform where Vietnamese teachers turn their own materials into tutoring, practice, and follow-up insight while staying in control of how the AI teaches.
 
 Hybrid proof calibration:
 
@@ -17,6 +17,13 @@ Hybrid proof calibration:
 - You may claim bounded automated proof that the unified Tutor turn path accepts `config.agent_spec_id` and changes behavior across two contrasting spec packs. Do not expand that into universal live turn-time binding unless broader paths are re-verified in the target demo environment.
 - Diagnosis claims should stay at: rule-assisted, confidence-tagged, teacher-reviewed hypothesis layer. Do not present the diagnosis engine as a benchmarked autonomous assessor.
 - Assessment claims should stay at: AI can draft questions and feedback, but teacher review is the primary safety gate before student-facing reuse.
+
+Teacher-value shorthand for Q&A:
+
+- `IDENTITY` = who this tutor is for.
+- `SOUL` = how this tutor teaches and encourages.
+- `RULES` = what this tutor is not allowed to do.
+- Dashboard value = which student or small group needs what next.
 
 Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/competition/pitch-notes.md).
 

--- a/docs/superpowers/pr-notes/2026-04-26-risk-lane-4-teacher-value-prop.md
+++ b/docs/superpowers/pr-notes/2026-04-26-risk-lane-4-teacher-value-prop.md
@@ -1,0 +1,31 @@
+# PR Note: Risk Lane 4 Teacher Value Proposition
+
+## Summary
+
+This PR hardens the teacher-facing story for judges and voters by translating Agent Specs and the evidence loop into classroom outcomes instead of system jargon.
+
+## What Changed
+
+- rewrote `/agents` copy to explain class fit, support style, and guardrails in teacher language
+- added explicit teacher-use-case framing to contest and pitch docs
+- added a simple behavior-diff story for `IDENTITY`, `SOUL`, and `RULES`
+
+## Main System Map
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because no shipped route, capability, or data-flow behavior changed
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Teacher["Teacher intent"]
+  Specs["/agents: IDENTITY, SOUL, RULES"]
+  Tutor["Tutor behavior"]
+  Dashboard["Observed -> Inferred -> Action"]
+  FollowUp["Teacher follow-up move"]
+
+  Teacher --> Specs
+  Specs --> Tutor
+  Tutor --> Dashboard
+  Dashboard --> FollowUp
+```

--- a/web/app/(workspace)/agents/page.tsx
+++ b/web/app/(workspace)/agents/page.tsx
@@ -97,7 +97,7 @@ export default function AgentsPage() {
             <p className="mt-1 text-[13px] text-[var(--primary)] animate-fade-in">{toast}</p>
           ) : (
             <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
-              {t("Author teacher-defined spec packs, then manage in-process TutorBot instances when needed")}
+              {t("Set how this class tutor explains, encourages, and gives hints before students start learning")}
             </p>
           )}
         </div>

--- a/web/components/agents/SpecPackAuthoringTab.tsx
+++ b/web/components/agents/SpecPackAuthoringTab.tsx
@@ -195,10 +195,10 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
         <div className="mb-4 flex items-center justify-between">
           <div>
             <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
-              {t("Spec Packs")}
+              {t("Class tutoring setup")}
             </p>
             <h2 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
-              {t("Teacher-defined agents")}
+              {t("Shape how the tutor teaches this class")}
             </h2>
           </div>
           <button
@@ -253,11 +253,14 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
           <div className="mb-4 flex items-center justify-between gap-4">
             <div>
               <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
-                {t("Hybrid narrow")}
+                {t("Teacher controls")}
               </p>
               <h2 className="mt-1 text-[18px] font-semibold text-[var(--foreground)]">
-                {t("Structured authoring for IDENTITY, SOUL, and RULES")}
+                {t("Choose class fit, support style, and guardrails")}
               </h2>
+              <p className="mt-2 max-w-[680px] text-[13px] text-[var(--muted-foreground)]">
+                {t("IDENTITY sets who this tutor is for, SOUL shapes how it responds when students are wrong or stuck, and RULES keep help within your classroom boundaries.")}
+              </p>
             </div>
             <div className="flex items-center gap-2">
               <button
@@ -298,7 +301,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
 
         <StructuredSection
           title={t("IDENTITY.md")}
-          description={t("Define the role, subject, and language of the teaching agent.")}
+          description={t("Choose the subject, student level, tone, and language students will experience.")}
         >
           <div className="grid gap-4 md:grid-cols-2">
             <LabeledInput label={t("Agent name")} value={draft.structured.identity.agent_name} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, identity: { ...current.structured.identity, agent_name: value } } }))} />
@@ -312,7 +315,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
 
         <StructuredSection
           title={t("SOUL.md")}
-          description={t("Capture the teaching philosophy and failure-response style.")}
+          description={t("Decide how the tutor encourages, scaffolds, and responds when a student is wrong or losing confidence.")}
         >
           <LabeledTextarea label={t("Teaching philosophy")} rows={4} value={draft.structured.soul.teaching_philosophy} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, soul: { ...current.structured.soul, teaching_philosophy: value } } }))} />
           <LabeledTextarea label={t("When the student is wrong")} rows={4} value={draft.structured.soul.when_student_wrong} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, soul: { ...current.structured.soul, when_student_wrong: value } } }))} />
@@ -322,7 +325,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
 
         <StructuredSection
           title={t("RULES.md")}
-          description={t("Add operating guardrails without baking runtime logic into the UI.")}
+          description={t("Set clear classroom boundaries such as hint limits, session expectations, and when the tutor should escalate.")}
         >
           <div className="grid gap-4 md:grid-cols-2">
             <LabeledInput label={t("Do not solve directly")} value={draft.structured.rules.do_not_solve_directly} onChange={(value) => setDraft((current) => ({ ...current, structured: { ...current.structured, rules: { ...current.structured.rules, do_not_solve_directly: value } } }))} />
@@ -341,6 +344,9 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
             <h3 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
               {t("Manual editing for the remaining files")}
             </h3>
+            <p className="mt-2 text-[13px] text-[var(--muted-foreground)]">
+              {t("Use these files when you want to define curriculum priorities, assessment signals, remediation flow, knowledge policy, or sharing metadata in your own words.")}
+            </p>
           </div>
           <div className="mb-3 flex flex-wrap gap-2">
             {MANUAL_FILES.map((filename) => (
@@ -377,7 +383,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
       <aside className="space-y-4">
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
           <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
-            {t("Runtime summary")}
+            {t("Teacher-facing summary")}
           </p>
           <h3 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
             {draft.display_name || t("Unsaved spec pack")}
@@ -386,7 +392,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
             <SummaryRow label={t("Subject")} value={draft.structured.identity.subject} />
             <SummaryRow label={t("Language")} value={draft.structured.identity.primary_language} />
             <SummaryRow label={t("Tone")} value={draft.structured.identity.tone} />
-            <SummaryRow label={t("Session rule")} value={runtimeSummary.join(" • ")} />
+            <SummaryRow label={t("What students will feel")} value={runtimeSummary.join(" • ")} />
             <SummaryRow label={t("Version")} value={draft.version > 0 ? `v${draft.version}` : t("New")} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reframe `/agents` and contest copy in teacher-benefit language
- add explicit explanations for `IDENTITY`, `SOUL`, and `RULES`
- add teacher use cases and a behavior-diff story for judges

## Validation
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/eslint.config.mjs "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/teacher-value-prop/web/app/(workspace)/agents/page.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/teacher-value-prop/web/components/agents/SpecPackAuthoringTab.tsx"`
- `git diff --check`

## Notes
- The targeted eslint command exits successfully but still prints the known Next warning about the `pages` path when run from a worktree.
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane only changes copy and contest positioning.
