### PR TITLE
feat(dashboard): harden teacher actionability [R5]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,6 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task.
+### Assignment
 
-Recommended next AI-owned task: open `docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md` from a fresh branch/worktree if the team wants to continue hardening judge-risk defenses.
+- Owner: Codex
+- Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability`
+- Task: `R5_DASHBOARD_ACTIONABILITY`
+- Status: in progress
+- Branch: `pod-a/dashboard-actionability`
+- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md`
+- Owned files: `web/app/(workspace)/dashboard/`, `web/components/dashboard/`, `web/lib/dashboard-api.ts`, `docs/contest/`, `ai_first/competition/`, task packet, PR note
+- PR:
+- Last update: 2026-04-26
+- Next action: tighten student and small-group cards around teacher moves, then update contest story artifacts
+- Blocker: none

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T17:05:00Z",
+    "last_updated": "2026-04-26T17:20:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 49
@@ -60,8 +60,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "R5_DASHBOARD_ACTIONABILITY"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -70,9 +72,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 2,
+      "count": 1,
       "tasks": [
-        "R5_DASHBOARD_ACTIONABILITY",
         "R6_CLAIM_CALIBRATION_PILOT"
       ]
     }
@@ -1153,8 +1154,8 @@
         "L5_TEACHER_INSIGHT_UI",
         "R2_DIAGNOSIS_CREDIBILITY"
       ],
-      "status": "not-started",
-      "notes": "Session-ready risk lane packet exists under docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md."
+      "status": "in-progress",
+      "notes": "Active on branch pod-a/dashboard-actionability. This lane tightens dashboard cards and contest artifacts around concrete teacher moves."
     },
     {
       "id": "R6_CLAIM_CALIBRATION_PILOT",

--- a/ai_first/competition/pitch-notes.md
+++ b/ai_first/competition/pitch-notes.md
@@ -18,6 +18,12 @@ Teacher-facing use cases:
 2. A grade 10 teacher can make the tutor more Socratic, push for reasoning steps, and escalate when students keep repeating the same mistake.
 3. A teacher reviewing the dashboard can spot which students need remediation now and which small group should revisit the same misconception together.
 
+Dashboard actionability stories:
+
+1. Repeated misses on one topic -> teacher move: reteach one prerequisite with one scaffolded example.
+2. Fast but inconsistent answers -> teacher move: ask for one reasoning step before another hint.
+3. Shared misconception cluster -> teacher move: pull one remediation mini-group before the next assessment.
+
 ## Why now
 
 LLM agents, RAG, and AI-assisted content generation make it possible to reduce lesson preparation cost while keeping teachers in control of knowledge sources.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -194,3 +194,9 @@
 - Started risk-lane 4 in worktree `.worktrees/teacher-value-prop` on branch `pod-a/teacher-value-prop`.
 - Reframed `/agents`, contest README, demo script, submission package, pitch notes, and product description in teacher-benefit language.
 - Added explicit explanations for `IDENTITY`, `SOUL`, and `RULES`, plus concrete teacher use cases and a behavior-diff judge story.
+
+## R5_DASHBOARD_ACTIONABILITY
+
+- Started risk-lane 5 in worktree `.worktrees/dashboard-actionability` on branch `pod-a/dashboard-actionability`.
+- Updated dashboard overview and detail surfaces so recommendations read as teacher moves with short evidence-backed reasons for both per-student and small-group cards.
+- Added concise dashboard story artifacts to contest docs and pitch notes.

--- a/docs/contest/DEMO_SCRIPT.md
+++ b/docs/contest/DEMO_SCRIPT.md
@@ -99,6 +99,10 @@ Steps:
 4. Confirm recent activity still distinguishes assessment and tutoring sessions.
 5. Confirm Knowledge Pack references appear when sessions used a selected pack.
 6. Explain one concrete teacher move, such as reteaching one concept to a small group or giving a gentler scaffold to one student next session.
+7. Reuse one of the prepared dashboard stories:
+   - repeated misses on one topic -> reteach one prerequisite with one scaffolded example
+   - quick but inconsistent answers -> ask for one reasoning step before another hint
+   - shared misconception cluster -> pull a remediation mini-group before the next check
 
 Evidence to capture:
 

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -48,6 +48,12 @@ The repository now includes bounded proof that the unified live turn path can ca
 2. A teacher can draft an assessment from a Knowledge Pack, review it, then reuse the same knowledge source during tutoring.
 3. A teacher can move from observed errors to a recommended next action instead of reading raw activity logs alone.
 
+## Dashboard Story Cards
+
+1. A student misses several items on one topic and needs repeated support, so the teacher move is to reteach one prerequisite with one more scaffolded example.
+2. A student answers quickly but inconsistently, so the teacher move is to slow the next check and require one reasoning step before another hint.
+3. A small group shares the same misconception, so the teacher move is to pull them into one remediation mini-group before the next assessment.
+
 ## Evidence Refresh Rules
 
 Run [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) first when local demo data may be stale, then run [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md), then refresh evidence using these rules:

--- a/docs/superpowers/plans/2026-04-26-risk-lane-5-dashboard-actionability.md
+++ b/docs/superpowers/plans/2026-04-26-risk-lane-5-dashboard-actionability.md
@@ -1,0 +1,463 @@
+# Risk Lane 5 Dashboard Actionability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the teacher dashboard read like a concrete decision aid by turning student and small-group recommendations into explicit teacher moves with evidence-backed reasons.
+
+**Architecture:** Keep the existing dashboard payload and layout intact. Tighten the presentation layer in the student cards, small-group cards, and student detail view so the current `Observed -> Inferred -> Recommended Action` structure is rephrased as a teacher-facing next move without inventing new diagnosis semantics. Support the same framing in contest-facing story artifacts.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, `react-i18next`, existing dashboard components under `web/components/dashboard/`, Markdown contest docs under `docs/contest/` and `ai_first/competition/`
+
+---
+
+## File Map
+
+- Modify: `web/components/dashboard/TeacherInsightPanel.tsx`
+  - tighten panel intro copy so it promises concrete teacher moves
+- Modify: `web/components/dashboard/StudentInsightCard.tsx`
+  - reframe recommendation output as `Teacher move` plus `Why this move`
+- Modify: `web/components/dashboard/SmallGroupInsightCard.tsx`
+  - reframe grouped recommendations as a classroom action with explicit grouping rationale
+- Modify: `web/components/dashboard/StudentInsightDetail.tsx`
+  - mirror the same teacher-move hierarchy used in overview cards
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+  - only bounded hero/label copy updates if needed to match the new framing
+- Modify: `web/app/(workspace)/dashboard/student/page.tsx`
+  - only bounded copy-level support if the detail page needs matching language
+- Modify: `docs/contest/DEMO_SCRIPT.md`
+  - add 2-3 concise dashboard story references for presenters
+- Modify: `docs/contest/README.md`
+  - tighten dashboard value proposition wording around teacher moves
+- Modify: `ai_first/competition/pitch-notes.md`
+  - mirror the same actionability phrasing for judge defense
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+  - record the active lane before code starts
+- Modify: `ai_first/TASK_REGISTRY.json`
+  - mark `R5_DASHBOARD_ACTIONABILITY` as `in-progress` on start
+- Modify: `ai_first/daily/2026-04-26.md`
+  - record work and validation
+- Create: `docs/superpowers/pr-notes/2026-04-26-risk-lane-5-dashboard-actionability.md`
+  - required PR architecture note with Mermaid diagram
+
+## Task 1: Start The Lane Cleanly
+
+**Files:**
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Test: `ai_first/TASK_REGISTRY.json`
+
+- [ ] **Step 1: Add the active assignment entry**
+
+Update `ai_first/ACTIVE_ASSIGNMENTS.md` so `main` no longer owns the lane and this worktree does. The entry should follow the existing template and look like:
+
+```md
+### Assignment
+
+- Owner: Codex
+- Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability`
+- Task: `R5_DASHBOARD_ACTIONABILITY`
+- Status: in progress
+- Branch: `pod-a/dashboard-actionability`
+- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md`
+- Owned files: `web/app/(workspace)/dashboard/`, `web/components/dashboard/`, `web/lib/dashboard-api.ts`, `docs/contest/`, `ai_first/competition/`, task packet, PR note
+- PR:
+- Last update: 2026-04-26
+- Next action: tighten student and small-group cards around teacher moves, then update contest story artifacts
+- Blocker: none
+```
+
+- [ ] **Step 2: Mark `R5` in progress in the registry**
+
+Update `ai_first/TASK_REGISTRY.json`:
+
+- move `R5_DASHBOARD_ACTIONABILITY` into `task_categories.in_progress.tasks`
+- update the `in_progress.count`
+- remove it from `pending.tasks`
+- update the task note to mention `pod-a/dashboard-actionability`
+
+The task object should end with a note similar to:
+
+```json
+"status": "in-progress",
+"notes": "Active on branch pod-a/dashboard-actionability. This lane tightens dashboard cards and contest artifacts around concrete teacher moves."
+```
+
+- [ ] **Step 3: Validate the registry before touching UI**
+
+Run:
+
+```bash
+python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+```
+
+Expected: command exits `0` with no output.
+
+- [ ] **Step 4: Commit the control-plane start**
+
+Run:
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json
+git commit -m "docs(ai-first): start dashboard actionability lane [R5]"
+```
+
+Expected: one small commit containing only lane-start tracking.
+
+## Task 2: Tighten Student Cards Around Teacher Moves
+
+**Files:**
+- Modify: `web/components/dashboard/StudentInsightCard.tsx`
+- Test: `web/components/dashboard/StudentInsightCard.tsx`
+
+- [ ] **Step 1: Write the target UI wording inline before editing**
+
+Use this target structure as the contract:
+
+```ts
+// Observed
+// Teacher move
+// Why this move
+```
+
+The recommendation title should stop reading like an abstract action type and start reading like a teacher move. The supporting sentence should explain why now using the current observed/inferred fields.
+
+- [ ] **Step 2: Implement the minimal copy-only refactor**
+
+Update `web/components/dashboard/StudentInsightCard.tsx` so the third panel reads like:
+
+```tsx
+<section className="rounded-2xl bg-emerald-50 p-3">
+  <InsightSectionLabel
+    eyebrow={t("Teacher move")}
+    title={recommendation?.action_type ?? t("No next move yet")}
+    toneClassName="text-emerald-700"
+  >
+    {recommendation?.rationale ?? t("No recommendation available")}
+  </InsightSectionLabel>
+  <div className="mt-3 text-[12px] text-emerald-900/80">
+    {diagnosis?.evidence?.[0]
+      ? t("Why this move: {{reason}}", { reason: diagnosis.evidence[0] })
+      : t("Why this move: based on the strongest recent learning signal.")}
+  </div>
+</section>
+```
+
+If the actual component structure needs a slightly different expression, keep the same behavior:
+
+- recommendation title remains sourced from existing payload
+- rationale stays visible
+- one short evidence-backed reason is added without inventing new backend data
+
+- [ ] **Step 3: Keep the observed section concrete**
+
+Make sure the observed block still reads as plain facts. If you touch it, only tighten wording like:
+
+```tsx
+<div>{t("Missed items: {{count}}", { count: student.observed?.miss_count ?? 0 })}</div>
+<div>{t("Response time: {{value}}", { value: formatLatency(student.observed?.avg_latency_seconds) ?? t("Unknown") })}</div>
+```
+
+Do not add new derived metrics.
+
+- [ ] **Step 4: Run focused lint**
+
+Run:
+
+```bash
+/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/eslint.config.mjs "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/StudentInsightCard.tsx"
+```
+
+Expected: exit `0`. If Next prints the known worktree `pages` warning, record it but treat it as non-failing.
+
+- [ ] **Step 5: Commit the student-card pass**
+
+Run:
+
+```bash
+git add web/components/dashboard/StudentInsightCard.tsx
+git commit -m "feat(dashboard): clarify per-student teacher moves [R5]"
+```
+
+## Task 3: Tighten Small-Group And Panel Framing
+
+**Files:**
+- Modify: `web/components/dashboard/SmallGroupInsightCard.tsx`
+- Modify: `web/components/dashboard/TeacherInsightPanel.tsx`
+- Test: `web/components/dashboard/SmallGroupInsightCard.tsx`
+- Test: `web/components/dashboard/TeacherInsightPanel.tsx`
+
+- [ ] **Step 1: Reframe the small-group card contract**
+
+The card should answer two questions:
+
+1. why are these students grouped?
+2. what should the teacher do with them next?
+
+Use this target wording:
+
+```tsx
+<InsightSectionLabel eyebrow={t("Shared signal")} title={group.topic}>
+  {group.diagnosis_type}
+</InsightSectionLabel>
+```
+
+and:
+
+```tsx
+<InsightSectionLabel
+  eyebrow={t("Teacher move")}
+  title={group.recommended_action}
+  toneClassName="text-emerald-700"
+/>
+```
+
+- [ ] **Step 2: Implement the group rationale line**
+
+Add a short line under the action block like:
+
+```tsx
+<div className="mt-3 text-[12px] text-emerald-900/80">
+  {t("Why these students are grouped: they show the same dominant learning signal.")}
+</div>
+```
+
+Keep the student list visible as the lightweight trace.
+
+- [ ] **Step 3: Tighten the panel intro copy**
+
+Update `web/components/dashboard/TeacherInsightPanel.tsx` intro copy from generic insight language to explicit actionability language. Target wording:
+
+```tsx
+<p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
+  {t("Review the strongest signals first, then act on the clearest next move for each student or small group.")}
+</p>
+```
+
+If needed, also tighten the empty-state message to mention concrete next steps unlock after assessment evidence exists.
+
+- [ ] **Step 4: Run focused lint**
+
+Run:
+
+```bash
+/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/eslint.config.mjs "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/SmallGroupInsightCard.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/TeacherInsightPanel.tsx"
+```
+
+Expected: exit `0`, with the same known non-failing worktree warning if emitted.
+
+- [ ] **Step 5: Commit the group/panel pass**
+
+Run:
+
+```bash
+git add web/components/dashboard/SmallGroupInsightCard.tsx web/components/dashboard/TeacherInsightPanel.tsx
+git commit -m "feat(dashboard): clarify small-group teacher moves [R5]"
+```
+
+## Task 4: Align Student Detail With Overview
+
+**Files:**
+- Modify: `web/components/dashboard/StudentInsightDetail.tsx`
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+- Modify: `web/app/(workspace)/dashboard/student/page.tsx`
+- Test: `web/components/dashboard/StudentInsightDetail.tsx`
+
+- [ ] **Step 1: Inspect the current detail labels and mirror the overview hierarchy**
+
+Before editing, confirm the detail view currently exposes the same evidence blocks. The new hierarchy must read:
+
+1. `Observed`
+2. `Teacher move`
+3. `Why this move`
+
+Do not add a different interpretation model here.
+
+- [ ] **Step 2: Implement bounded copy changes in detail**
+
+Update `web/components/dashboard/StudentInsightDetail.tsx` so the recommendation section uses the same teacher-facing wording as the overview card. If there is already a recommendation block, rename its eyebrow/title wording instead of restructuring the whole component.
+
+Use wording consistent with:
+
+```tsx
+eyebrow={t("Teacher move")}
+```
+
+and a short explanatory line:
+
+```tsx
+{t("Why this move: {{reason}}", { reason: ... })}
+```
+
+- [ ] **Step 3: Align page-level helper copy only if necessary**
+
+If `web/app/(workspace)/dashboard/page.tsx` or `web/app/(workspace)/dashboard/student/page.tsx` still present the dashboard as generic analytics, tighten only the top helper sentence. Example:
+
+```tsx
+{t("Review the strongest signals first, then decide the next classroom move.")}
+```
+
+Do not redesign the hero or filters.
+
+- [ ] **Step 4: Run focused lint on the touched dashboard files**
+
+Run:
+
+```bash
+/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/eslint.config.mjs "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/StudentInsightDetail.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/app/(workspace)/dashboard/page.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/app/(workspace)/dashboard/student/page.tsx"
+```
+
+Expected: exit `0`.
+
+- [ ] **Step 5: Commit the detail-alignment pass**
+
+Run:
+
+```bash
+git add web/components/dashboard/StudentInsightDetail.tsx web/app/'(workspace)'/dashboard/page.tsx web/app/'(workspace)'/dashboard/student/page.tsx
+git commit -m "feat(dashboard): align detail view with teacher moves [R5]"
+```
+
+## Task 5: Add Contest Story Artifacts
+
+**Files:**
+- Modify: `docs/contest/README.md`
+- Modify: `docs/contest/DEMO_SCRIPT.md`
+- Modify: `ai_first/competition/pitch-notes.md`
+- Test: docs files
+
+- [ ] **Step 1: Add 2-3 concise story patterns to contest docs**
+
+Update contest docs so they reuse the same wording as the UI. Add examples like:
+
+```md
+1. Student A missed multiple items on the same topic and needed repeated hints, so the teacher move is to reteach one prerequisite with one more scaffolded example.
+2. Student B answered quickly but unreliably, so the teacher move is to slow the next check and ask for one reasoning step before another hint.
+3. A small group shares the same misconception, so the teacher move is to pull them into one remediation mini-group before the next assessment.
+```
+
+- [ ] **Step 2: Keep the wording claim-safe**
+
+Make sure every story reads as:
+
+- evidence-backed
+- teacher-reviewable
+- non-private
+
+Do not introduce any benchmarked-accuracy or autonomous-teacher claims.
+
+- [ ] **Step 3: Run a focused text scan**
+
+Run:
+
+```bash
+rg -n "Teacher move|Why this move|small group|reteach|scaffold|reasoning step" docs/contest ai_first/competition -S
+```
+
+Expected: the new story language is present in the intended docs only.
+
+- [ ] **Step 4: Commit the contest-story pass**
+
+Run:
+
+```bash
+git add docs/contest/README.md docs/contest/DEMO_SCRIPT.md ai_first/competition/pitch-notes.md
+git commit -m "docs(contest): add dashboard actionability stories [R5]"
+```
+
+## Task 6: Finish The Lane For Review
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-26.md`
+- Create: `docs/superpowers/pr-notes/2026-04-26-risk-lane-5-dashboard-actionability.md`
+- Test: full lane diff
+
+- [ ] **Step 1: Write the PR architecture note**
+
+Create `docs/superpowers/pr-notes/2026-04-26-risk-lane-5-dashboard-actionability.md` with:
+
+- short summary
+- statement that `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated unless workflow boundaries truly changed
+- Mermaid diagram like:
+
+```md
+```mermaid
+flowchart LR
+  Observed["Observed signal"]
+  Inferred["Inferred diagnosis"]
+  Move["Teacher move"]
+  Why["Why this move"]
+  Action["Teacher classroom action"]
+
+  Observed --> Inferred
+  Inferred --> Move
+  Move --> Why
+  Why --> Action
+```
+```
+
+- [ ] **Step 2: Update the daily log**
+
+Append an `R5_DASHBOARD_ACTIONABILITY` section to `ai_first/daily/2026-04-26.md` including:
+
+- branch/worktree
+- UI files changed
+- docs changed
+- validation commands
+
+- [ ] **Step 3: Run final lane validation**
+
+Run:
+
+```bash
+/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/eslint.config.mjs "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/TeacherInsightPanel.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/StudentInsightCard.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/SmallGroupInsightCard.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/StudentInsightDetail.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/app/(workspace)/dashboard/page.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/app/(workspace)/dashboard/student/page.tsx"
+python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+git diff --check
+```
+
+Expected:
+
+- eslint exits `0`
+- JSON validation exits `0`
+- `git diff --check` prints nothing
+
+- [ ] **Step 4: Open the review PR**
+
+Run:
+
+```bash
+git status --short --branch
+git push -u origin pod-a/dashboard-actionability
+gh pr create --draft --base main --head pod-a/dashboard-actionability --title "feat(dashboard): harden teacher actionability [R5]"
+```
+
+Expected: Draft PR opened with validation notes and architecture note linked.
+
+## Self-Review
+
+### Spec Coverage
+
+- student cards gain explicit `Teacher move` and `Why this move`
+- small-group cards gain concrete grouped action and rationale
+- student detail mirrors overview wording
+- contest artifacts reuse the same classroom-action language
+- no backend/runtime scope has been added
+
+No spec gaps found.
+
+### Placeholder Scan
+
+The plan avoids `TBD`, `TODO`, and vague “implement later” instructions. Commands, files, and wording targets are explicit.
+
+### Type Consistency
+
+The plan assumes existing dashboard payload fields already used in the current components:
+
+- `student.observed`
+- `student.inferred`
+- `student.recommended_actions`
+- `group.topic`
+- `group.diagnosis_type`
+- `group.recommended_action`
+
+No new backend property names were introduced.

--- a/docs/superpowers/pr-notes/2026-04-26-risk-lane-5-dashboard-actionability.md
+++ b/docs/superpowers/pr-notes/2026-04-26-risk-lane-5-dashboard-actionability.md
@@ -1,0 +1,32 @@
+# PR Note: Risk Lane 5 Dashboard Actionability
+
+## Summary
+
+This PR hardens the teacher dashboard against the “looks smart but what should I do?” critique by turning recommendation copy into explicit teacher moves backed by visible reasons.
+
+## What Changed
+
+- reframed student cards around `Teacher move` and `Why this move`
+- reframed small-group cards around shared signal, grouped action, and grouping rationale
+- aligned student detail wording with the overview
+- added contest story artifacts that mirror the exact UI wording
+
+## Main System Map
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane changes presentation and contest framing, not route or data-flow boundaries
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Observed["Observed signal"]
+  Inferred["Inferred diagnosis"]
+  Move["Teacher move"]
+  Why["Why this move"]
+  Action["Teacher classroom action"]
+
+  Observed --> Inferred
+  Inferred --> Move
+  Move --> Why
+  Why --> Action
+```

--- a/docs/superpowers/specs/2026-04-26-risk-lane-5-dashboard-actionability-design.md
+++ b/docs/superpowers/specs/2026-04-26-risk-lane-5-dashboard-actionability-design.md
@@ -1,0 +1,153 @@
+# Risk Lane 5 Dashboard Actionability Design
+
+## Metadata
+
+- Date: 2026-04-26
+- Task ID: `R5_DASHBOARD_ACTIONABILITY`
+- Commit tag: `R5`
+- Branch: `pod-a/dashboard-actionability`
+- Scope: teacher dashboard actionability hardening for contest review and classroom-legibility
+
+## Problem
+
+The dashboard already shows `Observed`, `Inferred`, and `Recommended Action`, but the current cards still leave room for the attack that the system "looks smart without telling a teacher what to do next." The gap is not missing analytics. The gap is that the recommendation layer needs to read like a concrete teacher move anchored to visible evidence.
+
+## Goal
+
+Make the teacher dashboard defendable as a decision aid, not just an insight surface, by tightening the UI and demo artifacts around concrete next steps for both individual students and small groups.
+
+## Non-Goals
+
+- No redesign of the dashboard layout.
+- No change to diagnosis semantics, scoring, or confidence logic.
+- No new runtime-policy or agent-spec behavior.
+- No new backend recommendation engine unless an existing payload gap blocks the UI outright.
+
+## Recommended Approach
+
+Use a bounded `UI-copy + story structure` approach:
+
+1. Keep the current dashboard layout and data hierarchy.
+2. Reframe student and small-group cards around `Teacher move` and `Why this move`.
+3. Mirror the same language in the student detail view so overview and drill-down tell the same story.
+4. Add 2-3 concise contest story artifacts that reuse the same wording as the UI.
+
+This is the smallest change that makes the dashboard feel classroom-actionable without opening a new product lane.
+
+## Information Hierarchy
+
+### Student Insight Card
+
+Each student card keeps the evidence-first order, but the recommendation block becomes explicitly teacher-facing:
+
+1. `Observed`
+   - dominant topic
+   - misses / latency / support signal
+2. `Teacher move`
+   - one short directive describing the next classroom action
+   - examples:
+     - reteach one prerequisite with one scaffolded example
+     - lower the next check difficulty
+     - ask the student to explain one reasoning step before another hint
+3. `Why this move`
+   - one short explanation grounded in the current observed and inferred payload
+   - this is not a new diagnosis claim; it is a restatement of current evidence in teacher language
+
+### Small-Group Insight Card
+
+Each small-group card becomes a mini intervention plan:
+
+1. `Shared signal`
+   - topic
+   - diagnosis type
+2. `Teacher move`
+   - one concrete group action
+   - examples:
+     - pull these students into one remediation mini-group
+     - revisit the same misconception together before the next quiz
+3. `Why these students belong together`
+   - short explanation based on shared signal
+   - visible student list kept as lightweight trace
+
+### Student Detail View
+
+The detail page should not introduce a different narrative. It should extend the overview:
+
+1. `Observed`
+2. `Teacher move`
+3. `Why this move`
+
+The wording should stay aligned with the overview cards so a reviewer can move between screens without re-learning the dashboard logic.
+
+## File-Level Change Set
+
+### UI
+
+- `web/components/dashboard/TeacherInsightPanel.tsx`
+  - tighten section intro copy so the panel promises concrete teacher moves
+- `web/components/dashboard/StudentInsightCard.tsx`
+  - rename action framing from generic recommendation to teacher move
+  - add one short evidence-backed "why this move" line
+- `web/components/dashboard/SmallGroupInsightCard.tsx`
+  - add reason-for-grouping copy and more explicit group action phrasing
+- `web/components/dashboard/StudentInsightDetail.tsx`
+  - mirror the same teacher-move hierarchy used in overview
+- `web/app/(workspace)/dashboard/page.tsx`
+  - only bounded copy-level support if the overview hero or labels need to reflect the new framing
+- `web/app/(workspace)/dashboard/student/page.tsx`
+  - only bounded copy-level support if student detail needs matching labels
+
+### Docs / Contest Support
+
+- `docs/contest/`
+  - add or tighten 2-3 dashboard story artifacts for reviewer/demo use
+- `ai_first/competition/`
+  - reuse the same wording for contest defense and presenter notes
+
+## Data Contract Rules
+
+- Keep the existing hierarchy:
+  - `Observed`
+  - `Inferred`
+  - `Recommended Action`
+- UI may rephrase recommendation output as a teacher move, but must not invent new diagnosis semantics.
+- If a recommendation lacks enough evidence to become a concrete teacher move, the UI should stay explicit and narrow rather than fabricate specificity.
+
+## Acceptance Criteria
+
+1. At least 2-3 student or group stories are visible either in UI or directly supported by contest artifacts.
+2. Each story names a concrete teacher move, not only an action category.
+3. Each teacher move has a visible reason anchored to current evidence.
+4. Small-group cards can answer both:
+   - why these students are grouped
+   - what the teacher should do with that group next
+5. The overview and student detail surfaces use compatible wording.
+
+## Manual Verification
+
+Walk through at least three examples:
+
+1. one individual student needing gentler scaffolding
+2. one individual student needing stronger reasoning accountability
+3. one small group sharing the same misconception
+
+For each example, a non-technical reviewer should be able to answer:
+
+- what happened
+- what the system suggests the teacher do next
+- why the system suggests that move
+
+## Testing
+
+- focused frontend lint for touched dashboard files
+- `git diff --check`
+
+## Risks And Boundaries
+
+- The largest risk is over-writing the cards with generic educational prose. Keep each new line tied to current payload fields.
+- The second risk is accidentally changing diagnosis meaning in the UI. The lane must stay presentation-first.
+- If the existing payload cannot support one credible "why this move" sentence, stop and document the contract gap instead of inventing logic.
+
+## Architecture Note Requirement
+
+The PR must include a note under `docs/superpowers/pr-notes/` with a Mermaid diagram. `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged unless the dashboard workflow itself changes materially.

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -132,7 +132,7 @@ export default function DashboardPage() {
                 {t("Observed, diagnosed, and ready for action")}
               </h1>
               <p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
-                {t("Review observed facts first, then inspect diagnosis and next-step recommendations for each student or group.")}
+                {t("Review observed facts first, then decide the clearest next classroom move for each student or group.")}
               </p>
             </div>
             <Link

--- a/web/app/(workspace)/dashboard/student/page.tsx
+++ b/web/app/(workspace)/dashboard/student/page.tsx
@@ -312,7 +312,7 @@ function StudentDashboardContent() {
                 {activeStudent?.student_id || t("Inspect evidence before deciding the next move")}
               </h1>
               <p className="mt-2 max-w-[720px] text-[14px] leading-6 text-[var(--muted-foreground)]">
-                {t("Review observed evidence first, then inspect diagnosis and the recommended next move.")}
+                {t("Review observed evidence first, then inspect diagnosis and the clearest next classroom move.")}
               </p>
             </div>
             {loading && (

--- a/web/components/dashboard/SmallGroupInsightCard.tsx
+++ b/web/components/dashboard/SmallGroupInsightCard.tsx
@@ -15,7 +15,7 @@ export function SmallGroupInsightCard({
   return (
     <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
-        <InsightSectionLabel eyebrow={t("Small Group")} title={group.topic}>
+        <InsightSectionLabel eyebrow={t("Shared signal")} title={group.topic}>
           {group.diagnosis_type}
         </InsightSectionLabel>
         <span className="rounded-full bg-[var(--muted)] px-2.5 py-1 text-[11px] text-[var(--muted-foreground)]">
@@ -25,10 +25,13 @@ export function SmallGroupInsightCard({
 
       <div className="mt-4 rounded-2xl bg-emerald-50 p-3">
         <InsightSectionLabel
-          eyebrow={t("Recommended Action")}
+          eyebrow={t("Teacher move")}
           title={group.recommended_action}
           toneClassName="text-emerald-700"
         />
+        <div className="mt-3 text-[12px] text-emerald-900/80">
+          {t("Why these students are grouped: they show the same dominant learning signal.")}
+        </div>
         <div className="mt-3 text-[12px] text-[var(--muted-foreground)]">
           {t("Students: {{students}}", { students: group.student_ids.join(", ") })}
         </div>

--- a/web/components/dashboard/StudentInsightCard.tsx
+++ b/web/components/dashboard/StudentInsightCard.tsx
@@ -50,8 +50,8 @@ export function StudentInsightCard({
         <section className="rounded-2xl bg-[var(--muted)]/45 p-3">
           <InsightSectionLabel eyebrow={t("Observed")} title={student.observed?.topic ?? t("No recent evidence")} />
           <div className="mt-3 space-y-2 text-[12px] text-[var(--foreground)]">
-            <div>{t("Misses: {{count}}", { count: student.observed?.miss_count ?? 0 })}</div>
-            <div>{t("Latency: {{value}}", { value: formatLatency(student.observed?.avg_latency_seconds) ?? t("Unknown") })}</div>
+            <div>{t("Missed items: {{count}}", { count: student.observed?.miss_count ?? 0 })}</div>
+            <div>{t("Response time: {{value}}", { value: formatLatency(student.observed?.avg_latency_seconds) ?? t("Unknown") })}</div>
             {student.student_state?.support_level ? (
               <div>{t("Support: {{value}}", { value: student.student_state.support_level })}</div>
             ) : null}
@@ -82,12 +82,17 @@ export function StudentInsightCard({
 
         <section className="rounded-2xl bg-emerald-50 p-3">
           <InsightSectionLabel
-            eyebrow={t("Recommended Action")}
-            title={recommendation?.action_type ?? t("No action yet")}
+            eyebrow={t("Teacher move")}
+            title={recommendation?.action_type ?? t("No next move yet")}
             toneClassName="text-emerald-700"
           >
             {recommendation?.rationale ?? t("No recommendation available")}
           </InsightSectionLabel>
+          <div className="mt-3 text-[12px] text-emerald-900/80">
+            {diagnosis?.evidence?.[0]
+              ? t("Why this move: {{reason}}", { reason: diagnosis.evidence[0] })
+              : t("Why this move: based on the strongest recent learning signal.")}
+          </div>
         </section>
       </div>
     </article>

--- a/web/components/dashboard/StudentInsightDetail.tsx
+++ b/web/components/dashboard/StudentInsightDetail.tsx
@@ -83,8 +83,8 @@ export function StudentInsightDetail({
 
       <section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
         <InsightSectionLabel
-          eyebrow={t("Recommended Action")}
-          title={recommendation?.action_type ?? t("No action")}
+          eyebrow={t("Teacher move")}
+          title={recommendation?.action_type ?? t("No next move")}
           toneClassName="text-emerald-700"
         >
           {t("Use this as the next teacher move, not as an automatic intervention.")}
@@ -93,6 +93,11 @@ export function StudentInsightDetail({
         <div className="mt-4 rounded-2xl bg-emerald-50 p-4">
           <div className="text-[14px] font-medium text-[var(--foreground)]">
             {recommendation?.rationale ?? t("No recommendation available")}
+          </div>
+          <div className="mt-3 text-[12px] text-emerald-900/80">
+            {diagnosis?.evidence?.[0]
+              ? t("Why this move: {{reason}}", { reason: diagnosis.evidence[0] })
+              : t("Why this move: based on the strongest recent learning signal.")}
           </div>
           <div className="mt-4 space-y-2 text-[12px] text-[var(--muted-foreground)]">
             <div>{t("Topic: {{topic}}", { topic: recommendation?.topic ?? diagnosis?.topic ?? t("Unknown") })}</div>

--- a/web/components/dashboard/TeacherInsightPanel.tsx
+++ b/web/components/dashboard/TeacherInsightPanel.tsx
@@ -15,7 +15,7 @@ export function TeacherInsightPanel({
       <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
         <h2 className="text-[16px] font-semibold text-[var(--foreground)]">{t("Teacher insights")}</h2>
         <p className="mt-2 text-[13px] leading-6 text-[var(--muted-foreground)]">
-          {t("No structured evidence yet. Complete at least one assessment to unlock diagnosis and next-step actions.")}
+          {t("No structured evidence yet. Complete at least one assessment to unlock concrete teacher moves and next-step actions.")}
         </p>
       </section>
     );
@@ -27,7 +27,7 @@ export function TeacherInsightPanel({
         <div>
           <h2 className="text-[16px] font-semibold text-[var(--foreground)]">{t("Teacher insights")}</h2>
           <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
-            {t("Clear evidence, diagnosis, and next-step actions for students and small groups.")}
+            {t("Review the strongest signals first, then act on the clearest next move for each student or small group.")}
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -53,7 +53,7 @@ export function TeacherInsightPanel({
               {t("Small-group recommendations")}
             </div>
             <p className="mt-2 text-[13px] text-[var(--muted-foreground)]">
-              {t("Use shared teaching actions to support multiple students with the same learning signal.")}
+              {t("Use one shared classroom move when multiple students need help with the same misconception.")}
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- tighten student and small-group dashboard cards around explicit teacher moves
- align student detail and dashboard copy with the same actionability framing
- add contest story artifacts and PR architecture note for R5

## Validation
- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/node_modules/.bin/eslint --config /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web/eslint.config.mjs "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/TeacherInsightPanel.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/StudentInsightCard.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/SmallGroupInsightCard.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/components/dashboard/StudentInsightDetail.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/app/(workspace)/dashboard/page.tsx" "/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability/web/app/(workspace)/dashboard/student/page.tsx"`
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `rg -n "Teacher move|Why this move|small group|reteach one prerequisite|reasoning step|remediation mini-group" docs/contest ai_first/competition -S`
- `git diff --check`

## Notes
- Focused eslint exits successfully but still prints the known Next worktree warning about the `pages` path.
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane changes presentation and contest framing, not route/data boundaries.
