### PR TITLE
docs(ai-first): sync control plane after R5 merge [OPS-RISK-SYNC]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,6 @@ Rules:
 
 ## Active
 
-### Assignment
+No active AI implementation task.
 
-- Owner: Codex
-- Machine: local desktop
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/dashboard-actionability`
-- Task: `R5_DASHBOARD_ACTIONABILITY`
-- Status: in progress
-- Branch: `pod-a/dashboard-actionability`
-- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md`
-- Owned files: `web/app/(workspace)/dashboard/`, `web/components/dashboard/`, `web/lib/dashboard-api.ts`, `docs/contest/`, `ai_first/competition/`, task packet, PR note
-- PR:
-- Last update: 2026-04-26
-- Next action: tighten student and small-group cards around teacher moves, then update contest story artifacts
-- Blocker: none
+Recommended next AI-owned task: open `docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md` from a fresh branch/worktree if the team wants to continue hardening judge-risk defenses.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest feature-risk merge: `#157 [R4] docs(teacher-value): clarify teacher outcomes and agent copy`
+- Latest feature-risk merge: `#159 [R5] feat(dashboard): harden teacher actionability`
 - Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
@@ -20,6 +20,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 - Risk Lane 2 diagnosis credibility merged to `main` through PR `#153`.
 - Risk Lane 3 assessment safety merged to `main` through PR `#155`.
 - Risk Lane 4 teacher value proposition merged to `main` through PR `#157`.
+- Risk Lane 5 dashboard actionability merged to `main` through PR `#159`.
 - Latest smoke result: the 2026-04-26 scripted-reset smoke pass succeeded in lane 6 (`docs/evaluation-evidence-readiness`) against current `main` behavior.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -32,7 +33,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Next recommended task
 
-- If the team wants to continue AI-owned product hardening, start `R5_DASHBOARD_ACTIONABILITY` from `docs/superpowers/tasks/2026-04-26-risk-lane-5-dashboard-actionability.md`.
+- If the team wants to continue AI-owned product hardening, start `R6_CLAIM_CALIBRATION_PILOT` from `docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md`.
 - If not, the shortest remaining non-code path is still human review of the submission package, IP commitment, and optional video decision.
 - Any new AI task should start from a fresh branch/worktree off `main`, not from a merged lane branch.
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T17:20:00Z",
+    "last_updated": "2026-04-26T17:40:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 49
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 46,
+      "count": 47,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -55,15 +55,14 @@
         "T051_SESSION_CONTEXT_QUALITY_PASS",
         "R1_RUNTIME_BINDING_PROOF",
         "R2_DIAGNOSIS_CREDIBILITY",
-        "R3_ASSESSMENT_SAFETY"
+        "R3_ASSESSMENT_SAFETY",
+        "R5_DASHBOARD_ACTIONABILITY"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 1,
-      "tasks": [
-        "R5_DASHBOARD_ACTIONABILITY"
-      ]
+      "count": 0,
+      "tasks": []
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -1154,8 +1153,8 @@
         "L5_TEACHER_INSIGHT_UI",
         "R2_DIAGNOSIS_CREDIBILITY"
       ],
-      "status": "in-progress",
-      "notes": "Active on branch pod-a/dashboard-actionability. This lane tightens dashboard cards and contest artifacts around concrete teacher moves."
+      "status": "completed",
+      "notes": "Merged to main through PR #159. Dashboard cards and contest artifacts now frame recommendations as concrete teacher moves with visible reasons."
     },
     {
       "id": "R6_CLAIM_CALIBRATION_PILOT",

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -195,6 +195,15 @@
 - Reframed `/agents`, contest README, demo script, submission package, pitch notes, and product description in teacher-benefit language.
 - Added explicit explanations for `IDENTITY`, `SOUL`, and `RULES`, plus concrete teacher use cases and a behavior-diff judge story.
 
+## Post-159 Sync
+
+- Branch: `docs/post-159-risk-sync`
+- Task: `OPS_POST_159_RISK_SYNC`
+- Done: Reset the AI-first control plane after Risk Lane 5 merged so `main` no longer advertises the merged lane as active and the compact queue now points future AI workers to `R6_CLAIM_CALIBRATION_PILOT` as the next optional risk-hardening slice.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: None.
+- Next: Commit the sync and open the tiny docs PR before any R6 implementation starts.
+
 ## R5_DASHBOARD_ACTIONABILITY
 
 - Started risk-lane 5 in worktree `.worktrees/dashboard-actionability` on branch `pod-a/dashboard-actionability`.


### PR DESCRIPTION
## Summary
- clear stale R5 assignment from `main`
- mark R5 as completed in `TASK_REGISTRY.json`
- advance the optional risk-hardening queue to `R6_CLAIM_CALIBRATION_PILOT`

## Validation
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `git diff --check`
