### PR TITLE
docs(contest): calibrate claims and pilot status [R6]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,6 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task.
+### Assignment
 
-Recommended next AI-owned task: open `docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md` from a fresh branch/worktree if the team wants to continue hardening judge-risk defenses.
+- Owner: Codex
+- Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/claim-calibration-pilot`
+- Task: `R6_CLAIM_CALIBRATION_PILOT`
+- Status: in progress
+- Branch: `docs/claim-calibration-pilot`
+- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md`
+- Owned files: `docs/contest/`, `ai_first/competition/`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`, task packet, PR note
+- PR:
+- Last update: 2026-04-26
+- Next action: calibrate contest wording and add pilot-status artifact, then validate and open Draft PR
+- Blocker: none

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -30,8 +30,8 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 - Latest merged docs/control-plane PR: `#148 [OPS-SYNC] docs(ai-first): sync queue after evidence merge`
 - Current branch for this sync: none required on `main`
-- Product MVP path status: the core contest flow, the Wave 1 evidence spine, lane 1-6 roadmap slices, and the refreshed dashboard plus `/agents` screenshot evidence are all merged to `main`.
-- Current purpose: hold a correct terminal wait state while the remaining submission work is human review, optional video, and final sign-off.
+- Product MVP path status: the core contest flow, the Wave 1 evidence spine, lane 1-6 roadmap slices, and the refreshed dashboard plus `/agents` screenshot evidence are all merged to `main` as a validated prototype.
+- Current purpose: hold a correct terminal wait state while the remaining submission work is human review, optional video, final sign-off, or any explicitly opened risk-hardening docs lane.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -68,7 +68,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Wait for human review of the submission package, IP commitment, optional video decision, and final sign-off. Start a new AI task only if a fresh packet is opened from `main`.
+Wait for human review of the submission package, IP commitment, optional video decision, and final sign-off unless a fresh packet is explicitly opened from `main`.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -32,3 +32,4 @@ Use this file only as a compact queue mirror. Do not rely on it for the full ope
 1. Start new AI sessions from `main` only if a new task packet is explicitly opened.
 2. Use the matching packet before code edits.
 3. If no packet exists and the remaining work is human-only, stop instead of inventing a new AI lane.
+4. Keep contest wording at validated-prototype level unless a stronger repository artifact is added.

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T17:40:00Z",
+    "last_updated": "2026-04-26T18:05:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 49
@@ -61,8 +61,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "R6_CLAIM_CALIBRATION_PILOT"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -71,10 +73,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 1,
-      "tasks": [
-        "R6_CLAIM_CALIBRATION_PILOT"
-      ]
+      "count": 0,
+      "tasks": []
     }
   },
   "tasks": [
@@ -1176,8 +1176,8 @@
         "R1_RUNTIME_BINDING_PROOF",
         "R2_DIAGNOSIS_CREDIBILITY"
       ],
-      "status": "not-started",
-      "notes": "Session-ready risk lane packet exists under docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md."
+      "status": "in-progress",
+      "notes": "Active on branch docs/claim-calibration-pilot. This lane calibrates prototype claims and adds a pilot-status artifact."
     }
   ],
   "github_issues_template": {

--- a/ai_first/competition/pitch-notes.md
+++ b/ai_first/competition/pitch-notes.md
@@ -4,6 +4,8 @@
 
 An AI-first learning platform where Vietnamese teachers turn their own materials into classroom-ready tutoring, practice, and follow-up insight without giving up control over how the AI teaches.
 
+Current status: validated prototype with smoke-backed demo evidence, not a deployed classroom system.
+
 ## Problem
 
 Teachers already have lesson materials and teaching instincts, but they do not have enough time to turn them into personalized practice, tutoring support, and follow-up decisions for each learner.
@@ -27,6 +29,8 @@ Dashboard actionability stories:
 ## Why now
 
 LLM agents, RAG, and AI-assisted content generation make it possible to reduce lesson preparation cost while keeping teachers in control of knowledge sources.
+
+Architecture direction: agent-native today, with future multi-agent role separation as a design direction rather than a current autonomy claim.
 
 ## MVP demo story
 

--- a/ai_first/competition/product-description.md
+++ b/ai_first/competition/product-description.md
@@ -12,6 +12,8 @@ Education
 
 Multiagent Learning Platform is an AI-first learning platform that helps Vietnamese teachers turn their own teaching materials into reusable Knowledge Packs, draft assessments, support student tutoring, and review learning progress through one connected workflow while still deciding how the AI should teach.
 
+Current proof level: a validated prototype with contest-safe walkthrough validation, smoke-backed checks, and refreshed UI evidence.
+
 ## Problem
 
 Teachers often already have lesson materials, exercises, and teaching experience, but they do not have enough time to convert those resources into personalized practice, tutoring support, and progress tracking for each learner. Many AI tools also generate content without grounding it in teacher-approved materials, which makes classroom adoption harder.
@@ -50,9 +52,13 @@ Within that loop, diagnosis and recommendation outputs are positioned as evidenc
 
 The platform combines agent workflows, retrieval grounded in teacher-approved materials, assessment generation, tutoring, and dashboard review into one connected product path instead of isolated tools. Its practical novelty is not only “using AI,” but using AI while preserving teacher control over source content, teaching style, and evidence review.
 
+Its future direction can be described as multi-agent by design, because the architecture is prepared for stronger role separation later. The current merged product should still be described as an agent-native validated prototype rather than a full autonomous multi-agent deployment.
+
 ## Practical Applicability
 
 The current MVP already demonstrates the end-to-end classroom loop locally with demo-safe data and repeatable smoke validation. That makes it suitable for contest review, pilot demonstrations, and iterative deployment in education settings where reliability and explainability matter.
+
+This repository does not currently claim classroom outcome evidence or a scaled real-user pilot.
 
 ## Efficiency Impact
 

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -204,6 +204,13 @@
 - Blockers: None.
 - Next: Commit the sync and open the tiny docs PR before any R6 implementation starts.
 
+## R6_CLAIM_CALIBRATION_PILOT
+
+- Started risk-lane 6 in worktree `.worktrees/claim-calibration-pilot` on branch `docs/claim-calibration-pilot`.
+- Calibrated contest-facing wording around validated-prototype proof, future multi-agent direction, and explicit no-pilot-yet status.
+- Added `docs/contest/PILOT_STATUS.md` as the single artifact for honest pilot/external-feedback positioning.
+- Validation: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `rg -n "multi-agent|validated prototype|future direction|pilot|user study|deployment|smoke-backed|structured walkthrough" docs/contest ai_first/competition ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md -S`; `git diff --check`
+
 ## R5_DASHBOARD_ACTIONABILITY
 
 - Started risk-lane 5 in worktree `.worktrees/dashboard-actionability` on branch `pod-a/dashboard-actionability`.

--- a/docs/contest/HUMAN_REVIEW_HANDOFF.md
+++ b/docs/contest/HUMAN_REVIEW_HANDOFF.md
@@ -38,6 +38,7 @@ Before submission, quickly verify:
 - screenshots are clear and contain no private data
 - `docs/contest/VALIDATION_REPORT.md` still matches the intended demo environment
 - hybrid authoring claims stay calibrated: `/agents` authoring can be shown, and bounded automated proof now exists for the unified Tutor turn path; do not rewrite that as universal live binding across every entry point
+- pilot or external-feedback language stays honest: use [`PILOT_STATUS.md`](./PILOT_STATUS.md) instead of implying classroom validation that the repository does not contain
 - optional video is either not required or has been recorded separately using `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`
 
 ### 4. Final package sign-off

--- a/docs/contest/PILOT_STATUS.md
+++ b/docs/contest/PILOT_STATUS.md
@@ -1,0 +1,20 @@
+# Pilot Status
+
+## Current Status
+
+No pilot evidence yet is included in this repository.
+
+## What Exists Instead
+
+- structured walkthrough validation of the contest MVP flow
+- smoke-backed command evidence in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md)
+- contest screenshot bundle in [`screenshots/`](./screenshots/)
+- diagnosis case studies and teacher-review framing in [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md)
+
+## Why This Is Still Useful
+
+These artifacts show the current merged capability and repeatable demo behavior of the validated prototype. They are not a substitute for classroom deployment evidence or a real-user study.
+
+## Next Stronger Validation Step
+
+The next stronger step after the contest would be a small teacher walkthrough or limited pilot with clearly documented scope, dates, and feedback boundaries.

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -2,6 +2,8 @@
 
 This folder is the entry point for VnExpress Sang kien Khoa hoc 2026 demo evidence.
 
+Current framing: this repository is a validated prototype with smoke-backed evidence and contest-safe walkthrough artifacts. It is not positioned as a deployed classroom system.
+
 ## MVP Story
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
@@ -22,12 +24,15 @@ Teacher-value framing for presenters:
 
 The repository now includes bounded proof that the unified live turn path can carry `config.agent_spec_id` into Tutor runtime policy assembly and produce a visible behavior difference between two spec packs. Do not expand that claim into universal coverage across every entry point unless a fresh smoke run verifies those additional paths.
 
+The current product can be described as `agent-native` today and `multi-agent by design` as a future role-separation direction. Do not describe the current merged repository as a fully autonomous multi-agent deployment.
+
 ## Evidence Files
 
 - [`SUBMISSION_PACKAGE.md`](./SUBMISSION_PACKAGE.md): compact final review path for contest submission.
 - [`DEMO_SCRIPT.md`](./DEMO_SCRIPT.md): step-by-step demo path for a reviewer or presenter.
 - [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md): required screenshots, optional video, and pass/fail evidence fields.
 - [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md): local validation commands, results, limitations, and remaining capture work.
+- [`PILOT_STATUS.md`](./PILOT_STATUS.md): explicit status of pilot or external-feedback evidence.
 - [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md): judge-facing diagnosis examples and teacher-review framing.
 - [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md): smoke lane used to verify the MVP path before any evidence refresh.
 - [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md): demo-safe data inventory and reset runbook before smoke/evidence refresh.
@@ -41,6 +46,7 @@ The repository now includes bounded proof that the unified live turn path can ca
 - Screenshot evidence is captured in [`screenshots/`](./screenshots/), including the 2026-04-26 dashboard evidence-first refresh and the `/agents` authoring proof refresh.
 - Hybrid `/agents` screenshots are current, and the codebase now also carries automated bounded runtime-binding proof for the unified Tutor turn path. Keep the claim narrower than universal entry-point coverage.
 - Video capture is optional and deferred to avoid storing large media in the repository.
+- No pilot evidence is currently bundled; the strongest current proof is structured walkthrough validation plus smoke-backed and screenshot-backed artifacts.
 
 ## Judge-Friendly Use Cases
 

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -17,6 +17,8 @@ Hybrid proof calibration:
 - You may claim bounded automated proof that the unified Tutor turn path accepts `config.agent_spec_id` and changes behavior across two contrasting spec packs. Do not expand that into universal live turn-time binding unless broader paths are re-verified in the target demo environment.
 - Diagnosis claims should stay at: rule-assisted, confidence-tagged, teacher-reviewed hypothesis layer. Do not present the diagnosis engine as a benchmarked autonomous assessor.
 - Assessment claims should stay at: AI can draft questions and feedback, but teacher review is the primary safety gate before student-facing reuse.
+- Overall product framing should stay at: validated prototype, not school-scale deployment.
+- Architecture framing should stay at: agent-native today, prepared for deeper multi-agent role separation later.
 
 Teacher-value shorthand for Q&A:
 
@@ -38,6 +40,7 @@ Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/com
 | Screenshot bundle | Ready | [`screenshots/`](./screenshots/) |
 | Demo-safe reset command | Ready | [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) |
 | Smoke procedure | Ready | [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md) |
+| Pilot / external feedback status | Ready | [`PILOT_STATUS.md`](./PILOT_STATUS.md) |
 | Contest rules summary | Ready | [`ai_first/competition/vnexpress-rules-summary.md`](../../ai_first/competition/vnexpress-rules-summary.md) |
 | Product description draft | Ready for human review | [`ai_first/competition/product-description.md`](../../ai_first/competition/product-description.md) |
 | Fork modifications note | Ready | [`ai_first/competition/fork-modifications.md`](../../ai_first/competition/fork-modifications.md) |
@@ -57,7 +60,7 @@ The latest smoke-backed refresh passed on 2026-04-26 after running the scripted 
 - dashboard evidence-first and `/agents` authoring screenshots were recaptured on 2026-04-26;
 - frontend production build with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
 
-Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` and `#128` for smoke-backed evidence, and `#99` plus `#130` for the screenshot bundle.
+Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` and `#128` for smoke-backed evidence, and `#99` plus `#130` for the screenshot bundle. This validation record supports a validated prototype claim. It does not, by itself, establish classroom deployment or outcome evidence.
 
 ## Human Review Checklist
 

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -8,6 +8,8 @@ This report covers the current contest MVP path:
 
 Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
 
+This report validates prototype behavior and contest evidence only. It is not a classroom outcome study or deployment report.
+
 ## Evidence Freshness Status
 
 Latest smoke-backed refresh: 2026-04-26
@@ -47,6 +49,7 @@ Use these status values consistently:
 - Browser-backed screenshot refresh now works in a local worktree, but it still depends on a running backend and frontend plus demo-safe local data.
 - Runtime handoff from `config.agent_spec_id` through the unified live Tutor turn path now has bounded automated proof in repository tests, including a visible behavior difference between two spec packs. This report still does not claim universal wiring across every possible entry point.
 - Diagnosis credibility is grounded in deterministic rules plus teacher review framing. This report does not claim benchmark accuracy numbers for diagnosis or recommendation quality.
+- The repository currently documents no pilot cohort, classroom rollout, or real-user study. Use `PILOT_STATUS.md` for the explicit external-feedback status.
 - Local provider-backed assessment generation was unavailable during the 2026-04-25 screenshot refresh because the configured model key was still a placeholder. The refreshed `07` and `08` screenshots therefore use demo-safe local session content in the worktree data store instead of a live provider response.
 - Provider-backed AI quality depends on configured model credentials. If credentials are unavailable during a demo, use the command validation and recorded UI flow as fallback evidence.
 - This report uses demo-safe descriptions only. Do not add real student data.

--- a/docs/superpowers/plans/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md
+++ b/docs/superpowers/plans/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md
@@ -1,0 +1,395 @@
+# Risk Lane 6 Claim Calibration And Pilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten contest-facing claims, add an honest pilot-status artifact, and align compatibility snapshots so the project reads as a validated prototype rather than an overclaimed multi-agent deployment.
+
+**Architecture:** This lane is docs-only. It does not strengthen the product by adding new proof; it strengthens the contest defense by aligning wording across contest docs, competition narratives, and AI-first compatibility surfaces. The implementation hinges on a single source of truth for pilot/external-feedback status and scoped language for current capability versus future architecture direction.
+
+**Tech Stack:** Markdown docs under `docs/contest/`, AI-first narrative files under `ai_first/competition/`, compatibility snapshots under `ai_first/`, git/PR workflow
+
+---
+
+## File Map
+
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+  - mark lane start while work is active
+- Modify: `ai_first/TASK_REGISTRY.json`
+  - mark `R6_CLAIM_CALIBRATION_PILOT` in progress at start, completed after merge in a later sync PR
+- Modify: `docs/contest/README.md`
+  - calibrate top-level contest narrative and multi-agent wording
+- Modify: `docs/contest/SUBMISSION_PACKAGE.md`
+  - calibrate current-proof versus future-direction framing
+- Modify: `docs/contest/HUMAN_REVIEW_HANDOFF.md`
+  - make the shortest remaining manual review path claim-safe
+- Modify: `docs/contest/VALIDATION_REPORT.md`
+  - ensure validation evidence is clearly prototype-level and artifact-backed
+- Create: `docs/contest/PILOT_STATUS.md`
+  - dedicated pilot/external-feedback artifact or explicit no-pilot-yet note
+- Modify: `ai_first/competition/pitch-notes.md`
+  - contest pitch calibration
+- Modify: `ai_first/competition/product-description.md`
+  - public-facing description calibration
+- Modify: `ai_first/CURRENT_STATE.md`
+  - compatibility snapshot alignment
+- Modify: `ai_first/NEXT_ACTIONS.md`
+  - compatibility snapshot alignment
+- Modify: `ai_first/daily/2026-04-26.md`
+  - daily log
+- Create: `docs/superpowers/pr-notes/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md`
+  - required architecture note with Mermaid diagram
+
+## Task 1: Start The Lane In Control Plane
+
+**Files:**
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Test: `ai_first/TASK_REGISTRY.json`
+
+- [ ] **Step 1: Add the active assignment**
+
+Replace the idle state in `ai_first/ACTIVE_ASSIGNMENTS.md` with:
+
+```md
+### Assignment
+
+- Owner: Codex
+- Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/claim-calibration-pilot`
+- Task: `R6_CLAIM_CALIBRATION_PILOT`
+- Status: in progress
+- Branch: `docs/claim-calibration-pilot`
+- Task packet: `docs/superpowers/tasks/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md`
+- Owned files: `docs/contest/`, `ai_first/competition/`, `ai_first/CURRENT_STATE.md`, `ai_first/NEXT_ACTIONS.md`, task packet, PR note
+- PR:
+- Last update: 2026-04-26
+- Next action: calibrate contest wording and add pilot-status artifact, then validate and open Draft PR
+- Blocker: none
+```
+
+- [ ] **Step 2: Mark `R6` in progress**
+
+Update `ai_first/TASK_REGISTRY.json`:
+
+- move `R6_CLAIM_CALIBRATION_PILOT` from `pending` to `in_progress`
+- update the counts
+- change the task note to mention `docs/claim-calibration-pilot`
+
+Use a note like:
+
+```json
+"status": "in-progress",
+"notes": "Active on branch docs/claim-calibration-pilot. This lane calibrates prototype claims and adds a pilot-status artifact."
+```
+
+- [ ] **Step 3: Validate JSON**
+
+Run:
+
+```bash
+python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+```
+
+Expected: exit `0`.
+
+- [ ] **Step 4: Commit lane start**
+
+Run:
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json
+git commit -m "docs(ai-first): start claim calibration lane [R6]"
+```
+
+## Task 2: Sweep Contest Docs For Claim Calibration
+
+**Files:**
+- Modify: `docs/contest/README.md`
+- Modify: `docs/contest/SUBMISSION_PACKAGE.md`
+- Modify: `docs/contest/HUMAN_REVIEW_HANDOFF.md`
+- Modify: `docs/contest/VALIDATION_REPORT.md`
+- Test: contest docs text scan
+
+- [ ] **Step 1: Search for risky wording before editing**
+
+Run:
+
+```bash
+rg -n "multi-agent|production|deployment|classroom-ready|validated in classrooms|user study|pilot|real users|staged" docs/contest -S
+```
+
+Expected: identify every phrase that could overstate proof or imply stronger validation than the repo supports.
+
+- [ ] **Step 2: Calibrate `README.md`**
+
+Update `docs/contest/README.md` so:
+
+- current capability reads as `validated prototype`
+- architecture direction reads as `agent-native` or `multi-agent by design`
+- evidence wording points to current artifacts rather than ambition
+
+Keep sentences like:
+
+```md
+The current repository is a validated prototype with smoke-backed evidence, contest screenshots, and bounded runtime-binding proof for the shipped Tutor flow.
+```
+
+and avoid lines that imply broad deployment readiness.
+
+- [ ] **Step 3: Calibrate `SUBMISSION_PACKAGE.md`**
+
+Make the submission package explicitly separate:
+
+1. current merged capability
+2. current proof
+3. future direction
+
+Use wording like:
+
+```md
+Current status: validated prototype.
+Architecture direction: agent-native today, prepared for deeper multi-agent role separation later.
+```
+
+If `multi-agent` is present, qualify it in the same paragraph.
+
+- [ ] **Step 4: Calibrate `HUMAN_REVIEW_HANDOFF.md` and `VALIDATION_REPORT.md`**
+
+In `HUMAN_REVIEW_HANDOFF.md`, ensure human review tasks do not imply that classroom validation already exists.
+
+In `VALIDATION_REPORT.md`, ensure the report says the strongest current evidence is smoke-backed validation and recaptured UI artifacts, not deployment data.
+
+If needed, add a compact note such as:
+
+```md
+This report validates prototype behavior and demo evidence only. It is not a classroom outcome study.
+```
+
+- [ ] **Step 5: Run a focused text scan**
+
+Run:
+
+```bash
+rg -n "multi-agent|validated prototype|future direction|classroom|deployment|user study|smoke-backed|bounded runtime-binding proof" docs/contest -S
+```
+
+Expected: risky wording is either gone or explicitly qualified.
+
+- [ ] **Step 6: Commit the contest-doc sweep**
+
+Run:
+
+```bash
+git add docs/contest/README.md docs/contest/SUBMISSION_PACKAGE.md docs/contest/HUMAN_REVIEW_HANDOFF.md docs/contest/VALIDATION_REPORT.md
+git commit -m "docs(contest): calibrate prototype claims [R6]"
+```
+
+## Task 3: Add The Pilot Status Artifact
+
+**Files:**
+- Create: `docs/contest/PILOT_STATUS.md`
+- Modify: `docs/contest/SUBMISSION_PACKAGE.md`
+- Test: new artifact readability
+
+- [ ] **Step 1: Create `PILOT_STATUS.md` with the honest default**
+
+Create `docs/contest/PILOT_STATUS.md` with this structure:
+
+```md
+# Pilot Status
+
+## Current Status
+
+No pilot evidence yet is included in this repository.
+
+## What Exists Instead
+
+- structured walkthrough validation
+- smoke-backed command evidence
+- contest screenshot bundle
+- diagnosis case studies and teacher-review framing
+
+## Why This Is Still Useful
+
+These artifacts show current merged capability and repeatable demo behavior, but they are not a substitute for classroom deployment evidence.
+
+## Next Stronger Validation Step
+
+The next stronger step after the contest would be a small teacher walkthrough or limited pilot with clearly documented feedback and scope.
+```
+
+If a real artifact is already present in the repository, adapt the file to describe it narrowly rather than using the default “none yet” language.
+
+- [ ] **Step 2: Link the artifact from the submission package**
+
+Add one line to `docs/contest/SUBMISSION_PACKAGE.md` under evidence or review materials:
+
+```md
+- Pilot / external feedback status | Ready | [`PILOT_STATUS.md`](./PILOT_STATUS.md)
+```
+
+Keep the wording neutral.
+
+- [ ] **Step 3: Sanity-check the artifact**
+
+Run:
+
+```bash
+sed -n '1,220p' docs/contest/PILOT_STATUS.md
+```
+
+Expected: the file clearly answers “who used this?” without exaggeration or apology.
+
+- [ ] **Step 4: Commit the pilot-status artifact**
+
+Run:
+
+```bash
+git add docs/contest/PILOT_STATUS.md docs/contest/SUBMISSION_PACKAGE.md
+git commit -m "docs(contest): add pilot status artifact [R6]"
+```
+
+## Task 4: Align Competition And Compatibility Surfaces
+
+**Files:**
+- Modify: `ai_first/competition/pitch-notes.md`
+- Modify: `ai_first/competition/product-description.md`
+- Modify: `ai_first/CURRENT_STATE.md`
+- Modify: `ai_first/NEXT_ACTIONS.md`
+- Test: cross-file wording scan
+
+- [ ] **Step 1: Calibrate competition narratives**
+
+Update `ai_first/competition/pitch-notes.md` and `ai_first/competition/product-description.md` so they:
+
+- describe the product as a validated prototype
+- keep `multi-agent` scoped to architecture direction or design intent
+- avoid implying real classroom deployment unless an artifact backs it
+
+Target wording:
+
+```md
+The product is a validated prototype with teacher-defined tutoring, smoke-backed demo evidence, and a future path toward deeper role separation.
+```
+
+- [ ] **Step 2: Align compatibility snapshots**
+
+Update `ai_first/CURRENT_STATE.md` and `ai_first/NEXT_ACTIONS.md` so they do not reintroduce stronger claims than the contest docs. Keep them short and consistent with the lane outcome.
+
+If one file still says “multi-agent system” without qualification, replace it with scoped language like:
+
+```md
+agent-native platform with future multi-agent role separation
+```
+
+- [ ] **Step 3: Run a cross-file scan**
+
+Run:
+
+```bash
+rg -n "multi-agent|validated prototype|future direction|deployment|pilot|user study|classroom" docs/contest ai_first/competition ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md -S
+```
+
+Expected: the wording is consistent and properly scoped across all touched surfaces.
+
+- [ ] **Step 4: Commit the narrative alignment**
+
+Run:
+
+```bash
+git add ai_first/competition/pitch-notes.md ai_first/competition/product-description.md ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md
+git commit -m "docs(ai-first): align narrative with current proof [R6]"
+```
+
+## Task 5: Finish The Lane For Review
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-26.md`
+- Create: `docs/superpowers/pr-notes/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md`
+- Test: full lane diff
+
+- [ ] **Step 1: Write the PR architecture note**
+
+Create `docs/superpowers/pr-notes/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md` with:
+
+- summary
+- list of wording surfaces updated
+- statement that `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated
+- Mermaid diagram like:
+
+```md
+```mermaid
+flowchart LR
+  Capability["Current merged capability"]
+  Evidence["Current validated evidence"]
+  Pilot["Pilot status"]
+  Direction["Future architecture direction"]
+  Reviewer["Skeptical reviewer"]
+
+  Capability --> Reviewer
+  Evidence --> Reviewer
+  Pilot --> Reviewer
+  Direction --> Reviewer
+```
+```
+
+- [ ] **Step 2: Update the daily log**
+
+Append a `R6_CLAIM_CALIBRATION_PILOT` section to `ai_first/daily/2026-04-26.md` including:
+
+- branch/worktree
+- wording surfaces changed
+- pilot-status artifact added
+- validation commands
+
+- [ ] **Step 3: Run final lane validation**
+
+Run:
+
+```bash
+python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+rg -n "multi-agent|validated prototype|future direction|pilot|user study|deployment|smoke-backed|structured walkthrough" docs/contest ai_first/competition ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md -S
+git diff --check
+```
+
+Expected:
+
+- JSON validation exits `0`
+- the wording scan shows only intentionally scoped matches
+- `git diff --check` prints nothing
+
+- [ ] **Step 4: Open the review PR**
+
+Run:
+
+```bash
+git status --short --branch
+git push -u origin docs/claim-calibration-pilot
+gh pr create --draft --base main --head docs/claim-calibration-pilot --title "docs(contest): calibrate claims and pilot status [R6]"
+```
+
+Expected: Draft PR created with validation notes and the new pilot-status artifact.
+
+## Self-Review
+
+### Spec Coverage
+
+- contest docs are swept for overclaim
+- pilot status gets one dedicated artifact
+- competition and compatibility surfaces align with current proof
+- no runtime/product code changes are introduced
+
+No spec gaps found.
+
+### Placeholder Scan
+
+The plan avoids placeholders and uses concrete file paths, wording targets, and commands.
+
+### Consistency Check
+
+The plan uses one consistent framing:
+
+- current product = validated prototype
+- current evidence = smoke-backed + structured walkthrough artifacts
+- future role separation = scoped architecture direction
+- pilot status = explicit artifact, no fabricated evidence

--- a/docs/superpowers/pr-notes/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md
+++ b/docs/superpowers/pr-notes/2026-04-26-risk-lane-6-claim-calibration-and-pilot.md
@@ -1,0 +1,31 @@
+# PR Note: Risk Lane 6 Claim Calibration And Pilot
+
+## Summary
+
+This PR hardens contest defense by aligning all major narrative surfaces around the project’s actual proof level: validated prototype now, bounded evidence now, and future multi-agent role separation later.
+
+## What Changed
+
+- calibrated contest-facing docs to distinguish current capability, current evidence, and future direction
+- added `PILOT_STATUS.md` as the single honest answer to pilot or external-feedback questions
+- aligned compatibility snapshots and competition wording with the same prototype-level framing
+
+## Main System Map
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane changes wording and evidence framing, not shipped architecture boundaries
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Capability["Current merged capability"]
+  Evidence["Current validated evidence"]
+  Pilot["Pilot status"]
+  Direction["Future architecture direction"]
+  Reviewer["Skeptical reviewer"]
+
+  Capability --> Reviewer
+  Evidence --> Reviewer
+  Pilot --> Reviewer
+  Direction --> Reviewer
+```

--- a/docs/superpowers/specs/2026-04-26-risk-lane-6-claim-calibration-and-pilot-design.md
+++ b/docs/superpowers/specs/2026-04-26-risk-lane-6-claim-calibration-and-pilot-design.md
@@ -1,0 +1,160 @@
+# Risk Lane 6 Claim Calibration And Pilot Design
+
+## Metadata
+
+- Date: 2026-04-26
+- Task ID: `R6_CLAIM_CALIBRATION_PILOT`
+- Commit tag: `R6`
+- Branch: `docs/claim-calibration-pilot`
+- Scope: claim calibration, prototype-status framing, and minimal pilot/external-feedback positioning
+
+## Problem
+
+The project is vulnerable to three related attacks:
+
+1. the demo looks staged rather than validated
+2. the product overclaims “multi-agent” relative to current shipped proof
+3. reviewers may ask for real-user or teacher evidence that does not yet exist in a robust form
+
+The goal of this lane is not to invent stronger proof. It is to present the current proof level honestly and consistently so the strongest existing artifacts carry the narrative without accidental overclaim.
+
+## Goal
+
+Tighten contest-facing wording around current proof, future direction, and pilot status so a skeptical judge can quickly distinguish:
+
+- what is implemented now
+- what is validated now
+- what remains future architecture direction
+
+## Non-Goals
+
+- No runtime, API, or frontend feature changes
+- No fabricated teacher quotes, pilot counts, or external validation claims
+- No attempt to convert limited feedback into a research-study claim
+- No rewrite of the whole repository narrative beyond contest-facing and compatibility surfaces
+
+## Recommended Approach
+
+Use a bounded `docs sweep + pilot-status artifact` approach:
+
+1. sweep contest-facing docs for claim calibration
+2. keep the word `multi-agent` only when explicitly scoped as design direction or role-separation intent
+3. add one dedicated pilot/external-feedback artifact so the project has a single honest answer to “who used this?”
+4. keep compatibility snapshots aligned so humans and future AI sessions do not reintroduce old wording
+
+This is the smallest approach that reduces skepticism without pretending the project has stronger validation than it actually does.
+
+## Wording Rules
+
+### Current Proof Language
+
+Use phrases like:
+
+- `validated prototype`
+- `smoke-backed evidence`
+- `structured walkthrough validation`
+- `bounded runtime-binding proof`
+- `teacher-reviewed diagnosis`
+
+### Future Architecture Language
+
+Use phrases like:
+
+- `multi-agent by design`
+- `future direction`
+- `prepared for role separation`
+- `agent-native architecture`
+
+Avoid wording that implies the current shipped product already has production-grade inter-agent autonomy.
+
+### Pilot / External Feedback Language
+
+If no real pilot artifact exists:
+
+- say `no pilot evidence yet`
+- explain that the strongest current evidence is structured walkthrough validation plus smoke-backed artifacts
+
+If a small real artifact exists:
+
+- describe it as `limited external feedback`
+- keep the claim narrow and non-statistical
+
+Never use wording like:
+
+- `validated in classrooms`
+- `proven learning outcomes`
+- `user study`
+- `production deployment`
+
+unless an actual artifact in the repository supports that exact claim.
+
+## File Set
+
+### Contest / Submission Surface
+
+- `docs/contest/README.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `docs/contest/HUMAN_REVIEW_HANDOFF.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- `docs/contest/PILOT_STATUS.md` (new)
+
+### Competition / Narrative Surface
+
+- `ai_first/competition/pitch-notes.md`
+- `ai_first/competition/product-description.md`
+
+### Compatibility / AI-first Surface
+
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+
+### Operating / Review Surface
+
+- `docs/superpowers/pr-notes/*`
+- daily log
+- active assignment + task registry for lane start/finish
+
+## Pilot Status Artifact
+
+Preferred structure: create a dedicated file at `docs/contest/PILOT_STATUS.md`.
+
+The file should answer:
+
+1. What external or teacher feedback exists right now?
+2. If none exists, what is the honest current state?
+3. What evidence exists instead?
+4. What would count as the next stronger validation step after the contest?
+
+If the answer is “none yet,” that is acceptable and should be written plainly.
+
+## Acceptance Criteria
+
+1. Contest-facing docs consistently frame the product as a validated prototype, not a deployed school system.
+2. Any use of `multi-agent` is scoped as present design intent or future direction, not current autonomous behavior.
+3. The repository contains one explicit pilot/external-feedback artifact or one explicit no-pilot-yet note.
+4. A skeptical reviewer can see, in one pass, the difference between:
+   - current merged capabilities
+   - validated evidence
+   - future architecture direction
+5. Compatibility snapshots do not contradict the contest docs.
+
+## Manual Verification
+
+Read the contest package as if you are a skeptical judge and ask:
+
+1. Where is the proof?
+2. Where is the limitation note?
+3. Which lines talk about future direction rather than current capability?
+4. If I ask “has a real teacher used this?”, is there one honest answer with no contradiction across files?
+
+If any answer requires hand-waving, the docs are still too loose.
+
+## Risks And Boundaries
+
+- The main risk is turning calibration into under-selling. The fix is to be specific about current proof, not vague or apologetic.
+- The second risk is leaving old wording behind in one compatibility or contest file, which creates contradictions.
+- The third risk is quietly implying pilot validation through narrative tone even when the text avoids explicit claims.
+
+## Architecture Note Requirement
+
+The PR must include a note under `docs/superpowers/pr-notes/` with a Mermaid diagram. `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged unless shipped architecture language itself changes materially.


### PR DESCRIPTION
## Summary
- calibrate contest-facing wording around validated-prototype proof and future multi-agent direction
- add `docs/contest/PILOT_STATUS.md` as the single honest pilot/external-feedback artifact
- align competition and compatibility surfaces with the same proof level

## Validation
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `rg -n "multi-agent|validated prototype|future direction|pilot|user study|deployment|smoke-backed|structured walkthrough" docs/contest ai_first/competition ai_first/CURRENT_STATE.md ai_first/NEXT_ACTIONS.md -S`
- `git diff --check`

## Notes
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane changes wording and evidence framing, not shipped architecture boundaries.
- The pilot artifact intentionally states that no pilot evidence is currently bundled rather than fabricating external validation.
