### PR TITLE
feat(runtime): extend bounded capability binding coverage [F113]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
 - Task: `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`
-- Status: `draft-pr`
+- Status: `ready-review`
 - Branch: `pod-b/runtime-binding-coverage`
 - Task packet: `docs/superpowers/specs/2026-04-26-f113-capability-wide-runtime-binding-coverage-design.md`
 - Owned files: `deeptutor/capabilities/`, `deeptutor/services/runtime_policy/`, `deeptutor/services/session/turn_runtime.py`, bounded tests/docs
 - PR: `https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/164`
 - Last update: `2026-04-27T00:00:00+0700`
-- Next action: `Wait for CI and review on Draft PR #164, then address any blockers before marking ready.`
+- Next action: `Wait for CI and review on PR #164, then address any blockers before merge.`
 - Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
 - Task: `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`
-- Status: `in-progress`
+- Status: `draft-pr`
 - Branch: `pod-b/runtime-binding-coverage`
 - Task packet: `docs/superpowers/specs/2026-04-26-f113-capability-wide-runtime-binding-coverage-design.md`
 - Owned files: `deeptutor/capabilities/`, `deeptutor/services/runtime_policy/`, `deeptutor/services/session/turn_runtime.py`, bounded tests/docs
-- PR: `Draft, not opened yet`
-- Last update: `2026-04-26T23:46:46+0700`
-- Next action: `Implement request-contract widening and runtime-binding tests in the Session B worktree.`
+- PR: `https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/164`
+- Last update: `2026-04-27T00:00:00+0700`
+- Next action: `Wait for CI and review on Draft PR #164, then address any blockers before marking ready.`
 - Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,6 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task.
+### Assignment
 
-Recommended next AI-owned task: none. The remaining path is human review of the submission package, IP commitment, optional video decision, and final sign-off unless a fresh packet is explicitly opened from `main`.
+- Owner: Codex Session B
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
+- Task: `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`
+- Status: `in-progress`
+- Branch: `pod-b/runtime-binding-coverage`
+- Task packet: `docs/superpowers/specs/2026-04-26-f113-capability-wide-runtime-binding-coverage-design.md`
+- Owned files: `deeptutor/capabilities/`, `deeptutor/services/runtime_policy/`, `deeptutor/services/session/turn_runtime.py`, bounded tests/docs
+- PR: `Draft, not opened yet`
+- Last update: `2026-04-26T23:46:46+0700`
+- Next action: `Implement request-contract widening and runtime-binding tests in the Session B worktree.`
+- Blocker: `None`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1224,7 +1224,7 @@
       "dependencies": [
         "R5_DASHBOARD_ACTIONABILITY"
       ],
-      "status": "in-progress",
+      "status": "not-started",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
       "notes": "First recommended task for a new teacher-facing session after the contest MVP closes."
@@ -1250,7 +1250,7 @@
       "dependencies": [
         "F101_TEACHER_ACTION_EXECUTION_LOOP"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
       "notes": "Should stay teacher-facing first; richer outcome tracking can follow in Session B."

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1224,7 +1224,7 @@
       "dependencies": [
         "R5_DASHBOARD_ACTIONABILITY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
       "notes": "First recommended task for a new teacher-facing session after the contest MVP closes."

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -37,10 +37,10 @@ flowchart TD
   Capabilities --> DeepSolve["deep_solve"]
   Capabilities --> DeepQuestion["deep_question"]
   RuntimePolicy --> Chat
+  RuntimePolicy --> DeepSolve
   RuntimePolicy --> DeepQuestion
   RuntimePolicy --> PolicyBoundary["Teacher Spec / Student State / Session State"]
-  RuntimePolicy --> Chat
-  RuntimePolicy --> DeepQuestion
+  RuntimePolicy --> TurnBinding["Bounded turn binding: chat + deep_question + deep_solve"]
 
   Project --> Product["Contest MVP Product Layer"]
   Product --> TeacherWorkspace["Teacher Workspace"]

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -236,3 +236,15 @@
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `rg -n 'F10[1-9]|F11[0-9]|F12[0-4]|recommended_session_bucket|layer|\"status\": \"not-started\"' ai_first/TASK_REGISTRY.json -n -S`; `rg -n 'TODO|TBD|implement later|ad hoc|<teacher-facing-task>|<runtime-data-task>' docs/superpowers/tasks/2026-04-26-two-session-future-backlog.md -S`; `git diff --check`
 - Blockers: None.
 - Next: Open a Draft PR for this docs/control-plane lane, then let future sessions pick a concrete `F` task from the packet.
+
+## F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE
+
+- Branch: `pod-b/runtime-binding-coverage`
+- Worktree: `.worktrees/pod-b-runtime-binding-coverage`
+- Task: `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`
+- Done: Widened capability request contracts so `deep_question` and `deep_solve` explicitly accept `agent_spec_id`, preserving `chat` as the already-covered baseline.
+- Done: Added bounded runtime-policy assembly for `deep_solve` and new runtime proofs showing `config.agent_spec_id` reaches policy assembly on the unified `chat`, `deep_question`, and `deep_solve` turn paths.
+- Done: Updated the main system map and bounded contest claim surfaces so the repository now claims exactly those three covered runtime paths, not universal entry-point coverage.
+- Tests: `pytest tests/core/test_capabilities_runtime.py tests/api/test_unified_ws_turn_runtime.py tests/services/runtime_policy/test_compiler.py -q`; `git diff --check`
+- Blockers: None.
+- Next: Open a Draft PR with the runtime-binding PR note, then keep the branch in review until CI passes.

--- a/deeptutor/capabilities/deep_solve.py
+++ b/deeptutor/capabilities/deep_solve.py
@@ -14,6 +14,7 @@ from deeptutor.core.capability_protocol import BaseCapability, CapabilityManifes
 from deeptutor.core.context import UnifiedContext
 from deeptutor.core.stream_bus import StreamBus
 from deeptutor.core.trace import derive_trace_metadata, merge_trace_metadata
+from deeptutor.services.runtime_policy import ensure_runtime_policy, format_chat_system_context
 
 
 class DeepSolveCapability(BaseCapability):
@@ -29,6 +30,15 @@ class DeepSolveCapability(BaseCapability):
     async def run(self, context: UnifiedContext, stream: StreamBus) -> None:
         from deeptutor.agents.solve.main_solver import MainSolver
         from deeptutor.services.llm.config import get_llm_config
+
+        policy = ensure_runtime_policy(context, self.name)
+        policy_context = format_chat_system_context(policy)
+        await stream.progress(
+            message="Runtime policy slices assembled.",
+            source=self.name,
+            stage="planning",
+            metadata=context.metadata.get("runtime_policy", {}).get("debug", {}),
+        )
 
         llm_config = get_llm_config()
         detailed = context.config_overrides.get("detailed_answer", True)
@@ -242,13 +252,19 @@ class DeepSolveCapability(BaseCapability):
 
         solver._content_callback = _content_sink
 
+        conversation_context = str(
+            context.metadata.get("conversation_context_text", "") or ""
+        ).strip()
+        if policy_context:
+            conversation_context = "\n\n".join(
+                part for part in [policy_context, conversation_context] if part
+            ).strip()
+
         result = await solver.solve(
             question=context.user_message,
             verbose=False,
             detailed=detailed,
-            conversation_context=str(
-                context.metadata.get("conversation_context_text", "") or ""
-            ).strip(),
+            conversation_context=conversation_context,
         )
 
         final_answer = result.get("final_answer", "")

--- a/deeptutor/capabilities/request_contracts.py
+++ b/deeptutor/capabilities/request_contracts.py
@@ -28,6 +28,7 @@ class DeepSolveRequestConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     detailed_answer: bool = True
+    agent_spec_id: str = ""
 
 
 class DeepQuestionRequestConfig(BaseModel):
@@ -42,6 +43,7 @@ class DeepQuestionRequestConfig(BaseModel):
     preference: str = ""
     paper_path: str = ""
     max_questions: int = Field(default=10, ge=1, le=100)
+    agent_spec_id: str = ""
 
 
 class VisualizeRequestConfig(BaseModel):

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -22,7 +22,7 @@ Teacher-value framing for presenters:
 - `RULES` lets a teacher keep classroom boundaries such as no direct answers, hint limits, or escalation expectations.
 - The dashboard is not only reporting activity; it helps the teacher decide what to reteach, who needs follow-up, and which students can be grouped around the same misconception.
 
-The repository now includes bounded proof that the unified live turn path can carry `config.agent_spec_id` into Tutor runtime policy assembly and produce a visible behavior difference between two spec packs. Do not expand that claim into universal coverage across every entry point unless a fresh smoke run verifies those additional paths.
+The repository now includes bounded proof that the unified live turn paths for `chat`, `deep_question`, and `deep_solve` can carry `config.agent_spec_id` into runtime policy assembly. Do not expand that claim into universal coverage across every capability or entry point unless a fresh verification run proves those additional paths.
 
 The current product can be described as `agent-native` today and `multi-agent by design` as a future role-separation direction. Do not describe the current merged repository as a fully autonomous multi-agent deployment.
 
@@ -44,7 +44,7 @@ The current product can be described as `agent-native` today and `multi-agent by
 - Diagnosis and recommendation outputs are framed as rule-assisted, confidence-tagged, teacher-reviewed hypotheses rather than benchmarked autonomous judgments.
 - The latest scripted-reset smoke-backed MVP verification passed on 2026-04-26 and is recorded in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md).
 - Screenshot evidence is captured in [`screenshots/`](./screenshots/), including the 2026-04-26 dashboard evidence-first refresh and the `/agents` authoring proof refresh.
-- Hybrid `/agents` screenshots are current, and the codebase now also carries automated bounded runtime-binding proof for the unified Tutor turn path. Keep the claim narrower than universal entry-point coverage.
+- Hybrid `/agents` screenshots are current, and the codebase now also carries automated bounded runtime-binding proof for the unified `chat`, `deep_question`, and `deep_solve` turn paths. Keep the claim narrower than universal entry-point coverage.
 - Video capture is optional and deferred to avoid storing large media in the repository.
 - No pilot evidence is currently bundled; the strongest current proof is structured walkthrough validation plus smoke-backed and screenshot-backed artifacts.
 

--- a/docs/superpowers/plans/2026-04-26-f113-capability-wide-runtime-binding-coverage.md
+++ b/docs/superpowers/plans/2026-04-26-f113-capability-wide-runtime-binding-coverage.md
@@ -1,0 +1,227 @@
+# F113 Capability-Wide Runtime Binding Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend bounded runtime-binding proof from the unified `chat` path to the shipped `deep_question` and `deep_solve` turn paths without broadening into teacher-facing UX or universal capability claims.
+
+**Architecture:** Keep `agent_spec_id` as an explicit public request-contract field on covered capabilities, propagate it through `TurnRuntimeManager` via `UnifiedContext.config_overrides`, and make each covered capability compile and consume runtime policy in a capability-appropriate way. Preserve existing `chat` behavior, keep `deep_question` on the assessment-policy path, and add the smallest bounded runtime-policy injection to `deep_solve`.
+
+**Tech Stack:** Pydantic request contracts, unified capability runtime, runtime-policy compiler/helpers, pytest
+
+---
+
+### Task 1: Widen Covered Capability Request Contracts
+
+**Files:**
+- Modify: `deeptutor/capabilities/request_contracts.py`
+- Test: `tests/core/test_capabilities_runtime.py`
+
+- [ ] **Step 1: Write the failing request-contract tests**
+
+Add focused tests proving `deep_question` and `deep_solve` accept `agent_spec_id` while still rejecting unknown fields.
+
+- [ ] **Step 2: Run the targeted tests to confirm failure**
+
+Run: `pytest tests/core/test_capabilities_runtime.py -k "accepts_agent_spec_id or rejects_unknown_fields" -q`
+
+Expected: FAIL because `deep_question` and `deep_solve` configs do not yet expose `agent_spec_id`.
+
+- [ ] **Step 3: Add `agent_spec_id` to covered request models**
+
+Update `deeptutor/capabilities/request_contracts.py` so `DeepQuestionRequestConfig` and `DeepSolveRequestConfig` both define `agent_spec_id: str = ""`.
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run: `pytest tests/core/test_capabilities_runtime.py -k "accepts_agent_spec_id or rejects_unknown_fields" -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the request-contract slice**
+
+```bash
+git add deeptutor/capabilities/request_contracts.py tests/core/test_capabilities_runtime.py
+git commit -m "feat(runtime): widen covered capability request contracts [F113]"
+```
+
+### Task 2: Prove Runtime Binding For `deep_question`
+
+**Files:**
+- Modify: `tests/core/test_capabilities_runtime.py`
+- Modify: `tests/api/test_unified_ws_turn_runtime.py`
+
+- [ ] **Step 1: Write the failing capability-level `deep_question` binding test**
+
+Prove `DeepQuestionCapability` resolves runtime policy from an Agent Spec pack and injects `Teacher Assessment Runtime Policy:` into generation input.
+
+- [ ] **Step 2: Write the failing unified-turn `deep_question` propagation test**
+
+Prove `TurnRuntimeManager` accepts `config.agent_spec_id` on a `deep_question` turn and the capability consumes the bound policy.
+
+- [ ] **Step 3: Run the targeted `deep_question` tests**
+
+Run: `pytest tests/core/test_capabilities_runtime.py -k "deep_question and runtime_policy" -q`
+
+Run: `pytest tests/api/test_unified_ws_turn_runtime.py -k "deep_question_policy_binding" -q`
+
+Expected: FAIL until the proof is wired and assertions match the real path.
+
+- [ ] **Step 4: Keep production changes minimal**
+
+If the widened request contract is sufficient, keep `deep_question` production code unchanged and only land tests. If a small bounded fix is required, keep it inside existing runtime-policy assembly.
+
+- [ ] **Step 5: Re-run the targeted `deep_question` proof tests**
+
+Run: `pytest tests/core/test_capabilities_runtime.py -k "deep_question and runtime_policy" -q`
+
+Run: `pytest tests/api/test_unified_ws_turn_runtime.py -k "deep_question_policy_binding" -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the `deep_question` proof slice**
+
+```bash
+git add tests/core/test_capabilities_runtime.py tests/api/test_unified_ws_turn_runtime.py
+git commit -m "test(runtime): prove deep-question policy binding [F113]"
+```
+
+### Task 3: Add Bounded Runtime Policy Injection To `deep_solve`
+
+**Files:**
+- Modify: `deeptutor/capabilities/deep_solve.py`
+- Modify: `deeptutor/services/runtime_policy/compiler.py` only if a shared formatter/helper is required
+- Modify: `tests/core/test_capabilities_runtime.py`
+
+- [ ] **Step 1: Write the failing capability-level `deep_solve` binding test**
+
+Prove `DeepSolveCapability` compiles runtime policy and passes a bounded policy block into solver execution.
+
+- [ ] **Step 2: Run the targeted `deep_solve` test to confirm failure**
+
+Run: `pytest tests/core/test_capabilities_runtime.py -k "deep_solve and runtime_policy" -q`
+
+Expected: FAIL because `deep_solve` does not yet inject runtime policy.
+
+- [ ] **Step 3: Add the minimal policy assembly path to `deep_solve`**
+
+Compile runtime policy, emit one runtime-policy progress event, prepend the policy block to `conversation_context`, and pass that merged context into `solver.solve(...)`.
+
+- [ ] **Step 4: Add a shared formatter only if the existing chat formatter is the wrong fit**
+
+Prefer reusing `format_chat_system_context(policy)` unless tests show it is semantically unsuitable.
+
+- [ ] **Step 5: Re-run the targeted `deep_solve` tests**
+
+Run: `pytest tests/core/test_capabilities_runtime.py -k "deep_solve and runtime_policy" -q`
+
+Run: `pytest tests/services/runtime_policy/test_compiler.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the `deep_solve` runtime-policy slice**
+
+```bash
+git add deeptutor/capabilities/deep_solve.py deeptutor/services/runtime_policy/compiler.py tests/core/test_capabilities_runtime.py
+git commit -m "feat(runtime): bind deep-solve to teacher policy [F113]"
+```
+
+### Task 4: Prove Unified Turn Propagation For `deep_solve`
+
+**Files:**
+- Modify: `tests/api/test_unified_ws_turn_runtime.py`
+- Modify: `deeptutor/services/session/turn_runtime.py` only if bounded propagation fixes are required
+
+- [ ] **Step 1: Write the failing unified-turn `deep_solve` propagation test**
+
+Prove a `deep_solve` turn with `config.agent_spec_id` reaches capability execution and carries runtime policy into solver context.
+
+- [ ] **Step 2: Run the targeted unified-turn test**
+
+Run: `pytest tests/api/test_unified_ws_turn_runtime.py -k "deep_solve_policy_binding" -q`
+
+Expected: FAIL until the capability path is wired.
+
+- [ ] **Step 3: Make only bounded propagation fixes if the test exposes a real gap**
+
+Keep any runtime fix local to `deeptutor/services/session/turn_runtime.py` and avoid adding a second metadata-only path for `agent_spec_id`.
+
+- [ ] **Step 4: Re-run the targeted `deep_solve` propagation test**
+
+Run: `pytest tests/api/test_unified_ws_turn_runtime.py -k "deep_solve_policy_binding" -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the unified-turn proof slice**
+
+```bash
+git add deeptutor/services/session/turn_runtime.py tests/api/test_unified_ws_turn_runtime.py
+git commit -m "test(runtime): prove deep-solve turn binding [F113]"
+```
+
+### Task 5: Run The Full Bounded Validation Matrix
+
+**Files:**
+- Modify: `tests/core/test_capabilities_runtime.py` only if cleanup or deduplication is still needed
+- Modify: `tests/api/test_unified_ws_turn_runtime.py` only if cleanup or deduplication is still needed
+
+- [ ] **Step 1: Clean up duplicate or confusing runtime tests**
+
+Collapse any duplicate test definitions so each behavior has one authoritative test.
+
+- [ ] **Step 2: Run the bounded runtime-policy suite**
+
+Run: `pytest tests/core/test_capabilities_runtime.py tests/api/test_unified_ws_turn_runtime.py tests/services/runtime_policy/test_compiler.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run: `git diff --check`
+
+Expected: exit `0`.
+
+- [ ] **Step 4: Commit any final test cleanup**
+
+```bash
+git add tests/core/test_capabilities_runtime.py tests/api/test_unified_ws_turn_runtime.py
+git commit -m "test(runtime): stabilize capability binding coverage [F113]"
+```
+
+### Task 6: Record Scope-Bounded Docs And AI-First State
+
+**Files:**
+- Create: `docs/superpowers/pr-notes/2026-04-26-f113-capability-wide-runtime-binding-coverage.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-26.md`
+- Modify: `docs/contest/README.md` or `docs/contest/VALIDATION_REPORT.md` only if the proof scope actually widens
+
+- [ ] **Step 1: Create the runtime-binding PR note with an exact coverage diagram**
+
+Include one Mermaid diagram showing `TurnRuntimeManager -> config_overrides -> chat/deep_question/deep_solve -> runtime policy compiled`.
+
+- [ ] **Step 2: Record the active assignment and task status**
+
+Mark `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE` as `in-progress` when work begins and move the assignment to review-ready state when validation is done.
+
+- [ ] **Step 3: Append a daily log entry with test evidence**
+
+Capture branch/worktree, covered capabilities, validation commands, and whether contest-facing claim wording changed.
+
+- [ ] **Step 4: Update contest-facing docs only if the proof scope actually widened**
+
+If claim wording changes, keep it exact: `chat`, `deep_question`, and `deep_solve` only.
+
+- [ ] **Step 5: Run the final scoped validation commands**
+
+Run: `pytest tests/core/test_capabilities_runtime.py tests/api/test_unified_ws_turn_runtime.py tests/services/runtime_policy/test_compiler.py -q`
+
+Run: `git diff --check`
+
+Expected: both pass.
+
+- [ ] **Step 6: Commit the docs/state slice**
+
+```bash
+git add docs/superpowers/pr-notes/2026-04-26-f113-capability-wide-runtime-binding-coverage.md ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-26.md docs/contest/README.md docs/contest/VALIDATION_REPORT.md
+git commit -m "docs(runtime): record bounded binding coverage [F113]"
+```

--- a/docs/superpowers/pr-notes/2026-04-26-f113-capability-wide-runtime-binding-coverage.md
+++ b/docs/superpowers/pr-notes/2026-04-26-f113-capability-wide-runtime-binding-coverage.md
@@ -1,0 +1,29 @@
+# PR Note: F113 Capability-Wide Runtime Binding Coverage
+
+- Task: `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`
+- Scope: bounded runtime-policy coverage for `chat`, `deep_question`, and `deep_solve`
+- Main-system-map update: required and included in this branch
+
+## What Changed
+
+- widened public request contracts so `deep_question` and `deep_solve` accept `agent_spec_id`
+- preserved the existing `chat` runtime-binding proof
+- added explicit bounded runtime-policy injection to `deep_solve`
+- added unified-turn tests proving `config.agent_spec_id` survives request validation and reaches runtime policy assembly for all three covered capabilities
+- kept the claim surface narrow: covered shipped turn paths only, not universal capability coverage
+
+```mermaid
+flowchart LR
+  A["TurnRuntimeManager"] --> B["Validated config_overrides"]
+  B --> C["chat"]
+  B --> D["deep_question"]
+  B --> E["deep_solve"]
+  C --> F["Runtime policy compiled"]
+  D --> F
+  E --> F
+```
+
+## Validation
+
+- `pytest tests/core/test_capabilities_runtime.py tests/api/test_unified_ws_turn_runtime.py tests/services/runtime_policy/test_compiler.py -q`
+- `git diff --check`

--- a/docs/superpowers/specs/2026-04-26-f113-capability-wide-runtime-binding-coverage-design.md
+++ b/docs/superpowers/specs/2026-04-26-f113-capability-wide-runtime-binding-coverage-design.md
@@ -1,0 +1,124 @@
+# F113 Capability-Wide Runtime Binding Coverage Design
+
+## Metadata
+
+- Task ID: `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`
+- Commit tag: `F113`
+- Session bucket: `session-b-runtime-data`
+- Owner scope: `deeptutor/capabilities/`, `deeptutor/services/runtime_policy/`, `deeptutor/services/session/turn_runtime.py`, bounded runtime-policy tests and docs
+- Do-not-touch scope: teacher-facing dashboard UX, teacher workflow copy, Session A dashboard surfaces
+
+## Goal
+
+Extend the existing bounded runtime-binding proof from the unified Tutor `chat` path into additional shipped capability entry points so the repository can make a narrower but stronger claim: selected runtime capabilities consistently carry `agent_spec_id` through request validation, turn runtime, policy compilation, and capability execution.
+
+## Current State
+
+The repository already proves one live path:
+
+- `turn_runtime` accepts `config.agent_spec_id` for `chat`
+- `ChatCapability` compiles runtime policy from the referenced Agent Spec pack
+- focused tests show a deterministic behavior difference in the unified Tutor turn path
+
+Coverage is still partial:
+
+- `deep_question` compiles assessment policy, but turn-level proof for `agent_spec_id` is not established
+- `deep_solve` does not currently assemble runtime policy in its capability path
+- `deep_research` currently validates its own request config and does not participate in bounded runtime-policy proof
+- contest and architecture docs are calibrated to avoid overclaiming universal runtime binding
+
+## Scope
+
+### In Scope
+
+- add capability-level runtime binding support for selected shipped entry points beyond `chat`
+- preserve `agent_spec_id` as an allowed public config field for the covered capabilities
+- prove request-path wiring through `TurnRuntimeManager` for each covered capability
+- add or update bounded tests in:
+  - `tests/core/`
+  - `tests/api/test_unified_ws_turn_runtime.py`
+  - `tests/services/runtime_policy/` if helper/compiler behavior changes
+- add bounded docs proof and PR note describing exactly which capabilities are covered
+
+### Out of Scope
+
+- redesigning teacher-facing dashboard or `/agents` UX
+- changing student-model or evidence semantics unless required for runtime binding tests
+- universal binding claims across every plugin, router, or future capability
+- spec version pinning, trace slicing, or teacher-facing trust surfaces from later tasks (`F114+`)
+
+## Capability Coverage Decision
+
+### Recommended Coverage Set
+
+Cover these capabilities in `F113`:
+
+- `chat`
+- `deep_question`
+- `deep_solve`
+
+Do not expand `F113` to `deep_research` unless implementation shows it can consume teacher runtime policy without broadening semantics or requiring extra product decisions.
+
+### Why This Set
+
+- `chat` is the already-proved baseline and must remain green
+- `deep_question` already assembles assessment policy, so this task can close the missing turn-path proof
+- `deep_solve` is a shipped capability with a clear tutor-adjacent execution path and is the next strongest target for bounded binding
+- `deep_research` is higher-risk because its pipeline is more autonomous and less obviously governed by the current teacher policy slices
+
+## Design
+
+### 1. Runtime Binding Contract
+
+For each covered capability, the public request contract must accept `agent_spec_id` without relying on runtime-only bypasses.
+
+Expected contract behavior:
+
+- `chat` keeps `agent_spec_id`
+- `deep_question` gains or preserves `agent_spec_id`
+- `deep_solve` gains `agent_spec_id`
+- capability config validation must still reject unrelated unknown fields
+
+This keeps the binding path explicit and inspectable instead of hidden in ad hoc metadata mutation.
+
+### 2. Turn Runtime Propagation
+
+`TurnRuntimeManager.start_turn()` already validates capability config and passes the validated config into `UnifiedContext.config_overrides`.
+
+`F113` should preserve that shape and prove it for each covered capability:
+
+- incoming websocket turn payload contains `config.agent_spec_id`
+- capability-specific validator accepts it
+- `turn_runtime` passes it into `UnifiedContext.config_overrides`
+- orchestrator and capability execution can resolve runtime policy from that config
+
+No new side channel should be introduced if `config_overrides` already provides a sufficient contract.
+
+### 3. Capability Policy Assembly
+
+Covered capabilities should assemble teacher runtime policy in a capability-appropriate way:
+
+- `chat` continues using `format_chat_system_context`
+- `deep_question` continues using `format_assessment_context`
+- `deep_solve` should assemble runtime policy before solver execution and inject a bounded policy context into the solving pipeline
+
+For `deep_solve`, the policy effect should be minimal and explicit:
+
+- compile runtime policy with `ensure_runtime_policy(context, "deep_solve")`
+- inject a formatted policy block into the solver's conversation/runtime context without changing unrelated solver architecture
+- emit a progress/debug event similar to other covered capabilities so tests can inspect the compiled policy path
+
+The task does not need a new deep-solve-specific formatter unless the existing assessment/chat formatter is clearly wrong. Prefer the smallest formatter addition that matches current slices and use case.
+
+### 4. Bounded Claim Surface
+
+After `F113`, the repo may claim:
+
+- bounded runtime-binding coverage exists for the unified `chat`, `deep_question`, and `deep_solve` turn paths
+
+The repo must not claim:
+
+- every capability, plugin, or entry point is runtime-bound
+- teacher policy influences all research or visualization flows
+
+Docs must remain precise enough that a reviewer can map each claim to tests.

--- a/tests/api/test_unified_ws_turn_runtime.py
+++ b/tests/api/test_unified_ws_turn_runtime.py
@@ -57,7 +57,10 @@ async def test_turn_runtime_replays_events_and_materializes_messages(
             )
             yield StreamEvent(type=StreamEventType.DONE, source="chat")
 
-    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.llm.config.get_llm_config",
+        lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
     monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
     monkeypatch.setattr("deeptutor.runtime.orchestrator.ChatOrchestrator", FakeOrchestrator)
     monkeypatch.setattr(
@@ -138,7 +141,10 @@ async def test_turn_runtime_passes_deep_question_subject_config(
             )
             yield StreamEvent(type=StreamEventType.DONE, source="deep_question")
 
-    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.llm.config.get_llm_config",
+        lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
     monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
     monkeypatch.setattr("deeptutor.runtime.orchestrator.ChatOrchestrator", FakeOrchestrator)
     monkeypatch.setattr(
@@ -220,7 +226,10 @@ async def test_turn_runtime_bootstraps_question_followup_context_once(
             )
             yield StreamEvent(type=StreamEventType.DONE, source="chat")
 
-    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.llm.config.get_llm_config",
+        lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
     monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
     monkeypatch.setattr("deeptutor.runtime.orchestrator.ChatOrchestrator", FakeOrchestrator)
     monkeypatch.setattr(
@@ -335,7 +344,10 @@ async def test_turn_runtime_persists_deep_research_session_preference(
             )
             yield StreamEvent(type=StreamEventType.DONE, source="deep_research")
 
-    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.llm.config.get_llm_config",
+        lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
     monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
     monkeypatch.setattr("deeptutor.runtime.orchestrator.ChatOrchestrator", FakeOrchestrator)
     monkeypatch.setattr(
@@ -417,7 +429,10 @@ async def test_turn_runtime_injects_memory_and_refreshes_after_completion(
         refresh_calls.append(kwargs)
         return None
 
-    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.llm.config.get_llm_config",
+        lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
     monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
     monkeypatch.setattr("deeptutor.runtime.orchestrator.ChatOrchestrator", FakeOrchestrator)
     monkeypatch.setattr(
@@ -514,7 +529,10 @@ async def test_turn_runtime_passes_agent_spec_id_for_live_chat_policy_binding(
                 stage="responding",
             )
 
-    monkeypatch.setattr("deeptutor.services.llm.config.get_llm_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        "deeptutor.services.llm.config.get_llm_config",
+        lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
     monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
     monkeypatch.setattr(
         "deeptutor.services.memory.get_memory_service",
@@ -546,4 +564,181 @@ async def test_turn_runtime_passes_agent_spec_id_for_live_chat_policy_binding(
     assert captured["config_overrides"]["agent_spec_id"] == "strict-fractions"
     assert "Teacher Spec Reference:\nstrict-fractions" in str(captured["memory_context"])
     assert "Require justification before correction." in str(captured["memory_context"])
+    assert events[-1]["metadata"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_turn_runtime_passes_agent_spec_id_for_deep_question_policy_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    runtime = TurnRuntimeManager(store)
+    captured: dict[str, object] = {}
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="strict-fractions",
+        display_name="Strict Fractions",
+        structured={
+            "identity": {"agent_name": "Strict Fractions"},
+            "assessment": {"question_quality_bar": "Require justification prompts."},
+            "rules": {"guardrails": "Do not reveal final answers in stems."},
+        },
+    )
+
+    class FakeContextBuilder:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def build(self, **_kwargs):
+            return SimpleNamespace(
+                conversation_history=[],
+                conversation_summary="",
+                context_text="",
+                token_count=0,
+                budget=0,
+            )
+
+    class FakeCoordinator:
+        def __init__(self, **_kwargs) -> None:
+            self._callback = None
+
+        def set_ws_callback(self, callback) -> None:
+            self._callback = callback
+
+        async def generate_from_topic(self, **kwargs):
+            captured["preference"] = kwargs["preference"]
+            if self._callback is not None:
+                await self._callback({"type": "idea_round", "message": "ideas"})
+            return {"results": []}
+
+    import sys
+    import types
+
+    llm_module = types.ModuleType("deeptutor.services.llm.config")
+    llm_module.get_llm_config = lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1")
+    monkeypatch.setitem(sys.modules, "deeptutor.services.llm.config", llm_module)
+    monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
+    monkeypatch.setattr(
+        "deeptutor.services.memory.get_memory_service",
+        lambda: SimpleNamespace(build_memory_context=lambda: "", refresh_from_turn=_noop_refresh),
+    )
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    module = types.ModuleType("deeptutor.agents.question.coordinator")
+    module.AgentCoordinator = FakeCoordinator
+    monkeypatch.setitem(sys.modules, "deeptutor.agents.question.coordinator", module)
+
+    _session, turn = await runtime.start_turn(
+        {
+            "type": "start_turn",
+            "content": "make a quiz",
+            "session_id": None,
+            "capability": "deep_question",
+            "tools": ["rag"],
+            "knowledge_bases": ["math-pack"],
+            "attachments": [],
+            "language": "en",
+            "config": {
+                "mode": "custom",
+                "topic": "compare fractions",
+                "agent_spec_id": "strict-fractions",
+            },
+        }
+    )
+
+    events = []
+    async for event in runtime.subscribe_turn(turn["id"], after_seq=0):
+        events.append(event)
+
+    assert "Teacher Assessment Runtime Policy:" in str(captured["preference"])
+    assert "Strict Fractions" in str(captured["preference"])
+    assert events[-1]["metadata"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_turn_runtime_passes_agent_spec_id_for_deep_solve_policy_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    runtime = TurnRuntimeManager(store)
+    captured: dict[str, object] = {}
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="strict-fractions",
+        display_name="Strict Fractions",
+        structured={
+            "identity": {"agent_name": "Strict Fractions"},
+            "soul": {"teaching_philosophy": "Require justification before correction."},
+            "rules": {"guardrails": "Do not give final answers immediately."},
+        },
+    )
+
+    class FakeContextBuilder:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def build(self, **_kwargs):
+            return SimpleNamespace(
+                conversation_history=[],
+                conversation_summary="",
+                context_text="",
+                token_count=0,
+                budget=0,
+            )
+
+    class FakeSolver:
+        def __init__(self, **_kwargs) -> None:
+            self.logger = SimpleNamespace(
+                logger=SimpleNamespace(addHandler=lambda *_: None, removeHandler=lambda *_: None)
+            )
+
+        async def ainit(self) -> None:
+            return None
+
+        async def solve(self, **kwargs):
+            captured["conversation_context"] = kwargs["conversation_context"]
+            return {"final_answer": "Start by naming the denominator you want to build."}
+
+    import sys
+    import types
+
+    llm_module = types.ModuleType("deeptutor.services.llm.config")
+    llm_module.get_llm_config = lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1")
+    monkeypatch.setitem(sys.modules, "deeptutor.services.llm.config", llm_module)
+    monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
+    monkeypatch.setattr(
+        "deeptutor.services.memory.get_memory_service",
+        lambda: SimpleNamespace(build_memory_context=lambda: "", refresh_from_turn=_noop_refresh),
+    )
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    module = types.ModuleType("deeptutor.agents.solve.main_solver")
+    module.MainSolver = FakeSolver
+    monkeypatch.setitem(sys.modules, "deeptutor.agents.solve.main_solver", module)
+
+    _session, turn = await runtime.start_turn(
+        {
+            "type": "start_turn",
+            "content": "Can you solve 5/6 - 1/2 for me?",
+            "session_id": None,
+            "capability": "deep_solve",
+            "tools": ["rag"],
+            "knowledge_bases": ["math-pack"],
+            "attachments": [],
+            "language": "en",
+            "config": {
+                "detailed_answer": False,
+                "agent_spec_id": "strict-fractions",
+            },
+        }
+    )
+
+    events = []
+    async for event in runtime.subscribe_turn(turn["id"], after_seq=0):
+        events.append(event)
+
+    assert "Teacher Runtime Policy:" in str(captured["conversation_context"])
+    assert "Require justification before correction." in str(captured["conversation_context"])
     assert events[-1]["metadata"]["status"] == "completed"

--- a/tests/core/test_capabilities_runtime.py
+++ b/tests/core/test_capabilities_runtime.py
@@ -14,6 +14,7 @@ from deeptutor.capabilities.chat import ChatCapability
 from deeptutor.capabilities.deep_question import DeepQuestionCapability
 from deeptutor.capabilities.deep_research import DeepResearchCapability
 from deeptutor.capabilities.deep_solve import DeepSolveCapability
+from deeptutor.capabilities.request_contracts import validate_capability_config
 from deeptutor.core.context import Attachment, UnifiedContext
 from deeptutor.core.stream import StreamEvent, StreamEventType
 from deeptutor.core.stream_bus import StreamBus
@@ -101,40 +102,44 @@ def test_turn_runtime_skips_tutoring_observations_for_non_chat_capability() -> N
     assert rows == []
 
 
-def test_turn_runtime_builds_tutoring_observations_for_chat_capability() -> None:
-    rows = _build_tutoring_observations(
-        capability="chat",
-        session_id="session-1",
-        student_id="student-1",
-        user_message="I still get this wrong",
-        assistant_message="Hint: convert to a common denominator first.",
-        followup_question_context={
-            "question_id": "q_9",
-            "question": "Compute 5/6 - 1/2",
-            "is_correct": False,
+def test_validate_deep_question_request_config_accepts_agent_spec_id() -> None:
+    config = validate_capability_config(
+        "deep_question",
+        {
+            "mode": "custom",
+            "topic": "fractions",
+            "agent_spec_id": "strict-fractions",
         },
-        assistant_events=[{"timestamp": 1.0}, {"timestamp": 14.0}],
     )
 
-    assert len(rows) == 1
-    assert rows[0]["source"] == "tutoring"
-    assert rows[0]["student_id"] == "student-1"
-    assert rows[0]["question_id"] == "q_9"
-    assert rows[0]["is_correct"] is False
+    assert config["agent_spec_id"] == "strict-fractions"
+    assert config["topic"] == "fractions"
 
 
-def test_turn_runtime_skips_tutoring_observations_for_non_chat_capability() -> None:
-    rows = _build_tutoring_observations(
-        capability="deep_question",
-        session_id="session-2",
-        student_id="student-2",
-        user_message="generate quiz",
-        assistant_message="created",
-        followup_question_context=None,
-        assistant_events=[{"timestamp": 2.0}, {"timestamp": 4.0}],
+def test_validate_deep_solve_request_config_accepts_agent_spec_id() -> None:
+    config = validate_capability_config(
+        "deep_solve",
+        {
+            "detailed_answer": False,
+            "agent_spec_id": "strict-fractions",
+        },
     )
 
-    assert rows == []
+    assert config == {
+        "detailed_answer": False,
+        "agent_spec_id": "strict-fractions",
+    }
+
+
+def test_validate_deep_solve_request_config_rejects_unknown_fields() -> None:
+    with pytest.raises(ValueError, match="Invalid deep solve config"):
+        validate_capability_config(
+            "deep_solve",
+            {
+                "agent_spec_id": "strict-fractions",
+                "unexpected_flag": True,
+            },
+        )
 
 
 @pytest.mark.asyncio
@@ -506,6 +511,67 @@ async def test_deep_solve_capability_bridges_observation_and_retrieve_events(
 
 
 @pytest.mark.asyncio
+async def test_deep_solve_capability_resolves_runtime_policy_from_agent_spec_pack(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    captured: dict[str, Any] = {}
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="strict-fractions",
+        display_name="Strict Fractions",
+        structured={
+            "identity": {"agent_name": "Strict Fractions"},
+            "soul": {"teaching_philosophy": "Require justification before correction."},
+            "rules": {"guardrails": "Do not give final answers immediately."},
+            "workflow": {"step_sequence": "Ask for plan, then hint."},
+        },
+    )
+
+    class FakeMainSolver:
+        def __init__(self, **_kwargs: Any) -> None:
+            self.logger = SimpleNamespace(
+                logger=SimpleNamespace(addHandler=lambda *_: None, removeHandler=lambda *_: None)
+            )
+
+        async def ainit(self) -> None:
+            return None
+
+        async def solve(self, **kwargs: Any) -> dict[str, Any]:
+            captured["conversation_context"] = kwargs["conversation_context"]
+            return {
+                "final_answer": "Try finding a common denominator first.",
+                "output_dir": "/tmp/solve",
+                "metadata": {"steps": 1},
+            }
+
+    _install_module(monkeypatch, "deeptutor.agents.solve.main_solver", MainSolver=FakeMainSolver)
+    _install_module(
+        monkeypatch,
+        "deeptutor.services.llm.config",
+        get_llm_config=lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    context = UnifiedContext(
+        user_message="solve 5/6 - 1/2",
+        enabled_tools=["rag"],
+        knowledge_bases=["fractions"],
+        language="en",
+        config_overrides={"agent_spec_id": "strict-fractions"},
+    )
+    events = await _collect_events(lambda bus: DeepSolveCapability().run(context, bus))
+
+    assert any(
+        event.type == StreamEventType.PROGRESS
+        and event.content == "Runtime policy slices assembled."
+        for event in events
+    )
+    assert "Teacher Runtime Policy:" in captured["conversation_context"]
+    assert "Require justification before correction." in captured["conversation_context"]
+
+
+@pytest.mark.asyncio
 async def test_deep_question_capability_uses_user_message_as_topic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -567,6 +633,59 @@ async def test_deep_question_capability_uses_user_message_as_topic(
     assert any(event.type == StreamEventType.PROGRESS and event.stage == "ideation" for event in events)
     result_event = next(event for event in events if event.type == StreamEventType.RESULT)
     assert "Question 1" in result_event.metadata["response"]
+
+
+@pytest.mark.asyncio
+async def test_deep_question_capability_resolves_runtime_policy_from_agent_spec_pack(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    captured: dict[str, Any] = {}
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="strict-fractions",
+        display_name="Strict Fractions",
+        structured={
+            "identity": {"agent_name": "Strict Fractions"},
+            "assessment": {"question_quality_bar": "Require justification prompts."},
+            "rules": {"guardrails": "Do not reveal final answers in stems."},
+        },
+    )
+
+    class FakeCoordinator:
+        def __init__(self, **_kwargs: Any) -> None:
+            self._callback = None
+
+        def set_ws_callback(self, callback) -> None:
+            self._callback = callback
+
+        async def generate_from_topic(self, **kwargs: Any) -> dict[str, Any]:
+            captured["preference"] = kwargs["preference"]
+            if self._callback is not None:
+                await self._callback({"type": "idea_round", "message": "ideas"})
+            return {"results": []}
+
+    _install_module(
+        monkeypatch,
+        "deeptutor.agents.question.coordinator",
+        AgentCoordinator=FakeCoordinator,
+    )
+    _install_module(
+        monkeypatch,
+        "deeptutor.services.llm.config",
+        get_llm_config=lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    context = UnifiedContext(
+        user_message="compare fractions",
+        config_overrides={"mode": "custom", "agent_spec_id": "strict-fractions"},
+        language="en",
+    )
+    await _collect_events(lambda bus: DeepQuestionCapability().run(context, bus))
+
+    assert "Teacher Assessment Runtime Policy:" in captured["preference"]
+    assert "Strict Fractions" in captured["preference"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- widen runtime capability request contracts so `deep_question` and `deep_solve` explicitly accept `agent_spec_id`
- add bounded runtime-policy assembly for `deep_solve` and unified-turn proofs for `chat`, `deep_question`, and `deep_solve`
- update the AI-first runtime docs, PR note, system map, and bounded contest claim wording to match the verified coverage

## Testing
- `pytest tests/core/test_capabilities_runtime.py tests/api/test_unified_ws_turn_runtime.py tests/services/runtime_policy/test_compiler.py -q`
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `git diff --check`

## Architecture
- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`: yes
- PR note: `docs/superpowers/pr-notes/2026-04-26-f113-capability-wide-runtime-binding-coverage.md`
