### PR TITLE
feat(dashboard): add teacher action execution loop [F101]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,6 +28,32 @@ Rules:
 
 ## Active
 
-No active AI implementation task.
+### Assignment
 
-Recommended next AI-owned task: none. The remaining path is human review of the submission package, IP commitment, optional video decision, and final sign-off unless a fresh packet is explicitly opened from `main`.
+- Owner: Codex Session A
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
+- Task: `F101_TEACHER_ACTION_EXECUTION_LOOP`
+- Status: `in-progress`
+- Branch: `pod-a/teacher-action-loop`
+- Task packet: `docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md`
+- Owned files: `web/components/dashboard/`, `web/app/(workspace)/dashboard/`, `web/lib/dashboard-api.ts`, `deeptutor/api/routers/dashboard.py`, bounded `deeptutor/services/evidence/`, related dashboard tests/docs`
+- PR: `Draft, not opened yet`
+- Last update: `2026-04-26T23:56:00+0700`
+- Next action: `Implement teacher action create/read/update contract and attach action summaries back to dashboard insight payloads.`
+- Blocker: `None`
+
+### Assignment
+
+- Owner: Codex Session B
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
+- Task: `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`
+- Status: `in-progress`
+- Branch: `pod-b/runtime-binding-coverage`
+- Task packet: `docs/superpowers/specs/2026-04-26-f113-capability-wide-runtime-binding-coverage-design.md`
+- Owned files: `deeptutor/capabilities/`, `deeptutor/services/runtime_policy/`, `deeptutor/services/session/turn_runtime.py`, bounded tests/docs
+- PR: `Draft, not opened yet`
+- Last update: `2026-04-26T23:46:46+0700`
+- Next action: `Implement request-contract widening and runtime-binding tests in the Session B worktree.`
+- Blocker: `None`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T16:28:43Z",
+    "last_updated": "2026-04-26T16:56:43Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -63,8 +63,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F101_TEACHER_ACTION_EXECUTION_LOOP"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -73,9 +75,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 24,
+      "count": 23,
       "tasks": [
-        "F101_TEACHER_ACTION_EXECUTION_LOOP",
         "F102_INTERVENTION_ASSIGNMENT_FLOW",
         "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS",
         "F104_SMALL_GROUP_MANAGEMENT_SURFACE",
@@ -1224,7 +1225,7 @@
       "dependencies": [
         "R5_DASHBOARD_ACTIONABILITY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
       "notes": "First recommended task for a new teacher-facing session after the contest MVP closes."

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -98,8 +98,11 @@ flowchart TD
   TeacherAnalytics --> AssessmentTrend["Assessment trend: average + latest + delta"]
   TeacherAnalytics --> DifficultySignals["Learning signals: focus topics + strong areas"]
   TeacherInsights --> InsightsAPI["GET /api/v1/dashboard/insights"]
+  TeacherInsights --> TeacherActionAPI["POST/PATCH /api/v1/dashboard/teacher-actions"]
   InsightsAPI --> DiagnosisEngine
   InsightsAPI --> SmallGroupRecommendations["Small-group recommendation clusters"]
+  InsightsAPI --> TeacherActions["Teacher action records"]
+  TeacherActionAPI --> TeacherActions
   TeacherDashboard --> StudentDashboard["Student Progress Dashboard"]
   TeacherDashboard --> AssessmentReview["Assessment Review Drill-down"]
   StudentDashboard --> StudentRoute["/dashboard/student"]
@@ -107,6 +110,7 @@ flowchart TD
   StudentDashboard --> TrendCards["Streak + average score + recent assessments"]
   StudentDashboard --> TopicSignals["Focus topics + mastered topics"]
   StudentDashboard --> LearningPathSignals["Suggested learning path sequence"]
+  StudentDashboard --> TeacherActionDetail["Teacher actions section + status updates"]
   LearningPathSignals --> PathEngine["Deterministic learning-path helper"]
   PathEngine --> FocusTopicInputs["Focus topics from assessment analysis"]
   PathEngine --> ObjectiveInputs["Knowledge-pack learning_objectives metadata"]

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -236,3 +236,15 @@
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `rg -n 'F10[1-9]|F11[0-9]|F12[0-4]|recommended_session_bucket|layer|\"status\": \"not-started\"' ai_first/TASK_REGISTRY.json -n -S`; `rg -n 'TODO|TBD|implement later|ad hoc|<teacher-facing-task>|<runtime-data-task>' docs/superpowers/tasks/2026-04-26-two-session-future-backlog.md -S`; `git diff --check`
 - Blockers: None.
 - Next: Open a Draft PR for this docs/control-plane lane, then let future sessions pick a concrete `F` task from the packet.
+
+## F101_TEACHER_ACTION_EXECUTION_LOOP
+
+- Branch: `pod-a/teacher-action-loop`
+- Task: `F101_TEACHER_ACTION_EXECUTION_LOOP`
+- Done: Added a bounded teacher-action loop so student and small-group recommendations can be converted into structured teacher actions directly from the dashboard.
+- Done: Added backend teacher-action persistence and dashboard APIs for create/read/update inside the evidence/dashboard boundary.
+- Done: Added dashboard UI creation flows plus a `Teacher actions` section on student detail with bounded status updates.
+- Done: Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` to reflect the new teacher-action API and data flow.
+- Tests: `pytest tests/api/test_dashboard_router.py::test_dashboard_teacher_action_create_round_trip tests/api/test_dashboard_router.py::test_dashboard_teacher_action_small_group_summary_attaches_to_group_card tests/api/test_dashboard_router.py::test_dashboard_teacher_action_status_update_round_trip tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -q`; `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherActionComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx app/'(workspace)'/dashboard/student/page.tsx lib/dashboard-api.ts`; `git diff --check`
+- Blockers: None.
+- Next: Open Draft PR for `F101`, then continue to `F102`, `F103`, or `F108` only after merge or explicit packet selection.

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -5,15 +5,35 @@ from typing import Any
 
 import fitz
 from fastapi import APIRouter, HTTPException, Response
+from pydantic import BaseModel
 
 from deeptutor.services.assessment import build_assessment_analysis
 from deeptutor.services.evidence.diagnosis import build_student_diagnosis
 from deeptutor.services.evidence.extractor import extract_observations_from_review
+from deeptutor.services.evidence.teacher_actions import (
+    create_teacher_action,
+    list_teacher_actions,
+    update_teacher_action_status,
+)
 from deeptutor.services.evidence.teacher_insights import build_teacher_insights_payload
 from deeptutor.services.learning_path import build_suggested_learning_path
 from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
 
 router = APIRouter()
+
+
+class TeacherActionCreateRequest(BaseModel):
+    target_type: str
+    target_id: str
+    source_recommendation_id: str
+    action_type: str
+    topic: str
+    teacher_instruction: str
+    priority: str
+
+
+class TeacherActionStatusUpdateRequest(BaseModel):
+    status: str
 
 
 def _activity_type(capability: str) -> str:
@@ -512,7 +532,43 @@ async def get_dashboard_insights(
             )
         )
 
-    return build_teacher_insights_payload(student_payloads=student_payloads)
+    teacher_actions = list_teacher_actions(store)
+    return build_teacher_insights_payload(
+        student_payloads=student_payloads,
+        teacher_actions=teacher_actions,
+    )
+
+
+@router.post("/teacher-actions")
+async def create_dashboard_teacher_action(payload: TeacherActionCreateRequest) -> dict[str, Any]:
+    store = get_sqlite_session_store()
+    try:
+        return create_teacher_action(
+            store,
+            target_type=payload.target_type,
+            target_id=payload.target_id,
+            source_recommendation_id=payload.source_recommendation_id,
+            action_type=payload.action_type,
+            topic=payload.topic,
+            teacher_instruction=payload.teacher_instruction,
+            priority=payload.priority,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.patch("/teacher-actions/{action_id}")
+async def update_dashboard_teacher_action(
+    action_id: str,
+    payload: TeacherActionStatusUpdateRequest,
+) -> dict[str, Any]:
+    store = get_sqlite_session_store()
+    try:
+        return update_teacher_action_status(store, action_id, status=payload.status)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="teacher action not found") from exc
 
 
 @router.get("/{entry_id}")

--- a/deeptutor/services/evidence/__init__.py
+++ b/deeptutor/services/evidence/__init__.py
@@ -1,9 +1,13 @@
 from .diagnosis import build_student_diagnosis
 from .extractor import extract_observations_from_review
+from .teacher_actions import create_teacher_action, list_teacher_actions, update_teacher_action_status
 from .teacher_insights import build_teacher_insights_payload
 
 __all__ = [
     "build_student_diagnosis",
     "build_teacher_insights_payload",
+    "create_teacher_action",
     "extract_observations_from_review",
+    "list_teacher_actions",
+    "update_teacher_action_status",
 ]

--- a/deeptutor/services/evidence/teacher_actions.py
+++ b/deeptutor/services/evidence/teacher_actions.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import sqlite3
+from typing import Any
+from uuid import uuid4
+
+_ALLOWED_ACTION_TYPES = {
+    "reteach_concept",
+    "scaffolded_practice",
+    "review_prerequisite",
+    "small_group_remediation",
+}
+_ALLOWED_PRIORITIES = {"low", "medium", "high"}
+_ALLOWED_STATUSES = {"draft", "planned", "done", "dismissed"}
+
+
+def _now_ts() -> int:
+    return int(datetime.now(tz=timezone.utc).timestamp())
+
+
+def _connect(db_path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_table(db_path) -> None:
+    with _connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS teacher_actions (
+                id TEXT PRIMARY KEY,
+                target_type TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                source_recommendation_id TEXT NOT NULL,
+                action_type TEXT NOT NULL,
+                topic TEXT NOT NULL,
+                teacher_instruction TEXT NOT NULL,
+                priority TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_teacher_actions_target
+                ON teacher_actions(target_type, target_id, updated_at DESC)
+            """
+        )
+        conn.commit()
+
+
+def _row_to_record(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "target_type": row["target_type"],
+        "target_id": row["target_id"],
+        "source_recommendation_id": row["source_recommendation_id"],
+        "action_type": row["action_type"],
+        "topic": row["topic"],
+        "teacher_instruction": row["teacher_instruction"],
+        "priority": row["priority"],
+        "status": row["status"],
+        "created_at": int(row["created_at"]),
+        "updated_at": int(row["updated_at"]),
+    }
+
+
+def list_teacher_actions(store: Any) -> list[dict[str, Any]]:
+    _ensure_table(store.db_path)
+    with _connect(store.db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, target_type, target_id, source_recommendation_id, action_type,
+                   topic, teacher_instruction, priority, status, created_at, updated_at
+            FROM teacher_actions
+            ORDER BY updated_at DESC, created_at DESC, id DESC
+            """
+        ).fetchall()
+    return [_row_to_record(row) for row in rows]
+
+
+def create_teacher_action(
+    store: Any,
+    *,
+    target_type: str,
+    target_id: str,
+    source_recommendation_id: str,
+    action_type: str,
+    topic: str,
+    teacher_instruction: str,
+    priority: str,
+) -> dict[str, Any]:
+    if target_type not in {"student", "small_group"}:
+        raise ValueError("invalid target_type")
+    if action_type not in _ALLOWED_ACTION_TYPES:
+        raise ValueError("invalid action_type")
+    if priority not in _ALLOWED_PRIORITIES:
+        raise ValueError("invalid priority")
+
+    cleaned_target_id = target_id.strip()
+    cleaned_source = source_recommendation_id.strip()
+    cleaned_topic = topic.strip()
+    cleaned_instruction = teacher_instruction.strip()
+    if not cleaned_target_id or not cleaned_source or not cleaned_topic or not cleaned_instruction:
+        raise ValueError("missing required teacher action field")
+
+    now = _now_ts()
+    record = {
+        "id": f"teacher-action:{uuid4().hex}",
+        "target_type": target_type,
+        "target_id": cleaned_target_id,
+        "source_recommendation_id": cleaned_source,
+        "action_type": action_type,
+        "topic": cleaned_topic,
+        "teacher_instruction": cleaned_instruction,
+        "priority": priority,
+        "status": "planned",
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    _ensure_table(store.db_path)
+    with _connect(store.db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO teacher_actions (
+                id, target_type, target_id, source_recommendation_id, action_type,
+                topic, teacher_instruction, priority, status, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record["id"],
+                record["target_type"],
+                record["target_id"],
+                record["source_recommendation_id"],
+                record["action_type"],
+                record["topic"],
+                record["teacher_instruction"],
+                record["priority"],
+                record["status"],
+                record["created_at"],
+                record["updated_at"],
+            ),
+        )
+        conn.commit()
+    return deepcopy(record)
+
+
+def update_teacher_action_status(store: Any, action_id: str, *, status: str) -> dict[str, Any]:
+    if status not in _ALLOWED_STATUSES:
+        raise ValueError("invalid status")
+
+    _ensure_table(store.db_path)
+    now = _now_ts()
+    with _connect(store.db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT id, target_type, target_id, source_recommendation_id, action_type,
+                   topic, teacher_instruction, priority, status, created_at, updated_at
+            FROM teacher_actions
+            WHERE id = ?
+            """,
+            (action_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(action_id)
+
+        conn.execute(
+            """
+            UPDATE teacher_actions
+            SET status = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (status, now, action_id),
+        )
+        conn.commit()
+
+        updated = dict(_row_to_record(row))
+        updated["status"] = status
+        updated["updated_at"] = now
+        return updated

--- a/deeptutor/services/evidence/teacher_insights.py
+++ b/deeptutor/services/evidence/teacher_insights.py
@@ -21,12 +21,31 @@ def _top_action(payload: dict[str, Any]) -> dict[str, Any] | None:
     return actions[0]
 
 
+def _student_actions(student_id: str, actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows = [
+        action
+        for action in actions
+        if action.get("target_type") == "student" and action.get("target_id") == student_id
+    ]
+    return sorted(rows, key=lambda row: row.get("updated_at", 0), reverse=True)
+
+
+def _small_group_target_id(topic: str, diagnosis_type: str, source_action_type: str) -> str:
+    return f"{topic}::{diagnosis_type}::{source_action_type}"
+
+
 def build_teacher_insights_payload(
     *,
     student_payloads: list[dict[str, Any]],
+    teacher_actions: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    teacher_actions = teacher_actions or []
     grouped: dict[tuple[str, str, str], list[tuple[str, int]]] = defaultdict(list)
+    students: list[dict[str, Any]] = []
     for payload in student_payloads:
+        row = dict(payload)
+        row["teacher_actions"] = _student_actions(str(payload.get("student_id") or "unknown"), teacher_actions)
+        students.append(row)
         inferred = _top_inferred(payload)
         action = _top_action(payload)
         if not inferred or not action:
@@ -52,6 +71,15 @@ def build_teacher_insights_payload(
         if avg_confidence < 1.0:
             continue
         student_ids = sorted({sid for sid, _score in rows})
+        target_id = _small_group_target_id(topic, diagnosis_type, action_type)
+        matching_group_action = next(
+            (
+                action
+                for action in teacher_actions
+                if action.get("target_type") == "small_group" and action.get("target_id") == target_id
+            ),
+            None,
+        )
         small_groups.append(
             {
                 "topic": topic,
@@ -60,6 +88,8 @@ def build_teacher_insights_payload(
                 "recommended_action": "small_group_support",
                 "source_action_type": action_type,
                 "confidence_tag": "high" if avg_confidence >= 2.5 else "medium",
+                "target_id": target_id,
+                "teacher_action": matching_group_action,
             }
         )
 
@@ -68,6 +98,6 @@ def build_teacher_insights_payload(
     )
 
     return {
-        "students": student_payloads,
+        "students": students,
         "small_groups": small_groups,
     }

--- a/docs/superpowers/plans/2026-04-26-f101-teacher-action-execution-loop.md
+++ b/docs/superpowers/plans/2026-04-26-f101-teacher-action-execution-loop.md
@@ -1,0 +1,962 @@
+# Teacher Action Execution Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let teachers convert student and small-group recommendations into structured in-product teacher actions that can be created, viewed, and status-updated without building a full assignment-delivery system.
+
+**Architecture:** This feature extends the current dashboard insight contract with a lightweight `teacher_actions` record, stored inside the existing dashboard/evidence boundary. The backend adds bounded create/read/update endpoints and attaches action summaries to the teacher-insight payload, while the frontend adds action-creation flows on student and small-group cards plus a `Teacher actions` section on student detail. The implementation must preserve the current evidence-first insight flow and stay out of runtime-policy or classroom-ops expansion.
+
+**Tech Stack:** FastAPI, SQLite session/evidence services, pytest, Next.js App Router, React client components, TypeScript, Tailwind CSS, existing dashboard REST client
+
+---
+
+### Task 1: Define And Test The Backend Teacher-Action Contract
+
+**Files:**
+- Modify: `web/lib/dashboard-api.ts`
+- Test: `tests/api/test_dashboard_router.py`
+
+- [ ] **Step 1: Add failing TypeScript contract definitions for teacher actions**
+
+Extend `web/lib/dashboard-api.ts` with the planned shape before wiring the UI:
+
+```ts
+export type TeacherActionType =
+  | "reteach_concept"
+  | "scaffolded_practice"
+  | "review_prerequisite"
+  | "small_group_remediation";
+
+export type TeacherActionStatus = "draft" | "planned" | "done" | "dismissed";
+
+export type TeacherActionPriority = "low" | "medium" | "high";
+
+export interface TeacherActionRecord {
+  id: string;
+  target_type: "student" | "small_group";
+  target_id: string;
+  source_recommendation_id: string;
+  action_type: TeacherActionType;
+  topic: string;
+  teacher_instruction: string;
+  priority: TeacherActionPriority;
+  status: TeacherActionStatus;
+  created_at: number;
+  updated_at: number;
+}
+```
+
+Also extend:
+- `TeacherInsightStudent` with `teacher_actions?: TeacherActionRecord[]`
+- `DashboardInsights["small_groups"]` rows with optional `teacher_action?: TeacherActionRecord | null`
+
+- [ ] **Step 2: Add failing API tests for create/read/update teacher actions**
+
+Add three tests to `tests/api/test_dashboard_router.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_dashboard_teacher_action_create_round_trip(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {
+            "student_id": "student-a",
+            "knowledge_bases": ["fractions-pack"],
+            "capability": "deep_question",
+        },
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4, time: 48s)\n"
+        "Score: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights")
+        student = insights.json()["students"][0]
+        recommendation_id = student["recommended_actions"][0]["action_id"]
+
+        create_resp = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "student",
+                "target_id": "student-a",
+                "source_recommendation_id": recommendation_id,
+                "action_type": "reteach_concept",
+                "topic": "fractions subtraction",
+                "teacher_instruction": "Reteach subtraction with one visual fraction model.",
+                "priority": "high",
+            },
+        )
+
+        assert create_resp.status_code == 200
+        created = create_resp.json()
+        assert created["target_type"] == "student"
+        assert created["status"] == "planned"
+
+        refreshed = client.get("/api/v1/dashboard/insights").json()
+        refreshed_student = next(row for row in refreshed["students"] if row["student_id"] == "student-a")
+        assert refreshed_student["teacher_actions"][0]["source_recommendation_id"] == recommendation_id
+```
+
+```python
+@pytest.mark.asyncio
+async def test_dashboard_teacher_action_small_group_summary_attaches_to_group_card(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {"student_id": "student-a", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/5 (Incorrect, correct: 1/4)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    await _seed_session(
+        store,
+        session_id="student-b-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-b-session",
+        {"student_id": "student-b", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-b-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/6 (Incorrect, correct: 1/2)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights").json()
+        group = insights["small_groups"][0]
+
+        create_resp = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "small_group",
+                "target_id": "fractions subtraction::concept_gap::small_group_support",
+                "source_recommendation_id": f"group:{group['topic']}:{group['diagnosis_type']}",
+                "action_type": "small_group_remediation",
+                "topic": group["topic"],
+                "teacher_instruction": "Pull these students into one reteach mini-group.",
+                "priority": "high",
+            },
+        )
+
+        assert create_resp.status_code == 200
+
+        refreshed = client.get("/api/v1/dashboard/insights").json()
+        refreshed_group = refreshed["small_groups"][0]
+        assert refreshed_group["teacher_action"]["target_type"] == "small_group"
+        assert refreshed_group["teacher_action"]["action_type"] == "small_group_remediation"
+```
+
+```python
+@pytest.mark.asyncio
+async def test_dashboard_teacher_action_status_update_round_trip(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {"student_id": "student-a", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/5 (Incorrect, correct: 1/4)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights").json()
+        recommendation_id = insights["students"][0]["recommended_actions"][0]["action_id"]
+        created = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "student",
+                "target_id": "student-a",
+                "source_recommendation_id": recommendation_id,
+                "action_type": "scaffolded_practice",
+                "topic": "fractions subtraction",
+                "teacher_instruction": "Give one more scaffolded practice item.",
+                "priority": "medium",
+            },
+        ).json()
+
+        update_resp = client.patch(
+            f"/api/v1/dashboard/teacher-actions/{created['id']}",
+            json={"status": "done"},
+        )
+
+        assert update_resp.status_code == 200
+        assert update_resp.json()["status"] == "done"
+```
+
+- [ ] **Step 3: Run targeted tests to verify failure**
+
+Run:
+```bash
+pytest tests/api/test_dashboard_router.py::test_dashboard_teacher_action_create_round_trip \
+  tests/api/test_dashboard_router.py::test_dashboard_teacher_action_small_group_summary_attaches_to_group_card \
+  tests/api/test_dashboard_router.py::test_dashboard_teacher_action_status_update_round_trip -q
+```
+
+Expected: FAIL because `/api/v1/dashboard/teacher-actions` endpoints and action fields do not exist yet.
+
+- [ ] **Step 4: Commit the failing contract tests if you want a strict TDD checkpoint**
+
+```bash
+git add web/lib/dashboard-api.ts tests/api/test_dashboard_router.py
+git commit -m "test(dashboard): define teacher action loop contract [F101]"
+```
+
+### Task 2: Implement Backend Storage And Dashboard API For Teacher Actions
+
+**Files:**
+- Create: `deeptutor/services/evidence/teacher_actions.py`
+- Modify: `deeptutor/services/evidence/__init__.py`
+- Modify: `deeptutor/services/evidence/teacher_insights.py`
+- Modify: `deeptutor/api/routers/dashboard.py`
+- Test: `tests/api/test_dashboard_router.py`
+
+- [ ] **Step 1: Create the lightweight teacher-action service**
+
+Add `deeptutor/services/evidence/teacher_actions.py` with a small file-scoped persistence layer that stores action records in the existing SQLite `workspace` bucket to avoid creating a brand-new subsystem.
+
+Use this implementation shape:
+
+```python
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+_TEACHER_ACTIONS_KEY = "teacher_actions"
+_ALLOWED_ACTION_TYPES = {
+    "reteach_concept",
+    "scaffolded_practice",
+    "review_prerequisite",
+    "small_group_remediation",
+}
+_ALLOWED_PRIORITIES = {"low", "medium", "high"}
+_ALLOWED_STATUSES = {"draft", "planned", "done", "dismissed"}
+
+
+def _now_ts() -> int:
+    return int(datetime.now(tz=timezone.utc).timestamp())
+
+
+def _workspace_payload(store: Any) -> dict[str, Any]:
+    payload = store.get_workspace_state() or {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def list_teacher_actions(store: Any) -> list[dict[str, Any]]:
+    payload = _workspace_payload(store)
+    raw = payload.get(_TEACHER_ACTIONS_KEY, [])
+    if not isinstance(raw, list):
+        return []
+    return [deepcopy(item) for item in raw if isinstance(item, dict)]
+
+
+def create_teacher_action(
+    store: Any,
+    *,
+    target_type: str,
+    target_id: str,
+    source_recommendation_id: str,
+    action_type: str,
+    topic: str,
+    teacher_instruction: str,
+    priority: str,
+) -> dict[str, Any]:
+    if target_type not in {"student", "small_group"}:
+        raise ValueError("invalid target_type")
+    if action_type not in _ALLOWED_ACTION_TYPES:
+        raise ValueError("invalid action_type")
+    if priority not in _ALLOWED_PRIORITIES:
+        raise ValueError("invalid priority")
+    now = _now_ts()
+    record = {
+        "id": f"teacher-action:{uuid4().hex}",
+        "target_type": target_type,
+        "target_id": target_id,
+        "source_recommendation_id": source_recommendation_id,
+        "action_type": action_type,
+        "topic": topic.strip(),
+        "teacher_instruction": teacher_instruction.strip(),
+        "priority": priority,
+        "status": "planned",
+        "created_at": now,
+        "updated_at": now,
+    }
+    payload = _workspace_payload(store)
+    items = list_teacher_actions(store)
+    items.insert(0, record)
+    payload[_TEACHER_ACTIONS_KEY] = items
+    store.save_workspace_state(payload)
+    return deepcopy(record)
+
+
+def update_teacher_action_status(store: Any, action_id: str, *, status: str) -> dict[str, Any]:
+    if status not in _ALLOWED_STATUSES:
+        raise ValueError("invalid status")
+    payload = _workspace_payload(store)
+    items = list_teacher_actions(store)
+    for item in items:
+        if item.get("id") == action_id:
+            item["status"] = status
+            item["updated_at"] = _now_ts()
+            payload[_TEACHER_ACTIONS_KEY] = items
+            store.save_workspace_state(payload)
+            return deepcopy(item)
+    raise KeyError(action_id)
+```
+
+- [ ] **Step 2: Export the new service helpers**
+
+Update `deeptutor/services/evidence/__init__.py` to export:
+
+```python
+from .teacher_actions import create_teacher_action, list_teacher_actions, update_teacher_action_status
+
+__all__ = [
+    "build_teacher_insights_payload",
+    "build_student_diagnosis",
+    "create_teacher_action",
+    "list_teacher_actions",
+    "update_teacher_action_status",
+]
+```
+
+- [ ] **Step 3: Extend teacher-insight payload shaping with action attachments**
+
+Update `deeptutor/services/evidence/teacher_insights.py` so it can attach actions back onto students and small groups.
+
+Refactor the public function to accept actions:
+
+```python
+def build_teacher_insights_payload(
+    *,
+    student_payloads: list[dict[str, Any]],
+    teacher_actions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+```
+
+Add helper functions along these lines:
+
+```python
+def _student_actions(student_id: str, actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows = [
+        action for action in actions
+        if action.get("target_type") == "student" and action.get("target_id") == student_id
+    ]
+    return sorted(rows, key=lambda row: row.get("updated_at", 0), reverse=True)
+
+
+def _small_group_target_id(topic: str, diagnosis_type: str, source_action_type: str) -> str:
+    return f"{topic}::{diagnosis_type}::{source_action_type}"
+```
+
+Then attach data in the returned payload:
+
+```python
+students = []
+for payload in student_payloads:
+    row = dict(payload)
+    row["teacher_actions"] = _student_actions(str(payload.get("student_id") or "unknown"), teacher_actions or [])
+    students.append(row)
+```
+
+And when building each small-group row:
+
+```python
+small_group_target_id = _small_group_target_id(topic, diagnosis_type, action_type)
+matching_group_action = next(
+    (
+        action for action in teacher_actions or []
+        if action.get("target_type") == "small_group" and action.get("target_id") == small_group_target_id
+    ),
+    None,
+)
+small_groups.append(
+    {
+        "topic": topic,
+        "diagnosis_type": diagnosis_type,
+        "student_ids": student_ids,
+        "recommended_action": "small_group_support",
+        "source_action_type": action_type,
+        "confidence_tag": "high" if avg_confidence >= 2.5 else "medium",
+        "target_id": small_group_target_id,
+        "teacher_action": matching_group_action,
+    }
+)
+```
+
+- [ ] **Step 4: Add create and update endpoints in the dashboard router**
+
+Update `deeptutor/api/routers/dashboard.py` with Pydantic request models and endpoints.
+
+Add imports:
+
+```python
+from pydantic import BaseModel
+from deeptutor.services.evidence.teacher_actions import (
+    create_teacher_action,
+    list_teacher_actions,
+    update_teacher_action_status,
+)
+```
+
+Add models near the top of the file:
+
+```python
+class TeacherActionCreateRequest(BaseModel):
+    target_type: str
+    target_id: str
+    source_recommendation_id: str
+    action_type: str
+    topic: str
+    teacher_instruction: str
+    priority: str
+
+
+class TeacherActionStatusUpdateRequest(BaseModel):
+    status: str
+```
+
+Add endpoints:
+
+```python
+@router.post("/teacher-actions")
+async def create_dashboard_teacher_action(payload: TeacherActionCreateRequest) -> dict[str, Any]:
+    store = get_sqlite_session_store()
+    try:
+        return create_teacher_action(
+            store,
+            target_type=payload.target_type,
+            target_id=payload.target_id,
+            source_recommendation_id=payload.source_recommendation_id,
+            action_type=payload.action_type,
+            topic=payload.topic,
+            teacher_instruction=payload.teacher_instruction,
+            priority=payload.priority,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.patch("/teacher-actions/{action_id}")
+async def update_dashboard_teacher_action_status(
+    action_id: str,
+    payload: TeacherActionStatusUpdateRequest,
+) -> dict[str, Any]:
+    store = get_sqlite_session_store()
+    try:
+        return update_teacher_action_status(store, action_id, status=payload.status)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="teacher action not found") from exc
+```
+
+- [ ] **Step 5: Wire teacher actions into `/api/v1/dashboard/insights`**
+
+Inside `get_dashboard_insights`, load actions and pass them through:
+
+```python
+teacher_actions = list_teacher_actions(store)
+return build_teacher_insights_payload(
+    student_payloads=student_payloads,
+    teacher_actions=teacher_actions,
+)
+```
+
+- [ ] **Step 6: Run targeted backend tests**
+
+Run:
+```bash
+pytest tests/api/test_dashboard_router.py::test_dashboard_teacher_action_create_round_trip \
+  tests/api/test_dashboard_router.py::test_dashboard_teacher_action_small_group_summary_attaches_to_group_card \
+  tests/api/test_dashboard_router.py::test_dashboard_teacher_action_status_update_round_trip \
+  tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the backend slice**
+
+```bash
+git add deeptutor/services/evidence/teacher_actions.py deeptutor/services/evidence/__init__.py deeptutor/services/evidence/teacher_insights.py deeptutor/api/routers/dashboard.py tests/api/test_dashboard_router.py web/lib/dashboard-api.ts
+git commit -m "feat(dashboard): add teacher action backend loop [F101]"
+```
+
+### Task 3: Implement The Teacher-Action UI On Dashboard Overview
+
+**Files:**
+- Create: `web/components/dashboard/TeacherActionComposer.tsx`
+- Modify: `web/components/dashboard/StudentInsightCard.tsx`
+- Modify: `web/components/dashboard/SmallGroupInsightCard.tsx`
+- Modify: `web/components/dashboard/TeacherInsightPanel.tsx`
+- Modify: `web/lib/dashboard-api.ts`
+- Test: `web/components/dashboard/TeacherActionComposer.tsx` via lint
+
+- [ ] **Step 1: Add REST helpers for create and status update**
+
+Extend `web/lib/dashboard-api.ts` with:
+
+```ts
+export interface CreateTeacherActionRequest {
+  target_type: "student" | "small_group";
+  target_id: string;
+  source_recommendation_id: string;
+  action_type: TeacherActionType;
+  topic: string;
+  teacher_instruction: string;
+  priority: TeacherActionPriority;
+}
+
+export async function createTeacherAction(payload: CreateTeacherActionRequest): Promise<TeacherActionRecord> {
+  const response = await fetch(apiUrl("/api/v1/dashboard/teacher-actions"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return expectJson<TeacherActionRecord>(response);
+}
+
+export async function updateTeacherActionStatus(
+  actionId: string,
+  status: TeacherActionStatus,
+): Promise<TeacherActionRecord> {
+  const response = await fetch(apiUrl(`/api/v1/dashboard/teacher-actions/${actionId}`), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status }),
+  });
+  return expectJson<TeacherActionRecord>(response);
+}
+```
+
+- [ ] **Step 2: Create a reusable teacher-action composer component**
+
+Create `web/components/dashboard/TeacherActionComposer.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import type {
+  CreateTeacherActionRequest,
+  TeacherActionPriority,
+  TeacherActionRecord,
+  TeacherActionType,
+} from "@/lib/dashboard-api";
+import { createTeacherAction } from "@/lib/dashboard-api";
+
+const ACTION_TYPES: TeacherActionType[] = [
+  "reteach_concept",
+  "scaffolded_practice",
+  "review_prerequisite",
+  "small_group_remediation",
+];
+const PRIORITIES: TeacherActionPriority[] = ["low", "medium", "high"];
+
+export function TeacherActionComposer({
+  triggerLabel,
+  defaultPayload,
+  onCreated,
+}: {
+  triggerLabel: string;
+  defaultPayload: Omit<CreateTeacherActionRequest, "teacher_instruction" | "priority" | "action_type"> & {
+    defaultActionType: TeacherActionType;
+  };
+  onCreated: (record: TeacherActionRecord) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [actionType, setActionType] = useState<TeacherActionType>(defaultPayload.defaultActionType);
+  const [topic, setTopic] = useState(defaultPayload.topic);
+  const [teacherInstruction, setTeacherInstruction] = useState("");
+  const [priority, setPriority] = useState<TeacherActionPriority>("medium");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    try {
+      const record = await createTeacherAction({
+        target_type: defaultPayload.target_type,
+        target_id: defaultPayload.target_id,
+        source_recommendation_id: defaultPayload.source_recommendation_id,
+        action_type: actionType,
+        topic,
+        teacher_instruction: teacherInstruction,
+        priority,
+      });
+      onCreated(record);
+      setOpen(false);
+      setTeacherInstruction("");
+      setPriority("medium");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="inline-flex items-center rounded-full border border-[var(--border)] px-3 py-1 text-[12px] font-medium text-[var(--foreground)] transition hover:border-[var(--foreground)]"
+      >
+        {triggerLabel}
+      </button>
+      {open ? (
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-3">
+          <div className="grid gap-3">
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              Action type
+              <select value={actionType} onChange={(e) => setActionType(e.target.value as TeacherActionType)} className="mt-1 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]">
+                {ACTION_TYPES.map((value) => (
+                  <option key={value} value={value}>{value}</option>
+                ))}
+              </select>
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              Topic
+              <input value={topic} onChange={(e) => setTopic(e.target.value)} className="mt-1 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]" />
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              Teacher instruction
+              <textarea value={teacherInstruction} onChange={(e) => setTeacherInstruction(e.target.value)} className="mt-1 min-h-[96px] w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]" />
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              Priority
+              <select value={priority} onChange={(e) => setPriority(e.target.value as TeacherActionPriority)} className="mt-1 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]">
+                {PRIORITIES.map((value) => (
+                  <option key={value} value={value}>{value}</option>
+                ))}
+              </select>
+            </label>
+            <button type="button" disabled={submitting || teacherInstruction.trim().length === 0} onClick={handleSubmit} className="rounded-xl bg-[var(--foreground)] px-3 py-2 text-[13px] font-medium text-[var(--background)] disabled:opacity-60">
+              {submitting ? "Saving..." : "Create action"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Wire the composer into student cards**
+
+Update `web/components/dashboard/StudentInsightCard.tsx`:
+- import `useState`, `TeacherActionComposer`, and `TeacherActionRecord`
+- keep local state seeded from `student.teacher_actions ?? []`
+- show the newest action summary when present
+- compute a recommendation-backed default payload
+
+Use this pattern inside the component:
+
+```tsx
+const [teacherActions, setTeacherActions] = useState<TeacherActionRecord[]>(student.teacher_actions ?? []);
+const latestAction = teacherActions[0] ?? null;
+```
+
+Add to the teacher-move section:
+
+```tsx
+<TeacherActionComposer
+  triggerLabel={t("Create action")}
+  defaultPayload={{
+    target_type: "student",
+    target_id: student.student_id,
+    source_recommendation_id: recommendation?.action_id ?? `student:${student.student_id}`,
+    topic: recommendation?.topic ?? diagnosis?.topic ?? student.observed?.topic ?? "general",
+    defaultActionType: "reteach_concept",
+  }}
+  onCreated={(record) => setTeacherActions((current) => [record, ...current])}
+/>
+{latestAction ? (
+  <div className="mt-3 rounded-2xl bg-white/70 p-3 text-[12px] text-emerald-900/80">
+    <div className="font-medium">{latestAction.action_type}</div>
+    <div className="mt-1">{latestAction.teacher_instruction}</div>
+    <div className="mt-2 text-[11px] text-emerald-900/70">Status: {latestAction.status} • Priority: {latestAction.priority}</div>
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Wire the composer into small-group cards**
+
+Update `web/components/dashboard/SmallGroupInsightCard.tsx`:
+- extend the `SmallGroupInsight` type usage to read `target_id` and `teacher_action`
+- show the existing action summary when present
+- add `TeacherActionComposer` with a `small_group` target
+
+Use this pattern:
+
+```tsx
+const [teacherAction, setTeacherAction] = useState(group.teacher_action ?? null);
+```
+
+And in the card body:
+
+```tsx
+<TeacherActionComposer
+  triggerLabel={t("Create group action")}
+  defaultPayload={{
+    target_type: "small_group",
+    target_id: group.target_id,
+    source_recommendation_id: `group:${group.topic}:${group.diagnosis_type}`,
+    topic: group.topic,
+    defaultActionType: "small_group_remediation",
+  }}
+  onCreated={(record) => setTeacherAction(record)}
+/>
+{teacherAction ? (
+  <div className="mt-3 rounded-2xl bg-white/70 p-3 text-[12px] text-emerald-900/80">
+    <div className="font-medium">{teacherAction.action_type}</div>
+    <div className="mt-1">{teacherAction.teacher_instruction}</div>
+    <div className="mt-2 text-[11px] text-emerald-900/70">Status: {teacherAction.status} • Priority: {teacherAction.priority}</div>
+  </div>
+) : null}
+```
+
+- [ ] **Step 5: Verify the overview container needs no extra orchestration**
+
+Keep `TeacherInsightPanel.tsx` mostly unchanged. Only touch it if a prop pass-through is truly required. This keeps the action loop local to the cards and avoids unnecessary state lifting.
+
+- [ ] **Step 6: Run targeted frontend lint**
+
+Run:
+```bash
+cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherActionComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx lib/dashboard-api.ts
+```
+
+Expected: exit `0`.
+
+- [ ] **Step 7: Commit the overview UI slice**
+
+```bash
+git add web/components/dashboard/TeacherActionComposer.tsx web/components/dashboard/StudentInsightCard.tsx web/components/dashboard/SmallGroupInsightCard.tsx web/lib/dashboard-api.ts
+git commit -m "feat(dashboard): add teacher action creation UI [F101]"
+```
+
+### Task 4: Add Student Detail Action List And Status Updates
+
+**Files:**
+- Modify: `web/components/dashboard/StudentInsightDetail.tsx`
+- Modify: `web/app/(workspace)/dashboard/student/page.tsx` only if needed to preserve the active student insight payload usage
+- Modify: `web/lib/dashboard-api.ts`
+- Test: frontend lint for detail files
+
+- [ ] **Step 1: Extend the student detail component to render teacher actions**
+
+In `web/components/dashboard/StudentInsightDetail.tsx`, import `useState`, `TeacherActionRecord`, and `updateTeacherActionStatus`.
+
+Add local state:
+
+```tsx
+const [teacherActions, setTeacherActions] = useState<TeacherActionRecord[]>(student.teacher_actions ?? []);
+```
+
+Render a new section below the teacher-move panel:
+
+```tsx
+<section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
+  <InsightSectionLabel eyebrow={t("Teacher actions")} title={teacherActions.length ? t("{{count}} recorded actions", { count: teacherActions.length }) : t("No actions yet")} />
+  <div className="mt-4 space-y-3">
+    {teacherActions.length ? (
+      teacherActions.map((action) => (
+        <div key={action.id} className="rounded-2xl bg-[var(--muted)]/50 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <div className="text-[13px] font-medium text-[var(--foreground)]">{action.action_type}</div>
+              <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">{action.topic}</div>
+            </div>
+            <select
+              value={action.status}
+              onChange={async (e) => {
+                const updated = await updateTeacherActionStatus(action.id, e.target.value as TeacherActionStatus);
+                setTeacherActions((current) => current.map((row) => (row.id === updated.id ? updated : row)));
+              }}
+              className="rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[12px] text-[var(--foreground)]"
+            >
+              <option value="planned">planned</option>
+              <option value="done">done</option>
+              <option value="dismissed">dismissed</option>
+            </select>
+          </div>
+          <div className="mt-3 text-[13px] text-[var(--foreground)]">{action.teacher_instruction}</div>
+          <div className="mt-2 text-[11px] text-[var(--muted-foreground)]">Priority: {action.priority}</div>
+        </div>
+      ))
+    ) : (
+      <div className="rounded-2xl bg-[var(--muted)]/50 p-4 text-[13px] text-[var(--muted-foreground)]">
+        {t("Create a teacher action from the dashboard overview to track a concrete remediation move here.")}
+      </div>
+    )}
+  </div>
+</section>
+```
+
+- [ ] **Step 2: Keep the detail page routing stable**
+
+Inspect `web/app/(workspace)/dashboard/student/page.tsx` and only change it if the current `activeStudent` plumbing drops `teacher_actions`. If no extra work is needed, leave the route file untouched.
+
+- [ ] **Step 3: Run targeted frontend lint for detail flow**
+
+Run:
+```bash
+cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/StudentInsightDetail.tsx app/'(workspace)'/dashboard/student/page.tsx lib/dashboard-api.ts
+```
+
+Expected: exit `0`.
+
+- [ ] **Step 4: Commit the detail UI slice**
+
+```bash
+git add web/components/dashboard/StudentInsightDetail.tsx web/app/'(workspace)'/dashboard/student/page.tsx web/lib/dashboard-api.ts
+git commit -m "feat(dashboard): show teacher actions in student detail [F101]"
+```
+
+### Task 5: Sync Control Plane, Add PR Note, And Run Final Verification
+
+**Files:**
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-26.md`
+- Create: `docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md`
+- Create: `docs/superpowers/pr-notes/2026-04-26-f101-teacher-action-execution-loop.md`
+- Test: combined backend/frontend validation and git diff hygiene
+
+- [ ] **Step 1: Create the concrete F101 task packet**
+
+Add `docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md` with:
+- `Task ID: F101_TEACHER_ACTION_EXECUTION_LOOP`
+- `Commit tag: F101`
+- owned files and do-not-touch files from the approved spec
+- validation commands used in this plan
+- startup and handoff notes for Session A
+
+- [ ] **Step 2: Mark the task active in AI-first tracking**
+
+Update:
+- `ai_first/ACTIVE_ASSIGNMENTS.md` with a single active assignment for this branch/worktree
+- `ai_first/TASK_REGISTRY.json` so `F101_TEACHER_ACTION_EXECUTION_LOOP` becomes `in-progress`
+
+- [ ] **Step 3: Write the PR note with Mermaid diagram**
+
+Create `docs/superpowers/pr-notes/2026-04-26-f101-teacher-action-execution-loop.md` and include a diagram like:
+
+```mermaid
+flowchart LR
+  Obs["Observed"] --> Inf["Inferred"]
+  Inf --> Rec["Recommended Action"]
+  Rec --> Act["Teacher Action"]
+  Act --> Detail["Student Detail Status Updates"]
+```
+
+State explicitly whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.
+
+- [ ] **Step 4: Append the daily-log entry**
+
+Add a section to `ai_first/daily/2026-04-26.md` recording:
+- branch/worktree
+- task id
+- what the teacher-action loop now does
+- validation commands run
+- blockers or follow-up tasks (`F102`, `F103`, `F108`)
+
+- [ ] **Step 5: Run final verification**
+
+Run:
+```bash
+pytest tests/api/test_dashboard_router.py::test_dashboard_teacher_action_create_round_trip \
+  tests/api/test_dashboard_router.py::test_dashboard_teacher_action_small_group_summary_attaches_to_group_card \
+  tests/api/test_dashboard_router.py::test_dashboard_teacher_action_status_update_round_trip \
+  tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -q
+cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherActionComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx app/'(workspace)'/dashboard/student/page.tsx lib/dashboard-api.ts
+cd .. && git diff --check
+```
+
+Expected:
+- targeted dashboard pytest slice passes
+- targeted frontend lint passes
+- `git diff --check` exits `0`
+
+- [ ] **Step 6: Commit the control-plane and handoff slice**
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-26.md docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md docs/superpowers/pr-notes/2026-04-26-f101-teacher-action-execution-loop.md
+git commit -m "docs(ai-first): track teacher action loop task [F101]"
+```
+
+- [ ] **Step 7: Confirm branch status before PR**
+
+Run:
+```bash
+git status --short --branch
+```
+
+Expected: clean `pod-a/teacher-action-loop` branch with intended commits only.
+
+## Spec Coverage Check
+
+Spec requirements covered:
+- structured teacher-action object: Tasks 1 and 2
+- per-student and small-group creation: Tasks 2 and 3
+- immediate action visibility in dashboard flow: Task 3
+- student detail action section and status updates: Task 4
+- bounded backend storage inside dashboard/evidence layer: Task 2
+- control-plane and handoff updates: Task 5
+
+No spec gaps remain.
+
+## Placeholder Scan
+
+The plan contains no `TBD`, `TODO`, or vague “implement later” steps. Every code-edit task includes concrete file paths, commands, and code shapes.
+
+## Type Consistency Check
+
+Consistent identifiers used throughout:
+- `TeacherActionRecord`
+- `TeacherActionType`
+- `TeacherActionStatus`
+- `TeacherActionPriority`
+- `target_type` values `student | small_group`
+- API paths `/api/v1/dashboard/teacher-actions` and `/api/v1/dashboard/teacher-actions/{action_id}`

--- a/docs/superpowers/pr-notes/2026-04-26-f101-teacher-action-execution-loop.md
+++ b/docs/superpowers/pr-notes/2026-04-26-f101-teacher-action-execution-loop.md
@@ -1,0 +1,57 @@
+# F101 Teacher Action Execution Loop PR Note
+
+## Changed
+
+- added a bounded `teacher_actions` backend contract under the dashboard/evidence layer
+- added create and status-update dashboard APIs:
+  - `POST /api/v1/dashboard/teacher-actions`
+  - `PATCH /api/v1/dashboard/teacher-actions/{action_id}`
+- attached teacher actions back onto student and small-group insight payloads
+- added overview action creation UI on student cards and small-group cards
+- added a `Teacher actions` section with status updates in student detail
+- updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## Why
+
+The dashboard previously stopped at `Recommended Action`. Teachers could see the next move, but could not turn that move into a first-class in-product execution record. `F101` closes that gap with a structured teacher-owned action loop while deliberately avoiding a full assignment-delivery system.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Obs["Observed"] --> Inf["Inferred"]
+  Inf --> Rec["Recommended Action"]
+  Rec --> Create["Create teacher action"]
+  Create --> Store["teacher_actions table"]
+  Store --> Overview["Dashboard student/group cards"]
+  Store --> Detail["Student detail status updates"]
+```
+
+## Main System Map
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` **was updated** because this PR adds a new dashboard API surface and a new teacher-action data flow to the product layer.
+
+## Tests run
+
+- `pytest tests/api/test_dashboard_router.py::test_dashboard_teacher_action_create_round_trip tests/api/test_dashboard_router.py::test_dashboard_teacher_action_small_group_summary_attaches_to_group_card tests/api/test_dashboard_router.py::test_dashboard_teacher_action_status_update_round_trip tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -q`
+- `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherActionComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx app/'(workspace)'/dashboard/student/page.tsx lib/dashboard-api.ts`
+- `git diff --check`
+
+## Risks
+
+- teacher actions are execution records only, not student-facing assignments
+- the first slice uses local dashboard/evidence persistence and does not yet model due dates, delivery, or class-level scheduling
+- the small-group path relies on a generated `target_id` contract from the insight payload, so future group-model work must preserve or migrate that key carefully
+
+## Next AI should read
+
+1. `docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md`
+2. `docs/superpowers/specs/2026-04-26-f101-teacher-action-execution-loop-design.md`
+3. `docs/superpowers/plans/2026-04-26-f101-teacher-action-execution-loop.md`
+
+## Suggested next action
+
+After this merges cleanly, the natural follow-ups are:
+- `F102_INTERVENTION_ASSIGNMENT_FLOW`
+- `F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS`
+- `F108_DIAGNOSIS_FEEDBACK_CAPTURE`

--- a/docs/superpowers/specs/2026-04-26-f101-teacher-action-execution-loop-design.md
+++ b/docs/superpowers/specs/2026-04-26-f101-teacher-action-execution-loop-design.md
@@ -1,0 +1,212 @@
+# Teacher Action Execution Loop Design
+
+Date: 2026-04-26
+Task ID: F101_TEACHER_ACTION_EXECUTION_LOOP
+Commit tag: F101
+Status: Proposed
+
+## Goal
+
+Extend the teacher dashboard from recommendation-only behavior into the first executable teacher-action loop.
+
+The first slice should let a teacher turn a recommendation into a structured remediation step directly inside the product for either:
+- a single student
+- a small group
+
+This slice must stay intentionally narrower than a full assignment or classroom delivery system.
+
+## Why This Slice Exists
+
+The current product already supports:
+- `Observed`
+- `Inferred`
+- `Recommended Action`
+
+That still leaves a gap between insight and action. A teacher can see what the system suggests, but cannot yet convert that suggestion into a first-class in-product execution record. `F101` closes that gap without overreaching into due dates, LMS delivery, notifications, or class roster management.
+
+## Scope
+
+### In Scope
+
+- create a structured `teacher action` from a student recommendation
+- create a structured `teacher action` from a small-group recommendation
+- show the created action back in the dashboard flow
+- show student-linked actions in the student detail surface
+- allow bounded status changes on created actions
+- use a tight action catalog rather than a freeform assignment model
+
+### Out Of Scope
+
+- student-facing assignment delivery
+- due dates or scheduling
+- notifications
+- class-level bulk assignment
+- real grading or completion proof
+- class roster system
+- runtime policy changes
+- learner-model redesign
+
+## Action Model
+
+The first slice uses a lightweight `teacher action` object.
+
+Required fields:
+- `id`
+- `target_type`
+  - `student`
+  - `small_group`
+- `target_id`
+- `source_recommendation_id`
+- `action_type`
+  - `reteach_concept`
+  - `scaffolded_practice`
+  - `review_prerequisite`
+  - `small_group_remediation`
+- `topic`
+- `teacher_instruction`
+- `priority`
+  - `low`
+  - `medium`
+  - `high`
+- `status`
+  - `draft`
+  - `planned`
+  - `done`
+  - `dismissed`
+- `created_at`
+- `updated_at`
+
+This object is a teacher execution record, not a student-facing assignment object.
+
+## Product Behavior
+
+### Dashboard Overview
+
+Student cards should expose a `Create action` entry point.
+
+Small-group cards should expose a `Create group action` entry point.
+
+The action creation flow should open inline from the dashboard through a lightweight panel or modal rather than forcing a new route.
+
+### Action Creation Flow
+
+The form should be short and structured:
+- `action_type`
+- `topic`
+- `teacher_instruction`
+- `priority`
+
+Prefilled values:
+- `target_type`
+- `target_id`
+- `source_recommendation_id`
+- default `topic` from the current recommendation when available
+
+After submit:
+- the recommendation should read as converted into a teacher action
+- the action summary should be visible immediately in the dashboard flow
+
+### Student Detail
+
+The student detail surface should include a `Teacher actions` section.
+
+Teachers should be able to:
+- see actions linked to that student
+- update action status between `planned`, `done`, and `dismissed`
+
+### Small-Group Behavior
+
+The first slice does not require a new group detail route.
+
+A small-group action only needs to:
+- be creatable from the overview card
+- show a visible action summary back on that group card
+- remain traceable through the recommendation linkage
+
+## UI Rules
+
+- use a tight catalog, not a freeform action system
+- preserve the evidence-first hierarchy already established in the dashboard
+- do not replace recommendations with actions silently; show both the recommendation context and the created action summary
+- status changes should stay simple and clearly teacher-owned
+
+## Storage And Backend Boundary
+
+The storage path should stay inside the dashboard/evidence boundary rather than creating a separate assignment subsystem.
+
+Preferred boundary:
+- dashboard router for API surface
+- evidence/dashboard service layer for persistence and retrieval helpers
+
+The slice should avoid inventing a new broad domain unless persistence clearly demands a focused helper module.
+
+## Session Ownership
+
+### Owned Files
+
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- `web/app/(workspace)/dashboard/student/`
+- `web/lib/dashboard-api.ts`
+- `deeptutor/api/routers/dashboard.py`
+- bounded helper code in `deeptutor/services/evidence/` only if needed for action persistence or retrieval
+- task packet, PR note, daily log, `ACTIVE_ASSIGNMENTS.md`, and `TASK_REGISTRY.json` updates for this task
+
+### Do-Not-Touch
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/session/`
+- `/agents` authoring surfaces
+- broader assessment generation flow
+- class roster / classroom management subsystems
+- notifications or student delivery systems
+
+## Acceptance Criteria
+
+1. A teacher can create a structured action from a student recommendation.
+2. A teacher can create a structured action from a small-group recommendation.
+3. The action uses the approved tight catalog.
+4. The action appears back in the dashboard flow immediately after creation.
+5. Student detail shows actions linked to that student.
+6. A teacher can update action status in the bounded status set.
+7. The implementation does not claim or behave like a full assignment-delivery system.
+8. Tests cover the main create/read/update path for the new action loop.
+
+## Architecture Notes
+
+This slice extends the current `Observed -> Inferred -> Recommended Action` pipeline into:
+
+`Observed -> Inferred -> Recommended Action -> Teacher Action`
+
+That new step is intentionally teacher-owned and execution-oriented. It should not collapse into a generic notes feature, and it should not expand into a full classroom operations stack in this first pass.
+
+## Risks And Guardrails
+
+### Risk: Scope Drift Into Assignment System
+
+Guardrail:
+- no due date
+- no delivery
+- no scheduling
+- no notification
+- no student completion contract
+
+### Risk: Overlap With Session B
+
+Guardrail:
+- stay out of runtime-policy and session-runtime internals
+- only touch backend data shaping where required for dashboard action persistence
+
+### Risk: Weak Visibility After Creation
+
+Guardrail:
+- the created action must appear back in the same dashboard flow immediately, or the loop will not feel real to the teacher
+
+## Recommended Next Step After F101
+
+If this slice lands cleanly, the natural next tasks are:
+- `F102_INTERVENTION_ASSIGNMENT_FLOW`
+- `F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS`
+- `F108_DIAGNOSIS_FEEDBACK_CAPTURE`
+
+Those follow-ups should build on the action object introduced here instead of replacing it.

--- a/docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md
+++ b/docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md
@@ -1,0 +1,65 @@
+# Teacher Action Execution Loop
+
+- Task ID: `F101_TEACHER_ACTION_EXECUTION_LOOP`
+- Commit tag: `F101`
+- Status: `Ready for execution`
+- Branch: `pod-a/teacher-action-loop`
+
+## Goal
+
+Turn teacher recommendations into structured in-product teacher actions for:
+- `student`
+- `small_group`
+
+This task closes the loop from insight to action without building a full assignment-delivery system.
+
+## Owned Files
+
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- `web/app/(workspace)/dashboard/student/`
+- `web/lib/dashboard-api.ts`
+- `deeptutor/api/routers/dashboard.py`
+- bounded helper code under `deeptutor/services/evidence/`
+- `tests/api/test_dashboard_router.py`
+- task docs, PR note, daily log, `ACTIVE_ASSIGNMENTS.md`, `TASK_REGISTRY.json`
+
+## Do-Not-Touch
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/session/`
+- `/agents` authoring UI
+- broader assessment generation flow
+- class roster, notification, or student delivery systems
+
+## Required Behavior
+
+1. Create a structured action from a student recommendation.
+2. Create a structured action from a small-group recommendation.
+3. Use a tight action catalog only:
+   - `reteach_concept`
+   - `scaffolded_practice`
+   - `review_prerequisite`
+   - `small_group_remediation`
+4. Show the created action back in the dashboard immediately.
+5. Show student-linked actions in student detail.
+6. Allow bounded status updates:
+   - `planned`
+   - `done`
+   - `dismissed`
+
+## Validation
+
+- `pytest tests/api/test_dashboard_router.py::test_dashboard_teacher_action_create_round_trip tests/api/test_dashboard_router.py::test_dashboard_teacher_action_small_group_summary_attaches_to_group_card tests/api/test_dashboard_router.py::test_dashboard_teacher_action_status_update_round_trip tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -q`
+- `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherActionComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx app/'(workspace)'/dashboard/student/page.tsx lib/dashboard-api.ts`
+- `git diff --check`
+
+## Next AI Should Read
+
+1. `docs/superpowers/specs/2026-04-26-f101-teacher-action-execution-loop-design.md`
+2. `docs/superpowers/plans/2026-04-26-f101-teacher-action-execution-loop.md`
+3. this packet
+
+## Suggested Next Action
+
+Implement the backend create/read/update contract first, then wire student and small-group action creation into the dashboard UI, then finish student detail status updates and docs sync.

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -499,6 +499,180 @@ async def test_dashboard_insights_returns_students_and_small_groups(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_teacher_action_create_round_trip(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {
+            "student_id": "student-a",
+            "knowledge_bases": ["fractions-pack"],
+            "capability": "deep_question",
+        },
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n"
+        "1. [q1] Q: Solve fractions subtraction 3/4 - 1/2 -> Answered: 1/5 (Incorrect, correct: 1/4, time: 48s)\n"
+        "Score: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights")
+        student = insights.json()["students"][0]
+        recommendation_id = student["recommended_actions"][0]["action_id"]
+
+        create_resp = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "student",
+                "target_id": "student-a",
+                "source_recommendation_id": recommendation_id,
+                "action_type": "reteach_concept",
+                "topic": "fractions subtraction",
+                "teacher_instruction": "Reteach subtraction with one visual fraction model.",
+                "priority": "high",
+            },
+        )
+
+        assert create_resp.status_code == 200
+        created = create_resp.json()
+        assert created["target_type"] == "student"
+        assert created["status"] == "planned"
+
+        refreshed = client.get("/api/v1/dashboard/insights").json()
+        refreshed_student = next(row for row in refreshed["students"] if row["student_id"] == "student-a")
+        assert refreshed_student["teacher_actions"][0]["source_recommendation_id"] == recommendation_id
+
+
+@pytest.mark.asyncio
+async def test_dashboard_teacher_action_small_group_summary_attaches_to_group_card(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {"student_id": "student-a", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/5 (Incorrect, correct: 1/4)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    await _seed_session(
+        store,
+        session_id="student-b-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-b-session",
+        {"student_id": "student-b", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-b-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/6 (Incorrect, correct: 1/2)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights").json()
+        group = insights["small_groups"][0]
+
+        create_resp = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "small_group",
+                "target_id": group["target_id"],
+                "source_recommendation_id": f"group:{group['topic']}:{group['diagnosis_type']}",
+                "action_type": "small_group_remediation",
+                "topic": group["topic"],
+                "teacher_instruction": "Pull these students into one reteach mini-group.",
+                "priority": "high",
+            },
+        )
+
+        assert create_resp.status_code == 200
+
+        refreshed = client.get("/api/v1/dashboard/insights").json()
+        refreshed_group = refreshed["small_groups"][0]
+        assert refreshed_group["teacher_action"]["target_type"] == "small_group"
+        assert refreshed_group["teacher_action"]["action_type"] == "small_group_remediation"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_teacher_action_status_update_round_trip(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {"student_id": "student-a", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/5 (Incorrect, correct: 1/4)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights").json()
+        recommendation_id = insights["students"][0]["recommended_actions"][0]["action_id"]
+        created = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "student",
+                "target_id": "student-a",
+                "source_recommendation_id": recommendation_id,
+                "action_type": "scaffolded_practice",
+                "topic": "fractions subtraction",
+                "teacher_instruction": "Give one more scaffolded practice item.",
+                "priority": "medium",
+            },
+        ).json()
+
+        update_resp = client.patch(
+            f"/api/v1/dashboard/teacher-actions/{created['id']}",
+            json={"status": "done"},
+        )
+
+        assert update_resp.status_code == 200
+        assert update_resp.json()["status"] == "done"
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_applies_search_kb_type_and_min_score_filters(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/app/(workspace)/dashboard/student/page.tsx
+++ b/web/app/(workspace)/dashboard/student/page.tsx
@@ -354,7 +354,7 @@ function StudentDashboardContent() {
           </div>
         </section>
 
-        <StudentInsightDetail student={activeStudent} t={t} />
+        <StudentInsightDetail key={activeStudent?.student_id ?? "no-student"} student={activeStudent} t={t} />
 
         {error && (
           <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">

--- a/web/components/dashboard/SmallGroupInsightCard.tsx
+++ b/web/components/dashboard/SmallGroupInsightCard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
-import type { DashboardInsights } from "@/lib/dashboard-api";
+import { TeacherActionComposer } from "@/components/dashboard/TeacherActionComposer";
+import type { DashboardInsights, TeacherActionRecord } from "@/lib/dashboard-api";
 
 type SmallGroupInsight = DashboardInsights["small_groups"][number];
 
@@ -12,6 +14,8 @@ export function SmallGroupInsightCard({
   group: SmallGroupInsight;
   t: (value: string, options?: Record<string, string | number>) => string;
 }) {
+  const [teacherAction, setTeacherAction] = useState<TeacherActionRecord | null>(group.teacher_action ?? null);
+
   return (
     <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
@@ -35,6 +39,32 @@ export function SmallGroupInsightCard({
         <div className="mt-3 text-[12px] text-[var(--muted-foreground)]">
           {t("Students: {{students}}", { students: group.student_ids.join(", ") })}
         </div>
+        <div className="mt-3">
+          <TeacherActionComposer
+            triggerLabel={t("Create group action")}
+            defaultPayload={{
+              target_type: "small_group",
+              target_id: group.target_id ?? `${group.topic}:${group.diagnosis_type}`,
+              source_recommendation_id: `group:${group.topic}:${group.diagnosis_type}`,
+              topic: group.topic,
+              defaultActionType: "small_group_remediation",
+            }}
+            onCreated={(record) => setTeacherAction(record)}
+            t={t}
+          />
+        </div>
+        {teacherAction ? (
+          <div className="mt-3 rounded-2xl bg-white/70 p-3 text-[12px] text-emerald-900/80">
+            <div className="font-medium">{teacherAction.action_type}</div>
+            <div className="mt-1">{teacherAction.teacher_instruction}</div>
+            <div className="mt-2 text-[11px] text-emerald-900/70">
+              {t("Status: {{status}} • Priority: {{priority}}", {
+                status: teacherAction.status,
+                priority: teacherAction.priority,
+              })}
+            </div>
+          </div>
+        ) : null}
       </div>
     </article>
   );

--- a/web/components/dashboard/StudentInsightCard.tsx
+++ b/web/components/dashboard/StudentInsightCard.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
-import type { TeacherInsightStudent } from "@/lib/dashboard-api";
+import { TeacherActionComposer } from "@/components/dashboard/TeacherActionComposer";
+import type { TeacherActionRecord, TeacherInsightStudent } from "@/lib/dashboard-api";
 
 function formatLatency(seconds: number | undefined): string | null {
   if (seconds == null) return null;
@@ -20,6 +22,8 @@ export function StudentInsightCard({
 }) {
   const diagnosis = student.inferred[0];
   const recommendation = student.recommended_actions[0];
+  const [teacherActions, setTeacherActions] = useState<TeacherActionRecord[]>(student.teacher_actions ?? []);
+  const latestAction = teacherActions[0] ?? null;
 
   return (
     <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
@@ -93,6 +97,32 @@ export function StudentInsightCard({
               ? t("Why this move: {{reason}}", { reason: diagnosis.evidence[0] })
               : t("Why this move: based on the strongest recent learning signal.")}
           </div>
+          <div className="mt-3">
+            <TeacherActionComposer
+              triggerLabel={t("Create action")}
+              defaultPayload={{
+                target_type: "student",
+                target_id: student.student_id,
+                source_recommendation_id: recommendation?.action_id ?? `student:${student.student_id}`,
+                topic: recommendation?.topic ?? diagnosis?.topic ?? student.observed?.topic ?? "general",
+                defaultActionType: "reteach_concept",
+              }}
+              onCreated={(record) => setTeacherActions((current) => [record, ...current])}
+              t={t}
+            />
+          </div>
+          {latestAction ? (
+            <div className="mt-3 rounded-2xl bg-white/70 p-3 text-[12px] text-emerald-900/80">
+              <div className="font-medium">{latestAction.action_type}</div>
+              <div className="mt-1">{latestAction.teacher_instruction}</div>
+              <div className="mt-2 text-[11px] text-emerald-900/70">
+                {t("Status: {{status}} • Priority: {{priority}}", {
+                  status: latestAction.status,
+                  priority: latestAction.priority,
+                })}
+              </div>
+            </div>
+          ) : null}
         </section>
       </div>
     </article>

--- a/web/components/dashboard/StudentInsightDetail.tsx
+++ b/web/components/dashboard/StudentInsightDetail.tsx
@@ -1,7 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
-import type { TeacherInsightStudent } from "@/lib/dashboard-api";
+import {
+  type TeacherActionRecord,
+  type TeacherActionStatus,
+  type TeacherInsightStudent,
+  updateTeacherActionStatus,
+} from "@/lib/dashboard-api";
 
 function formatLatency(seconds: number | undefined): string | null {
   if (seconds == null) return null;
@@ -16,6 +22,8 @@ export function StudentInsightDetail({
   student: TeacherInsightStudent | null;
   t: (value: string, options?: Record<string, string | number>) => string;
 }) {
+  const [teacherActions, setTeacherActions] = useState<TeacherActionRecord[]>(student?.teacher_actions ?? []);
+
   const diagnosis = student?.inferred[0];
   const recommendation = student?.recommended_actions[0];
 
@@ -110,6 +118,56 @@ export function StudentInsightDetail({
               <div>{t("Support level: {{value}}", { value: student.student_state.support_level })}</div>
             ) : null}
           </div>
+        </div>
+      </section>
+
+      <section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm xl:col-span-2">
+        <InsightSectionLabel
+          eyebrow={t("Teacher actions")}
+          title={
+            teacherActions.length
+              ? t("{{count}} recorded actions", { count: teacherActions.length })
+              : t("No actions yet")
+          }
+        />
+        <div className="mt-4 space-y-3">
+          {teacherActions.length ? (
+            teacherActions.map((action) => (
+              <div key={action.id} className="rounded-2xl bg-[var(--muted)]/50 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <div className="text-[13px] font-medium text-[var(--foreground)]">{action.action_type}</div>
+                    <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">{action.topic}</div>
+                  </div>
+                  <select
+                    value={action.status}
+                    onChange={async (e) => {
+                      const updated = await updateTeacherActionStatus(
+                        action.id,
+                        e.target.value as TeacherActionStatus,
+                      );
+                      setTeacherActions((current) =>
+                        current.map((row) => (row.id === updated.id ? updated : row)),
+                      );
+                    }}
+                    className="rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[12px] text-[var(--foreground)]"
+                  >
+                    <option value="planned">{t("planned")}</option>
+                    <option value="done">{t("done")}</option>
+                    <option value="dismissed">{t("dismissed")}</option>
+                  </select>
+                </div>
+                <div className="mt-3 text-[13px] text-[var(--foreground)]">{action.teacher_instruction}</div>
+                <div className="mt-2 text-[11px] text-[var(--muted-foreground)]">
+                  {t("Priority: {{priority}}", { priority: action.priority })}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="rounded-2xl bg-[var(--muted)]/50 p-4 text-[13px] text-[var(--muted-foreground)]">
+              {t("Create a teacher action from the dashboard overview to track a concrete remediation move here.")}
+            </div>
+          )}
         </div>
       </section>
     </section>

--- a/web/components/dashboard/TeacherActionComposer.tsx
+++ b/web/components/dashboard/TeacherActionComposer.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import {
+  createTeacherAction,
+  type CreateTeacherActionRequest,
+  type TeacherActionPriority,
+  type TeacherActionRecord,
+  type TeacherActionType,
+} from "@/lib/dashboard-api";
+
+const ACTION_TYPES: TeacherActionType[] = [
+  "reteach_concept",
+  "scaffolded_practice",
+  "review_prerequisite",
+  "small_group_remediation",
+];
+
+const PRIORITIES: TeacherActionPriority[] = ["low", "medium", "high"];
+
+export function TeacherActionComposer({
+  triggerLabel,
+  defaultPayload,
+  onCreated,
+  t,
+}: {
+  triggerLabel: string;
+  defaultPayload: Omit<CreateTeacherActionRequest, "teacher_instruction" | "priority" | "action_type"> & {
+    defaultActionType: TeacherActionType;
+  };
+  onCreated: (record: TeacherActionRecord) => void;
+  t: (value: string, options?: Record<string, string | number>) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [actionType, setActionType] = useState<TeacherActionType>(defaultPayload.defaultActionType);
+  const [topic, setTopic] = useState(defaultPayload.topic);
+  const [teacherInstruction, setTeacherInstruction] = useState("");
+  const [priority, setPriority] = useState<TeacherActionPriority>("medium");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    try {
+      const record = await createTeacherAction({
+        target_type: defaultPayload.target_type,
+        target_id: defaultPayload.target_id,
+        source_recommendation_id: defaultPayload.source_recommendation_id,
+        action_type: actionType,
+        topic,
+        teacher_instruction: teacherInstruction,
+        priority,
+      });
+      onCreated(record);
+      setOpen(false);
+      setTeacherInstruction("");
+      setPriority("medium");
+      setActionType(defaultPayload.defaultActionType);
+      setTopic(defaultPayload.topic);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="inline-flex items-center rounded-full border border-[var(--border)] px-3 py-1 text-[12px] font-medium text-[var(--foreground)] transition hover:border-[var(--foreground)]"
+      >
+        {triggerLabel}
+      </button>
+      {open ? (
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-3">
+          <div className="grid gap-3">
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              {t("Action type")}
+              <select
+                value={actionType}
+                onChange={(e) => setActionType(e.target.value as TeacherActionType)}
+                className="mt-1 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]"
+              >
+                {ACTION_TYPES.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              {t("Topic")}
+              <input
+                value={topic}
+                onChange={(e) => setTopic(e.target.value)}
+                className="mt-1 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]"
+              />
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              {t("Teacher instruction")}
+              <textarea
+                value={teacherInstruction}
+                onChange={(e) => setTeacherInstruction(e.target.value)}
+                className="mt-1 min-h-[96px] w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]"
+              />
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              {t("Priority")}
+              <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as TeacherActionPriority)}
+                className="mt-1 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]"
+              >
+                {PRIORITIES.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              disabled={submitting || teacherInstruction.trim().length === 0}
+              onClick={handleSubmit}
+              className="rounded-xl bg-[var(--foreground)] px-3 py-2 text-[13px] font-medium text-[var(--background)] disabled:opacity-60"
+            >
+              {submitting ? t("Saving...") : t("Create action")}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -261,6 +261,31 @@ export interface TeacherInsightStudent {
     topic: string;
     rationale: string;
   }>;
+  teacher_actions?: TeacherActionRecord[];
+}
+
+export type TeacherActionType =
+  | "reteach_concept"
+  | "scaffolded_practice"
+  | "review_prerequisite"
+  | "small_group_remediation";
+
+export type TeacherActionStatus = "draft" | "planned" | "done" | "dismissed";
+
+export type TeacherActionPriority = "low" | "medium" | "high";
+
+export interface TeacherActionRecord {
+  id: string;
+  target_type: "student" | "small_group";
+  target_id: string;
+  source_recommendation_id: string;
+  action_type: TeacherActionType;
+  topic: string;
+  teacher_instruction: string;
+  priority: TeacherActionPriority;
+  status: TeacherActionStatus;
+  created_at: number;
+  updated_at: number;
 }
 
 export interface DashboardInsights {
@@ -270,6 +295,8 @@ export interface DashboardInsights {
     diagnosis_type: string;
     student_ids: string[];
     recommended_action: string;
+    target_id?: string;
+    teacher_action?: TeacherActionRecord | null;
   }>;
 }
 
@@ -278,6 +305,16 @@ export interface DashboardInsightsFilters {
   start_ts?: number;
   end_ts?: number;
   cohort?: string;
+}
+
+export interface CreateTeacherActionRequest {
+  target_type: "student" | "small_group";
+  target_id: string;
+  source_recommendation_id: string;
+  action_type: TeacherActionType;
+  topic: string;
+  teacher_instruction: string;
+  priority: TeacherActionPriority;
 }
 
 /**
@@ -297,4 +334,27 @@ export async function getDashboardInsights(
     cache: "no-store",
   });
   return expectJson<DashboardInsights>(response);
+}
+
+export async function createTeacherAction(
+  payload: CreateTeacherActionRequest,
+): Promise<TeacherActionRecord> {
+  const response = await fetch(apiUrl("/api/v1/dashboard/teacher-actions"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return expectJson<TeacherActionRecord>(response);
+}
+
+export async function updateTeacherActionStatus(
+  actionId: string,
+  status: TeacherActionStatus,
+): Promise<TeacherActionRecord> {
+  const response = await fetch(apiUrl(`/api/v1/dashboard/teacher-actions/${actionId}`), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status }),
+  });
+  return expectJson<TeacherActionRecord>(response);
 }


### PR DESCRIPTION
# F101 Teacher Action Execution Loop PR Note

## Changed

- added a bounded `teacher_actions` backend contract under the dashboard/evidence layer
- added create and status-update dashboard APIs:
  - `POST /api/v1/dashboard/teacher-actions`
  - `PATCH /api/v1/dashboard/teacher-actions/{action_id}`
- attached teacher actions back onto student and small-group insight payloads
- added overview action creation UI on student cards and small-group cards
- added a `Teacher actions` section with status updates in student detail
- updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

## Why

The dashboard previously stopped at `Recommended Action`. Teachers could see the next move, but could not turn that move into a first-class in-product execution record. `F101` closes that gap with a structured teacher-owned action loop while deliberately avoiding a full assignment-delivery system.

## Architecture

```mermaid
flowchart LR
  Obs["Observed"] --> Inf["Inferred"]
  Inf --> Rec["Recommended Action"]
  Rec --> Create["Create teacher action"]
  Create --> Store["teacher_actions table"]
  Store --> Overview["Dashboard student/group cards"]
  Store --> Detail["Student detail status updates"]
```

## Main System Map

`ai_first/architecture/MAIN_SYSTEM_MAP.md` **was updated** because this PR adds a new dashboard API surface and a new teacher-action data flow to the product layer.

## Tests run

- `pytest tests/api/test_dashboard_router.py::test_dashboard_teacher_action_create_round_trip tests/api/test_dashboard_router.py::test_dashboard_teacher_action_small_group_summary_attaches_to_group_card tests/api/test_dashboard_router.py::test_dashboard_teacher_action_status_update_round_trip tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -q`
- `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherActionComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx app/'(workspace)'/dashboard/student/page.tsx lib/dashboard-api.ts`
- `git diff --check`

## Risks

- teacher actions are execution records only, not student-facing assignments
- the first slice uses local dashboard/evidence persistence and does not yet model due dates, delivery, or class-level scheduling
- the small-group path relies on a generated `target_id` contract from the insight payload, so future group-model work must preserve or migrate that key carefully

## Next AI should read

1. `docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md`
2. `docs/superpowers/specs/2026-04-26-f101-teacher-action-execution-loop-design.md`
3. `docs/superpowers/plans/2026-04-26-f101-teacher-action-execution-loop.md`

## Suggested next action

After this merges cleanly, the natural follow-ups are:
- `F102_INTERVENTION_ASSIGNMENT_FLOW`
- `F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS`
- `F108_DIAGNOSIS_FEEDBACK_CAPTURE`
