### PR TITLE
docs(ai-first): sync control plane after F101 merge [OPS-F101-SYNC]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,28 +30,13 @@ Rules:
 
 ### Assignment
 
-- Owner: Codex Session A
-- Machine: local
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: `F101_TEACHER_ACTION_EXECUTION_LOOP`
-- Status: `in-progress`
-- Branch: `pod-a/teacher-action-loop`
-- Task packet: `docs/superpowers/tasks/2026-04-26-f101-teacher-action-execution-loop.md`
-- Owned files: `web/components/dashboard/`, `web/app/(workspace)/dashboard/`, `web/lib/dashboard-api.ts`, `deeptutor/api/routers/dashboard.py`, bounded `deeptutor/services/evidence/`, related dashboard tests/docs`
-- PR: `Draft, not opened yet`
-- Last update: `2026-04-26T23:56:00+0700`
-- Next action: `Implement teacher action create/read/update contract and attach action summaries back to dashboard insight payloads.`
-- Blocker: `None`
-
-### Assignment
-
 - Owner: Codex Session B
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
 - Task: `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`
 - Status: `in-progress`
 - Branch: `pod-b/runtime-binding-coverage`
-- Task packet: `docs/superpowers/specs/2026-04-26-f113-capability-wide-runtime-binding-coverage-design.md`
+- Task packet: `docs/superpowers/tasks/2026-04-26-two-session-future-backlog.md` (`Session B`, task `F113`)
 - Owned files: `deeptutor/capabilities/`, `deeptutor/services/runtime_policy/`, `deeptutor/services/session/turn_runtime.py`, bounded tests/docs
 - PR: `Draft, not opened yet`
 - Last update: `2026-04-26T23:46:46+0700`

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest feature-risk merge: `#161 [R6] docs(contest): calibrate claims and pilot status`
+- Latest feature-risk merge: `#165 [F101] feat(dashboard): add teacher action execution loop`
 - Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
@@ -22,6 +22,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 - Risk Lane 4 teacher value proposition merged to `main` through PR `#157`.
 - Risk Lane 5 dashboard actionability merged to `main` through PR `#159`.
 - Risk Lane 6 claim calibration and pilot status merged to `main` through PR `#161`.
+- Future backlog Session A task `F101_TEACHER_ACTION_EXECUTION_LOOP` merged to `main` through PR `#165`.
 - Latest smoke result: the 2026-04-26 scripted-reset smoke pass succeeded in lane 6 (`docs/evaluation-evidence-readiness`) against current `main` behavior.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -29,14 +30,16 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Active queue
 
-- No active AI implementation task remains on `main`.
-- The contest repo now also has six merged risk-hardening lane packets for judge/voter attack-surface defense.
+- Session B remains active on `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`.
+- Session A `F101_TEACHER_ACTION_EXECUTION_LOOP` is complete on `main`.
 
 ## Next recommended task
 
-- The optional AI-owned risk-hardening lane set is complete on `main`.
-- The remaining path is human review of the submission package, IP commitment, optional video decision, and final sign-off.
-- Any new AI task should start from a fresh branch/worktree off `main`, not from a merged lane branch.
+- Continue `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE` in its assigned Session B worktree until its Draft PR is open and validated.
+- After `F113`, the preferred next pair from the future backlog packet remains:
+  - Session A: `F102_INTERVENTION_ASSIGNMENT_FLOW` or `F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS`
+  - Session B: `F114_SPEC_VERSION_PINNING_PER_SESSION` or `F116_STUDENT_MODEL_ENRICHMENT`
+- Any new AI task should still start from a fresh branch/worktree off `main`, not from a merged lane branch.
 
 If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
 
@@ -51,7 +54,7 @@ If a requested task appears to span multiple packets, stop and ask the human to 
 
 ## AI-owned blockers
 
-- None currently. The next AI-owned work is optional risk-hardening, not a blocker for the already-validated MVP path.
+- None blocking the merged MVP path. The only active AI-owned product work is the post-contest future backlog through Session B.
 
 ## Human-review blockers
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T16:56:43Z",
+    "last_updated": "2026-04-26T17:00:25Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 49,
+      "count": 50,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -58,14 +58,15 @@
         "R3_ASSESSMENT_SAFETY",
         "R4_TEACHER_VALUE_PROP",
         "R5_DASHBOARD_ACTIONABILITY",
-        "R6_CLAIM_CALIBRATION_PILOT"
+        "R6_CLAIM_CALIBRATION_PILOT",
+        "F101_TEACHER_ACTION_EXECUTION_LOOP"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
       "count": 1,
       "tasks": [
-        "F101_TEACHER_ACTION_EXECUTION_LOOP"
+        "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE"
       ]
     },
     "blocked": {
@@ -75,7 +76,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 23,
+      "count": 22,
       "tasks": [
         "F102_INTERVENTION_ASSIGNMENT_FLOW",
         "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS",
@@ -88,7 +89,6 @@
         "F110_TEACHER_OVERRIDE_LOG",
         "F111_ASSESSMENT_REVIEW_RUBRIC_CONTROLS",
         "F112_PROVENANCE_AND_REASON_TRACE_SURFACES",
-        "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE",
         "F114_SPEC_VERSION_PINNING_PER_SESSION",
         "F115_RUNTIME_POLICY_AUDIT_TRACE",
         "F116_STUDENT_MODEL_ENRICHMENT",
@@ -1225,10 +1225,10 @@
       "dependencies": [
         "R5_DASHBOARD_ACTIONABILITY"
       ],
-      "status": "in-progress",
+      "status": "completed",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
-      "notes": "First recommended task for a new teacher-facing session after the contest MVP closes."
+      "notes": "Merged to main through PR #165. Dashboard recommendations can now be converted into structured teacher actions for students and small groups, with status updates visible in student detail."
     },
     {
       "id": "F102_INTERVENTION_ASSIGNMENT_FLOW",
@@ -1534,7 +1534,7 @@
       "dependencies": [
         "R1_RUNTIME_BINDING_PROOF"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "runtime-policy",
       "notes": "First recommended task for a new runtime/data session after the contest MVP closes."

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -248,3 +248,13 @@
 - Tests: `pytest tests/api/test_dashboard_router.py::test_dashboard_teacher_action_create_round_trip tests/api/test_dashboard_router.py::test_dashboard_teacher_action_small_group_summary_attaches_to_group_card tests/api/test_dashboard_router.py::test_dashboard_teacher_action_status_update_round_trip tests/api/test_dashboard_router.py::test_dashboard_insights_returns_students_and_small_groups -q`; `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/TeacherActionComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx app/'(workspace)'/dashboard/student/page.tsx lib/dashboard-api.ts`; `git diff --check`
 - Blockers: None.
 - Next: Open Draft PR for `F101`, then continue to `F102`, `F103`, or `F108` only after merge or explicit packet selection.
+
+## Post-165 Sync
+
+- Branch: `docs/post-165-f101-sync`
+- Task: `OPS_POST_165_F101_SYNC`
+- Done: Reset the AI-first control plane after `F101` merged so `F101_TEACHER_ACTION_EXECUTION_LOOP` is now marked `completed` and no longer appears as the active Session A task.
+- Done: Restored Session B as the sole active assignment and advanced the compact queue to `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: None.
+- Next: Merge the tiny sync PR if CI is green, then let Session B continue as the only active product lane.

--- a/docs/superpowers/pr-notes/2026-04-26-post-165-f101-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-26-post-165-f101-sync.md
@@ -1,0 +1,48 @@
+# PR Architecture Note: Post-165 F101 Control-Plane Sync
+
+## Summary
+
+This PR advances the AI-first control plane after `F101_TEACHER_ACTION_EXECUTION_LOOP` merged to `main`. It removes Session A from the active assignment board, marks `F101` as completed in the task registry, and keeps Session B focused on `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE` through the merged two-session backlog packet.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  Merge["PR #165 merged on main"]
+  Registry["TASK_REGISTRY.json"]
+  Assignments["ACTIVE_ASSIGNMENTS.md"]
+  Queue["EXECUTION_QUEUE.md"]
+  SessionB["Session B / F113"]
+
+  Merge --> Registry
+  Merge --> Assignments
+  Merge --> Queue
+  Registry --> SessionB
+  Assignments --> SessionB
+  Queue --> SessionB
+```
+
+## Files Changed
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/pr-notes/2026-04-26-post-165-f101-sync.md`
+
+## Main System Map Update
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated. This PR only synchronizes AI-first task state after `F101` merged; it does not change runtime topology or product architecture.
+
+## Validation
+
+```bash
+python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+git diff --check
+```
+
+## Handoff Notes
+
+- `F101_TEACHER_ACTION_EXECUTION_LOOP` is complete on `main`.
+- Session B remains the only active implementation lane through `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`.
+- The active assignment board now points to the merged two-session startup packet instead of an untracked local design file.


### PR DESCRIPTION
## Summary

This PR advances the AI-first control plane after `F101_TEACHER_ACTION_EXECUTION_LOOP` merged to `main`. It removes Session A from the active assignment board, marks `F101` as completed in the task registry, and keeps Session B focused on `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE` through the merged two-session backlog packet.

## Main Changes

- remove Session A `F101` from `ai_first/ACTIVE_ASSIGNMENTS.md`
- point the remaining Session B assignment at the merged two-session startup packet instead of an untracked local design file
- mark `F101` as `completed` and move `F113` to `in-progress` in `ai_first/TASK_REGISTRY.json`
- advance `ai_first/EXECUTION_QUEUE.md` so the compact queue reflects `#165` and the active follow-up on `F113`
- record the sync in the daily log and add a PR architecture note

## Main System Map Update

`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated. This PR only synchronizes AI-first task state after `F101` merged; it does not change runtime topology or product architecture.

## Validation

```bash
python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
git diff --check
```

## Handoff Notes

- `F101_TEACHER_ACTION_EXECUTION_LOOP` is complete on `main`.
- Session B remains the only active implementation lane through `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE`.
- The active assignment board now points to the merged two-session startup packet instead of an untracked local design file.
