### PR TITLE
feat(runtime): pin spec versions per session [F114]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
 - Task: `F114_SPEC_VERSION_PINNING_PER_SESSION`
-- Status: `in-progress`
+- Status: `ready-review`
 - Branch: `pod-b/spec-version-pinning`
 - Task packet: `docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md`
 - Owned files: `deeptutor/services/agent_spec/`, `deeptutor/services/session/`, `deeptutor/services/runtime_policy/`, bounded tests/docs
-- PR: `Not opened yet`
-- Last update: `2026-04-27T00:27:00+0700`
-- Next action: `Write the bounded PR note, run final hygiene, and publish the Draft PR after implementation verification.`
+- PR: `#169 ready for review`
+- Last update: `2026-04-27T00:35:00+0700`
+- Next action: `Wait for CI and review on PR #169, then address only bounded F114 feedback.`
 - Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
 - Task: `F114_SPEC_VERSION_PINNING_PER_SESSION`
-- Status: `planning`
+- Status: `in-progress`
 - Branch: `pod-b/spec-version-pinning`
 - Task packet: `docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md`
 - Owned files: `deeptutor/services/agent_spec/`, `deeptutor/services/session/`, `deeptutor/services/runtime_policy/`, bounded tests/docs
 - PR: `Not opened yet`
-- Last update: `2026-04-27T00:10:00+0700`
-- Next action: `Use the new F114 design and implementation plan to start the bounded session-pinning implementation.`
+- Last update: `2026-04-27T00:27:00+0700`
+- Next action: `Write the bounded PR note, run final hygiene, and publish the Draft PR after implementation verification.`
 - Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-- No active AI implementation task is currently assigned on `main`.
-- The next product work should start from a fresh Session A or Session B branch/worktree after the human or AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Codex Session B
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
+- Task: `F114_SPEC_VERSION_PINNING_PER_SESSION`
+- Status: `planning`
+- Branch: `pod-b/spec-version-pinning`
+- Task packet: `docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md`
+- Owned files: `deeptutor/services/agent_spec/`, `deeptutor/services/session/`, `deeptutor/services/runtime_policy/`, bounded tests/docs
+- PR: `Not opened yet`
+- Last update: `2026-04-27T00:10:00+0700`
+- Next action: `Use the new F114 design and implementation plan to start the bounded session-pinning implementation.`
+- Blocker: `None`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1300,7 +1300,7 @@
       "dependencies": [
         "R5_DASHBOARD_ACTIONABILITY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
       "notes": "Depends on the existing grouped-card pattern but not on full class-roster infrastructure yet."
@@ -1326,7 +1326,7 @@
       "dependencies": [
         "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-insight",
       "notes": "Benefits from class roster work later, but can start as a queue over current student/group signals."
@@ -1351,7 +1351,7 @@
       "dependencies": [
         "R5_DASHBOARD_ACTIONABILITY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-insight",
       "notes": "Should stay evidence-first and avoid adding frontend-only diagnosis logic."
@@ -1377,7 +1377,7 @@
       "dependencies": [
         "F102_INTERVENTION_ASSIGNMENT_FLOW"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-insight",
       "notes": "Pairs naturally with F120 later, but does not require outcome scoring on day one."

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -303,3 +303,12 @@
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
 - Blockers: None.
 - Next: Start a fresh Session A or Session B branch/worktree for `F103/F107` or `F114/F116`.
+
+## Session B Runtime Data
+
+- Branch: `pod-b/spec-version-pinning`
+- Task: `F114_SPEC_VERSION_PINNING_PER_SESSION`
+- Done: Added bounded session-level spec version pinning by introducing historical Agent Spec snapshot reads, persisting `preferences.agent_spec_pin` on the first runtime-bound turn, reusing that exact version in runtime policy on later turns, and exposing pinned version metadata in runtime-policy debug payloads.
+- Tests: `pytest tests/services/agent_spec/test_service.py tests/services/session/test_sqlite_store.py tests/services/runtime_policy/test_compiler.py tests/api/test_unified_ws_turn_runtime.py -q`
+- Blockers: None.
+- Next: Run `git diff --check`, commit the branch, and open the Draft PR for review.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -309,6 +309,7 @@
 - Branch: `pod-b/spec-version-pinning`
 - Task: `F114_SPEC_VERSION_PINNING_PER_SESSION`
 - Done: Added bounded session-level spec version pinning by introducing historical Agent Spec snapshot reads, persisting `preferences.agent_spec_pin` on the first runtime-bound turn, reusing that exact version in runtime policy on later turns, and exposing pinned version metadata in runtime-policy debug payloads.
+- Done: Published PR `#169` from `pod-b/spec-version-pinning`, opened it as Draft first, completed self-review, and moved it to Ready for review.
 - Tests: `pytest tests/services/agent_spec/test_service.py tests/services/session/test_sqlite_store.py tests/services/runtime_policy/test_compiler.py tests/api/test_unified_ws_turn_runtime.py -q`
 - Blockers: None.
-- Next: Run `git diff --check`, commit the branch, and open the Draft PR for review.
+- Next: Watch CI on `#169` and only take bounded review follow-ups inside the F114 runtime/data scope.

--- a/deeptutor/services/agent_spec/service.py
+++ b/deeptutor/services/agent_spec/service.py
@@ -196,6 +196,21 @@ class AgentSpecService:
         files = self._read_current_files(paths.root)
         return self._build_payload(agent_id, metadata, files)
 
+    def get_pack_version(self, agent_id: str, version: int) -> dict[str, object]:
+        normalized_agent_id = self._validate_agent_id(agent_id)
+        paths = self._get_paths(normalized_agent_id)
+        version_dir = paths.versions_dir / f"v{int(version):04d}"
+        metadata_file = version_dir / "metadata.json"
+        if not metadata_file.exists():
+            raise FileNotFoundError(f"{normalized_agent_id}@v{int(version):04d}")
+
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        files = {
+            filename: (version_dir / filename).read_text(encoding="utf-8")
+            for filename in SPEC_FILES
+        }
+        return self._build_payload(normalized_agent_id, metadata, files)
+
     def create_pack(
         self,
         *,

--- a/deeptutor/services/runtime_policy/compiler.py
+++ b/deeptutor/services/runtime_policy/compiler.py
@@ -36,6 +36,7 @@ class RuntimePolicy:
 
     capability: str
     agent_spec_id: str
+    agent_spec_version: int | None
     slices: dict[str, str]
     sources: dict[str, str]
     knowledge_policy: str
@@ -50,6 +51,7 @@ class RuntimePolicy:
         return {
             "capability": self.capability,
             "agent_spec_id": self.agent_spec_id,
+            "agent_spec_version": self.agent_spec_version,
             "slices": dict(self.slices),
             "sources": dict(self.sources),
             "knowledge_policy": self.knowledge_policy,
@@ -62,6 +64,7 @@ class RuntimePolicy:
                 "missing_slices": missing,
                 "slice_sources": dict(self.sources),
                 "agent_spec_id": self.agent_spec_id,
+                "agent_spec_version": self.agent_spec_version,
                 "has_teacher_kb_context": bool(self.teacher_kb_context.strip()),
             },
         }
@@ -74,6 +77,11 @@ def ensure_runtime_policy(context: UnifiedContext, capability: str) -> RuntimePo
         return RuntimePolicy(
             capability=str(existing.get("capability") or capability),
             agent_spec_id=str(existing.get("agent_spec_id") or ""),
+            agent_spec_version=(
+                int(existing["agent_spec_version"])
+                if existing.get("agent_spec_version") is not None
+                else None
+            ),
             slices={k: str(v or "") for k, v in dict(existing.get("slices") or {}).items()},
             sources={k: str(v or "") for k, v in dict(existing.get("sources") or {}).items()},
             knowledge_policy=str(existing.get("knowledge_policy") or DEFAULT_KNOWLEDGE_POLICY),
@@ -147,12 +155,18 @@ def _compile_runtime_policy(context: UnifiedContext, capability: str) -> Runtime
 
     knowledge_policy = _resolve_knowledge_policy(teacher_spec, slices)
     agent_spec_id = str(teacher_spec.get("agent_spec_id") or "")
+    agent_spec_version = (
+        int(teacher_spec["agent_spec_version"])
+        if teacher_spec.get("agent_spec_version") is not None
+        else None
+    )
     teacher_kb_context, teacher_kb_source = _build_teacher_kb_context(context)
     if teacher_kb_source:
         sources.setdefault("KNOWLEDGE_BASE", teacher_kb_source)
     return RuntimePolicy(
         capability=capability,
         agent_spec_id=agent_spec_id,
+        agent_spec_version=agent_spec_version,
         slices=slices,
         sources=sources,
         knowledge_policy=knowledge_policy,
@@ -176,6 +190,20 @@ def _get_teacher_spec(context: UnifiedContext) -> dict[str, Any]:
             normalized = _normalize_teacher_spec(candidate)
             if normalized:
                 return normalized
+
+    pin = _resolve_agent_spec_pin(context)
+    if pin:
+        pinned_agent_id = str(pin.get("agent_spec_id") or "").strip()
+        pinned_version = pin.get("version")
+        if pinned_agent_id and pinned_version is not None:
+            try:
+                pack = get_agent_spec_service().get_pack_version(
+                    pinned_agent_id,
+                    int(pinned_version),
+                )
+            except FileNotFoundError:
+                return {}
+            return _normalize_teacher_spec(_pack_to_teacher_spec(pack))
 
     agent_spec_id = _resolve_agent_spec_id(context)
     if agent_spec_id:
@@ -235,10 +263,24 @@ def _resolve_agent_spec_id(context: UnifiedContext) -> str:
     return ""
 
 
+def _resolve_agent_spec_pin(context: UnifiedContext) -> dict[str, Any] | None:
+    candidates = [
+        context.metadata.get("agent_spec_pin"),
+        (context.metadata.get("session_preferences") or {}).get("agent_spec_pin")
+        if isinstance(context.metadata.get("session_preferences"), dict)
+        else None,
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            return candidate
+    return None
+
+
 def _pack_to_teacher_spec(pack: dict[str, Any]) -> dict[str, Any]:
     files = dict(pack.get("files") or {})
     compiled: dict[str, Any] = {
         "agent_spec_id": str(pack.get("agent_id") or ""),
+        "agent_spec_version": pack.get("version"),
         "knowledge_policy": str((pack.get("summary") or {}).get("knowledge_policy") or ""),
     }
     for filename, slice_name in SPEC_FILE_TO_SLICE.items():

--- a/deeptutor/services/session/turn_runtime.py
+++ b/deeptutor/services/session/turn_runtime.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from deeptutor.core.stream import StreamEvent, StreamEventType
 from deeptutor.services.path_service import get_path_service
+from deeptutor.services.runtime_policy import compiler as runtime_policy_compiler
 from deeptutor.services.session.sqlite_store import SQLiteSessionStore, get_sqlite_session_store
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,35 @@ def _clip_text(value: str, limit: int = 4000) -> str:
     if len(text) <= limit:
         return text
     return text[:limit].rstrip() + "\n...[truncated]"
+
+
+async def _ensure_agent_spec_pin(
+    store: SQLiteSessionStore,
+    session_id: str,
+    request_config: dict[str, Any],
+) -> dict[str, Any]:
+    session = await store.get_session(session_id)
+    preferences = dict((session or {}).get("preferences") or {})
+    existing_pin = preferences.get("agent_spec_pin")
+    if isinstance(existing_pin, dict):
+        return preferences
+
+    agent_spec_id = str(request_config.get("agent_spec_id") or "").strip()
+    if not agent_spec_id:
+        return preferences
+
+    try:
+        pack = runtime_policy_compiler.get_agent_spec_service().get_pack(agent_spec_id)
+    except FileNotFoundError:
+        return preferences
+
+    preferences["agent_spec_pin"] = {
+        "agent_spec_id": str(pack.get("agent_id") or agent_spec_id),
+        "version": int(pack.get("version") or 1),
+        "updated_at": str(pack.get("updated_at") or ""),
+    }
+    await store.update_session_preferences(session_id, {"agent_spec_pin": preferences["agent_spec_pin"]})
+    return preferences
 
 
 def _extract_followup_question_context(
@@ -259,6 +289,11 @@ class TurnRuntimeManager:
                 "language": str(payload.get("language") or "en"),
             },
         )
+        await _ensure_agent_spec_pin(
+            self.store,
+            session["id"],
+            dict(payload.get("config", {}) or {}),
+        )
         turn = await self.store.create_turn(session["id"], capability=capability)
         execution = _TurnExecution(
             turn_id=turn["id"],
@@ -415,6 +450,11 @@ class TurnRuntimeManager:
             )
             memory_service = get_memory_service()
             memory_context = memory_service.build_memory_context()
+            session_preferences = await _ensure_agent_spec_pin(
+                self.store,
+                session_id,
+                request_config,
+            )
 
             if notebook_references:
                 referenced_records = notebook_manager.get_records_by_references(notebook_references)
@@ -531,6 +571,12 @@ class TurnRuntimeManager:
                     "notebook_references": notebook_references,
                     "history_references": history_references,
                     "memory_context": memory_context,
+                    "session_preferences": session_preferences,
+                    "agent_spec_pin": (
+                        session_preferences.get("agent_spec_pin")
+                        if isinstance(session_preferences.get("agent_spec_pin"), dict)
+                        else {}
+                    ),
                 },
             )
 

--- a/docs/superpowers/plans/2026-04-27-f114-spec-version-pinning-per-session.md
+++ b/docs/superpowers/plans/2026-04-27-f114-spec-version-pinning-per-session.md
@@ -1,0 +1,189 @@
+# F114 Spec Version Pinning Per Session Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist and reuse an exact Agent Spec version pin per session so runtime policy remains reproducible across turns after teachers edit the current pack.
+
+**Architecture:** Introduce a bounded Agent Spec version-fetch API, store a session-level `agent_spec_pin`, and teach runtime policy/session runtime to create or reuse that pin without changing teacher-facing UX. The first turn using `agent_spec_id` writes the pin; later turns resolve the pinned snapshot instead of the latest pack.
+
+**Tech Stack:** AgentSpec service, SQLite session preferences JSON, runtime-policy compiler, unified-turn runtime, pytest
+
+---
+
+### Task 1: Add The F114 Task Contract
+
+**Files:**
+- Create: `docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md`
+- Create: `docs/superpowers/specs/2026-04-27-f114-spec-version-pinning-per-session-design.md`
+- Create: `docs/superpowers/plans/2026-04-27-f114-spec-version-pinning-per-session.md`
+
+- [ ] **Step 1: Write the task packet**
+
+Create the packet with owned files under `deeptutor/services/agent_spec/`, `deeptutor/services/session/`, and `deeptutor/services/runtime_policy/`, plus an explicit do-not-touch boundary for teacher-facing dashboard files.
+
+- [ ] **Step 2: Write the design doc**
+
+Record the session pin model, first-turn pinning rule, version-fetch service API, and runtime metadata expectations.
+
+- [ ] **Step 3: Write the implementation plan**
+
+Save this plan file before any production edits.
+
+- [ ] **Step 4: Commit the planning artifacts**
+
+```bash
+git add docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md docs/superpowers/specs/2026-04-27-f114-spec-version-pinning-per-session-design.md docs/superpowers/plans/2026-04-27-f114-spec-version-pinning-per-session.md
+git commit -m "docs(runtime): define F114 session pinning plan [F114]"
+```
+
+### Task 2: Add Version Snapshot Fetching To Agent Spec Service
+
+**Files:**
+- Modify: `deeptutor/services/agent_spec/service.py`
+- Modify: `tests/services/agent_spec/test_service.py`
+
+- [ ] **Step 1: Write the failing service test**
+
+Add a test proving a saved version snapshot can be loaded after the current pack has advanced:
+
+```python
+def test_get_pack_version_reads_historical_snapshot(tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(agent_id="fraction-coach", display_name="Fraction Coach")
+    service.save_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        files={"WORKFLOW.md": "# Workflow\n\nVersion two"},
+    )
+
+    version_one = service.get_pack_version("fraction-coach", 1)
+    version_two = service.get_pack_version("fraction-coach", 2)
+
+    assert "Version two" not in version_one["files"]["WORKFLOW.md"]
+    assert "Version two" in version_two["files"]["WORKFLOW.md"]
+```
+
+- [ ] **Step 2: Run the targeted test to confirm failure**
+
+Run: `pytest tests/services/agent_spec/test_service.py -k historical_snapshot -q`
+
+Expected: FAIL because the version-fetch API does not exist yet.
+
+- [ ] **Step 3: Add the version-fetch helper**
+
+Implement a dedicated helper in `service.py` that reads `versions/vNNNN/metadata.json` and versioned markdown files.
+
+- [ ] **Step 4: Re-run the targeted service test**
+
+Run: `pytest tests/services/agent_spec/test_service.py -k historical_snapshot -q`
+
+Expected: PASS.
+
+### Task 3: Persist Session-Level Agent Spec Pins
+
+**Files:**
+- Modify: `deeptutor/services/session/sqlite_store.py`
+- Modify: `tests/services/session/test_sqlite_store.py`
+
+- [ ] **Step 1: Write the failing session-store test**
+
+Add a test proving session preferences can store and later return an `agent_spec_pin`.
+
+- [ ] **Step 2: Run the targeted session-store test**
+
+Run: `pytest tests/services/session/test_sqlite_store.py -k agent_spec_pin -q`
+
+Expected: FAIL until the helper path is explicit in tests or implementation.
+
+- [ ] **Step 3: Add bounded helpers if needed**
+
+Prefer using the existing session preferences JSON update path. Add a tiny helper only if it makes pin read/write clearer and testable.
+
+- [ ] **Step 4: Re-run the targeted session-store test**
+
+Run: `pytest tests/services/session/test_sqlite_store.py -k agent_spec_pin -q`
+
+Expected: PASS.
+
+### Task 4: Reuse Pinned Versions In Runtime Policy
+
+**Files:**
+- Modify: `deeptutor/services/runtime_policy/compiler.py`
+- Modify: `tests/services/runtime_policy/test_compiler.py`
+
+- [ ] **Step 1: Write the failing runtime-policy test**
+
+Prove that a session pin forces runtime policy to use a historical snapshot even when the current pack has changed.
+
+- [ ] **Step 2: Run the targeted runtime-policy test**
+
+Run: `pytest tests/services/runtime_policy/test_compiler.py -k pinned_version -q`
+
+Expected: FAIL because runtime policy still resolves the latest pack only.
+
+- [ ] **Step 3: Teach runtime policy to prefer the session pin**
+
+Read `agent_spec_pin` from session-scoped metadata/preferences, resolve the pinned version via the Agent Spec service helper, and expose the pinned version in runtime debug metadata.
+
+- [ ] **Step 4: Re-run the targeted runtime-policy test**
+
+Run: `pytest tests/services/runtime_policy/test_compiler.py -k pinned_version -q`
+
+Expected: PASS.
+
+### Task 5: Create And Reuse Pins In Unified Turn Runtime
+
+**Files:**
+- Modify: `deeptutor/services/session/turn_runtime.py`
+- Modify: `tests/api/test_unified_ws_turn_runtime.py`
+
+- [ ] **Step 1: Write the failing unified-turn tests**
+
+Add one test for first-turn pin creation and one for later-turn reuse after the current pack changes.
+
+- [ ] **Step 2: Run the targeted unified-turn tests**
+
+Run: `pytest tests/api/test_unified_ws_turn_runtime.py -k \"agent_spec_pin or pinned_version\" -q`
+
+Expected: FAIL because the turn runtime does not yet persist or reload the pin.
+
+- [ ] **Step 3: Add bounded pin create/reuse logic**
+
+Persist the pin when a turn first resolves `agent_spec_id`, then inject it into later turns through the existing session/runtime context path.
+
+- [ ] **Step 4: Re-run the targeted unified-turn tests**
+
+Run: `pytest tests/api/test_unified_ws_turn_runtime.py -k \"agent_spec_pin or pinned_version\" -q`
+
+Expected: PASS.
+
+### Task 6: Final Validation And PR Note
+
+**Files:**
+- Create: `docs/superpowers/pr-notes/2026-04-27-f114-spec-version-pinning-per-session.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-27.md` or `2026-04-26.md` depending on execution date
+
+- [ ] **Step 1: Write the PR note**
+
+Include one Mermaid diagram showing `agent_spec_id -> first turn pin -> later turn reuse`.
+
+- [ ] **Step 2: Run the bounded suite**
+
+Run: `pytest tests/services/agent_spec/test_service.py tests/services/session/test_sqlite_store.py tests/services/runtime_policy/test_compiler.py tests/api/test_unified_ws_turn_runtime.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run: `git diff --check`
+
+Expected: exit `0`.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add deeptutor/services/agent_spec/service.py deeptutor/services/session/sqlite_store.py deeptutor/services/runtime_policy/compiler.py deeptutor/services/session/turn_runtime.py tests/services/agent_spec/test_service.py tests/services/session/test_sqlite_store.py tests/services/runtime_policy/test_compiler.py tests/api/test_unified_ws_turn_runtime.py docs/superpowers/pr-notes/2026-04-27-f114-spec-version-pinning-per-session.md ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-27.md
+git commit -m "feat(runtime): pin spec versions per session [F114]"
+```

--- a/docs/superpowers/pr-notes/2026-04-27-f114-spec-version-pinning-per-session.md
+++ b/docs/superpowers/pr-notes/2026-04-27-f114-spec-version-pinning-per-session.md
@@ -1,0 +1,27 @@
+# PR Note: F114 Spec Version Pinning Per Session
+
+- Task: `F114_SPEC_VERSION_PINNING_PER_SESSION`
+- Scope: bounded session-level Agent Spec version pinning for runtime-policy reproducibility
+- Main-system-map update: not required because no user-visible entry point or topology changed
+
+## What Changed
+
+- added `AgentSpecService.get_pack_version()` so runtime code can read an exact historical pack snapshot
+- persisted a session-scoped `agent_spec_pin` the first time a turn resolves `config.agent_spec_id`
+- taught runtime policy to prefer the pinned version over the mutable latest pack
+- surfaced `agent_spec_version` in runtime-policy payload/debug metadata for bounded auditability
+- added tests for historical snapshot fetch, session pin persistence, pinned runtime-policy compilation, and multi-turn reuse after the current pack changes
+
+```mermaid
+flowchart LR
+  A["Turn request with agent_spec_id"] --> B["Resolve current Agent Spec pack"]
+  B --> C["Persist session preferences.agent_spec_pin"]
+  C --> D["Later turn in same session"]
+  D --> E["Runtime policy loads pinned version"]
+  E --> F["Stable teacher policy slices"]
+```
+
+## Validation
+
+- `pytest tests/services/agent_spec/test_service.py tests/services/session/test_sqlite_store.py tests/services/runtime_policy/test_compiler.py tests/api/test_unified_ws_turn_runtime.py -q`
+- `git diff --check`

--- a/docs/superpowers/specs/2026-04-27-f114-spec-version-pinning-per-session-design.md
+++ b/docs/superpowers/specs/2026-04-27-f114-spec-version-pinning-per-session-design.md
@@ -1,0 +1,106 @@
+# F114 Spec Version Pinning Per Session Design
+
+## Metadata
+
+- Task ID: `F114_SPEC_VERSION_PINNING_PER_SESSION`
+- Commit tag: `F114`
+- Session bucket: `session-b-runtime-data`
+- Owner scope: `deeptutor/services/agent_spec/`, `deeptutor/services/session/`, `deeptutor/services/runtime_policy/`, bounded tests/docs
+- Do-not-touch scope: teacher-facing dashboard UX, Session A dashboard workflow files, broad `/agents` UI changes
+
+## Goal
+
+Pin each session to the exact teacher-spec version resolved at runtime so later turns, debugging, and audit surfaces do not drift if the teacher edits the underlying Agent Spec pack after the session has already started.
+
+## Current State
+
+- `F113` proves that `agent_spec_id` can reach runtime policy assembly on `chat`, `deep_question`, and `deep_solve`.
+- Runtime policy currently resolves the latest Agent Spec pack by `agent_spec_id`.
+- Agent Spec storage already versions packs under `agent_specs/<agent_id>/versions/vNNNN/`.
+- Session persistence already stores session-level preferences and turn/event history, but it does not persist a stable spec-version pin that runtime policy can reuse.
+
+## Problem
+
+Without version pinning, two turns from the same session may resolve different spec content if the teacher edits the pack between turns. That breaks reproducibility for:
+
+- teacher/runtime debugging
+- trust/audit traces planned for later Session B tasks
+- stable explanation of which policy actually governed a session
+
+## Design
+
+### 1. Session Pin Model
+
+Add a session-level persisted pin with at least:
+
+- `agent_spec_id`
+- `agent_spec_version`
+- optional `agent_spec_updated_at`
+
+The pin belongs to session preferences/state, not turn-local metadata. It should be written the first time a runtime-bound turn resolves a teacher spec and then reused for future turns in the same session.
+
+### 2. Resolution Rule
+
+For covered runtime paths:
+
+1. if a session already has a spec pin, runtime policy must resolve that exact version
+2. if no pin exists and the request supplies `agent_spec_id`, resolve the current pack once and persist its version as the session pin
+3. if no `agent_spec_id` is present, keep current fallback behavior and do not invent a pin
+
+This rule keeps the first resolved version stable without changing unrelated sessions.
+
+### 3. Agent Spec Service Contract
+
+Add a bounded way to read a specific version snapshot from `versions/vNNNN/` without mutating the current pack API. The minimal contract can be one of:
+
+- `get_pack_version(agent_id, version)`
+- or `get_pack(agent_id, version=...)`
+
+Recommendation: add a dedicated version-fetch helper so the default `get_pack()` remains clearly “latest/current”.
+
+### 4. Runtime Policy Contract
+
+Extend runtime policy metadata/debug output so it reports:
+
+- `agent_spec_id`
+- pinned `agent_spec_version`
+- whether the current turn reused an existing session pin or created a new one
+
+Do not change teacher-facing claim surfaces in this task. This is runtime provenance groundwork.
+
+### 5. Session Store Contract
+
+Persist the spec pin inside session preferences JSON or a bounded session-state field already owned by Session B.
+
+Recommendation: use session preferences JSON so pinning is session-scoped, lightweight, and does not require a new table.
+
+Expected shape:
+
+```json
+{
+  "capability": "chat",
+  "agent_spec_pin": {
+    "agent_spec_id": "strict-fractions",
+    "version": 2,
+    "updated_at": "2026-04-26T10:15:00Z"
+  }
+}
+```
+
+### 6. Scope Boundary
+
+`F114` should not add UI for version history or teacher-facing provenance. It should only make the runtime/session contract reproducible so later tasks can expose it safely.
+
+## Testing Strategy
+
+- service tests for loading a specific Agent Spec version snapshot
+- session-store tests proving the pin is persisted and readable
+- runtime-policy tests proving an existing pin overrides later “latest” edits
+- unified-turn tests proving the first runtime-bound turn creates the pin and later turns reuse it
+
+## Success Criteria
+
+1. the first runtime-bound turn in a session can persist a spec-version pin
+2. later turns in the same session reuse that exact version even if the current pack has changed
+3. runtime-policy metadata/debug output identifies the pinned version
+4. no teacher-facing dashboard or `/agents` UX files are modified

--- a/docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md
+++ b/docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md
@@ -2,7 +2,7 @@
 
 - Task ID: `F114_SPEC_VERSION_PINNING_PER_SESSION`
 - Commit tag: `F114`
-- Status: `In Progress`
+- Status: `Ready for Review`
 - Branch recommendation: `pod-b/spec-version-pinning`
 
 ## Goal

--- a/docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md
+++ b/docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md
@@ -1,0 +1,34 @@
+# F114 Spec Version Pinning Per Session
+
+- Task ID: `F114_SPEC_VERSION_PINNING_PER_SESSION`
+- Commit tag: `F114`
+- Status: `Planning`
+- Branch recommendation: `pod-b/spec-version-pinning`
+
+## Goal
+
+Pin each learning session to the exact teacher-spec version first resolved at runtime so later debugging, audit, and teacher-trust surfaces can reconstruct the same spec context instead of drifting to the latest saved pack.
+
+## Owned Files
+
+- `deeptutor/services/agent_spec/`
+- `deeptutor/services/session/`
+- `deeptutor/services/runtime_policy/`
+- bounded session/runtime tests
+- `docs/superpowers/specs/`
+- `docs/superpowers/plans/`
+- `docs/superpowers/pr-notes/`
+
+## Do Not Touch
+
+- teacher-facing dashboard presentation files
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- broad `/agents` UX changes unless the packet is explicitly expanded
+
+## Constraints
+
+- preserve current `F113` runtime-binding behavior
+- pin by exact spec version or version snapshot metadata, not by mutable latest pack lookup
+- avoid changing teacher-facing flows in the same branch
+- keep the first persisted session contract inspectable and testable

--- a/docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md
+++ b/docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md
@@ -2,7 +2,7 @@
 
 - Task ID: `F114_SPEC_VERSION_PINNING_PER_SESSION`
 - Commit tag: `F114`
-- Status: `Planning`
+- Status: `In Progress`
 - Branch recommendation: `pod-b/spec-version-pinning`
 
 ## Goal
@@ -32,3 +32,9 @@ Pin each learning session to the exact teacher-spec version first resolved at ru
 - pin by exact spec version or version snapshot metadata, not by mutable latest pack lookup
 - avoid changing teacher-facing flows in the same branch
 - keep the first persisted session contract inspectable and testable
+
+## Session Notes
+
+- Runtime scope stays bounded to Agent Spec storage, session preferences, runtime-policy compilation, and unified turn runtime.
+- Session pins use `preferences.agent_spec_pin = {agent_spec_id, version, updated_at}`.
+- No teacher-facing dashboard or `/agents` UX files are part of this packet.

--- a/tests/api/test_unified_ws_turn_runtime.py
+++ b/tests/api/test_unified_ws_turn_runtime.py
@@ -568,6 +568,117 @@ async def test_turn_runtime_passes_agent_spec_id_for_live_chat_policy_binding(
 
 
 @pytest.mark.asyncio
+async def test_turn_runtime_pins_agent_spec_version_per_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    runtime = TurnRuntimeManager(store)
+    captured: list[str] = []
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {"agent_name": "Fraction Coach"},
+            "soul": {"teaching_philosophy": "Version one philosophy."},
+            "rules": {"guardrails": "Version one guardrails."},
+        },
+    )
+
+    class FakeContextBuilder:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def build(self, **_kwargs):
+            return SimpleNamespace(
+                conversation_history=[],
+                conversation_summary="",
+                context_text="",
+                token_count=0,
+                budget=0,
+            )
+
+    class FakePipeline:
+        def __init__(self, language: str = "en") -> None:
+            captured.append(f"lang={language}")
+
+        async def run(self, context, stream) -> None:
+            captured.append(str(context.memory_context))
+            captured.append(str(context.metadata.get("session_preferences", {})))
+            await stream.content("Pinned response", source="chat", stage="responding")
+
+    monkeypatch.setattr(
+        "deeptutor.services.llm.config.get_llm_config",
+        lambda: SimpleNamespace(api_key="k", base_url="u", api_version="v1"),
+    )
+    monkeypatch.setattr("deeptutor.services.session.context_builder.ContextBuilder", FakeContextBuilder)
+    monkeypatch.setattr(
+        "deeptutor.services.memory.get_memory_service",
+        lambda: SimpleNamespace(build_memory_context=lambda: "", refresh_from_turn=_noop_refresh),
+    )
+    monkeypatch.setattr("deeptutor.capabilities.chat.AgenticChatPipeline", FakePipeline)
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    session, turn = await runtime.start_turn(
+        {
+            "type": "start_turn",
+            "content": "Help me with fractions",
+            "session_id": None,
+            "capability": "chat",
+            "tools": [],
+            "knowledge_bases": [],
+            "attachments": [],
+            "language": "en",
+            "config": {
+                "agent_spec_id": "fraction-coach",
+            },
+        }
+    )
+
+    async for _event in runtime.subscribe_turn(turn["id"], after_seq=0):
+        pass
+
+    persisted = await store.get_session(session["id"])
+    assert persisted is not None
+    assert "agent_spec_pin" in captured[-1]
+    assert persisted["preferences"]["agent_spec_pin"]["agent_spec_id"] == "fraction-coach"
+    assert persisted["preferences"]["agent_spec_pin"]["version"] == 1
+
+    service.save_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {"agent_name": "Fraction Coach"},
+            "soul": {"teaching_philosophy": "Version two philosophy."},
+            "rules": {"guardrails": "Version two guardrails."},
+        },
+    )
+
+    _session, second_turn = await runtime.start_turn(
+        {
+            "type": "start_turn",
+            "content": "Help me again",
+            "session_id": session["id"],
+            "capability": "chat",
+            "tools": [],
+            "knowledge_bases": [],
+            "attachments": [],
+            "language": "en",
+            "config": {},
+        }
+    )
+
+    async for _event in runtime.subscribe_turn(second_turn["id"], after_seq=0):
+        pass
+
+    memory_contexts = [entry for entry in captured if "Teacher Runtime Policy:" in entry]
+    assert "Version one philosophy." in memory_contexts[0]
+    assert "Version one philosophy." in memory_contexts[1]
+    assert "Version two philosophy." not in memory_contexts[1]
+
+
+@pytest.mark.asyncio
 async def test_turn_runtime_passes_agent_spec_id_for_deep_question_policy_binding(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/services/agent_spec/test_service.py
+++ b/tests/services/agent_spec/test_service.py
@@ -94,3 +94,27 @@ def test_export_pack_archive_contains_all_markdown_files(tmp_path) -> None:
     assert "fraction-coach/IDENTITY.md" in names
     assert "fraction-coach/SOUL.md" in names
     assert "fraction-coach/MARKETPLACE.md" in names
+
+
+def test_get_pack_version_reads_historical_snapshot(tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured=_sample_structured(),
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion one.\n"},
+    )
+    service.save_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured=_sample_structured(),
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion two.\n"},
+    )
+
+    version_one = service.get_pack_version("fraction-coach", 1)
+    version_two = service.get_pack_version("fraction-coach", 2)
+
+    assert "Version two." not in version_one["files"]["WORKFLOW.md"]
+    assert "Version two." in version_two["files"]["WORKFLOW.md"]
+    assert version_one["version"] == 1
+    assert version_two["version"] == 2

--- a/tests/services/runtime_policy/test_compiler.py
+++ b/tests/services/runtime_policy/test_compiler.py
@@ -113,3 +113,49 @@ def test_runtime_policy_reads_teacher_kb_context_from_metadata(monkeypatch) -> N
     assert "Knowledge Pack: algebra-pack" in payload["teacher_kb_context"]
     assert payload["sources"]["KNOWLEDGE_BASE"] == "knowledge_base.algebra-pack.metadata"
     assert payload["slices"]["CURRICULUM"].startswith("Knowledge Pack: algebra-pack")
+
+
+def test_runtime_policy_prefers_pinned_agent_spec_version(monkeypatch, tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {"agent_name": "Fraction Coach"},
+            "soul": {"teaching_philosophy": "Version one philosophy."},
+            "rules": {"guardrails": "Version one guardrails."},
+        },
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion one.\n"},
+    )
+    service.save_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {"agent_name": "Fraction Coach"},
+            "soul": {"teaching_philosophy": "Version two philosophy."},
+            "rules": {"guardrails": "Version two guardrails."},
+        },
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion two.\n"},
+    )
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    context = UnifiedContext(
+        metadata={
+            "agent_spec_id": "fraction-coach",
+            "session_preferences": {
+                "agent_spec_pin": {
+                    "agent_spec_id": "fraction-coach",
+                    "version": 1,
+                    "updated_at": "2026-04-27T00:00:00Z",
+                }
+            },
+        }
+    )
+    policy = ensure_runtime_policy(context, "chat")
+    payload = policy.to_dict()
+
+    assert payload["agent_spec_id"] == "fraction-coach"
+    assert payload["agent_spec_version"] == 1
+    assert "Version one philosophy." in payload["slices"]["SOUL"]
+    assert "Version two philosophy." not in payload["slices"]["SOUL"]
+    assert payload["debug"]["agent_spec_version"] == 1

--- a/tests/services/session/test_sqlite_store.py
+++ b/tests/services/session/test_sqlite_store.py
@@ -154,3 +154,30 @@ async def test_sqlite_store_builds_recency_aware_student_state_rollup(tmp_path: 
     assert rollup["confidence_trend"] in {"up", "flat", "down"}
     assert rollup["recency_summary"]["total_observations"] == 3
     assert rollup["recency_summary"]["bucket_counts"]["last_24h"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_sqlite_store_persists_agent_spec_pin_in_session_preferences(tmp_path: Path) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    session = await store.create_session(title="Pinned session")
+
+    updated = await store.update_session_preferences(
+        session["id"],
+        {
+            "agent_spec_pin": {
+                "agent_spec_id": "fraction-coach",
+                "version": 2,
+                "updated_at": "2026-04-27T00:00:00Z",
+            }
+        },
+    )
+
+    detail = await store.get_session(session["id"])
+
+    assert updated is True
+    assert detail is not None
+    assert detail["preferences"]["agent_spec_pin"] == {
+        "agent_spec_id": "fraction-coach",
+        "version": 2,
+        "updated_at": "2026-04-27T00:00:00Z",
+    }


### PR DESCRIPTION
# PR Note: F114 Spec Version Pinning Per Session

- Task: `F114_SPEC_VERSION_PINNING_PER_SESSION`
- Scope: bounded session-level Agent Spec version pinning for runtime-policy reproducibility
- Main-system-map update: not required because no user-visible entry point or topology changed

## What Changed

- added `AgentSpecService.get_pack_version()` so runtime code can read an exact historical pack snapshot
- persisted a session-scoped `agent_spec_pin` the first time a turn resolves `config.agent_spec_id`
- taught runtime policy to prefer the pinned version over the mutable latest pack
- surfaced `agent_spec_version` in runtime-policy payload/debug metadata for bounded auditability
- added tests for historical snapshot fetch, session pin persistence, pinned runtime-policy compilation, and multi-turn reuse after the current pack changes

```mermaid
flowchart LR
  A["Turn request with agent_spec_id"] --> B["Resolve current Agent Spec pack"]
  B --> C["Persist session preferences.agent_spec_pin"]
  C --> D["Later turn in same session"]
  D --> E["Runtime policy loads pinned version"]
  E --> F["Stable teacher policy slices"]
```

## Validation

- `pytest tests/services/agent_spec/test_service.py tests/services/session/test_sqlite_store.py tests/services/runtime_policy/test_compiler.py tests/api/test_unified_ws_turn_runtime.py -q`
- `git diff --check`
