### PR TITLE
feat(dashboard): add intervention assignment flow [F102]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
 - Task: `F102_INTERVENTION_ASSIGNMENT_FLOW`
-- Status: `review-prep`
+- Status: `draft-review`
 - Branch: `pod-a/intervention-assignment-flow`
 - Task packet: `docs/superpowers/tasks/2026-04-27-f102-intervention-assignment-flow.md`
 - Owned files: `web/components/dashboard/`, `web/app/(workspace)/dashboard/`, `web/app/(workspace)/dashboard/student/`, `web/lib/dashboard-api.ts`, `deeptutor/api/routers/dashboard.py`, bounded `deeptutor/services/evidence/`, related dashboard tests/docs`
-- PR: `Not opened yet`
+- PR: `https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/170`
 - Last update: `2026-04-27T00:14:15+0700`
-- Next action: `Commit the validated implementation, open a Draft PR, and wait for CI before moving to ready-review.`
+- Next action: `Wait for CI on PR #170, then move to ready-review if checks stay green.`
 - Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
 - Task: `F102_INTERVENTION_ASSIGNMENT_FLOW`
-- Status: `design-in-progress`
+- Status: `review-prep`
 - Branch: `pod-a/intervention-assignment-flow`
-- Task packet: `docs/superpowers/tasks/2026-04-26-two-session-future-backlog.md` (`Session A`, task `F102`)
+- Task packet: `docs/superpowers/tasks/2026-04-27-f102-intervention-assignment-flow.md`
 - Owned files: `web/components/dashboard/`, `web/app/(workspace)/dashboard/`, `web/app/(workspace)/dashboard/student/`, `web/lib/dashboard-api.ts`, `deeptutor/api/routers/dashboard.py`, bounded `deeptutor/services/evidence/`, related dashboard tests/docs`
 - PR: `Not opened yet`
 - Last update: `2026-04-27T00:14:15+0700`
-- Next action: `Write F102 design/spec for a bounded intervention-assignment shell built on top of teacher actions.`
+- Next action: `Commit the validated implementation, open a Draft PR, and wait for CI before moving to ready-review.`
 - Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-- No active AI implementation task is currently assigned on `main`.
-- The next product work should start from a fresh Session A or Session B branch/worktree after the human or AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Codex Session A
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
+- Task: `F102_INTERVENTION_ASSIGNMENT_FLOW`
+- Status: `design-in-progress`
+- Branch: `pod-a/intervention-assignment-flow`
+- Task packet: `docs/superpowers/tasks/2026-04-26-two-session-future-backlog.md` (`Session A`, task `F102`)
+- Owned files: `web/components/dashboard/`, `web/app/(workspace)/dashboard/`, `web/app/(workspace)/dashboard/student/`, `web/lib/dashboard-api.ts`, `deeptutor/api/routers/dashboard.py`, bounded `deeptutor/services/evidence/`, related dashboard tests/docs`
+- PR: `Not opened yet`
+- Last update: `2026-04-27T00:14:15+0700`
+- Next action: `Write F102 design/spec for a bounded intervention-assignment shell built on top of teacher actions.`
+- Blocker: `None`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T17:14:24Z",
+    "last_updated": "2026-04-26T17:24:57Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -1254,7 +1254,7 @@
       "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
-      "notes": "Session A started on 2026-04-27 from branch pod-a/intervention-assignment-flow. Scope is a bounded teacher-facing assignment/remediation shell built on top of F101 teacher actions."
+      "notes": "Draft PR #170 is open on branch pod-a/intervention-assignment-flow. The branch adds linked intervention assignments on top of F101 teacher actions."
     },
     {
       "id": "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T17:09:37Z",
+    "last_updated": "2026-04-26T17:14:24Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -65,8 +65,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F102_INTERVENTION_ASSIGNMENT_FLOW"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -75,9 +77,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 22,
+      "count": 21,
       "tasks": [
-        "F102_INTERVENTION_ASSIGNMENT_FLOW",
         "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS",
         "F104_SMALL_GROUP_MANAGEMENT_SURFACE",
         "F105_CLASS_INTERVENTION_QUEUE",
@@ -1253,7 +1254,7 @@
       "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
-      "notes": "Should stay teacher-facing first; richer outcome tracking can follow in Session B."
+      "notes": "Session A started on 2026-04-27 from branch pod-a/intervention-assignment-flow. Scope is a bounded teacher-facing assignment/remediation shell built on top of F101 teacher actions."
     },
     {
       "id": "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -1,6 +1,6 @@
 # Main System Map
 
-Last updated: 2026-04-26
+Last updated: 2026-04-27
 
 This is the required top-level Mermaid map for the project. Any PR that adds, removes, or materially changes product features, capabilities, tools, routers, routes, data models, or AI-first workflow must update this map.
 
@@ -99,10 +99,14 @@ flowchart TD
   TeacherAnalytics --> DifficultySignals["Learning signals: focus topics + strong areas"]
   TeacherInsights --> InsightsAPI["GET /api/v1/dashboard/insights"]
   TeacherInsights --> TeacherActionAPI["POST/PATCH /api/v1/dashboard/teacher-actions"]
+  TeacherInsights --> InterventionAssignmentAPI["POST/PATCH /api/v1/dashboard/intervention-assignments"]
   InsightsAPI --> DiagnosisEngine
   InsightsAPI --> SmallGroupRecommendations["Small-group recommendation clusters"]
   InsightsAPI --> TeacherActions["Teacher action records"]
+  InsightsAPI --> InterventionAssignments["Intervention assignment records"]
   TeacherActionAPI --> TeacherActions
+  TeacherActions --> InterventionAssignmentAPI
+  InterventionAssignmentAPI --> InterventionAssignments
   TeacherDashboard --> StudentDashboard["Student Progress Dashboard"]
   TeacherDashboard --> AssessmentReview["Assessment Review Drill-down"]
   StudentDashboard --> StudentRoute["/dashboard/student"]
@@ -111,6 +115,7 @@ flowchart TD
   StudentDashboard --> TopicSignals["Focus topics + mastered topics"]
   StudentDashboard --> LearningPathSignals["Suggested learning path sequence"]
   StudentDashboard --> TeacherActionDetail["Teacher actions section + status updates"]
+  StudentDashboard --> AssignmentDetail["Intervention assignments section + status updates"]
   LearningPathSignals --> PathEngine["Deterministic learning-path helper"]
   PathEngine --> FocusTopicInputs["Focus topics from assessment analysis"]
   PathEngine --> ObjectiveInputs["Knowledge-pack learning_objectives metadata"]

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -289,6 +289,7 @@
 - Done: Wrote the initial design spec for a bounded intervention-assignment shell linked to merged `teacher_action` records from `F101`.
 - Done: Implemented the linked `intervention_assignments` backend helper, dashboard routes, payload attachment, assignment composer, and student detail assignment section.
 - Done: Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` and wrote the `F102` PR note/task packet.
+- Done: Opened Draft PR `#170` for review/CI.
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `pytest tests/api/test_dashboard_router.py -k "teacher_action or intervention_assignment or dashboard_insights" -q`; `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/InterventionAssignmentComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts`; `git diff --check`
 - Blockers: None.
-- Next: Open the Draft PR for `F102`, wait for CI, and then move the branch to ready-review if checks stay green.
+- Next: Wait for CI on `#170`, then move the branch to ready-review if checks stay green.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -280,3 +280,13 @@
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
 - Blockers: None.
 - Next: If the human or AI loop wants to continue product work, start fresh from `F102/F103` or `F114/F116` on a new branch/worktree instead of reviving merged lanes.
+
+## F102_INTERVENTION_ASSIGNMENT_FLOW
+
+- Branch: `pod-a/intervention-assignment-flow`
+- Task: `F102_INTERVENTION_ASSIGNMENT_FLOW`
+- Done: Marked `F102` as `in-progress` in the task registry and set Session A active again on a fresh branch.
+- Done: Wrote the initial design spec for a bounded intervention-assignment shell linked to merged `teacher_action` records from `F101`.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: None.
+- Next: Write the implementation plan, then create the concrete task packet and begin bounded dashboard/evidence implementation.

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -287,6 +287,8 @@
 - Task: `F102_INTERVENTION_ASSIGNMENT_FLOW`
 - Done: Marked `F102` as `in-progress` in the task registry and set Session A active again on a fresh branch.
 - Done: Wrote the initial design spec for a bounded intervention-assignment shell linked to merged `teacher_action` records from `F101`.
-- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Done: Implemented the linked `intervention_assignments` backend helper, dashboard routes, payload attachment, assignment composer, and student detail assignment section.
+- Done: Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` and wrote the `F102` PR note/task packet.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `pytest tests/api/test_dashboard_router.py -k "teacher_action or intervention_assignment or dashboard_insights" -q`; `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/InterventionAssignmentComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts`; `git diff --check`
 - Blockers: None.
-- Next: Write the implementation plan, then create the concrete task packet and begin bounded dashboard/evidence implementation.
+- Next: Open the Draft PR for `F102`, wait for CI, and then move the branch to ready-review if checks stay green.

--- a/deeptutor/api/routers/dashboard.py
+++ b/deeptutor/api/routers/dashboard.py
@@ -15,6 +15,11 @@ from deeptutor.services.evidence.teacher_actions import (
     list_teacher_actions,
     update_teacher_action_status,
 )
+from deeptutor.services.evidence.intervention_assignments import (
+    create_intervention_assignment,
+    list_intervention_assignments,
+    update_intervention_assignment_status,
+)
 from deeptutor.services.evidence.teacher_insights import build_teacher_insights_payload
 from deeptutor.services.learning_path import build_suggested_learning_path
 from deeptutor.services.session import extract_assessment_review, get_sqlite_session_store
@@ -33,6 +38,18 @@ class TeacherActionCreateRequest(BaseModel):
 
 
 class TeacherActionStatusUpdateRequest(BaseModel):
+    status: str
+
+
+class InterventionAssignmentCreateRequest(BaseModel):
+    teacher_action_id: str
+    assignment_type: str
+    title: str
+    teacher_note: str
+    practice_note: str
+
+
+class InterventionAssignmentStatusUpdateRequest(BaseModel):
     status: str
 
 
@@ -533,9 +550,11 @@ async def get_dashboard_insights(
         )
 
     teacher_actions = list_teacher_actions(store)
+    intervention_assignments = list_intervention_assignments(store)
     return build_teacher_insights_payload(
         student_payloads=student_payloads,
         teacher_actions=teacher_actions,
+        intervention_assignments=intervention_assignments,
     )
 
 
@@ -569,6 +588,40 @@ async def update_dashboard_teacher_action(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="teacher action not found") from exc
+
+
+@router.post("/intervention-assignments")
+async def create_dashboard_intervention_assignment(
+    payload: InterventionAssignmentCreateRequest,
+) -> dict[str, Any]:
+    store = get_sqlite_session_store()
+    try:
+        return create_intervention_assignment(
+            store,
+            teacher_action_id=payload.teacher_action_id,
+            assignment_type=payload.assignment_type,
+            title=payload.title,
+            teacher_note=payload.teacher_note,
+            practice_note=payload.practice_note,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="teacher action not found") from exc
+
+
+@router.patch("/intervention-assignments/{assignment_id}")
+async def update_dashboard_intervention_assignment(
+    assignment_id: str,
+    payload: InterventionAssignmentStatusUpdateRequest,
+) -> dict[str, Any]:
+    store = get_sqlite_session_store()
+    try:
+        return update_intervention_assignment_status(store, assignment_id, status=payload.status)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="intervention assignment not found") from exc
 
 
 @router.get("/{entry_id}")

--- a/deeptutor/services/evidence/__init__.py
+++ b/deeptutor/services/evidence/__init__.py
@@ -1,13 +1,21 @@
 from .diagnosis import build_student_diagnosis
 from .extractor import extract_observations_from_review
+from .intervention_assignments import (
+    create_intervention_assignment,
+    list_intervention_assignments,
+    update_intervention_assignment_status,
+)
 from .teacher_actions import create_teacher_action, list_teacher_actions, update_teacher_action_status
 from .teacher_insights import build_teacher_insights_payload
 
 __all__ = [
     "build_student_diagnosis",
     "build_teacher_insights_payload",
+    "create_intervention_assignment",
     "create_teacher_action",
     "extract_observations_from_review",
+    "list_intervention_assignments",
     "list_teacher_actions",
+    "update_intervention_assignment_status",
     "update_teacher_action_status",
 ]

--- a/deeptutor/services/evidence/intervention_assignments.py
+++ b/deeptutor/services/evidence/intervention_assignments.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import sqlite3
+from typing import Any
+from uuid import uuid4
+
+_ALLOWED_ASSIGNMENT_TYPES = {
+    "practice_set",
+    "reteach_session",
+    "prerequisite_review",
+    "small_group_activity",
+}
+_ALLOWED_ASSIGNMENT_STATUSES = {"draft", "planned", "done", "dismissed"}
+
+
+def _now_ts() -> int:
+    return int(datetime.now(tz=timezone.utc).timestamp())
+
+
+def _connect(db_path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_tables(db_path) -> None:
+    with _connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS intervention_assignments (
+                id TEXT PRIMARY KEY,
+                teacher_action_id TEXT NOT NULL,
+                target_type TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                assignment_type TEXT NOT NULL,
+                topic TEXT NOT NULL,
+                title TEXT NOT NULL,
+                teacher_note TEXT NOT NULL,
+                practice_note TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_intervention_assignments_target
+                ON intervention_assignments(target_type, target_id, updated_at DESC)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_intervention_assignments_action
+                ON intervention_assignments(teacher_action_id, updated_at DESC)
+            """
+        )
+        conn.commit()
+
+
+def _row_to_record(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "teacher_action_id": row["teacher_action_id"],
+        "target_type": row["target_type"],
+        "target_id": row["target_id"],
+        "assignment_type": row["assignment_type"],
+        "topic": row["topic"],
+        "title": row["title"],
+        "teacher_note": row["teacher_note"],
+        "practice_note": row["practice_note"],
+        "status": row["status"],
+        "created_at": int(row["created_at"]),
+        "updated_at": int(row["updated_at"]),
+    }
+
+
+def list_intervention_assignments(store: Any) -> list[dict[str, Any]]:
+    _ensure_tables(store.db_path)
+    with _connect(store.db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, teacher_action_id, target_type, target_id, assignment_type,
+                   topic, title, teacher_note, practice_note, status, created_at, updated_at
+            FROM intervention_assignments
+            ORDER BY updated_at DESC, created_at DESC, id DESC
+            """
+        ).fetchall()
+    return [_row_to_record(row) for row in rows]
+
+
+def create_intervention_assignment(
+    store: Any,
+    *,
+    teacher_action_id: str,
+    assignment_type: str,
+    title: str,
+    teacher_note: str,
+    practice_note: str,
+) -> dict[str, Any]:
+    if assignment_type not in _ALLOWED_ASSIGNMENT_TYPES:
+        raise ValueError("invalid assignment_type")
+
+    cleaned_action_id = teacher_action_id.strip()
+    cleaned_title = title.strip()
+    cleaned_teacher_note = teacher_note.strip()
+    cleaned_practice_note = practice_note.strip()
+    if not cleaned_action_id or not cleaned_title or not cleaned_teacher_note or not cleaned_practice_note:
+        raise ValueError("missing required intervention assignment field")
+
+    _ensure_tables(store.db_path)
+    now = _now_ts()
+    with _connect(store.db_path) as conn:
+        action = conn.execute(
+            """
+            SELECT id, target_type, target_id, topic
+            FROM teacher_actions
+            WHERE id = ?
+            """,
+            (cleaned_action_id,),
+        ).fetchone()
+        if action is None:
+            raise KeyError(cleaned_action_id)
+
+        record = {
+            "id": f"intervention-assignment:{uuid4().hex}",
+            "teacher_action_id": cleaned_action_id,
+            "target_type": action["target_type"],
+            "target_id": action["target_id"],
+            "assignment_type": assignment_type,
+            "topic": action["topic"],
+            "title": cleaned_title,
+            "teacher_note": cleaned_teacher_note,
+            "practice_note": cleaned_practice_note,
+            "status": "planned",
+            "created_at": now,
+            "updated_at": now,
+        }
+        conn.execute(
+            """
+            INSERT INTO intervention_assignments (
+                id, teacher_action_id, target_type, target_id, assignment_type,
+                topic, title, teacher_note, practice_note, status, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record["id"],
+                record["teacher_action_id"],
+                record["target_type"],
+                record["target_id"],
+                record["assignment_type"],
+                record["topic"],
+                record["title"],
+                record["teacher_note"],
+                record["practice_note"],
+                record["status"],
+                record["created_at"],
+                record["updated_at"],
+            ),
+        )
+        conn.commit()
+    return deepcopy(record)
+
+
+def update_intervention_assignment_status(
+    store: Any,
+    assignment_id: str,
+    *,
+    status: str,
+) -> dict[str, Any]:
+    if status not in _ALLOWED_ASSIGNMENT_STATUSES:
+        raise ValueError("invalid status")
+
+    _ensure_tables(store.db_path)
+    now = _now_ts()
+    with _connect(store.db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT id, teacher_action_id, target_type, target_id, assignment_type,
+                   topic, title, teacher_note, practice_note, status, created_at, updated_at
+            FROM intervention_assignments
+            WHERE id = ?
+            """,
+            (assignment_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(assignment_id)
+
+        conn.execute(
+            """
+            UPDATE intervention_assignments
+            SET status = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (status, now, assignment_id),
+        )
+        conn.commit()
+
+        updated = dict(_row_to_record(row))
+        updated["status"] = status
+        updated["updated_at"] = now
+        return updated

--- a/deeptutor/services/evidence/teacher_insights.py
+++ b/deeptutor/services/evidence/teacher_insights.py
@@ -30,6 +30,15 @@ def _student_actions(student_id: str, actions: list[dict[str, Any]]) -> list[dic
     return sorted(rows, key=lambda row: row.get("updated_at", 0), reverse=True)
 
 
+def _student_assignments(student_id: str, assignments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows = [
+        assignment
+        for assignment in assignments
+        if assignment.get("target_type") == "student" and assignment.get("target_id") == student_id
+    ]
+    return sorted(rows, key=lambda row: row.get("updated_at", 0), reverse=True)
+
+
 def _small_group_target_id(topic: str, diagnosis_type: str, source_action_type: str) -> str:
     return f"{topic}::{diagnosis_type}::{source_action_type}"
 
@@ -38,13 +47,19 @@ def build_teacher_insights_payload(
     *,
     student_payloads: list[dict[str, Any]],
     teacher_actions: list[dict[str, Any]] | None = None,
+    intervention_assignments: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     teacher_actions = teacher_actions or []
+    intervention_assignments = intervention_assignments or []
     grouped: dict[tuple[str, str, str], list[tuple[str, int]]] = defaultdict(list)
     students: list[dict[str, Any]] = []
     for payload in student_payloads:
         row = dict(payload)
         row["teacher_actions"] = _student_actions(str(payload.get("student_id") or "unknown"), teacher_actions)
+        row["intervention_assignments"] = _student_assignments(
+            str(payload.get("student_id") or "unknown"),
+            intervention_assignments,
+        )
         students.append(row)
         inferred = _top_inferred(payload)
         action = _top_action(payload)
@@ -80,6 +95,14 @@ def build_teacher_insights_payload(
             ),
             None,
         )
+        matching_group_assignment = next(
+            (
+                assignment
+                for assignment in intervention_assignments
+                if assignment.get("target_type") == "small_group" and assignment.get("target_id") == target_id
+            ),
+            None,
+        )
         small_groups.append(
             {
                 "topic": topic,
@@ -90,6 +113,7 @@ def build_teacher_insights_payload(
                 "confidence_tag": "high" if avg_confidence >= 2.5 else "medium",
                 "target_id": target_id,
                 "teacher_action": matching_group_action,
+                "intervention_assignment": matching_group_assignment,
             }
         )
 

--- a/docs/superpowers/plans/2026-04-27-f102-intervention-assignment-flow.md
+++ b/docs/superpowers/plans/2026-04-27-f102-intervention-assignment-flow.md
@@ -1,0 +1,384 @@
+# Intervention Assignment Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let teachers convert an existing `teacher_action` into a bounded `intervention_assignment` that appears back in the dashboard flow for student and small-group remediation.
+
+**Architecture:** This feature adds a lightweight `intervention_assignments` store inside the existing dashboard/evidence boundary, linked to the `teacher_actions` created in `F101`. The backend exposes create/update routes and attaches assignment summaries back onto student and group insight payloads, while the frontend adds a compact assignment composer and readback surfaces without introducing delivery, due dates, or completion semantics.
+
+**Tech Stack:** FastAPI, SQLite-backed evidence helpers, pytest, Next.js App Router, React client components, TypeScript, Tailwind CSS, existing dashboard REST client
+
+---
+
+### Task 1: Add The Intervention Assignment Store And Failing Tests
+
+**Files:**
+- Create: `deeptutor/services/evidence/intervention_assignments.py`
+- Modify: `deeptutor/services/evidence/__init__.py`
+- Test: `tests/api/test_dashboard_router.py`
+
+- [ ] **Step 1: Write failing backend tests for intervention assignment create/read/update**
+
+Add tests to `tests/api/test_dashboard_router.py` that assert:
+- a student teacher action can be converted into an assignment
+- a small-group teacher action can be converted into an assignment
+- assignment summaries round-trip back into dashboard insight payloads
+- assignment status updates persist
+
+Use these target test names:
+
+```python
+async def test_dashboard_intervention_assignment_create_round_trip(...)
+async def test_dashboard_intervention_assignment_attaches_to_student_payload(...)
+async def test_dashboard_group_intervention_assignment_summary_attaches_to_group_card(...)
+async def test_dashboard_intervention_assignment_status_update_round_trip(...)
+```
+
+- [ ] **Step 2: Run the targeted tests and confirm they fail**
+
+Run:
+
+```bash
+pytest tests/api/test_dashboard_router.py -k intervention_assignment -q
+```
+
+Expected:
+- failures for missing routes, payload keys, or helper functions
+
+- [ ] **Step 3: Implement the SQLite helper for intervention assignments**
+
+Create `deeptutor/services/evidence/intervention_assignments.py` with:
+
+```python
+_ALLOWED_ASSIGNMENT_TYPES = {
+    "practice_set",
+    "reteach_session",
+    "prerequisite_review",
+    "small_group_activity",
+}
+_ALLOWED_ASSIGNMENT_STATUSES = {"draft", "planned", "done", "dismissed"}
+```
+
+and bounded functions:
+
+```python
+def create_intervention_assignment(
+    store: Any,
+    *,
+    teacher_action_id: str,
+    assignment_type: str,
+    title: str,
+    teacher_note: str,
+    practice_note: str,
+) -> dict[str, Any]:
+    ...
+
+def update_intervention_assignment_status(
+    store: Any,
+    assignment_id: str,
+    *,
+    status: str,
+) -> dict[str, Any]:
+    ...
+
+def list_intervention_assignments(store: Any) -> list[dict[str, Any]]:
+    ...
+```
+
+Use the linked `teacher_action` row to inherit:
+- `target_type`
+- `target_id`
+- `topic`
+
+- [ ] **Step 4: Export the helper from `deeptutor/services/evidence/__init__.py`**
+
+Add explicit imports alongside the teacher-action helper so the router can use the new store functions.
+
+- [ ] **Step 5: Run the targeted tests again**
+
+Run:
+
+```bash
+pytest tests/api/test_dashboard_router.py -k intervention_assignment -q
+```
+
+Expected:
+- route tests still fail, but helper-level failures are gone
+
+- [ ] **Step 6: Commit the backend helper slice**
+
+```bash
+git add deeptutor/services/evidence/intervention_assignments.py deeptutor/services/evidence/__init__.py tests/api/test_dashboard_router.py
+git commit -m "feat(evidence): add intervention assignment store [F102]"
+```
+
+### Task 2: Extend Dashboard Routes And Insight Payload Assembly
+
+**Files:**
+- Modify: `deeptutor/api/routers/dashboard.py`
+- Modify: `deeptutor/services/evidence/teacher_insights.py`
+- Test: `tests/api/test_dashboard_router.py`
+
+- [ ] **Step 1: Add request models for assignment create and status update**
+
+Inside `deeptutor/api/routers/dashboard.py`, add:
+
+```python
+class InterventionAssignmentCreateRequest(BaseModel):
+    teacher_action_id: str
+    assignment_type: str
+    title: str
+    teacher_note: str
+    practice_note: str
+
+
+class InterventionAssignmentStatusUpdateRequest(BaseModel):
+    status: str
+```
+
+- [ ] **Step 2: Add the create and update routes**
+
+Implement:
+
+```python
+@router.post("/intervention-assignments")
+async def create_dashboard_intervention_assignment(
+    payload: InterventionAssignmentCreateRequest,
+) -> dict[str, Any]:
+    ...
+
+
+@router.patch("/intervention-assignments/{assignment_id}")
+async def update_dashboard_intervention_assignment_status(
+    assignment_id: str,
+    payload: InterventionAssignmentStatusUpdateRequest,
+) -> dict[str, Any]:
+    ...
+```
+
+Translate:
+- invalid linked action -> `400`
+- missing row -> `404`
+
+- [ ] **Step 3: Attach assignment summaries into insight payloads**
+
+Extend `deeptutor/services/evidence/teacher_insights.py` so:
+- each student row can expose `intervention_assignments`
+- each small-group row can expose the newest linked assignment summary as `intervention_assignment`
+
+Keep this bounded:
+- use latest assignment summary only on overview cards
+- keep full per-student assignment list on detail payloads
+
+- [ ] **Step 4: Run the targeted dashboard tests**
+
+Run:
+
+```bash
+pytest tests/api/test_dashboard_router.py -k "teacher_action or intervention_assignment or dashboard_insights" -q
+```
+
+Expected:
+- all targeted dashboard API tests pass
+
+- [ ] **Step 5: Commit the route/payload slice**
+
+```bash
+git add deeptutor/api/routers/dashboard.py deeptutor/services/evidence/teacher_insights.py tests/api/test_dashboard_router.py
+git commit -m "feat(dashboard): add intervention assignment routes [F102]"
+```
+
+### Task 3: Extend The Dashboard API Client Types
+
+**Files:**
+- Modify: `web/lib/dashboard-api.ts`
+
+- [ ] **Step 1: Define assignment types and request contracts**
+
+Add:
+
+```ts
+export type InterventionAssignmentType =
+  | "practice_set"
+  | "reteach_session"
+  | "prerequisite_review"
+  | "small_group_activity";
+
+export type InterventionAssignmentStatus = "draft" | "planned" | "done" | "dismissed";
+
+export interface InterventionAssignmentRecord {
+  id: string;
+  teacher_action_id: string;
+  target_type: "student" | "small_group";
+  target_id: string;
+  assignment_type: InterventionAssignmentType;
+  topic: string;
+  title: string;
+  teacher_note: string;
+  practice_note: string;
+  status: InterventionAssignmentStatus;
+  created_at: number;
+  updated_at: number;
+}
+```
+
+- [ ] **Step 2: Extend dashboard payload types**
+
+Add:
+- `intervention_assignments?: InterventionAssignmentRecord[]` to `TeacherInsightStudent`
+- `intervention_assignment?: InterventionAssignmentRecord | null` to small-group rows
+
+- [ ] **Step 3: Add API helpers**
+
+Create:
+
+```ts
+export async function createInterventionAssignment(...)
+export async function updateInterventionAssignmentStatus(...)
+```
+
+using `/api/v1/dashboard/intervention-assignments`.
+
+- [ ] **Step 4: Run targeted frontend lint for the API client**
+
+Run:
+
+```bash
+cd web && ./node_modules/.bin/eslint --config eslint.config.mjs lib/dashboard-api.ts
+```
+
+Expected:
+- pass
+
+- [ ] **Step 5: Commit the client contract slice**
+
+```bash
+git add web/lib/dashboard-api.ts
+git commit -m "feat(dashboard): add intervention assignment client contracts [F102]"
+```
+
+### Task 4: Add The Assignment Composer And Overview Surfaces
+
+**Files:**
+- Create: `web/components/dashboard/InterventionAssignmentComposer.tsx`
+- Modify: `web/components/dashboard/StudentInsightCard.tsx`
+- Modify: `web/components/dashboard/SmallGroupInsightCard.tsx`
+
+- [ ] **Step 1: Create the assignment composer**
+
+Implement a client component that:
+- takes a `teacherAction` record
+- prefills `assignment_type`, `title`, `teacher_note`, `practice_note`
+- posts to `createInterventionAssignment`
+- returns the created record through `onCreated`
+
+Use a compact UI parallel to `TeacherActionComposer.tsx`.
+
+- [ ] **Step 2: Render the composer from student cards**
+
+On `StudentInsightCard.tsx`:
+- keep the existing `TeacherActionComposer`
+- when a latest teacher action exists, show `Convert to assignment`
+- after create, show a summary box:
+  - assignment type
+  - title
+  - status
+
+- [ ] **Step 3: Render the composer from small-group cards**
+
+On `SmallGroupInsightCard.tsx`:
+- show `Convert to assignment` only after a group teacher action exists
+- show latest assignment summary after create
+
+- [ ] **Step 4: Run targeted frontend lint**
+
+Run:
+
+```bash
+cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/InterventionAssignmentComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx
+```
+
+Expected:
+- pass
+
+- [ ] **Step 5: Commit the overview UI slice**
+
+```bash
+git add web/components/dashboard/InterventionAssignmentComposer.tsx web/components/dashboard/StudentInsightCard.tsx web/components/dashboard/SmallGroupInsightCard.tsx
+git commit -m "feat(dashboard): add intervention assignment composer [F102]"
+```
+
+### Task 5: Extend Student Detail And Task Packet/PR Note
+
+**Files:**
+- Modify: `web/components/dashboard/StudentInsightDetail.tsx`
+- Create: `docs/superpowers/tasks/2026-04-27-f102-intervention-assignment-flow.md`
+- Create: `docs/superpowers/pr-notes/2026-04-27-f102-intervention-assignment-flow.md`
+- Modify: `ai_first/daily/2026-04-26.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+- [ ] **Step 1: Add the `Intervention assignments` section to student detail**
+
+Render:
+- assignment type
+- title
+- topic
+- teacher note
+- practice note
+- status select using `updateInterventionAssignmentStatus`
+
+- [ ] **Step 2: Create the task packet**
+
+Add a packet that records:
+- task ID `F102_INTERVENTION_ASSIGNMENT_FLOW`
+- commit tag `F102`
+- goal
+- owned files
+- do-not-touch files
+- validations
+
+- [ ] **Step 3: Create the PR note with Mermaid diagram**
+
+Add a note showing:
+- recommendation
+- teacher action
+- intervention assignment
+- dashboard/detail surfaces
+
+- [ ] **Step 4: Run final targeted validation**
+
+Run:
+
+```bash
+pytest tests/api/test_dashboard_router.py -k "teacher_action or intervention_assignment or dashboard_insights" -q
+cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/InterventionAssignmentComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts
+git diff --check
+```
+
+Expected:
+- targeted pytest passes
+- targeted eslint passes
+- diff check clean
+
+- [ ] **Step 5: Update daily log and assignment status**
+
+Record:
+- implementation done
+- validations run
+- next likely follow-up (`F103`, `F107`, or `F120`)
+
+- [ ] **Step 6: Commit the final slice**
+
+```bash
+git add web/components/dashboard/StudentInsightDetail.tsx docs/superpowers/tasks/2026-04-27-f102-intervention-assignment-flow.md docs/superpowers/pr-notes/2026-04-27-f102-intervention-assignment-flow.md ai_first/daily/2026-04-26.md ai_first/ACTIVE_ASSIGNMENTS.md
+git commit -m "feat(dashboard): show intervention assignments in detail [F102]"
+```
+
+## Spec Coverage Check
+
+- linked assignment object: covered by Tasks 1 and 2
+- student + small-group create flow: covered by Task 4
+- student detail assignment section: covered by Task 5
+- bounded API/status update contract: covered by Tasks 2, 3, and 5
+- non-goals (no delivery/due date/completion): enforced by file scope and omitted route/data fields
+

--- a/docs/superpowers/pr-notes/2026-04-27-f102-intervention-assignment-flow.md
+++ b/docs/superpowers/pr-notes/2026-04-27-f102-intervention-assignment-flow.md
@@ -1,0 +1,56 @@
+# F102 Intervention Assignment Flow PR Note
+
+## Changed
+
+- added a bounded `intervention_assignments` backend contract inside the dashboard/evidence layer
+- added dashboard APIs:
+  - `POST /api/v1/dashboard/intervention-assignments`
+  - `PATCH /api/v1/dashboard/intervention-assignments/{assignment_id}`
+- attached intervention assignment summaries back onto student and small-group insight payloads
+- added an intervention assignment composer for teacher-created follow-up activities
+- added an `Intervention assignments` section on student detail with bounded status updates
+- updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+## Why
+
+`F101` let teachers convert AI recommendations into structured teacher actions, but the product still stopped short of a concrete remediation artifact. `F102` adds the next bounded step: a teacher-facing intervention assignment shell linked to a teacher action, while deliberately avoiding a full assignment delivery or classroom-operations system.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Rec["Recommended Action"] --> Action["Teacher Action"]
+  Action --> AssignAPI["POST/PATCH intervention-assignments"]
+  AssignAPI --> AssignStore["intervention_assignments table"]
+  AssignStore --> Overview["Student card / Small-group card summary"]
+  AssignStore --> Detail["Student detail assignment section"]
+```
+
+## Main System Map
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` **was updated** because this PR adds a new dashboard API surface and a new teacher-facing intervention assignment data flow.
+
+## Tests run
+
+- `pytest tests/api/test_dashboard_router.py -k "teacher_action or intervention_assignment or dashboard_insights" -q`
+- `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/InterventionAssignmentComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts`
+- `git diff --check`
+
+## Risks
+
+- intervention assignments are still teacher-facing records only, not student-delivered assignments
+- this first pass does not add due dates, notifications, class roster links, or completion tracking
+- the model assumes a teacher action exists before an intervention assignment can be created
+
+## Next AI should read
+
+1. `docs/superpowers/tasks/2026-04-27-f102-intervention-assignment-flow.md`
+2. `docs/superpowers/specs/2026-04-27-f102-intervention-assignment-flow-design.md`
+3. `docs/superpowers/plans/2026-04-27-f102-intervention-assignment-flow.md`
+
+## Suggested next action
+
+If this lands cleanly, the most natural follow-ups are:
+- `F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS`
+- `F107_INTERVENTION_HISTORY_VIEW`
+- `F120_INTERVENTION_EFFECTIVENESS_TRACKING`

--- a/docs/superpowers/specs/2026-04-27-f102-intervention-assignment-flow-design.md
+++ b/docs/superpowers/specs/2026-04-27-f102-intervention-assignment-flow-design.md
@@ -1,0 +1,274 @@
+# F102 Intervention Assignment Flow Design
+
+Date: 2026-04-27
+Status: Proposed
+Task ID: `F102_INTERVENTION_ASSIGNMENT_FLOW`
+Commit tag: `F102`
+Branch: `pod-a/intervention-assignment-flow`
+
+## Goal
+
+Extend the merged `F101_TEACHER_ACTION_EXECUTION_LOOP` so a teacher can turn a bounded teacher action into a concrete remediation assignment or follow-up activity without opening a full LMS or classroom-operations subsystem.
+
+This slice must make the dashboard loop stronger:
+
+`Observed -> Inferred -> Recommended Action -> Teacher Action -> Intervention Assignment`
+
+## Why This Slice Exists
+
+`F101` proved that teachers can convert a recommendation into a structured teacher action. That still leaves a gap between:
+- a teacher decision
+- a concrete remediation artifact that can be referenced, reviewed, and reused
+
+Without `F102`, the product still stops one step short of a usable execution loop. The teacher can say what they want to do, but not turn that decision into a bounded assignment/remediation shell inside the product.
+
+## Scope
+
+This design adds a lightweight `intervention_assignment` object linked to an existing `teacher_action`.
+
+The assignment object is intentionally teacher-facing first:
+- it records what follow-up activity the teacher intends to run
+- it stays inside the dashboard/evidence boundary
+- it does not become a student delivery contract yet
+
+## Non-Goals
+
+This first pass must not add:
+- due dates
+- student-facing delivery
+- notifications
+- submission/completion contracts
+- grading
+- class roster integration
+- calendar/scheduling workflows
+
+Those belong to later tasks such as classroom operations or richer intervention tracking.
+
+## Approaches Considered
+
+### 1. Expand `teacher_action` only
+
+Add more fields directly onto the existing `teacher_action` record and treat it as both the decision and the assignment.
+
+Pros:
+- smallest backend delta
+- lowest migration cost
+
+Cons:
+- blurs the boundary between teacher intent and teacher-created remediation artifact
+- makes later assignment history and intervention tracking harder to model cleanly
+
+### 2. Add a linked `intervention_assignment` shell
+
+Keep `teacher_action` as the decision object, and add a second object linked to it for the assignment/remediation shell.
+
+Pros:
+- keeps product semantics clean
+- creates a clear upgrade path for intervention history and effectiveness tracking
+- still fits inside the teacher-facing dashboard slice
+
+Cons:
+- slightly more backend and UI work than option 1
+
+### 3. Build a mini LMS flow
+
+Create a more complete assignment system with delivery semantics, due dates, and completion tracking.
+
+Pros:
+- stronger long-term structure
+
+Cons:
+- too large for this slice
+- immediately drags in classroom operations and student-facing contracts
+
+## Recommended Approach
+
+Choose **Approach 2: linked `intervention_assignment` shell**.
+
+This keeps the product model clean:
+- `teacher_action` = teacher intent / planned move
+- `intervention_assignment` = concrete follow-up activity created from that move
+
+It is the smallest approach that still creates a real product step beyond notes or status tags.
+
+## Data Model
+
+Add a new `intervention_assignment` record in the same bounded storage area currently used for dashboard teacher actions.
+
+### Intervention Assignment Shape
+
+- `id`
+- `teacher_action_id`
+- `target_type`
+  - `student`
+  - `small_group`
+- `target_id`
+- `assignment_type`
+  - `practice_set`
+  - `reteach_session`
+  - `prerequisite_review`
+  - `small_group_activity`
+- `topic`
+- `title`
+- `teacher_note`
+- `practice_note`
+- `status`
+  - `draft`
+  - `planned`
+  - `done`
+  - `dismissed`
+- `created_at`
+- `updated_at`
+
+### Boundary Rules
+
+- Every intervention assignment must be linked to an existing `teacher_action`.
+- A teacher action can exist without an intervention assignment.
+- This slice does not require multiple assignments per action, but the model should not prevent that later.
+
+## UI Flow
+
+### Student Path
+
+1. Teacher opens a student insight card or student detail view.
+2. Teacher sees an existing `teacher_action`.
+3. Teacher clicks `Convert to assignment`.
+4. The system opens a compact assignment composer with prefills from the teacher action:
+   - topic
+   - likely assignment type
+   - base teacher instruction
+5. Teacher edits:
+   - assignment type
+   - title
+   - teacher note
+   - practice note
+6. On save, the dashboard immediately shows the assignment summary under that action.
+
+### Small-Group Path
+
+1. Teacher creates or views a group action from the small-group card.
+2. Teacher clicks `Convert to assignment`.
+3. The assignment shell is created for the whole group with a group-appropriate default type.
+4. The group card shows the assignment summary immediately.
+
+## Teacher-Facing Surfaces
+
+### Dashboard Overview
+
+- Student cards continue to show the latest `teacher_action`.
+- If an assignment exists for the newest action, show a compact summary:
+  - assignment type
+  - title
+  - status
+
+### Student Detail
+
+Add a new section:
+- `Intervention assignments`
+
+Each record shows:
+- assignment type
+- title
+- topic
+- note summary
+- status
+
+### Small-Group Card
+
+Show the latest linked assignment summary for the group action if one exists.
+
+## API Contract
+
+Add bounded dashboard endpoints:
+
+- `POST /api/v1/dashboard/intervention-assignments`
+- `PATCH /api/v1/dashboard/intervention-assignments/{assignment_id}`
+
+The create route should:
+- validate the linked `teacher_action_id`
+- inherit `target_type` and `target_id` from the teacher action
+- require non-empty assignment content fields
+
+The update route should only support bounded status changes in this slice.
+
+## Storage Boundary
+
+Keep storage inside the current dashboard/evidence boundary next to `teacher_actions`.
+
+Do not create a new classroom or delivery subsystem.
+
+A dedicated helper module under `deeptutor/services/evidence/` is acceptable, for example:
+- `intervention_assignments.py`
+
+## Guardrails
+
+### Guardrail: Do not build delivery
+
+This slice produces an assignment shell only. It does not claim the student has received or completed anything.
+
+### Guardrail: Do not replace teacher actions
+
+Assignments are downstream artifacts from teacher actions. They should not bypass the `teacher_action` step.
+
+### Guardrail: Keep the loop visible
+
+If the created assignment does not appear back in the same dashboard flow immediately, the feature will not feel real.
+
+## Testing Strategy
+
+### Backend
+
+Add tests for:
+- create assignment from valid teacher action
+- reject assignment when linked action does not exist
+- list/attach assignment summaries back to student/group insight payloads
+- update assignment status
+
+### Frontend
+
+Add targeted coverage or bounded validation for:
+- assignment composer render and create flow
+- student detail assignment summary render
+- group assignment summary render
+
+### Validation Commands
+
+- targeted `pytest` for dashboard router and evidence helpers
+- targeted `eslint` for changed dashboard files
+- `git diff --check`
+
+## Owned Files
+
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- `web/app/(workspace)/dashboard/student/`
+- `web/lib/dashboard-api.ts`
+- `deeptutor/api/routers/dashboard.py`
+- bounded `deeptutor/services/evidence/`
+- related dashboard tests
+- `docs/superpowers/tasks/`
+- `docs/superpowers/pr-notes/`
+
+## Do-Not-Touch
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/session/`
+- `/agents` authoring UX
+- broader classroom operations or roster systems
+- assessment-generation internals outside bounded dashboard needs
+
+## Acceptance Criteria
+
+1. A teacher can convert a `teacher_action` into an `intervention_assignment`.
+2. The flow works for both `student` and `small_group` targets.
+3. The assignment appears immediately in the same dashboard flow after creation.
+4. Student detail exposes intervention assignments as a separate teacher-facing section.
+5. The feature does not introduce delivery, due dates, or completion semantics.
+6. The backend and UI remain inside the dashboard/evidence boundary.
+
+## Follow-On Tasks
+
+If this lands cleanly, the most natural next tasks are:
+- `F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS`
+- `F107_INTERVENTION_HISTORY_VIEW`
+- `F120_INTERVENTION_EFFECTIVENESS_TRACKING`

--- a/docs/superpowers/tasks/2026-04-27-f102-intervention-assignment-flow.md
+++ b/docs/superpowers/tasks/2026-04-27-f102-intervention-assignment-flow.md
@@ -1,0 +1,66 @@
+# Intervention Assignment Flow
+
+- Task ID: `F102_INTERVENTION_ASSIGNMENT_FLOW`
+- Commit tag: `F102`
+- Status: `Ready for execution`
+- Branch: `pod-a/intervention-assignment-flow`
+
+## Goal
+
+Let teachers convert an existing `teacher_action` into a bounded `intervention_assignment` for:
+- `student`
+- `small_group`
+
+This task extends the dashboard loop from `Teacher Action` to a concrete remediation assignment shell without building a full delivery or classroom-operations system.
+
+## Owned Files
+
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- `web/app/(workspace)/dashboard/student/`
+- `web/lib/dashboard-api.ts`
+- `deeptutor/api/routers/dashboard.py`
+- bounded helper code under `deeptutor/services/evidence/`
+- `tests/api/test_dashboard_router.py`
+- task docs, PR note, daily log, `ACTIVE_ASSIGNMENTS.md`, `TASK_REGISTRY.json`
+
+## Do-Not-Touch
+
+- `deeptutor/services/runtime_policy/`
+- `deeptutor/services/session/`
+- `/agents` authoring UI
+- classroom roster, scheduling, or notification systems
+- student-facing assignment delivery contracts
+- broader assessment generation flow
+
+## Required Behavior
+
+1. Convert a student-linked `teacher_action` into an `intervention_assignment`.
+2. Convert a small-group `teacher_action` into an `intervention_assignment`.
+3. Keep a tight assignment catalog only:
+   - `practice_set`
+   - `reteach_session`
+   - `prerequisite_review`
+   - `small_group_activity`
+4. Show the created assignment back in the same dashboard flow immediately.
+5. Show intervention assignments in student detail as a separate teacher-facing section.
+6. Allow bounded assignment status updates only:
+   - `planned`
+   - `done`
+   - `dismissed`
+
+## Validation
+
+- `pytest tests/api/test_dashboard_router.py -k "teacher_action or intervention_assignment or dashboard_insights" -q`
+- `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/InterventionAssignmentComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts`
+- `git diff --check`
+
+## Next AI Should Read
+
+1. `docs/superpowers/specs/2026-04-27-f102-intervention-assignment-flow-design.md`
+2. `docs/superpowers/plans/2026-04-27-f102-intervention-assignment-flow.md`
+3. this packet
+
+## Suggested Next Action
+
+Implement the linked backend assignment store first, then extend dashboard routes and insight payloads, then wire the assignment composer plus detail surfaces, and finish with docs sync and targeted validation.

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -673,6 +673,242 @@ async def test_dashboard_teacher_action_status_update_round_trip(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_intervention_assignment_create_round_trip(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {"student_id": "student-a", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/5 (Incorrect, correct: 1/4)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights").json()
+        recommendation_id = insights["students"][0]["recommended_actions"][0]["action_id"]
+        teacher_action = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "student",
+                "target_id": "student-a",
+                "source_recommendation_id": recommendation_id,
+                "action_type": "reteach_concept",
+                "topic": "fractions subtraction",
+                "teacher_instruction": "Reteach fractions subtraction with one visual model.",
+                "priority": "high",
+            },
+        ).json()
+
+        create_resp = client.post(
+            "/api/v1/dashboard/intervention-assignments",
+            json={
+                "teacher_action_id": teacher_action["id"],
+                "assignment_type": "reteach_session",
+                "title": "Reteach fractions subtraction",
+                "teacher_note": "Model the denominator alignment step once before guided practice.",
+                "practice_note": "Use one visual bar model and one scaffolded equation.",
+            },
+        )
+
+        assert create_resp.status_code == 200
+        created = create_resp.json()
+        assert created["teacher_action_id"] == teacher_action["id"]
+        assert created["target_type"] == "student"
+        assert created["status"] == "planned"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_intervention_assignment_attaches_to_student_payload(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {"student_id": "student-a", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/5 (Incorrect, correct: 1/4)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights").json()
+        recommendation_id = insights["students"][0]["recommended_actions"][0]["action_id"]
+        teacher_action = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "student",
+                "target_id": "student-a",
+                "source_recommendation_id": recommendation_id,
+                "action_type": "scaffolded_practice",
+                "topic": "fractions subtraction",
+                "teacher_instruction": "Give one scaffolded practice item before independent work.",
+                "priority": "medium",
+            },
+        ).json()
+
+        created = client.post(
+            "/api/v1/dashboard/intervention-assignments",
+            json={
+                "teacher_action_id": teacher_action["id"],
+                "assignment_type": "practice_set",
+                "title": "Scaffolded fractions practice",
+                "teacher_note": "Start with one worked example, then one guided problem.",
+                "practice_note": "Keep denominators under 8 for this round.",
+            },
+        ).json()
+
+        refreshed = client.get("/api/v1/dashboard/insights").json()
+        refreshed_student = next(row for row in refreshed["students"] if row["student_id"] == "student-a")
+        assert refreshed_student["intervention_assignments"][0]["id"] == created["id"]
+        assert refreshed_student["intervention_assignments"][0]["assignment_type"] == "practice_set"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_group_intervention_assignment_summary_attaches_to_group_card(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    for sid, student_id, answer in [
+        ("student-a-session", "student-a", "1/5"),
+        ("student-b-session", "student-b", "1/6"),
+    ]:
+        await _seed_session(
+            store,
+            session_id=sid,
+            capability="deep_question",
+            message="Generate a quiz on fractions",
+            knowledge_bases=["fractions-pack"],
+        )
+        await store.update_session_preferences(
+            sid,
+            {"student_id": student_id, "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+        )
+        await store.add_message(
+            sid,
+            "user",
+            f"[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: {answer} (Incorrect, correct: 1/4)\nScore: 0/1 (0%)",
+            capability="deep_question",
+        )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights").json()
+        group = insights["small_groups"][0]
+        teacher_action = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "small_group",
+                "target_id": group["target_id"],
+                "source_recommendation_id": f"group:{group['topic']}:{group['diagnosis_type']}",
+                "action_type": "small_group_remediation",
+                "topic": group["topic"],
+                "teacher_instruction": "Pull the students into one mini-group reteach.",
+                "priority": "high",
+            },
+        ).json()
+
+        created = client.post(
+            "/api/v1/dashboard/intervention-assignments",
+            json={
+                "teacher_action_id": teacher_action["id"],
+                "assignment_type": "small_group_activity",
+                "title": "Fractions mini-group reteach",
+                "teacher_note": "Run one 10-minute mini-group on equivalent denominators.",
+                "practice_note": "End with two shared practice items.",
+            },
+        ).json()
+
+        refreshed = client.get("/api/v1/dashboard/insights").json()
+        refreshed_group = refreshed["small_groups"][0]
+        assert refreshed_group["intervention_assignment"]["id"] == created["id"]
+        assert refreshed_group["intervention_assignment"]["assignment_type"] == "small_group_activity"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_intervention_assignment_status_update_round_trip(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+    await _seed_session(
+        store,
+        session_id="student-a-session",
+        capability="deep_question",
+        message="Generate a quiz on fractions",
+        knowledge_bases=["fractions-pack"],
+    )
+    await store.update_session_preferences(
+        "student-a-session",
+        {"student_id": "student-a", "knowledge_bases": ["fractions-pack"], "capability": "deep_question"},
+    )
+    await store.add_message(
+        "student-a-session",
+        "user",
+        "[Quiz Performance]\n1. [q1] Q: fractions subtraction -> Answered: 1/5 (Incorrect, correct: 1/4)\nScore: 0/1 (0%)",
+        capability="deep_question",
+    )
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        insights = client.get("/api/v1/dashboard/insights").json()
+        recommendation_id = insights["students"][0]["recommended_actions"][0]["action_id"]
+        teacher_action = client.post(
+            "/api/v1/dashboard/teacher-actions",
+            json={
+                "target_type": "student",
+                "target_id": "student-a",
+                "source_recommendation_id": recommendation_id,
+                "action_type": "review_prerequisite",
+                "topic": "fractions subtraction",
+                "teacher_instruction": "Review equivalent fractions before the next attempt.",
+                "priority": "medium",
+            },
+        ).json()
+
+        created = client.post(
+            "/api/v1/dashboard/intervention-assignments",
+            json={
+                "teacher_action_id": teacher_action["id"],
+                "assignment_type": "prerequisite_review",
+                "title": "Equivalent fractions review",
+                "teacher_note": "Start with one equivalence check and one denominator match task.",
+                "practice_note": "Avoid mixed numbers in this first pass.",
+            },
+        ).json()
+
+        update_resp = client.patch(
+            f"/api/v1/dashboard/intervention-assignments/{created['id']}",
+            json={"status": "done"},
+        )
+
+        assert update_resp.status_code == 200
+        assert update_resp.json()["status"] == "done"
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_applies_search_kb_type_and_min_score_filters(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/web/components/dashboard/InterventionAssignmentComposer.tsx
+++ b/web/components/dashboard/InterventionAssignmentComposer.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import {
+  createInterventionAssignment,
+  type CreateInterventionAssignmentRequest,
+  type InterventionAssignmentRecord,
+  type InterventionAssignmentType,
+  type TeacherActionRecord,
+} from "@/lib/dashboard-api";
+
+const ASSIGNMENT_TYPES: InterventionAssignmentType[] = [
+  "practice_set",
+  "reteach_session",
+  "prerequisite_review",
+  "small_group_activity",
+];
+
+function defaultAssignmentType(actionType: TeacherActionRecord["action_type"]): InterventionAssignmentType {
+  if (actionType === "small_group_remediation") return "small_group_activity";
+  if (actionType === "review_prerequisite") return "prerequisite_review";
+  if (actionType === "scaffolded_practice") return "practice_set";
+  return "reteach_session";
+}
+
+function defaultTitle(action: TeacherActionRecord): string {
+  return `${action.topic}: ${action.action_type.replaceAll("_", " ")}`;
+}
+
+export function InterventionAssignmentComposer({
+  triggerLabel,
+  teacherAction,
+  onCreated,
+  t,
+}: {
+  triggerLabel: string;
+  teacherAction: TeacherActionRecord;
+  onCreated: (record: InterventionAssignmentRecord) => void;
+  t: (value: string, options?: Record<string, string | number>) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [assignmentType, setAssignmentType] = useState<InterventionAssignmentType>(
+    defaultAssignmentType(teacherAction.action_type),
+  );
+  const [title, setTitle] = useState(defaultTitle(teacherAction));
+  const [teacherNote, setTeacherNote] = useState(teacherAction.teacher_instruction);
+  const [practiceNote, setPracticeNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    try {
+      const payload: CreateInterventionAssignmentRequest = {
+        teacher_action_id: teacherAction.id,
+        assignment_type: assignmentType,
+        title,
+        teacher_note: teacherNote,
+        practice_note: practiceNote,
+      };
+      const record = await createInterventionAssignment(payload);
+      onCreated(record);
+      setOpen(false);
+      setAssignmentType(defaultAssignmentType(teacherAction.action_type));
+      setTitle(defaultTitle(teacherAction));
+      setTeacherNote(teacherAction.teacher_instruction);
+      setPracticeNote("");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="inline-flex items-center rounded-full border border-[var(--border)] px-3 py-1 text-[12px] font-medium text-[var(--foreground)] transition hover:border-[var(--foreground)]"
+      >
+        {triggerLabel}
+      </button>
+      {open ? (
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-3">
+          <div className="grid gap-3">
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              {t("Assignment type")}
+              <select
+                value={assignmentType}
+                onChange={(e) => setAssignmentType(e.target.value as InterventionAssignmentType)}
+                className="mt-1 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]"
+              >
+                {ASSIGNMENT_TYPES.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              {t("Title")}
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="mt-1 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]"
+              />
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              {t("Teacher note")}
+              <textarea
+                value={teacherNote}
+                onChange={(e) => setTeacherNote(e.target.value)}
+                className="mt-1 min-h-[80px] w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]"
+              />
+            </label>
+            <label className="text-[12px] text-[var(--muted-foreground)]">
+              {t("Practice note")}
+              <textarea
+                value={practiceNote}
+                onChange={(e) => setPracticeNote(e.target.value)}
+                className="mt-1 min-h-[80px] w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)]"
+              />
+            </label>
+            <button
+              type="button"
+              disabled={submitting || title.trim().length === 0 || teacherNote.trim().length === 0 || practiceNote.trim().length === 0}
+              onClick={handleSubmit}
+              className="rounded-xl bg-[var(--foreground)] px-3 py-2 text-[13px] font-medium text-[var(--background)] disabled:opacity-60"
+            >
+              {submitting ? t("Saving...") : t("Create assignment")}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/components/dashboard/SmallGroupInsightCard.tsx
+++ b/web/components/dashboard/SmallGroupInsightCard.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { InterventionAssignmentComposer } from "@/components/dashboard/InterventionAssignmentComposer";
 import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
 import { TeacherActionComposer } from "@/components/dashboard/TeacherActionComposer";
-import type { DashboardInsights, TeacherActionRecord } from "@/lib/dashboard-api";
+import type { DashboardInsights, InterventionAssignmentRecord, TeacherActionRecord } from "@/lib/dashboard-api";
 
 type SmallGroupInsight = DashboardInsights["small_groups"][number];
 
@@ -15,6 +16,9 @@ export function SmallGroupInsightCard({
   t: (value: string, options?: Record<string, string | number>) => string;
 }) {
   const [teacherAction, setTeacherAction] = useState<TeacherActionRecord | null>(group.teacher_action ?? null);
+  const [interventionAssignment, setInterventionAssignment] = useState<InterventionAssignmentRecord | null>(
+    group.intervention_assignment ?? null,
+  );
 
   return (
     <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
@@ -54,6 +58,16 @@ export function SmallGroupInsightCard({
           />
         </div>
         {teacherAction ? (
+          <div className="mt-3">
+            <InterventionAssignmentComposer
+              triggerLabel={t("Convert to assignment")}
+              teacherAction={teacherAction}
+              onCreated={(record) => setInterventionAssignment(record)}
+              t={t}
+            />
+          </div>
+        ) : null}
+        {teacherAction ? (
           <div className="mt-3 rounded-2xl bg-white/70 p-3 text-[12px] text-emerald-900/80">
             <div className="font-medium">{teacherAction.action_type}</div>
             <div className="mt-1">{teacherAction.teacher_instruction}</div>
@@ -62,6 +76,15 @@ export function SmallGroupInsightCard({
                 status: teacherAction.status,
                 priority: teacherAction.priority,
               })}
+            </div>
+          </div>
+        ) : null}
+        {interventionAssignment ? (
+          <div className="mt-3 rounded-2xl border border-emerald-200 bg-white/80 p-3 text-[12px] text-emerald-900/80">
+            <div className="font-medium">{interventionAssignment.assignment_type}</div>
+            <div className="mt-1">{interventionAssignment.title}</div>
+            <div className="mt-2 text-[11px] text-emerald-900/70">
+              {t("Assignment status: {{status}}", { status: interventionAssignment.status })}
             </div>
           </div>
         ) : null}

--- a/web/components/dashboard/StudentInsightCard.tsx
+++ b/web/components/dashboard/StudentInsightCard.tsx
@@ -3,9 +3,10 @@
 import Link from "next/link";
 import { useState } from "react";
 import { ArrowRight } from "lucide-react";
+import { InterventionAssignmentComposer } from "@/components/dashboard/InterventionAssignmentComposer";
 import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
 import { TeacherActionComposer } from "@/components/dashboard/TeacherActionComposer";
-import type { TeacherActionRecord, TeacherInsightStudent } from "@/lib/dashboard-api";
+import type { InterventionAssignmentRecord, TeacherActionRecord, TeacherInsightStudent } from "@/lib/dashboard-api";
 
 function formatLatency(seconds: number | undefined): string | null {
   if (seconds == null) return null;
@@ -23,7 +24,11 @@ export function StudentInsightCard({
   const diagnosis = student.inferred[0];
   const recommendation = student.recommended_actions[0];
   const [teacherActions, setTeacherActions] = useState<TeacherActionRecord[]>(student.teacher_actions ?? []);
+  const [interventionAssignments, setInterventionAssignments] = useState<InterventionAssignmentRecord[]>(
+    student.intervention_assignments ?? [],
+  );
   const latestAction = teacherActions[0] ?? null;
+  const latestAssignment = interventionAssignments[0] ?? null;
 
   return (
     <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
@@ -112,6 +117,16 @@ export function StudentInsightCard({
             />
           </div>
           {latestAction ? (
+            <div className="mt-3">
+              <InterventionAssignmentComposer
+                triggerLabel={t("Convert to assignment")}
+                teacherAction={latestAction}
+                onCreated={(record) => setInterventionAssignments((current) => [record, ...current])}
+                t={t}
+              />
+            </div>
+          ) : null}
+          {latestAction ? (
             <div className="mt-3 rounded-2xl bg-white/70 p-3 text-[12px] text-emerald-900/80">
               <div className="font-medium">{latestAction.action_type}</div>
               <div className="mt-1">{latestAction.teacher_instruction}</div>
@@ -120,6 +135,15 @@ export function StudentInsightCard({
                   status: latestAction.status,
                   priority: latestAction.priority,
                 })}
+              </div>
+            </div>
+          ) : null}
+          {latestAssignment ? (
+            <div className="mt-3 rounded-2xl border border-emerald-200 bg-white/80 p-3 text-[12px] text-emerald-900/80">
+              <div className="font-medium">{latestAssignment.assignment_type}</div>
+              <div className="mt-1">{latestAssignment.title}</div>
+              <div className="mt-2 text-[11px] text-emerald-900/70">
+                {t("Assignment status: {{status}}", { status: latestAssignment.status })}
               </div>
             </div>
           ) : null}

--- a/web/components/dashboard/StudentInsightDetail.tsx
+++ b/web/components/dashboard/StudentInsightDetail.tsx
@@ -3,9 +3,12 @@
 import { useState } from "react";
 import { InsightSectionLabel } from "@/components/dashboard/InsightSectionLabel";
 import {
+  type InterventionAssignmentRecord,
+  type InterventionAssignmentStatus,
   type TeacherActionRecord,
   type TeacherActionStatus,
   type TeacherInsightStudent,
+  updateInterventionAssignmentStatus,
   updateTeacherActionStatus,
 } from "@/lib/dashboard-api";
 
@@ -23,6 +26,9 @@ export function StudentInsightDetail({
   t: (value: string, options?: Record<string, string | number>) => string;
 }) {
   const [teacherActions, setTeacherActions] = useState<TeacherActionRecord[]>(student?.teacher_actions ?? []);
+  const [interventionAssignments, setInterventionAssignments] = useState<InterventionAssignmentRecord[]>(
+    student?.intervention_assignments ?? [],
+  );
 
   const diagnosis = student?.inferred[0];
   const recommendation = student?.recommended_actions[0];
@@ -166,6 +172,55 @@ export function StudentInsightDetail({
           ) : (
             <div className="rounded-2xl bg-[var(--muted)]/50 p-4 text-[13px] text-[var(--muted-foreground)]">
               {t("Create a teacher action from the dashboard overview to track a concrete remediation move here.")}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm xl:col-span-2">
+        <InsightSectionLabel
+          eyebrow={t("Intervention assignments")}
+          title={
+            interventionAssignments.length
+              ? t("{{count}} recorded assignments", { count: interventionAssignments.length })
+              : t("No assignments yet")
+          }
+        />
+        <div className="mt-4 space-y-3">
+          {interventionAssignments.length ? (
+            interventionAssignments.map((assignment) => (
+              <div key={assignment.id} className="rounded-2xl bg-[var(--muted)]/50 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <div className="text-[13px] font-medium text-[var(--foreground)]">{assignment.assignment_type}</div>
+                    <div className="mt-1 text-[12px] text-[var(--muted-foreground)]">{assignment.title}</div>
+                  </div>
+                  <select
+                    value={assignment.status}
+                    onChange={async (e) => {
+                      const updated = await updateInterventionAssignmentStatus(
+                        assignment.id,
+                        e.target.value as InterventionAssignmentStatus,
+                      );
+                      setInterventionAssignments((current) =>
+                        current.map((row) => (row.id === updated.id ? updated : row)),
+                      );
+                    }}
+                    className="rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[12px] text-[var(--foreground)]"
+                  >
+                    <option value="planned">{t("planned")}</option>
+                    <option value="done">{t("done")}</option>
+                    <option value="dismissed">{t("dismissed")}</option>
+                  </select>
+                </div>
+                <div className="mt-3 text-[12px] text-[var(--muted-foreground)]">{assignment.topic}</div>
+                <div className="mt-3 text-[13px] text-[var(--foreground)]">{assignment.teacher_note}</div>
+                <div className="mt-2 text-[12px] text-[var(--muted-foreground)]">{assignment.practice_note}</div>
+              </div>
+            ))
+          ) : (
+            <div className="rounded-2xl bg-[var(--muted)]/50 p-4 text-[13px] text-[var(--muted-foreground)]">
+              {t("Convert a teacher action into an intervention assignment from the dashboard overview to track a concrete remediation shell here.")}
             </div>
           )}
         </div>

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -262,6 +262,7 @@ export interface TeacherInsightStudent {
     rationale: string;
   }>;
   teacher_actions?: TeacherActionRecord[];
+  intervention_assignments?: InterventionAssignmentRecord[];
 }
 
 export type TeacherActionType =
@@ -288,6 +289,29 @@ export interface TeacherActionRecord {
   updated_at: number;
 }
 
+export type InterventionAssignmentType =
+  | "practice_set"
+  | "reteach_session"
+  | "prerequisite_review"
+  | "small_group_activity";
+
+export type InterventionAssignmentStatus = "draft" | "planned" | "done" | "dismissed";
+
+export interface InterventionAssignmentRecord {
+  id: string;
+  teacher_action_id: string;
+  target_type: "student" | "small_group";
+  target_id: string;
+  assignment_type: InterventionAssignmentType;
+  topic: string;
+  title: string;
+  teacher_note: string;
+  practice_note: string;
+  status: InterventionAssignmentStatus;
+  created_at: number;
+  updated_at: number;
+}
+
 export interface DashboardInsights {
   students: TeacherInsightStudent[];
   small_groups: Array<{
@@ -297,6 +321,7 @@ export interface DashboardInsights {
     recommended_action: string;
     target_id?: string;
     teacher_action?: TeacherActionRecord | null;
+    intervention_assignment?: InterventionAssignmentRecord | null;
   }>;
 }
 
@@ -315,6 +340,14 @@ export interface CreateTeacherActionRequest {
   topic: string;
   teacher_instruction: string;
   priority: TeacherActionPriority;
+}
+
+export interface CreateInterventionAssignmentRequest {
+  teacher_action_id: string;
+  assignment_type: InterventionAssignmentType;
+  title: string;
+  teacher_note: string;
+  practice_note: string;
 }
 
 /**
@@ -357,4 +390,27 @@ export async function updateTeacherActionStatus(
     body: JSON.stringify({ status }),
   });
   return expectJson<TeacherActionRecord>(response);
+}
+
+export async function createInterventionAssignment(
+  payload: CreateInterventionAssignmentRequest,
+): Promise<InterventionAssignmentRecord> {
+  const response = await fetch(apiUrl("/api/v1/dashboard/intervention-assignments"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return expectJson<InterventionAssignmentRecord>(response);
+}
+
+export async function updateInterventionAssignmentStatus(
+  assignmentId: string,
+  status: InterventionAssignmentStatus,
+): Promise<InterventionAssignmentRecord> {
+  const response = await fetch(apiUrl(`/api/v1/dashboard/intervention-assignments/${assignmentId}`), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status }),
+  });
+  return expectJson<InterventionAssignmentRecord>(response);
 }


### PR DESCRIPTION
## Changed

- added a bounded `intervention_assignments` backend contract inside the dashboard/evidence layer
- added dashboard APIs:
  - `POST /api/v1/dashboard/intervention-assignments`
  - `PATCH /api/v1/dashboard/intervention-assignments/{assignment_id}`
- attached intervention assignment summaries back onto student and small-group insight payloads
- added an intervention assignment composer for teacher-created follow-up activities
- added an `Intervention assignments` section on student detail with bounded status updates
- updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`

## Why

`F101` let teachers convert AI recommendations into structured teacher actions, but the product still stopped short of a concrete remediation artifact. `F102` adds the next bounded step: a teacher-facing intervention assignment shell linked to a teacher action, while deliberately avoiding a full assignment delivery or classroom-operations system.

## Main System Map

`ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated because this PR adds a new dashboard API surface and a new teacher-facing intervention assignment data flow.

## Tests run

- `pytest tests/api/test_dashboard_router.py -k "teacher_action or intervention_assignment or dashboard_insights" -q`
- `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/InterventionAssignmentComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts`
- `git diff --check`

## Risks

- intervention assignments are still teacher-facing records only, not student-delivered assignments
- this first pass does not add due dates, notifications, class roster links, or completion tracking
- the model assumes a teacher action exists before an intervention assignment can be created
