### PR TITLE
docs(ai-first): sync control plane after F102 merge [OPS-F102-SYNC]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,5 @@ Rules:
 
 ## Active
 
-### Assignment
-
-- Owner: Codex Session A
-- Machine: local
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: `F102_INTERVENTION_ASSIGNMENT_FLOW`
-- Status: `draft-review`
-- Branch: `pod-a/intervention-assignment-flow`
-- Task packet: `docs/superpowers/tasks/2026-04-27-f102-intervention-assignment-flow.md`
-- Owned files: `web/components/dashboard/`, `web/app/(workspace)/dashboard/`, `web/app/(workspace)/dashboard/student/`, `web/lib/dashboard-api.ts`, `deeptutor/api/routers/dashboard.py`, bounded `deeptutor/services/evidence/`, related dashboard tests/docs`
-- PR: `https://github.com/Creative-Science-Contest-2026/Multiagent-learning-platform/pull/170`
-- Last update: `2026-04-27T00:14:15+0700`
-- Next action: `Wait for CI on PR #170, then move to ready-review if checks stay green.`
-- Blocker: `None`
+- No active AI implementation task is currently assigned on `main`.
+- The next product work should start from a fresh Session A or Session B branch/worktree after the human or AI loop selects the next future-backlog task.

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -7,7 +7,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Latest merged result
 
-- Latest feature-risk merge: `#165 [F101] feat(dashboard): add teacher action execution loop`
+- Latest feature-risk merge: `#170 [F102] feat(dashboard): add intervention assignment flow`
 - Lane 1 (`2026-04-26-lane-1-agent-spec-authoring`) merged to `main` through PR `#136`.
 - Lane 2 (`2026-04-26-lane-2-spec-runtime-assembly`) merged to `main` through PR `#135`.
 - Lane 3 (`2026-04-26-lane-3-observation-student-state`) merged to `main` through PR `#140`.
@@ -25,6 +25,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 - Future backlog Session B task `F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE` merged to `main` through PR `#164`.
 - Future backlog Session A task `F101_TEACHER_ACTION_EXECUTION_LOOP` merged to `main` through PR `#165`.
 - Post-`F113` control-plane sync merged to `main` through PR `#167`, but it left stale Session A state that this repair PR removes.
+- Future backlog Session A task `F102_INTERVENTION_ASSIGNMENT_FLOW` merged to `main` through PR `#170`.
 - Latest smoke result: the 2026-04-26 scripted-reset smoke pass succeeded in lane 6 (`docs/evaluation-evidence-readiness`) against current `main` behavior.
 - The two-lane contest MVP polish experiment is now fully merged to `main`:
   `#122` (`T044`), `#124` (`T045`), `#125` (`T046`), `#121` (`T049`), `#123` (`T050`), and `#126` (`T051`).
@@ -37,8 +38,8 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 
 ## Next recommended task
 
-- After `F101` and `F113`, the preferred next pair from the future backlog packet is:
-  - Session A: `F102_INTERVENTION_ASSIGNMENT_FLOW` or `F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS`
+- After `F101`, `F102`, and `F113`, the preferred next pair from the future backlog packet is:
+  - Session A: `F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS` or `F107_INTERVENTION_HISTORY_VIEW`
   - Session B: `F114_SPEC_VERSION_PINNING_PER_SESSION` or `F116_STUDENT_MODEL_ENRICHMENT`
 - Any new AI task should start from a fresh branch/worktree off `main`, not from a merged lane branch.
 
@@ -55,7 +56,7 @@ If a requested task appears to span multiple packets, stop and ask the human to 
 
 ## AI-owned blockers
 
-- None currently. The next AI-owned work is the post-contest future backlog, but no session is active by default after the `F101` and `F113` merges.
+- None currently. The next AI-owned work is the post-contest future backlog, but no session is active by default after the `F101`, `F102`, and `F113` merges.
 
 ## Human-review blockers
 

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T17:24:57Z",
+    "last_updated": "2026-04-26T17:28:08Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 51,
+      "count": 52,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -60,15 +60,14 @@
         "R5_DASHBOARD_ACTIONABILITY",
         "R6_CLAIM_CALIBRATION_PILOT",
         "F101_TEACHER_ACTION_EXECUTION_LOOP",
-        "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE"
+        "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE",
+        "F102_INTERVENTION_ASSIGNMENT_FLOW"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 1,
-      "tasks": [
-        "F102_INTERVENTION_ASSIGNMENT_FLOW"
-      ]
+      "count": 0,
+      "tasks": []
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -1251,10 +1250,10 @@
       "dependencies": [
         "F101_TEACHER_ACTION_EXECUTION_LOOP"
       ],
-      "status": "in-progress",
+      "status": "completed",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-workflow",
-      "notes": "Draft PR #170 is open on branch pod-a/intervention-assignment-flow. The branch adds linked intervention assignments on top of F101 teacher actions."
+      "notes": "Merged to main through PR #170. Teachers can now convert teacher actions into linked intervention assignments for students and small groups inside the dashboard flow."
     },
     {
       "id": "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS",

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -293,3 +293,13 @@
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `pytest tests/api/test_dashboard_router.py -k "teacher_action or intervention_assignment or dashboard_insights" -q`; `cd web && ./node_modules/.bin/eslint --config eslint.config.mjs components/dashboard/InterventionAssignmentComposer.tsx components/dashboard/StudentInsightCard.tsx components/dashboard/SmallGroupInsightCard.tsx components/dashboard/StudentInsightDetail.tsx lib/dashboard-api.ts`; `git diff --check`
 - Blockers: None.
 - Next: Wait for CI on `#170`, then move the branch to ready-review if checks stay green.
+
+## OPS_POST_170_F102_SYNC
+
+- Branch: `docs/post-170-f102-sync`
+- Task: `OPS_POST_170_F102_SYNC`
+- Done: Reset the AI-first control plane after `F102_INTERVENTION_ASSIGNMENT_FLOW` merged through PR `#170`.
+- Done: Cleared the active Session A assignment from `main` and advanced the queue to the next clean future-backlog pair.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: None.
+- Next: Start a fresh Session A or Session B branch/worktree for `F103/F107` or `F114/F116`.

--- a/docs/superpowers/pr-notes/2026-04-27-post-170-f102-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-27-post-170-f102-sync.md
@@ -1,0 +1,48 @@
+# PR Architecture Note: Post-170 F102 Control-Plane Sync
+
+## Summary
+
+This PR synchronizes the AI-first control plane after `F102_INTERVENTION_ASSIGNMENT_FLOW` merged to `main`. It clears the active Session A assignment from `main`, marks `F102` as completed in the task registry, and advances the future-backlog queue to the next clean Session A / Session B pair.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart TD
+  Merge["PR #170 merged on main"]
+  Registry["TASK_REGISTRY.json"]
+  Assignments["ACTIVE_ASSIGNMENTS.md"]
+  Queue["EXECUTION_QUEUE.md"]
+  NextPair["Next pair: F103/F114"]
+
+  Merge --> Registry
+  Merge --> Assignments
+  Merge --> Queue
+  Registry --> NextPair
+  Assignments --> NextPair
+  Queue --> NextPair
+```
+
+## Files Changed
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-26.md`
+- `docs/superpowers/pr-notes/2026-04-27-post-170-f102-sync.md`
+
+## Main System Map Update
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated. This PR only synchronizes AI-first task state after `F102` merged; it does not change runtime topology or product architecture.
+
+## Validation
+
+```bash
+python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+git diff --check
+```
+
+## Handoff Notes
+
+- `F102_INTERVENTION_ASSIGNMENT_FLOW` is complete on `main`.
+- No AI implementation lane remains active by default after this sync lands.
+- The next safe product pair is `F103/F107` for Session A and `F114/F116` for Session B.


### PR DESCRIPTION
## Summary

This PR synchronizes the AI-first control plane after `F102_INTERVENTION_ASSIGNMENT_FLOW` merged to `main`. It clears the active Session A assignment from `main`, marks `F102` as completed in the task registry, and advances the future-backlog queue to the next clean Session A / Session B pair.

## Main Changes

- clear the merged Session A assignment from `ai_first/ACTIVE_ASSIGNMENTS.md`
- mark `F102` as `completed` in `ai_first/TASK_REGISTRY.json`
- advance `ai_first/EXECUTION_QUEUE.md` so the next clean pair is `F103/F107` and `F114/F116`
- record the sync in the daily log and add a PR architecture note

## Main System Map Update

`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated. This PR only synchronizes AI-first task state after `F102` merged; it does not change runtime topology or product architecture.

## Validation

```bash
python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
git diff --check
```

## Handoff Notes

- `F102_INTERVENTION_ASSIGNMENT_FLOW` is complete on `main`.
- No AI implementation lane remains active by default after this sync lands.
- The next safe product pair is `F103/F107` for Session A and `F114/F116` for Session B.
