### PR TITLE
docs(ai-first): sync control plane after F114 merge [OPS-F114-SYNC]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,5 @@ Rules:
 
 ## Active
 
-### Assignment
-
-- Owner: Codex Session B
-- Machine: local
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-binding-coverage`
-- Task: `F114_SPEC_VERSION_PINNING_PER_SESSION`
-- Status: `ready-review`
-- Branch: `pod-b/spec-version-pinning`
-- Task packet: `docs/superpowers/tasks/2026-04-27-f114-spec-version-pinning-per-session.md`
-- Owned files: `deeptutor/services/agent_spec/`, `deeptutor/services/session/`, `deeptutor/services/runtime_policy/`, bounded tests/docs
-- PR: `#169 ready for review`
-- Last update: `2026-04-27T00:35:00+0700`
-- Next action: `Wait for CI and review on PR #169, then address only bounded F114 feedback.`
-- Blocker: `None`
+- No active AI implementation task is currently assigned on `main`.
+- The next product work should start from a fresh Session A or Session B branch/worktree after the human or AI loop selects the next future-backlog task.

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T17:28:08Z",
+    "last_updated": "2026-04-26T17:38:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 52,
+      "count": 53,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -61,7 +61,8 @@
         "R6_CLAIM_CALIBRATION_PILOT",
         "F101_TEACHER_ACTION_EXECUTION_LOOP",
         "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE",
-        "F102_INTERVENTION_ASSIGNMENT_FLOW"
+        "F102_INTERVENTION_ASSIGNMENT_FLOW",
+        "F114_SPEC_VERSION_PINNING_PER_SESSION"
       ]
     },
     "in_progress": {
@@ -1559,10 +1560,10 @@
       "dependencies": [
         "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE"
       ],
-      "status": "not-started",
+      "status": "completed",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "runtime-policy",
-      "notes": "Best done before provenance surfaces so later teacher-facing traces can reference stable spec versions."
+      "notes": "Merged to main through PR #169. Learning sessions now persist and reuse exact Agent Spec version pins so later runtime policy assembly remains reproducible across turns."
     },
     {
       "id": "F115_RUNTIME_POLICY_AUDIT_TRACE",

--- a/ai_first/daily/2026-04-26.md
+++ b/ai_first/daily/2026-04-26.md
@@ -313,3 +313,13 @@
 - Tests: `pytest tests/services/agent_spec/test_service.py tests/services/session/test_sqlite_store.py tests/services/runtime_policy/test_compiler.py tests/api/test_unified_ws_turn_runtime.py -q`
 - Blockers: None.
 - Next: Watch CI on `#169` and only take bounded review follow-ups inside the F114 runtime/data scope.
+
+## OPS_POST_169_F114_SYNC
+
+- Branch: `docs/post-169-f114-sync`
+- Task: `OPS_POST_169_F114_SYNC`
+- Done: Reset the AI-first control plane after `F114_SPEC_VERSION_PINNING_PER_SESSION` merged through PR `#169`.
+- Done: Cleared the active Session B assignment from `main` and marked `F114` completed in the registry.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: None.
+- Next: Start a fresh Session A or Session B branch/worktree for the next future-backlog task instead of reviving `F114`.

--- a/docs/superpowers/tasks/2026-04-27-post-f114-sync.md
+++ b/docs/superpowers/tasks/2026-04-27-post-f114-sync.md
@@ -1,0 +1,29 @@
+# OPS Post-F114 Sync
+
+- Task ID: `OPS_POST_169_F114_SYNC`
+- Commit tag: `OPS-F114-SYNC`
+- Status: `In Progress`
+- Branch recommendation: `docs/post-169-f114-sync`
+
+## Goal
+
+Reset the AI-first control plane after `F114_SPEC_VERSION_PINNING_PER_SESSION` merged through PR `#169` so `main` reflects completed truth instead of the temporary review-state artifacts from the feature branch.
+
+## Owned Files
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-26.md`
+- bounded docs packet updates under `docs/superpowers/tasks/`
+
+## Do Not Touch
+
+- feature implementation files from `F114`
+- teacher-facing dashboard files
+- unrelated future-backlog packets beyond bounded control-plane sync
+
+## Required Updates
+
+- clear the stale Session B active assignment from `main`
+- mark `F114_SPEC_VERSION_PINNING_PER_SESSION` as `completed`
+- record the merge and sync in the daily log


### PR DESCRIPTION
## Summary
- clear the stale Session B F114 assignment from main
- mark F114 as completed in the task registry and add the post-merge sync packet
- append the bounded post-merge sync note to the daily log

## Tests
- python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
- git diff --check