### PR TITLE
feat(runtime): add runtime policy audit trace [F115]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-- No active AI implementation task is currently assigned on `main`.
-- The next product work should start from a fresh Session A or Session B branch/worktree after the human or AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Codex Session B
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-policy-audit-trace`
+- Task: `F115_RUNTIME_POLICY_AUDIT_TRACE`
+- Status: `planning`
+- Branch: `pod-b/runtime-policy-audit-trace`
+- Task packet: `docs/superpowers/tasks/2026-04-27-f115-runtime-policy-audit-trace.md`
+- Owned files: `deeptutor/services/runtime_policy/`, bounded `deeptutor/api/routers/agent_specs.py` or a debug route, related tests/docs
+- PR: `Not opened yet`
+- Last update: `2026-04-27T00:50:00+0700`
+- Next action: `Write the F115 task packet, design spec, and implementation plan before code changes.`
+- Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-policy-audit-trace`
 - Task: `F115_RUNTIME_POLICY_AUDIT_TRACE`
-- Status: `planning`
+- Status: `ready-review`
 - Branch: `pod-b/runtime-policy-audit-trace`
 - Task packet: `docs/superpowers/tasks/2026-04-27-f115-runtime-policy-audit-trace.md`
 - Owned files: `deeptutor/services/runtime_policy/`, bounded `deeptutor/api/routers/agent_specs.py` or a debug route, related tests/docs
-- PR: `Not opened yet`
-- Last update: `2026-04-27T00:50:00+0700`
-- Next action: `Write the F115 task packet, design spec, and implementation plan before code changes.`
+- PR: `Draft, not opened yet`
+- Last update: `2026-04-27T01:10:00+0700`
+- Next action: `Commit the verified F115 branch, open the Draft PR, then move it to Ready for review after self-check.`
 - Blocker: `None`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T17:38:00Z",
+    "last_updated": "2026-04-26T18:10:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -67,8 +67,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F115_RUNTIME_POLICY_AUDIT_TRACE"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -77,7 +79,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 21,
+      "count": 19,
       "tasks": [
         "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS",
         "F104_SMALL_GROUP_MANAGEMENT_SURFACE",
@@ -89,8 +91,6 @@
         "F110_TEACHER_OVERRIDE_LOG",
         "F111_ASSESSMENT_REVIEW_RUBRIC_CONTROLS",
         "F112_PROVENANCE_AND_REASON_TRACE_SURFACES",
-        "F114_SPEC_VERSION_PINNING_PER_SESSION",
-        "F115_RUNTIME_POLICY_AUDIT_TRACE",
         "F116_STUDENT_MODEL_ENRICHMENT",
         "F117_CONFIDENCE_CALIBRATION_REFINEMENT",
         "F118_MISCONCEPTION_TAXONOMY_EXPANSION",
@@ -1586,10 +1586,10 @@
       "dependencies": [
         "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "runtime-policy",
-      "notes": "This is the backend half of future provenance UI work but should stand on its own."
+      "notes": "Active on branch pod-b/runtime-policy-audit-trace. This stays as the backend half of future provenance UI work and exposes a bounded inspectable audit contract on top of runtime-policy compilation."
     },
     {
       "id": "F116_STUDENT_MODEL_ENRICHMENT",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -22,6 +22,7 @@ flowchart TD
   Runtime --> RuntimePolicy["Runtime Policy Compiler"]
   Runtime --> RuntimePolicy["Runtime Policy Assembly"]
   RuntimePolicy --> PolicyCompiler["services/runtime_policy/compiler.py"]
+  RuntimePolicy --> PolicyAudit["Inspectable audit trace: slices + sources + version"]
   RuntimePolicy --> PolicySlices["SOUL/RULES/WORKFLOW/ASSESSMENT/KNOWLEDGE"]
   RuntimePolicy --> SourcePriority["teacher_kb > curriculum_excerpt > teacher_rules > llm_prior_knowledge"]
 
@@ -47,8 +48,10 @@ flowchart TD
   TeacherWorkspace --> AgentSpecAuthoring["Agent Spec Authoring"]
   AgentSpecAuthoring --> AgentSpecUI["/agents authoring tab"]
   AgentSpecAuthoring --> AgentSpecAPI["/api/v1/agent-specs"]
+  AgentSpecAuthoring --> AgentSpecAuditAPI["/api/v1/agent-specs/{agent_id}/runtime-policy-audit"]
   AgentSpecAuthoring --> AgentSpecStorage["Versioned Markdown spec packs"]
   AgentSpecStorage --> RuntimePolicy
+  AgentSpecAuditAPI --> RuntimePolicy
   Product --> KnowledgePack["Knowledge Pack"]
   KnowledgePack --> KPMetaFlow["Metadata Create/Edit/Update Flow"]
   KnowledgePack --> KPVersions["Versioned teacher-pack metadata: current_version + version_history"]

--- a/ai_first/daily/2026-04-27.md
+++ b/ai_first/daily/2026-04-27.md
@@ -1,0 +1,11 @@
+# Daily Log: 2026-04-27
+
+## Session B Runtime Policy
+
+- Branch: `pod-b/runtime-policy-audit-trace`
+- Task: `F115_RUNTIME_POLICY_AUDIT_TRACE`
+- Done: Added a bounded runtime-policy audit helper plus `GET /api/v1/agent-specs/{agent_id}/runtime-policy-audit` so current or historical Agent Spec snapshots can be inspected through compiled slices, sources, version metadata, and existing debug fields.
+- Done: Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` to reflect the new audit route as a backend runtime-policy surface.
+- Tests: `pytest tests/services/runtime_policy/test_compiler.py tests/api/test_agent_specs_router.py -q`
+- Blockers: None.
+- Next: Publish the verified branch as a Draft PR and move it to Ready for review if GitHub state stays clean.

--- a/deeptutor/api/routers/agent_specs.py
+++ b/deeptutor/api/routers/agent_specs.py
@@ -5,6 +5,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 from deeptutor.services.agent_spec import get_agent_spec_service
+from deeptutor.services.runtime_policy.compiler import build_runtime_policy_audit
 
 router = APIRouter()
 
@@ -72,6 +73,22 @@ async def get_agent_spec(agent_id: str):
     service = get_agent_spec_service()
     try:
         return service.get_pack(agent_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Agent spec not found") from exc
+
+
+@router.get("/{agent_id}/runtime-policy-audit")
+async def get_agent_spec_runtime_policy_audit(
+    agent_id: str,
+    capability: str = "chat",
+    version: int | None = None,
+):
+    try:
+        return build_runtime_policy_audit(
+            agent_spec_id=agent_id,
+            capability=capability,
+            version=version,
+        )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Agent spec not found") from exc
 

--- a/deeptutor/services/runtime_policy/compiler.py
+++ b/deeptutor/services/runtime_policy/compiler.py
@@ -97,6 +97,35 @@ def ensure_runtime_policy(context: UnifiedContext, capability: str) -> RuntimePo
     return policy
 
 
+def build_runtime_policy_audit(
+    *,
+    agent_spec_id: str,
+    capability: str = "chat",
+    version: int | None = None,
+    knowledge_bases: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a serializable runtime-policy audit payload for a selected Agent Spec."""
+    service = get_agent_spec_service()
+    pack = service.get_pack_version(agent_spec_id, int(version)) if version is not None else service.get_pack(agent_spec_id)
+    metadata: dict[str, Any] = {
+        "agent_spec_id": str(pack.get("agent_id") or agent_spec_id),
+        "teacher_spec_compiled": _pack_to_teacher_spec(pack),
+    }
+    context = UnifiedContext(
+        active_capability=capability,
+        knowledge_bases=list(knowledge_bases or []),
+        config_overrides={"agent_spec_id": str(pack.get("agent_id") or agent_spec_id)},
+        metadata=metadata,
+    )
+    policy = ensure_runtime_policy(context, capability)
+    return {
+        "agent_spec_id": policy.agent_spec_id,
+        "agent_spec_version": policy.agent_spec_version,
+        "capability": capability,
+        "runtime_policy": policy.to_dict(),
+    }
+
+
 def format_chat_system_context(policy: RuntimePolicy) -> str:
     """Build tutoring-oriented system guidance from assembled slices."""
     sections = [

--- a/docs/superpowers/plans/2026-04-27-f115-runtime-policy-audit-trace.md
+++ b/docs/superpowers/plans/2026-04-27-f115-runtime-policy-audit-trace.md
@@ -1,0 +1,104 @@
+# F115 Runtime Policy Audit Trace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose a bounded, inspectable runtime-policy audit trace for current or historical Agent Spec snapshots without changing teacher-facing UX.
+
+**Architecture:** Add a runtime-policy audit assembly helper, expose a small read endpoint near Agent Specs, and prove both latest-pack and historical-version audit behavior with focused tests.
+
+**Tech Stack:** FastAPI, runtime-policy compiler/service helpers, Agent Spec service, pytest
+
+---
+
+### Task 1: Add The F115 Task Contract
+
+**Files:**
+- Create: `docs/superpowers/tasks/2026-04-27-f115-runtime-policy-audit-trace.md`
+- Create: `docs/superpowers/specs/2026-04-27-f115-runtime-policy-audit-trace-design.md`
+- Create: `docs/superpowers/plans/2026-04-27-f115-runtime-policy-audit-trace.md`
+
+- [ ] **Step 1: Write the task packet**
+- [ ] **Step 2: Write the design doc**
+- [ ] **Step 3: Write the implementation plan**
+- [ ] **Step 4: Commit the planning artifacts**
+
+### Task 2: Add A Bounded Audit Assembly Helper
+
+**Files:**
+- Modify: `deeptutor/services/runtime_policy/compiler.py`
+- Modify: `tests/services/runtime_policy/test_compiler.py`
+
+- [ ] **Step 1: Write the failing runtime-policy audit tests**
+
+Add tests proving:
+- an audit helper can return the existing runtime-policy payload for a chosen `agent_spec_id`
+- a requested historical version returns the pinned snapshot instead of the latest pack
+
+- [ ] **Step 2: Run the targeted runtime-policy tests**
+
+Run: `pytest tests/services/runtime_policy/test_compiler.py -k "audit or pinned_version" -q`
+
+Expected: FAIL until the audit helper exists.
+
+- [ ] **Step 3: Implement the audit helper**
+
+Prefer a helper that builds a minimal `UnifiedContext` from explicit inputs and returns `RuntimePolicy.to_dict()` plus top-level metadata needed by the API route.
+
+- [ ] **Step 4: Re-run the targeted runtime-policy tests**
+
+Run: `pytest tests/services/runtime_policy/test_compiler.py -k "audit or pinned_version" -q`
+
+Expected: PASS.
+
+### Task 3: Expose The Audit Route
+
+**Files:**
+- Modify: `deeptutor/api/routers/agent_specs.py`
+- Add or modify: relevant API tests
+
+- [ ] **Step 1: Write the failing API tests**
+
+Add tests for:
+- latest runtime-policy audit by `agent_id`
+- historical runtime-policy audit by `agent_id` + `version`
+- 404 when the Agent Spec or version is missing
+
+- [ ] **Step 2: Run the targeted API tests**
+
+Run: `pytest tests/api -k "runtime_policy_audit or agent_spec_audit" -q`
+
+Expected: FAIL until the route exists.
+
+- [ ] **Step 3: Implement the bounded route**
+
+Add a small GET endpoint that delegates to the runtime-policy audit helper and returns a stable JSON envelope.
+
+- [ ] **Step 4: Re-run the targeted API tests**
+
+Run: `pytest tests/api -k "runtime_policy_audit or agent_spec_audit" -q`
+
+Expected: PASS.
+
+### Task 4: Final Validation And PR Note
+
+**Files:**
+- Create: `docs/superpowers/pr-notes/2026-04-27-f115-runtime-policy-audit-trace.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-27.md` or `2026-04-26.md` depending on execution date
+
+- [ ] **Step 1: Write the PR note**
+
+Include one Mermaid diagram showing `Agent Spec -> audit helper -> API audit route`.
+
+- [ ] **Step 2: Run the bounded suite**
+
+Run the exact focused tests added for compiler and API behavior.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run: `git diff --check`
+
+- [ ] **Step 4: Commit the implementation**
+
+Use commit messages tagged with `[F115]`.

--- a/docs/superpowers/pr-notes/2026-04-27-f115-runtime-policy-audit-trace.md
+++ b/docs/superpowers/pr-notes/2026-04-27-f115-runtime-policy-audit-trace.md
@@ -1,0 +1,26 @@
+# PR Note: F115 Runtime Policy Audit Trace
+
+- Task: `F115_RUNTIME_POLICY_AUDIT_TRACE`
+- Scope: bounded backend audit contract for inspectable runtime-policy traces
+- Main-system-map update: required and included in this branch
+
+## What Changed
+
+- added a runtime-policy audit helper that builds a serializable trace for a selected Agent Spec and capability
+- reused `F114` version-fetch support so audit calls can inspect either the latest pack or an exact historical version
+- exposed `GET /api/v1/agent-specs/{agent_id}/runtime-policy-audit` for bounded backend inspection
+- kept the surface policy-centric and avoided exposing session-history or teacher-facing UI in this task
+
+```mermaid
+flowchart LR
+  A["Agent Spec pack or version"] --> B["build_runtime_policy_audit()"]
+  B --> C["RuntimePolicy compiler"]
+  C --> D["slices + sources + debug metadata"]
+  D --> E["GET /api/v1/agent-specs/{agent_id}/runtime-policy-audit"]
+```
+
+## Validation
+
+- `pytest tests/services/runtime_policy/test_compiler.py tests/api/test_agent_specs_router.py -q`
+- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`

--- a/docs/superpowers/specs/2026-04-27-f115-runtime-policy-audit-trace-design.md
+++ b/docs/superpowers/specs/2026-04-27-f115-runtime-policy-audit-trace-design.md
@@ -1,0 +1,111 @@
+# F115 Runtime Policy Audit Trace Design
+
+## Metadata
+
+- Task ID: `F115_RUNTIME_POLICY_AUDIT_TRACE`
+- Commit tag: `F115`
+- Session bucket: `session-b-runtime-data`
+- Owner scope: `deeptutor/services/runtime_policy/`, bounded API/tests/docs
+- Do-not-touch scope: teacher-facing dashboard UX, `/agents` UX, unrelated evidence features
+
+## Goal
+
+Make compiled runtime policy inspectable through a bounded backend contract so debugging, trust review, and future provenance surfaces can read what policy actually applied without scraping prompt text.
+
+## Current State
+
+- `F113` proved runtime binding reaches shipped turn paths.
+- `F114` pinned the exact Agent Spec version per session so runtime policy can stay reproducible across turns.
+- Runtime policy already serializes a debug block in-process, but that block is only visible inside runtime context and tests.
+- There is no stable backend endpoint or helper dedicated to returning an audit trace for a selected runtime-policy snapshot.
+
+## Problem
+
+Without an inspectable audit trace, later debugging and teacher-trust work has to infer policy behavior indirectly from logs, prompt text, or code assumptions. That makes version pinning less useful because the pinned runtime state cannot yet be queried cleanly.
+
+## Recommended Approach
+
+Add a small runtime-policy audit service/helper plus a bounded backend read surface that returns:
+
+- `agent_spec_id`
+- `agent_spec_version` when available
+- applied slices and raw slice text
+- slice sources
+- knowledge-policy mode
+- teacher KB context summary
+- debug fields already derived by the compiler
+
+The route should compile or normalize runtime policy from an explicit request context rather than exposing turn history or session internals directly.
+
+## Contract Shape
+
+Recommended API shape:
+
+- `GET /api/v1/agent-specs/{agent_id}/runtime-policy-audit`
+
+Optional query parameters:
+
+- `capability`
+- `version`
+
+Behavior:
+
+1. `agent_id` is required.
+2. `version` is optional; when present it should read the historical Agent Spec snapshot.
+3. `capability` defaults to `chat` but can support the bounded shipped capabilities already covered by `F113`.
+4. The response returns compiled runtime policy plus a compact audit envelope.
+
+Example response shape:
+
+```json
+{
+  "agent_spec_id": "fraction-coach",
+  "agent_spec_version": 2,
+  "capability": "chat",
+  "runtime_policy": {
+    "knowledge_policy": "kb_preferred",
+    "source_priority": ["teacher_kb", "curriculum_excerpt", "teacher_rules", "llm_prior_knowledge"],
+    "slices": {"SOUL": "...", "RULES": "..."},
+    "sources": {"SOUL": "teacher_spec.SOUL", "RULES": "teacher_spec.RULES"},
+    "debug": {
+      "applied_slices": ["SOUL", "RULES"],
+      "missing_slices": ["ASSESSMENT"],
+      "slice_sources": {"SOUL": "teacher_spec.SOUL", "RULES": "teacher_spec.RULES"},
+      "agent_spec_id": "fraction-coach",
+      "agent_spec_version": 2,
+      "has_teacher_kb_context": false
+    }
+  }
+}
+```
+
+## Design Notes
+
+### 1. Keep Audit Assembly Inside Runtime Policy Layer
+
+Prefer adding a dedicated helper in `deeptutor/services/runtime_policy/` that builds a `RuntimePolicy` from explicit audit inputs. This keeps route code thin and avoids duplicating compiler assembly logic in the API layer.
+
+### 2. Support Historical Versions
+
+Reuse the `F114` version-fetching seam so the audit route can inspect a historical spec snapshot with `version=...`, not just the latest pack.
+
+### 3. No Session-History Exposure
+
+`F115` should not expose a general “inspect any past session” endpoint. The bounded contract is policy-centric, not turn-history-centric. Session-specific audit can be layered later once provenance surfaces are designed.
+
+### 4. Stable Debug Envelope
+
+The response should use the existing `runtime_policy.debug` model as the foundation so tests and later UI work can depend on one shape instead of ad hoc payloads.
+
+## Testing Strategy
+
+- runtime-policy service tests for audit payload assembly from latest and version-pinned Agent Specs
+- API tests for the audit route success path and 404 behavior
+- bounded assertions that no teacher-facing UI files are touched
+
+## Success Criteria
+
+1. an explicit backend route or helper can return an inspectable runtime-policy trace for an Agent Spec
+2. the trace includes `agent_spec_id`, `agent_spec_version`, slices, sources, and debug fields
+3. historical version inspection works when a version is requested
+4. no teacher-facing dashboard or `/agents` UX files change

--- a/docs/superpowers/tasks/2026-04-27-f115-runtime-policy-audit-trace.md
+++ b/docs/superpowers/tasks/2026-04-27-f115-runtime-policy-audit-trace.md
@@ -2,7 +2,7 @@
 
 - Task ID: `F115_RUNTIME_POLICY_AUDIT_TRACE`
 - Commit tag: `F115`
-- Status: `Planning`
+- Status: `Ready for Review`
 - Branch recommendation: `pod-b/runtime-policy-audit-trace`
 
 ## Goal

--- a/docs/superpowers/tasks/2026-04-27-f115-runtime-policy-audit-trace.md
+++ b/docs/superpowers/tasks/2026-04-27-f115-runtime-policy-audit-trace.md
@@ -1,0 +1,35 @@
+# F115 Runtime Policy Audit Trace
+
+- Task ID: `F115_RUNTIME_POLICY_AUDIT_TRACE`
+- Commit tag: `F115`
+- Status: `Planning`
+- Branch recommendation: `pod-b/runtime-policy-audit-trace`
+
+## Goal
+
+Provide a bounded, inspectable runtime-policy trace for debugging and future teacher-trust surfaces without changing teacher-facing dashboard or `/agents` UX.
+
+## Owned Files
+
+- `deeptutor/services/runtime_policy/`
+- bounded `deeptutor/api/routers/agent_specs.py` changes or a sibling debug route if needed
+- `tests/services/runtime_policy/`
+- bounded API tests for the chosen audit surface
+- `docs/superpowers/specs/`
+- `docs/superpowers/plans/`
+- `docs/superpowers/pr-notes/`
+
+## Do Not Touch
+
+- teacher-facing dashboard presentation files
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- broad `/agents` UX changes
+- unrelated evidence or student-model features outside runtime-policy audit scope
+
+## Constraints
+
+- keep the API/debug surface bounded and inspectable
+- do not expose more internal state than needed for runtime-policy audit
+- preserve the existing `F113` and `F114` runtime behavior
+- avoid inventing teacher-facing provenance UX in this task

--- a/tests/api/test_agent_specs_router.py
+++ b/tests/api/test_agent_specs_router.py
@@ -10,6 +10,7 @@ except Exception:  # pragma: no cover
     TestClient = None
 
 from deeptutor.services.agent_spec.service import AgentSpecService
+from deeptutor.services.runtime_policy import compiler as runtime_policy_compiler
 
 pytestmark = pytest.mark.skipif(FastAPI is None or TestClient is None, reason="fastapi not installed")
 
@@ -20,6 +21,7 @@ def _build_app(service: AgentSpecService, monkeypatch: pytest.MonkeyPatch) -> Fa
     app = FastAPI()
     app.include_router(agent_specs.router, prefix="/api/v1/agent-specs")
     monkeypatch.setattr(agent_specs, "get_agent_spec_service", lambda: service)
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
     return app
 
 
@@ -92,3 +94,59 @@ def test_agent_specs_router_returns_404_for_missing_pack(tmp_path, monkeypatch: 
         response = client.get("/api/v1/agent-specs/missing-pack")
 
     assert response.status_code == 404
+
+
+def test_agent_specs_router_returns_runtime_policy_audit_for_latest_and_versioned_pack(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured=_payload()["structured"],
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion one.\n"},
+    )
+    service.save_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            **_payload()["structured"],
+            "soul": {
+                **_payload()["structured"]["soul"],
+                "teaching_philosophy": "Version two philosophy.",
+            },
+        },
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion two.\n"},
+    )
+
+    with TestClient(_build_app(service, monkeypatch)) as client:
+        latest = client.get("/api/v1/agent-specs/fraction-coach/runtime-policy-audit")
+        assert latest.status_code == 200
+        assert latest.json()["agent_spec_version"] == 2
+        assert "Version two philosophy." in latest.json()["runtime_policy"]["slices"]["SOUL"]
+
+        version_one = client.get("/api/v1/agent-specs/fraction-coach/runtime-policy-audit?version=1")
+        assert version_one.status_code == 200
+        assert version_one.json()["agent_spec_version"] == 1
+        assert "Version two philosophy." not in version_one.json()["runtime_policy"]["slices"]["SOUL"]
+
+
+def test_agent_specs_router_returns_404_for_missing_runtime_policy_audit_pack_or_version(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured=_payload()["structured"],
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion one.\n"},
+    )
+
+    with TestClient(_build_app(service, monkeypatch)) as client:
+        missing_pack = client.get("/api/v1/agent-specs/missing-pack/runtime-policy-audit")
+        missing_version = client.get("/api/v1/agent-specs/fraction-coach/runtime-policy-audit?version=9")
+
+    assert missing_pack.status_code == 404
+    assert missing_version.status_code == 404

--- a/tests/services/runtime_policy/test_compiler.py
+++ b/tests/services/runtime_policy/test_compiler.py
@@ -159,3 +159,65 @@ def test_runtime_policy_prefers_pinned_agent_spec_version(monkeypatch, tmp_path)
     assert "Version one philosophy." in payload["slices"]["SOUL"]
     assert "Version two philosophy." not in payload["slices"]["SOUL"]
     assert payload["debug"]["agent_spec_version"] == 1
+
+
+def test_runtime_policy_audit_returns_latest_pack_trace(monkeypatch, tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {"agent_name": "Fraction Coach"},
+            "soul": {"teaching_philosophy": "Latest philosophy."},
+            "rules": {"guardrails": "Latest guardrails."},
+        },
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nLatest flow.\n"},
+    )
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    payload = runtime_policy_compiler.build_runtime_policy_audit(
+        agent_spec_id="fraction-coach",
+        capability="chat",
+    )
+
+    assert payload["agent_spec_id"] == "fraction-coach"
+    assert payload["agent_spec_version"] == 1
+    assert payload["capability"] == "chat"
+    assert payload["runtime_policy"]["debug"]["agent_spec_version"] == 1
+    assert "Latest philosophy." in payload["runtime_policy"]["slices"]["SOUL"]
+
+
+def test_runtime_policy_audit_returns_requested_historical_version(monkeypatch, tmp_path) -> None:
+    service = AgentSpecService(tmp_path / "agent_specs")
+    service.create_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {"agent_name": "Fraction Coach"},
+            "soul": {"teaching_philosophy": "Version one philosophy."},
+            "rules": {"guardrails": "Version one guardrails."},
+        },
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion one.\n"},
+    )
+    service.save_pack(
+        agent_id="fraction-coach",
+        display_name="Fraction Coach",
+        structured={
+            "identity": {"agent_name": "Fraction Coach"},
+            "soul": {"teaching_philosophy": "Version two philosophy."},
+            "rules": {"guardrails": "Version two guardrails."},
+        },
+        files={"WORKFLOW.md": "# Workflow\n\n## Session Flow\n\nVersion two.\n"},
+    )
+    monkeypatch.setattr(runtime_policy_compiler, "get_agent_spec_service", lambda: service)
+
+    payload = runtime_policy_compiler.build_runtime_policy_audit(
+        agent_spec_id="fraction-coach",
+        capability="chat",
+        version=1,
+    )
+
+    assert payload["agent_spec_id"] == "fraction-coach"
+    assert payload["agent_spec_version"] == 1
+    assert "Version one philosophy." in payload["runtime_policy"]["slices"]["SOUL"]
+    assert "Version two philosophy." not in payload["runtime_policy"]["slices"]["SOUL"]


### PR DESCRIPTION
# PR Note: F115 Runtime Policy Audit Trace

- Task: `F115_RUNTIME_POLICY_AUDIT_TRACE`
- Scope: bounded backend audit contract for inspectable runtime-policy traces
- Main-system-map update: required and included in this branch

## What Changed

- added a runtime-policy audit helper that builds a serializable trace for a selected Agent Spec and capability
- reused `F114` version-fetch support so audit calls can inspect either the latest pack or an exact historical version
- exposed `GET /api/v1/agent-specs/{agent_id}/runtime-policy-audit` for bounded backend inspection
- kept the surface policy-centric and avoided exposing session-history or teacher-facing UI in this task

```mermaid
flowchart LR
  A["Agent Spec pack or version"] --> B["build_runtime_policy_audit()"]
  B --> C["RuntimePolicy compiler"]
  C --> D["slices + sources + debug metadata"]
  D --> E["GET /api/v1/agent-specs/{agent_id}/runtime-policy-audit"]
```

## Validation

- `pytest tests/services/runtime_policy/test_compiler.py tests/api/test_agent_specs_router.py -q`
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `git diff --check`
