### PR TITLE
docs(ai-first): sync control plane after F115 merge [OPS-F115-SYNC]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,17 +28,5 @@ Rules:
 
 ## Active
 
-### Assignment
-
-- Owner: Codex Session B
-- Machine: local
-- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-runtime-policy-audit-trace`
-- Task: `F115_RUNTIME_POLICY_AUDIT_TRACE`
-- Status: `ready-review`
-- Branch: `pod-b/runtime-policy-audit-trace`
-- Task packet: `docs/superpowers/tasks/2026-04-27-f115-runtime-policy-audit-trace.md`
-- Owned files: `deeptutor/services/runtime_policy/`, bounded `deeptutor/api/routers/agent_specs.py` or a debug route, related tests/docs
-- PR: `Draft, not opened yet`
-- Last update: `2026-04-27T01:10:00+0700`
-- Next action: `Commit the verified F115 branch, open the Draft PR, then move it to Ready for review after self-check.`
-- Blocker: `None`
+- No active AI implementation task is currently assigned on `main`.
+- The next product work should start from a fresh Session A or Session B branch/worktree after the human or AI loop selects the next future-backlog task.

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-26T18:10:00Z",
+    "last_updated": "2026-04-27T16:05:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -8,7 +8,7 @@
   "task_categories": {
     "completed": {
       "description": "Features fully implemented and merged to main",
-      "count": 53,
+      "count": 54,
       "tasks": [
         "T009_MARKETPLACE_IMPORT_IMPLEMENTATION",
         "T010_ASSESSMENT_FEEDBACK_DETAILS",
@@ -62,15 +62,14 @@
         "F101_TEACHER_ACTION_EXECUTION_LOOP",
         "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE",
         "F102_INTERVENTION_ASSIGNMENT_FLOW",
-        "F114_SPEC_VERSION_PINNING_PER_SESSION"
+        "F114_SPEC_VERSION_PINNING_PER_SESSION",
+        "F115_RUNTIME_POLICY_AUDIT_TRACE"
       ]
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 1,
-      "tasks": [
-        "F115_RUNTIME_POLICY_AUDIT_TRACE"
-      ]
+      "count": 0,
+      "tasks": []
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -79,7 +78,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 19,
+      "count": 18,
       "tasks": [
         "F103_RECOMMENDATION_ACKNOWLEDGEMENT_AND_STATUS",
         "F104_SMALL_GROUP_MANAGEMENT_SURFACE",
@@ -1586,10 +1585,10 @@
       "dependencies": [
         "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE"
       ],
-      "status": "in-progress",
+      "status": "completed",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "runtime-policy",
-      "notes": "Active on branch pod-b/runtime-policy-audit-trace. This stays as the backend half of future provenance UI work and exposes a bounded inspectable audit contract on top of runtime-policy compilation."
+      "notes": "Merged to main through PR #173. Runtime policy is now inspectable through a bounded backend audit route that supports current and historical Agent Spec snapshots."
     },
     {
       "id": "F116_STUDENT_MODEL_ENRICHMENT",

--- a/ai_first/daily/2026-04-27.md
+++ b/ai_first/daily/2026-04-27.md
@@ -8,4 +8,14 @@
 - Done: Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` to reflect the new audit route as a backend runtime-policy surface.
 - Tests: `pytest tests/services/runtime_policy/test_compiler.py tests/api/test_agent_specs_router.py -q`
 - Blockers: None.
-- Next: Publish the verified branch as a Draft PR and move it to Ready for review if GitHub state stays clean.
+- Next: Keep `main` clean through the post-merge sync and then start the next fresh backlog lane instead of reviving `F115`.
+
+## OPS_POST_173_F115_SYNC
+
+- Branch: `docs/post-173-f115-sync`
+- Task: `OPS_POST_173_F115_SYNC`
+- Done: Reset the AI-first control plane after `F115_RUNTIME_POLICY_AUDIT_TRACE` merged through PR `#173`.
+- Done: Cleared the active Session B assignment from `main` and marked `F115` completed in the registry.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: None.
+- Next: Start a fresh Session A or Session B branch/worktree for the next backlog task instead of reviving `F115`.

--- a/docs/superpowers/tasks/2026-04-27-post-f115-sync.md
+++ b/docs/superpowers/tasks/2026-04-27-post-f115-sync.md
@@ -1,0 +1,23 @@
+# OPS Post-F115 Sync
+
+- Task ID: `OPS_POST_173_F115_SYNC`
+- Commit tag: `OPS-F115-SYNC`
+- Status: `In Progress`
+- Branch recommendation: `docs/post-173-f115-sync`
+
+## Goal
+
+Reset the AI-first control plane after `F115_RUNTIME_POLICY_AUDIT_TRACE` merged through PR `#173` so `main` reflects completed truth instead of the temporary review-state artifacts from the feature branch.
+
+## Owned Files
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-27.md`
+- bounded docs packet updates under `docs/superpowers/tasks/`
+
+## Required Updates
+
+- clear the stale Session B active assignment from `main`
+- mark `F115_RUNTIME_POLICY_AUDIT_TRACE` as `completed`
+- record the merge and sync in the daily log


### PR DESCRIPTION
## Summary
- clear the stale Session B F115 assignment from main
- mark F115 as completed in the task registry and add the post-merge sync packet
- append the bounded post-merge sync note to the 2026-04-27 daily log

## Tests
- python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
- git diff --check