### PR TITLE
feat(student-model): enrich student state signals [F116]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-student-model-enrichment`
 - Task: `F116_STUDENT_MODEL_ENRICHMENT`
-- Status: `planning`
+- Status: `ready-review`
 - Branch: `pod-b/student-model-enrichment`
 - Task packet: `docs/superpowers/tasks/2026-04-27-f116-student-model-enrichment.md`
 - Owned files: `deeptutor/services/evidence/`, `deeptutor/services/session/`, related backend tests/docs, bounded architecture map updates if shared contracts change
-- PR: `Not opened yet`
-- Last update: `2026-04-27T23:15:00+0700`
-- Next action: `Write the F116 task packet, design spec, and implementation plan before code changes.`
+- PR: `Draft, not opened yet`
+- Last update: `2026-04-27T23:35:00+0700`
+- Next action: `Commit the verified F116 branch, open the Draft PR, then move it to Ready for review after self-check.`
 - Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-- No active AI implementation task is currently assigned on `main`.
-- The next product work should start from a fresh Session A or Session B branch/worktree after the human or AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Codex Session B
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-student-model-enrichment`
+- Task: `F116_STUDENT_MODEL_ENRICHMENT`
+- Status: `planning`
+- Branch: `pod-b/student-model-enrichment`
+- Task packet: `docs/superpowers/tasks/2026-04-27-f116-student-model-enrichment.md`
+- Owned files: `deeptutor/services/evidence/`, `deeptutor/services/session/`, related backend tests/docs, bounded architecture map updates if shared contracts change
+- PR: `Not opened yet`
+- Last update: `2026-04-27T23:15:00+0700`
+- Next action: `Write the F116 task packet, design spec, and implementation plan before code changes.`
+- Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -38,7 +38,7 @@ Rules:
 - Branch: `pod-b/student-model-enrichment`
 - Task packet: `docs/superpowers/tasks/2026-04-27-f116-student-model-enrichment.md`
 - Owned files: `deeptutor/services/evidence/`, `deeptutor/services/session/`, related backend tests/docs, bounded architecture map updates if shared contracts change
-- PR: `Draft, not opened yet`
-- Last update: `2026-04-27T23:35:00+0700`
-- Next action: `Commit the verified F116 branch, open the Draft PR, then move it to Ready for review after self-check.`
+- PR: `#176`
+- Last update: `2026-04-27T23:27:00+0700`
+- Next action: `Keep PR #176 green and mergeable after any required rebases on main, then run the post-merge AI-first sync branch.`
 - Blocker: `None`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -69,8 +69,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F116_STUDENT_MODEL_ENRICHMENT"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -79,7 +81,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 18,
+      "count": 17,
       "tasks": [
         "F104_SMALL_GROUP_MANAGEMENT_SURFACE",
         "F105_CLASS_INTERVENTION_QUEUE",
@@ -90,7 +92,6 @@
         "F110_TEACHER_OVERRIDE_LOG",
         "F111_ASSESSMENT_REVIEW_RUBRIC_CONTROLS",
         "F112_PROVENANCE_AND_REASON_TRACE_SURFACES",
-        "F116_STUDENT_MODEL_ENRICHMENT",
         "F117_CONFIDENCE_CALIBRATION_REFINEMENT",
         "F118_MISCONCEPTION_TAXONOMY_EXPANSION",
         "F119_ABSTAIN_AND_WEAK_EVIDENCE_REFINEMENT",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1611,10 +1611,10 @@
       "dependencies": [
         "R2_DIAGNOSIS_CREDIBILITY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "student-model",
-      "notes": "This should remain conservative and evidence-backed rather than turning into an opaque mastery score engine."
+      "notes": "Active on branch pod-b/student-model-enrichment. This remains conservative and evidence-backed by deriving additive mastery, support, and misconception signals from observations rather than inventing opaque scores."
     },
     {
       "id": "F117_CONFIDENCE_CALIBRATION_REFINEMENT",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -80,8 +80,10 @@ flowchart TD
   AssessmentRecommendAPI --> RecommendEngine["Assessment Recommendation Engine"]
   RecommendEngine --> AssessmentSignals["Weak topics + score trend + KB context"]
   AssessmentDiagnosisAPI --> EvidenceExtractor["Observation extractor (assessment + tutoring runtime)"]
-  EvidenceExtractor --> ObservationStore["SQLite observations + student_states (+ recency rollups)"]
+  EvidenceExtractor --> ObservationStore["SQLite observations + student_states (+ enriched rollups)"]
   ObservationStore --> DiagnosisEngine["Rule-first diagnosis + action selection"]
+  ObservationStore --> StudentModel["Student model signals: mastery + support + misconception"]
+  StudentModel --> DiagnosisEngine
   AdaptiveDifficulty --> QuizHistory["[Quiz Performance] session context"]
   AdaptiveDifficulty --> DeepQuestion
   

--- a/ai_first/daily/2026-04-27.md
+++ b/ai_first/daily/2026-04-27.md
@@ -1,14 +1,14 @@
 # Daily Log: 2026-04-27
 
-## Session B Runtime Policy
+## Session B Student Model
 
-- Branch: `pod-b/runtime-policy-audit-trace`
-- Task: `F115_RUNTIME_POLICY_AUDIT_TRACE`
-- Done: Added a bounded runtime-policy audit helper plus `GET /api/v1/agent-specs/{agent_id}/runtime-policy-audit` so current or historical Agent Spec snapshots can be inspected through compiled slices, sources, version metadata, and existing debug fields.
-- Done: Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` to reflect the new audit route as a backend runtime-policy surface.
-- Tests: `pytest tests/services/runtime_policy/test_compiler.py tests/api/test_agent_specs_router.py -q`
+- Branch: `pod-b/student-model-enrichment`
+- Task: `F116_STUDENT_MODEL_ENRICHMENT`
+- Done: Enriched persisted student state with additive mastery, support, and misconception signals derived from observations while preserving the existing evidence-first diagnosis policy.
+- Done: Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` so the student-model layer explicitly reflects richer rollups feeding diagnosis context.
+- Tests: `pytest tests/services/session/test_sqlite_store.py tests/services/evidence/test_diagnosis.py -q`
 - Blockers: None.
-- Next: Keep `main` clean through the post-merge sync and then start the next fresh backlog lane instead of reviving `F115`.
+- Next: Keep the PR green and mergeable after rebases on `main`, then finish the post-merge AI-first sync on a fresh docs branch.
 
 ## OPS_POST_173_F115_SYNC
 

--- a/deeptutor/services/evidence/contracts.py
+++ b/deeptutor/services/evidence/contracts.py
@@ -29,6 +29,10 @@ class StudentStateRecord(TypedDict):
     repeated_mistakes: list[str]
     support_level: SupportLevel
     confidence_trend: ConfidenceTrend
+    recency_summary: dict[str, object]
+    mastery_signals: dict[str, object]
+    support_signals: dict[str, object]
+    misconception_signals: dict[str, object]
 
 
 class DiagnosisRecord(TypedDict):

--- a/deeptutor/services/session/context_builder.py
+++ b/deeptutor/services/session/context_builder.py
@@ -115,16 +115,30 @@ class ContextBuilder:
         support = str(state.get("support_level") or "independent")
         trend = str(state.get("confidence_trend") or "flat")
         recency = state.get("recency_summary") if isinstance(state.get("recency_summary"), dict) else {}
+        mastery = state.get("mastery_signals") if isinstance(state.get("mastery_signals"), dict) else {}
+        support_signals = state.get("support_signals") if isinstance(state.get("support_signals"), dict) else {}
+        misconception = (
+            state.get("misconception_signals")
+            if isinstance(state.get("misconception_signals"), dict)
+            else {}
+        )
         bucket_counts = recency.get("bucket_counts") if isinstance(recency, dict) else {}
         last_24h = int((bucket_counts or {}).get("last_24h", 0))
         last_7d = int((bucket_counts or {}).get("last_7d", 0))
         recent_incorrect = int((recency or {}).get("recent_incorrect", 0))
+        at_risk = ", ".join(mastery.get("at_risk_topics") or []) or "none"
+        stable = ", ".join(mastery.get("stable_topics") or []) or "none"
+        support_burden = str(support_signals.get("recent_support_burden") or "steady")
+        persistent = ", ".join(misconception.get("persistent_topics") or []) or "none"
         return (
             "Student state snapshot:\n"
             f"- repeated_mistakes: {repeated}\n"
             f"- support_level: {support}\n"
             f"- confidence_trend: {trend}\n"
-            f"- recency_summary: last_24h={last_24h}, last_7d={last_7d}, recent_incorrect={recent_incorrect}"
+            f"- recency_summary: last_24h={last_24h}, last_7d={last_7d}, recent_incorrect={recent_incorrect}\n"
+            f"- mastery_signals: at_risk={at_risk}, stable={stable}\n"
+            f"- support_signals: recent_support_burden={support_burden}\n"
+            f"- misconception_signals: persistent_topics={persistent}"
         )
 
     def _build_history(

--- a/deeptutor/services/session/sqlite_store.py
+++ b/deeptutor/services/session/sqlite_store.py
@@ -171,6 +171,9 @@ class SQLiteSessionStore:
                     support_level TEXT NOT NULL DEFAULT 'independent',
                     confidence_trend TEXT NOT NULL DEFAULT 'flat',
                     recency_summary_json TEXT NOT NULL DEFAULT '{}',
+                    mastery_signals_json TEXT NOT NULL DEFAULT '{}',
+                    support_signals_json TEXT NOT NULL DEFAULT '{}',
+                    misconception_signals_json TEXT NOT NULL DEFAULT '{}',
                     updated_at REAL NOT NULL
                 );
                 """
@@ -186,6 +189,18 @@ class SQLiteSessionStore:
             if "recency_summary_json" not in student_state_columns:
                 conn.execute(
                     "ALTER TABLE student_states ADD COLUMN recency_summary_json TEXT NOT NULL DEFAULT '{}'"
+                )
+            if "mastery_signals_json" not in student_state_columns:
+                conn.execute(
+                    "ALTER TABLE student_states ADD COLUMN mastery_signals_json TEXT NOT NULL DEFAULT '{}'"
+                )
+            if "support_signals_json" not in student_state_columns:
+                conn.execute(
+                    "ALTER TABLE student_states ADD COLUMN support_signals_json TEXT NOT NULL DEFAULT '{}'"
+                )
+            if "misconception_signals_json" not in student_state_columns:
+                conn.execute(
+                    "ALTER TABLE student_states ADD COLUMN misconception_signals_json TEXT NOT NULL DEFAULT '{}'"
                 )
             conn.commit()
 
@@ -540,13 +555,17 @@ class SQLiteSessionStore:
             conn.execute(
                 """
                 INSERT INTO student_states (
-                    student_id, repeated_mistakes_json, support_level, confidence_trend, recency_summary_json, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                    student_id, repeated_mistakes_json, support_level, confidence_trend, recency_summary_json,
+                    mastery_signals_json, support_signals_json, misconception_signals_json, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(student_id) DO UPDATE SET
                     repeated_mistakes_json = excluded.repeated_mistakes_json,
                     support_level = excluded.support_level,
                     confidence_trend = excluded.confidence_trend,
                     recency_summary_json = excluded.recency_summary_json,
+                    mastery_signals_json = excluded.mastery_signals_json,
+                    support_signals_json = excluded.support_signals_json,
+                    misconception_signals_json = excluded.misconception_signals_json,
                     updated_at = excluded.updated_at
                 """,
                 (
@@ -555,6 +574,9 @@ class SQLiteSessionStore:
                     state.get("support_level", "independent"),
                     state.get("confidence_trend", "flat"),
                     _json_dumps(state.get("recency_summary", {})),
+                    _json_dumps(state.get("mastery_signals", {})),
+                    _json_dumps(state.get("support_signals", {})),
+                    _json_dumps(state.get("misconception_signals", {})),
                     now,
                 ),
             )
@@ -567,7 +589,8 @@ class SQLiteSessionStore:
         with self._connect() as conn:
             row = conn.execute(
                 """
-                SELECT student_id, repeated_mistakes_json, support_level, confidence_trend, recency_summary_json, updated_at
+                SELECT student_id, repeated_mistakes_json, support_level, confidence_trend, recency_summary_json,
+                       mastery_signals_json, support_signals_json, misconception_signals_json, updated_at
                 FROM student_states
                 WHERE student_id = ?
                 """,
@@ -581,6 +604,9 @@ class SQLiteSessionStore:
             "support_level": row["support_level"],
             "confidence_trend": row["confidence_trend"],
             "recency_summary": _json_loads(row["recency_summary_json"], {}),
+            "mastery_signals": _json_loads(row["mastery_signals_json"], {}),
+            "support_signals": _json_loads(row["support_signals_json"], {}),
+            "misconception_signals": _json_loads(row["misconception_signals_json"], {}),
             "updated_at": row["updated_at"],
         }
 
@@ -635,7 +661,7 @@ class SQLiteSessionStore:
         with self._connect() as conn:
             rows = conn.execute(
                 """
-                SELECT topic, is_correct, hint_count, retry_count, created_at
+                SELECT topic, is_correct, hint_count, retry_count, dominant_error, created_at
                 FROM observations
                 WHERE student_id = ?
                 ORDER BY created_at DESC
@@ -648,6 +674,11 @@ class SQLiteSessionStore:
 
         now = time.time()
         weighted_topic_misses: Counter[str] = Counter()
+        topic_attempts: Counter[str] = Counter()
+        topic_correct: Counter[str] = Counter()
+        heavy_hint_topics: Counter[str] = Counter()
+        retry_heavy_topics: Counter[str] = Counter()
+        dominant_errors: Counter[tuple[str, str]] = Counter()
         recent_rows = []
         recency_counter: Counter[str] = Counter()
         for row in rows:
@@ -655,15 +686,25 @@ class SQLiteSessionStore:
             is_correct = bool(row["is_correct"])
             hint_count = int(row["hint_count"] or 0)
             retry_count = int(row["retry_count"] or 0)
+            dominant_error = str(row["dominant_error"] or "").strip()
             created_at = float(row["created_at"] or now)
             age_seconds = max(0.0, now - created_at)
             recency_counter[self._recency_bucket(age_seconds)] += 1
+            topic_attempts[topic] += 1
+            if is_correct:
+                topic_correct[topic] += 1
 
             if not is_correct:
                 half_life_seconds = 7 * 24 * 60 * 60
                 weight = 2 ** (-age_seconds / half_life_seconds)
                 weighted_topic_misses[topic] += weight
-            recent_rows.append((is_correct, hint_count, retry_count))
+            if hint_count >= 2:
+                heavy_hint_topics[topic] += 1
+            if retry_count >= 2:
+                retry_heavy_topics[topic] += 1
+            if dominant_error:
+                dominant_errors[(topic, dominant_error)] += 1
+            recent_rows.append((topic, is_correct, hint_count, retry_count))
 
         repeated_mistakes = [
             topic
@@ -675,8 +716,8 @@ class SQLiteSessionStore:
         ]
 
         recent_slice = recent_rows[: min(8, len(recent_rows))]
-        incorrect_recent = sum(1 for item in recent_slice if not item[0])
-        heavy_support_recent = sum(1 for item in recent_slice if item[1] >= 2 or item[2] >= 2)
+        incorrect_recent = sum(1 for item in recent_slice if not item[1])
+        heavy_support_recent = sum(1 for item in recent_slice if item[2] >= 2 or item[3] >= 2)
         if incorrect_recent >= 3 and heavy_support_recent >= 2:
             support_level = "intensive"
         elif incorrect_recent >= 1 or heavy_support_recent >= 1:
@@ -686,7 +727,7 @@ class SQLiteSessionStore:
 
         chronological = list(reversed(recent_slice))
         perf_scores: list[float] = []
-        for is_correct, hint_count, retry_count in chronological:
+        for _topic, is_correct, hint_count, retry_count in chronological:
             base = 1.0 if is_correct else -1.0
             base -= 0.15 * min(3, hint_count)
             base -= 0.1 * min(3, retry_count)
@@ -718,12 +759,58 @@ class SQLiteSessionStore:
             },
         }
 
+        at_risk_topics = [
+            topic
+            for topic, _score in sorted(weighted_topic_misses.items(), key=lambda item: item[1], reverse=True)
+            if weighted_topic_misses[topic] >= 0.5
+        ][:3]
+        stable_topics = [
+            topic
+            for topic, attempts in topic_attempts.items()
+            if attempts >= 2 and topic_correct[topic] == attempts
+        ][:3]
+        emerging_topics = [
+            topic
+            for topic in repeated_mistakes
+            if topic not in at_risk_topics
+        ][:3]
+
+        if heavy_support_recent >= 3:
+            recent_support_burden = "high"
+        elif heavy_support_recent >= 1:
+            recent_support_burden = "elevated"
+        else:
+            recent_support_burden = "steady"
+
+        dominant_error_by_topic: dict[str, str] = {}
+        for (topic, error), _count in dominant_errors.most_common():
+            dominant_error_by_topic.setdefault(topic, error)
+        persistent_topics = [
+            topic
+            for topic in repeated_mistakes
+            if topic in dominant_error_by_topic or topic in at_risk_topics
+        ]
+
         return {
             "student_id": student_id,
             "repeated_mistakes": repeated_mistakes,
             "support_level": support_level,
             "confidence_trend": confidence_trend,
             "recency_summary": recency_summary,
+            "mastery_signals": {
+                "emerging_topics": emerging_topics,
+                "stable_topics": stable_topics,
+                "at_risk_topics": at_risk_topics,
+            },
+            "support_signals": {
+                "heavy_hint_topics": list(heavy_hint_topics.keys())[:3],
+                "retry_heavy_topics": list(retry_heavy_topics.keys())[:3],
+                "recent_support_burden": recent_support_burden,
+            },
+            "misconception_signals": {
+                "dominant_errors": dominant_error_by_topic,
+                "persistent_topics": persistent_topics[:3],
+            },
         }
 
     async def build_student_state_rollup(self, student_id: str, limit: int = 24) -> dict[str, Any] | None:

--- a/docs/superpowers/plans/2026-04-27-f116-student-model-enrichment.md
+++ b/docs/superpowers/plans/2026-04-27-f116-student-model-enrichment.md
@@ -1,0 +1,116 @@
+# F116 Student Model Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich the student-state contract with additive mastery, support, and misconception signals while keeping the existing evidence-first behavior stable.
+
+**Architecture:** Extend the student-state contract and rollup derivation in session/evidence layers, then prove the new signals through focused storage and diagnosis tests.
+
+**Tech Stack:** SQLite session store, evidence contracts/diagnosis helpers, pytest
+
+---
+
+### Task 1: Add The F116 Task Contract
+
+**Files:**
+- Create: `docs/superpowers/tasks/2026-04-27-f116-student-model-enrichment.md`
+- Create: `docs/superpowers/specs/2026-04-27-f116-student-model-enrichment-design.md`
+- Create: `docs/superpowers/plans/2026-04-27-f116-student-model-enrichment.md`
+
+- [ ] **Step 1: Write the task packet**
+- [ ] **Step 2: Write the design doc**
+- [ ] **Step 3: Write the implementation plan**
+- [ ] **Step 4: Commit the planning artifacts**
+
+### Task 2: Enrich The Student-State Contract
+
+**Files:**
+- Modify: `deeptutor/services/evidence/contracts.py`
+- Modify: `tests/services/session/test_sqlite_store.py`
+
+- [ ] **Step 1: Write failing storage/contract tests**
+
+Add tests proving enriched student-state fields survive persistence and rollup generation.
+
+- [ ] **Step 2: Run the targeted tests**
+
+Run: `pytest tests/services/session/test_sqlite_store.py -k "student_state or rollup" -q`
+
+Expected: FAIL until the richer shape is produced or persisted.
+
+- [ ] **Step 3: Implement additive contract/storage support**
+
+Keep existing top-level fields stable and add nested signal groups.
+
+- [ ] **Step 4: Re-run the targeted storage tests**
+
+Expected: PASS.
+
+### Task 3: Derive Richer Signals From Observations
+
+**Files:**
+- Modify: `deeptutor/services/session/sqlite_store.py`
+- Modify: `tests/services/session/test_sqlite_store.py`
+
+- [ ] **Step 1: Write failing rollup-detail tests**
+
+Prove the store can derive topic-level mastery/support/misconception signals from mixed recent observations.
+
+- [ ] **Step 2: Run the targeted rollup tests**
+
+- [ ] **Step 3: Implement bounded derivation logic**
+
+Use explainable topic buckets and recent-support summaries rather than opaque scoring.
+
+- [ ] **Step 4: Re-run the targeted rollup tests**
+
+Expected: PASS.
+
+### Task 4: Keep Diagnosis Compatible With The Enriched Model
+
+**Files:**
+- Modify: `deeptutor/services/evidence/diagnosis.py`
+- Modify: `tests/services/evidence/test_diagnosis.py`
+
+- [ ] **Step 1: Write failing diagnosis tests**
+
+Add tests showing diagnosis payloads preserve or consume the enriched student-state shape without changing the observation-first policy.
+
+- [ ] **Step 2: Run the targeted diagnosis tests**
+
+Run: `pytest tests/services/evidence/test_diagnosis.py -q`
+
+Expected: FAIL until the enriched model is handled cleanly.
+
+- [ ] **Step 3: Implement bounded diagnosis compatibility**
+
+Keep diagnosis scoring centered on observations and treat enriched state as context only.
+
+- [ ] **Step 4: Re-run the targeted diagnosis tests**
+
+Expected: PASS.
+
+### Task 5: Final Validation And PR Note
+
+**Files:**
+- Create: `docs/superpowers/pr-notes/2026-04-27-f116-student-model-enrichment.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-27.md`
+- Modify: `ai_first/architecture/MAIN_SYSTEM_MAP.md` if shared contract framing changes
+
+- [ ] **Step 1: Write the PR note**
+
+Include one Mermaid diagram showing observations -> student-state rollup -> diagnosis context.
+
+- [ ] **Step 2: Run the bounded suite**
+
+Run the focused session/evidence tests touched by the task.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run: `git diff --check`
+
+- [ ] **Step 4: Commit the implementation**
+
+Use commit messages tagged with `[F116]`.

--- a/docs/superpowers/pr-notes/2026-04-27-f116-student-model-enrichment.md
+++ b/docs/superpowers/pr-notes/2026-04-27-f116-student-model-enrichment.md
@@ -1,0 +1,28 @@
+# PR Note: F116 Student Model Enrichment
+
+- Task: `F116_STUDENT_MODEL_ENRICHMENT`
+- Scope: bounded enrichment of stored student-state signals
+- Main-system-map update: required and included in this branch
+
+## What Changed
+
+- extended persisted student state beyond recency-only fields with additive `mastery_signals`, `support_signals`, and `misconception_signals`
+- kept diagnosis observation-first while allowing enriched state to pass through as bounded context
+- updated session context formatting so richer student-state signals are readable downstream without introducing opaque scores
+
+```mermaid
+flowchart LR
+  A["Observations"] --> B["Student-state rollup"]
+  B --> C["mastery_signals"]
+  B --> D["support_signals"]
+  B --> E["misconception_signals"]
+  C --> F["Diagnosis context"]
+  D --> F
+  E --> F
+```
+
+## Validation
+
+- `pytest tests/services/session/test_sqlite_store.py tests/services/evidence/test_diagnosis.py -q`
+- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`

--- a/docs/superpowers/specs/2026-04-27-f116-student-model-enrichment-design.md
+++ b/docs/superpowers/specs/2026-04-27-f116-student-model-enrichment-design.md
@@ -1,0 +1,101 @@
+# F116 Student Model Enrichment Design
+
+## Metadata
+
+- Task ID: `F116_STUDENT_MODEL_ENRICHMENT`
+- Commit tag: `F116`
+- Session bucket: `session-b-runtime-data`
+- Owner scope: `deeptutor/services/evidence/`, `deeptutor/services/session/`, bounded tests/docs
+- Do-not-touch scope: teacher-facing dashboard UX, `/agents` UX, unrelated runtime-policy surfaces
+
+## Goal
+
+Enrich the existing student-state contract so diagnosis and future teacher-trust work can use more than repeated mistakes, support level, and confidence trend, while still staying grounded in observed evidence.
+
+## Current State
+
+- student state currently stores `repeated_mistakes`, `support_level`, `confidence_trend`, and a `recency_summary`
+- rollups are derived from recent observations in `SQLiteSessionStore`
+- diagnosis uses student state only as bounded context and falls back to a tiny derived state when nothing is persisted
+- there is no structured place for topic-specific mastery signals, misconception persistence, or support-pattern summaries beyond the current thin rollup
+
+## Problem
+
+The current student model is useful but shallow. Later tasks like confidence calibration, taxonomy expansion, and intervention effectiveness need richer context than:
+
+- a short repeated-mistakes list
+- one coarse support label
+- one confidence trend
+
+Without richer but still inspectable signals, later features will either duplicate rollup logic in multiple places or drift toward ad hoc heuristics.
+
+## Recommended Approach
+
+Extend the student-state record with additive, evidence-backed substructures such as:
+
+- `mastery_signals`
+- `support_signals`
+- `misconception_signals`
+
+These should be derived directly from observed assessment/tutoring behavior and stored alongside the existing fields, not replace them.
+
+## Proposed Contract
+
+Keep the current top-level fields and add nested dictionaries:
+
+```json
+{
+  "student_id": "student-a",
+  "repeated_mistakes": ["fractions", "equations"],
+  "support_level": "guided",
+  "confidence_trend": "down",
+  "recency_summary": {...},
+  "mastery_signals": {
+    "emerging_topics": ["fractions"],
+    "stable_topics": [],
+    "at_risk_topics": ["equations"]
+  },
+  "support_signals": {
+    "heavy_hint_topics": ["fractions"],
+    "retry_heavy_topics": ["equations"],
+    "recent_support_burden": "elevated"
+  },
+  "misconception_signals": {
+    "dominant_errors": {
+      "fractions": "concept_gap"
+    },
+    "persistent_topics": ["fractions"]
+  }
+}
+```
+
+## Design Notes
+
+### 1. Derive, Don’t Invent
+
+Every new field must map back to observed rows or the existing diagnosis taxonomy. Avoid synthetic scores that cannot be explained from recorded evidence.
+
+### 2. Keep Diagnosis Observation-First
+
+Diagnosis should continue to score from observations first. The enriched student state is context that can sharpen teacher-readable summaries and later ranking, not a replacement inference engine.
+
+### 3. Prefer Topic Buckets Over Global Scores
+
+Topic-level buckets like `at_risk_topics` or `heavy_hint_topics` are easier to audit and safer than compressing a student into one numeric mastery score.
+
+### 4. Preserve Compatibility
+
+Existing readers that only use `repeated_mistakes`, `support_level`, `confidence_trend`, and `recency_summary` should continue to work unchanged.
+
+## Testing Strategy
+
+- session-store tests for richer rollup output
+- evidence/diagnosis tests proving enriched state is preserved and remains bounded
+- bounded API test updates only if an existing backend payload materially changes shape
+
+## Success Criteria
+
+1. student state persists richer mastery/support/misconception substructures
+2. rollup logic stays explainable from observations
+3. existing diagnosis behavior remains observation-first and compatible
+4. no teacher-facing dashboard presentation files are modified

--- a/docs/superpowers/tasks/2026-04-27-f116-student-model-enrichment.md
+++ b/docs/superpowers/tasks/2026-04-27-f116-student-model-enrichment.md
@@ -1,0 +1,35 @@
+# F116 Student Model Enrichment
+
+- Task ID: `F116_STUDENT_MODEL_ENRICHMENT`
+- Commit tag: `F116`
+- Status: `Planning`
+- Branch recommendation: `pod-b/student-model-enrichment`
+
+## Goal
+
+Expand student state beyond thin recency summaries into richer, evidence-backed mastery, support, and misconception signals that later diagnosis and teacher-insight work can reuse.
+
+## Owned Files
+
+- `deeptutor/services/evidence/`
+- `deeptutor/services/session/`
+- related backend tests for evidence/session contracts
+- `docs/superpowers/specs/`
+- `docs/superpowers/plans/`
+- `docs/superpowers/pr-notes/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` if shared student-state contracts change
+
+## Do Not Touch
+
+- teacher-facing dashboard presentation files
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- broad `/agents` UX changes
+- runtime-policy or agent-spec routes unless a bounded dependency is discovered
+
+## Constraints
+
+- keep the student model conservative and evidence-backed
+- do not introduce opaque global mastery scores
+- preserve observation-first diagnosis behavior
+- prefer additive student-state fields over broad contract rewrites

--- a/docs/superpowers/tasks/2026-04-27-f116-student-model-enrichment.md
+++ b/docs/superpowers/tasks/2026-04-27-f116-student-model-enrichment.md
@@ -2,7 +2,7 @@
 
 - Task ID: `F116_STUDENT_MODEL_ENRICHMENT`
 - Commit tag: `F116`
-- Status: `Planning`
+- Status: `Ready for Review`
 - Branch recommendation: `pod-b/student-model-enrichment`
 
 ## Goal

--- a/tests/services/evidence/test_diagnosis.py
+++ b/tests/services/evidence/test_diagnosis.py
@@ -37,6 +37,20 @@ def test_build_student_diagnosis_returns_structured_hypotheses_and_actions() -> 
         "repeated_mistakes": ["fractions subtraction"],
         "support_level": "guided",
         "confidence_trend": "down",
+        "mastery_signals": {
+            "emerging_topics": ["fractions subtraction"],
+            "stable_topics": [],
+            "at_risk_topics": ["fractions subtraction"],
+        },
+        "support_signals": {
+            "heavy_hint_topics": ["fractions subtraction"],
+            "retry_heavy_topics": [],
+            "recent_support_burden": "elevated",
+        },
+        "misconception_signals": {
+            "dominant_errors": {"fractions subtraction": "concept_gap"},
+            "persistent_topics": ["fractions subtraction"],
+        },
     }
 
     payload = build_student_diagnosis(
@@ -55,6 +69,9 @@ def test_build_student_diagnosis_returns_structured_hypotheses_and_actions() -> 
     assert "teacher-reviewable hypothesis" in payload["inferred"][0]["teacher_review_note"]
     assert payload["recommended_actions"][0]["action_type"] == "review_prerequisite"
     assert "Teacher should confirm" in payload["recommended_actions"][0]["teacher_review_note"]
+    assert payload["student_state"]["mastery_signals"]["at_risk_topics"] == ["fractions subtraction"]
+    assert payload["student_state"]["support_signals"]["recent_support_burden"] == "elevated"
+    assert payload["student_state"]["misconception_signals"]["dominant_errors"]["fractions subtraction"] == "concept_gap"
 
 
 def test_build_student_diagnosis_routes_careless_error_to_retry_action() -> None:
@@ -125,3 +142,65 @@ def test_build_student_diagnosis_abstains_on_weak_or_non_error_signal() -> None:
     assert payload["observed"]["abstain_reason"] == "Evidence is too weak or too mixed for a confident diagnosis."
     assert payload["inferred"] == []
     assert payload["recommended_actions"] == []
+
+
+def test_build_student_diagnosis_keeps_enriched_student_state_as_context_only() -> None:
+    observations = [
+        {
+            "observation_id": "obs_s1",
+            "session_id": "quiz-4",
+            "student_id": "student-e",
+            "source": "assessment",
+            "topic": "equations",
+            "question_id": "q1",
+            "is_correct": False,
+            "latency_seconds": 32,
+            "hint_count": 2,
+            "retry_count": 0,
+            "dominant_error": "needs_scaffold",
+        },
+        {
+            "observation_id": "obs_s2",
+            "session_id": "quiz-4",
+            "student_id": "student-e",
+            "source": "assessment",
+            "topic": "equations",
+            "question_id": "q2",
+            "is_correct": False,
+            "latency_seconds": 35,
+            "hint_count": 2,
+            "retry_count": 1,
+            "dominant_error": "needs_scaffold",
+        },
+    ]
+    enriched_state = {
+        "student_id": "student-e",
+        "repeated_mistakes": ["equations"],
+        "support_level": "guided",
+        "confidence_trend": "down",
+        "mastery_signals": {
+            "emerging_topics": [],
+            "stable_topics": [],
+            "at_risk_topics": ["equations"],
+        },
+        "support_signals": {
+            "heavy_hint_topics": ["equations"],
+            "retry_heavy_topics": [],
+            "recent_support_burden": "elevated",
+        },
+        "misconception_signals": {
+            "dominant_errors": {"equations": "needs_scaffold"},
+            "persistent_topics": ["equations"],
+        },
+    }
+
+    payload = build_student_diagnosis(
+        student_id="student-e",
+        observations=observations,
+        student_state=enriched_state,
+    )
+
+    assert payload["observed"]["topic"] == "equations"
+    assert payload["observed"]["abstained"] is False
+    assert payload["inferred"][0]["diagnosis_type"] == "needs_scaffold"
+    assert payload["student_state"]["misconception_signals"]["persistent_topics"] == ["equations"]

--- a/tests/services/session/test_sqlite_store.py
+++ b/tests/services/session/test_sqlite_store.py
@@ -80,6 +80,20 @@ async def test_sqlite_store_persists_observations_and_student_state(tmp_path: Pa
             "support_level": "guided",
             "confidence_trend": "down",
             "recency_summary": {"total_observations": 1},
+            "mastery_signals": {
+                "emerging_topics": ["fractions subtraction"],
+                "stable_topics": [],
+                "at_risk_topics": ["fractions subtraction"],
+            },
+            "support_signals": {
+                "heavy_hint_topics": ["fractions subtraction"],
+                "retry_heavy_topics": [],
+                "recent_support_burden": "elevated",
+            },
+            "misconception_signals": {
+                "dominant_errors": {"fractions subtraction": "concept_gap"},
+                "persistent_topics": ["fractions subtraction"],
+            },
         },
     )
 
@@ -92,6 +106,9 @@ async def test_sqlite_store_persists_observations_and_student_state(tmp_path: Pa
     assert state["support_level"] == "guided"
     assert state["confidence_trend"] == "down"
     assert state["recency_summary"]["total_observations"] == 1
+    assert state["mastery_signals"]["at_risk_topics"] == ["fractions subtraction"]
+    assert state["support_signals"]["recent_support_burden"] == "elevated"
+    assert state["misconception_signals"]["dominant_errors"]["fractions subtraction"] == "concept_gap"
 
 
 @pytest.mark.asyncio
@@ -154,6 +171,11 @@ async def test_sqlite_store_builds_recency_aware_student_state_rollup(tmp_path: 
     assert rollup["confidence_trend"] in {"up", "flat", "down"}
     assert rollup["recency_summary"]["total_observations"] == 3
     assert rollup["recency_summary"]["bucket_counts"]["last_24h"] >= 2
+    assert rollup["mastery_signals"]["at_risk_topics"][0] == "fractions subtraction"
+    assert "fractions subtraction" in rollup["support_signals"]["heavy_hint_topics"]
+    assert rollup["support_signals"]["recent_support_burden"] in {"elevated", "high"}
+    assert rollup["misconception_signals"]["dominant_errors"]["fractions subtraction"] == "needs_scaffold"
+    assert "fractions subtraction" in rollup["misconception_signals"]["persistent_topics"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR Note: F116 Student Model Enrichment

- Task: `F116_STUDENT_MODEL_ENRICHMENT`
- Scope: bounded enrichment of stored student-state signals
- Main-system-map update: required and included in this branch

## What Changed

- extended persisted student state beyond recency-only fields with additive `mastery_signals`, `support_signals`, and `misconception_signals`
- kept diagnosis observation-first while allowing enriched state to pass through as bounded context
- updated session context formatting so richer student-state signals are readable downstream without introducing opaque scores

```mermaid
flowchart LR
  A["Observations"] --> B["Student-state rollup"]
  B --> C["mastery_signals"]
  B --> D["support_signals"]
  B --> E["misconception_signals"]
  C --> F["Diagnosis context"]
  D --> F
  E --> F
```

## Validation

- `pytest tests/services/session/test_sqlite_store.py tests/services/evidence/test_diagnosis.py -q`
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `git diff --check`
