### PR TITLE
feat(trust): add provenance and reason trace surfaces [F112]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task is currently assigned on `main`.
-The next product work should start from a fresh Session A or Session B branch/worktree after the AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Codex Session A
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-a-provenance-reason-traces`
+- Task: `F112_PROVENANCE_AND_REASON_TRACE_SURFACES`
+- Status: `planning`
+- Branch: `pod-a/provenance-reason-traces`
+- Task packet: `docs/superpowers/tasks/2026-04-28-f112-provenance-and-reason-trace-surfaces.md`
+- Owned files: `web/components/dashboard/`, `web/components/agents/`, `web/app/(workspace)/agents/`, `web/lib/dashboard-api.ts`, `web/lib/agent-spec-api.ts`, bounded read-only trust payload shaping in `deeptutor/services/evidence/teacher_insights.py`, related dashboard/agent-spec tests/docs`
+- PR: `Not opened yet`
+- Last update: `2026-04-28T13:12:00+0700`
+- Next action: `Write the F112 task packet, spec, and implementation plan before implementation.`
+- Blocker: `None`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-a-provenance-reason-traces`
 - Task: `F112_PROVENANCE_AND_REASON_TRACE_SURFACES`
-- Status: `planning`
+- Status: `draft-pr-open`
 - Branch: `pod-a/provenance-reason-traces`
 - Task packet: `docs/superpowers/tasks/2026-04-28-f112-provenance-and-reason-trace-surfaces.md`
 - Owned files: `web/components/dashboard/`, `web/components/agents/`, `web/app/(workspace)/agents/`, `web/lib/dashboard-api.ts`, `web/lib/agent-spec-api.ts`, bounded read-only trust payload shaping in `deeptutor/services/evidence/teacher_insights.py`, related dashboard/agent-spec tests/docs`
-- PR: `Not opened yet`
-- Last update: `2026-04-28T13:12:00+0700`
-- Next action: `Write the F112 task packet, spec, and implementation plan before implementation.`
+- PR: `#199`
+- Last update: `2026-04-28T13:21:00+0700`
+- Next action: `Watch PR #199 CI, then move it to Ready for review when required checks are green.`
 - Blocker: `None`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-28T05:24:00Z",
+    "last_updated": "2026-04-28T06:12:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -83,8 +83,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F112_PROVENANCE_AND_REASON_TRACE_SURFACES"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -93,9 +95,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 4,
+      "count": 3,
       "tasks": [
-        "F112_PROVENANCE_AND_REASON_TRACE_SURFACES",
         "F122_PILOT_FEEDBACK_INGESTION_PATH",
         "F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION",
         "F124_EVIDENCE_AUTOMATION_REFRESH"
@@ -1507,10 +1508,10 @@
         "R1_RUNTIME_BINDING_PROOF",
         "R2_DIAGNOSIS_CREDIBILITY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-a-teacher-facing",
       "layer": "teacher-quality-control",
-      "notes": "Should consume bounded traces produced by Session B rather than invent frontend-only explanations."
+      "notes": "Session A started on 2026-04-28 from worktree .worktrees/pod-a-provenance-reason-traces. Scope is bounded trust surfaces that reuse runtime-policy audit and evidence payloads already produced by the platform instead of inventing frontend-only explanations."
     },
     {
       "id": "F113_CAPABILITY_WIDE_RUNTIME_BINDING_COVERAGE",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -49,6 +49,7 @@ flowchart TD
   AgentSpecAuthoring --> AgentSpecUI["/agents authoring tab"]
   AgentSpecAuthoring --> AgentSpecAPI["/api/v1/agent-specs"]
   AgentSpecAuthoring --> AgentSpecAuditAPI["/api/v1/agent-specs/{agent_id}/runtime-policy-audit"]
+  AgentSpecAuditAPI --> AgentSpecTrustSurface["Runtime policy audit panel: slices + sources + knowledge policy"]
   AgentSpecAuthoring --> AgentSpecStorage["Versioned Markdown spec packs"]
   AgentSpecStorage --> RuntimePolicy
   AgentSpecAuditAPI --> RuntimePolicy
@@ -112,6 +113,7 @@ flowchart TD
   TeacherInsights --> TeacherOverrideAPI["POST/PATCH /api/v1/dashboard/teacher-overrides"]
   TeacherInsights --> TeacherActionAPI["POST/PATCH /api/v1/dashboard/teacher-actions"]
   TeacherInsights --> InterventionAssignmentAPI["POST/PATCH /api/v1/dashboard/intervention-assignments"]
+  TeacherInsights --> InsightTrustTrace["Student + small-group trust traces"]
   InsightsAPI --> DiagnosisEngine
   EvidenceGate --> InsightsAPI
   InsightsAPI --> DiagnosisFeedback["Diagnosis feedback records"]

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -60,6 +60,7 @@
 - Done: Added bounded `reason_trace` payloads for student and small-group insights by reusing diagnosis policy, teacher-review framing, abstain state, and existing evidence facts.
 - Done: Added a runtime policy audit fetch contract and `/agents` trust panel showing applied slices, source priority, slice sources, and knowledge policy for the selected spec pack and capability.
 - Done: Added dashboard trust surfaces on student cards, student detail, and small-group cards without exposing chain-of-thought or changing runtime semantics.
+- Done: Opened Draft PR `#199` after local validation and control-plane updates.
 - Tests: `pytest tests/api/test_dashboard_router.py -k "dashboard_insights_returns_students_and_small_groups or preserve_procedure_breakdown_taxonomy_for_small_groups or skips_small_groups_for_stale_evidence" -q`; `pytest tests/api/test_agent_specs_router.py -k "runtime_policy_audit" -q`; targeted eslint for touched dashboard/agent files; `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
 - Blockers: None.
-- Next: run final `git diff --check`, push the branch, and open a Draft PR for `F112`.
+- Next: watch PR `#199` CI and move it to Ready for review once required checks are green.

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -52,3 +52,14 @@
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; `git diff --check`
 - Blockers: None.
 - Next: start a fresh Session A or Session B branch/worktree for `F112`, `F122`, or `F123` instead of reviving `F121`.
+
+## Session A Provenance And Reason Trace Surfaces
+
+- Branch: `pod-a/provenance-reason-traces`
+- Task: `F112_PROVENANCE_AND_REASON_TRACE_SURFACES`
+- Done: Added bounded `reason_trace` payloads for student and small-group insights by reusing diagnosis policy, teacher-review framing, abstain state, and existing evidence facts.
+- Done: Added a runtime policy audit fetch contract and `/agents` trust panel showing applied slices, source priority, slice sources, and knowledge policy for the selected spec pack and capability.
+- Done: Added dashboard trust surfaces on student cards, student detail, and small-group cards without exposing chain-of-thought or changing runtime semantics.
+- Tests: `pytest tests/api/test_dashboard_router.py -k "dashboard_insights_returns_students_and_small_groups or preserve_procedure_breakdown_taxonomy_for_small_groups or skips_small_groups_for_stale_evidence" -q`; `pytest tests/api/test_agent_specs_router.py -k "runtime_policy_audit" -q`; targeted eslint for touched dashboard/agent files; `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- Blockers: None.
+- Next: run final `git diff --check`, push the branch, and open a Draft PR for `F112`.

--- a/deeptutor/services/evidence/teacher_insights.py
+++ b/deeptutor/services/evidence/teacher_insights.py
@@ -214,6 +214,62 @@ def _small_group_target_id(topic: str, diagnosis_type: str, source_action_type: 
     return f"{topic}::{diagnosis_type}::{source_action_type}"
 
 
+def _student_reason_trace(
+    *,
+    payload: dict[str, Any],
+    top_inferred: dict[str, Any] | None,
+    top_action: dict[str, Any] | None,
+) -> dict[str, Any]:
+    observed = payload.get("observed") or {}
+    inferred = top_inferred or {}
+    return {
+        "diagnosis_policy": str(payload.get("diagnosis_policy") or ""),
+        "teacher_review_required": bool(payload.get("teacher_review_required")),
+        "confidence_tag": str(inferred.get("confidence_tag") or ""),
+        "topic": str(inferred.get("topic") or observed.get("topic") or "general"),
+        "evidence": list(inferred.get("evidence") or []),
+        "teacher_review_note": str(inferred.get("teacher_review_note") or ""),
+        "recommendation_rationale": str(top_action.get("rationale") or "") if top_action else "",
+        "abstained": bool(observed.get("abstained")),
+        "abstain_reason": str(observed.get("abstain_reason") or ""),
+    }
+
+
+def _small_group_reason_trace(
+    *,
+    topic: str,
+    diagnosis_type: str,
+    source_action_type: str,
+    confidence_tag: str,
+    member_payloads: list[dict[str, Any]],
+) -> dict[str, Any]:
+    evidence: list[str] = []
+    for payload in member_payloads:
+        inferred = _top_inferred(payload)
+        if not inferred:
+            continue
+        for fact in list(inferred.get("evidence") or []):
+            if fact not in evidence:
+                evidence.append(str(fact))
+            if len(evidence) >= 3:
+                break
+        if len(evidence) >= 3:
+            break
+    return {
+        "topic": topic,
+        "diagnosis_type": diagnosis_type,
+        "source_action_type": source_action_type,
+        "confidence_tag": confidence_tag,
+        "grouping_rule": "same_topic_same_diagnosis_same_recommended_move",
+        "shared_evidence": evidence,
+        "teacher_review_note": "Use this cluster as a teacher-reviewable grouping cue, not as an automatic placement decision.",
+        "supporting_student_ids": [
+            str(payload.get("student_id") or "unknown")
+            for payload in member_payloads
+        ],
+    }
+
+
 def build_teacher_insights_payload(
     *,
     student_payloads: list[dict[str, Any]],
@@ -239,6 +295,11 @@ def build_teacher_insights_payload(
         top_action = _top_action(payload)
         student_id = str(payload.get("student_id") or "unknown")
         top_inferred = _top_inferred(payload)
+        row["reason_trace"] = _student_reason_trace(
+            payload=payload,
+            top_inferred=top_inferred,
+            top_action=top_action,
+        )
         row["diagnosis_feedback"] = (
             _latest_diagnosis_feedback(
                 student_id=student_id,
@@ -310,6 +371,11 @@ def build_teacher_insights_payload(
         )
 
     small_groups: list[dict[str, Any]] = []
+    student_payload_by_id = {
+        str(payload.get("student_id") or "unknown"): payload
+        for payload in student_payloads
+    }
+
     for (topic, diagnosis_type, action_type), rows in grouped.items():
         if len(rows) < 2:
             continue
@@ -318,6 +384,11 @@ def build_teacher_insights_payload(
         if avg_confidence < 1.0:
             continue
         student_ids = sorted({sid for sid, _score in rows})
+        member_payloads = [
+            student_payload_by_id[sid]
+            for sid in student_ids
+            if sid in student_payload_by_id
+        ]
         target_id = _small_group_target_id(topic, diagnosis_type, action_type)
         matching_group_action = next(
             (
@@ -361,6 +432,13 @@ def build_teacher_insights_payload(
                 "recommended_action": "small_group_support",
                 "source_action_type": action_type,
                 "confidence_tag": "high" if avg_confidence >= 2.5 else "medium",
+                "reason_trace": _small_group_reason_trace(
+                    topic=topic,
+                    diagnosis_type=diagnosis_type,
+                    source_action_type=action_type,
+                    confidence_tag="high" if avg_confidence >= 2.5 else "medium",
+                    member_payloads=member_payloads,
+                ),
                 "target_id": target_id,
                 "recommendation_ack": matching_group_ack,
                 "recommendation_feedback": matching_group_feedback,

--- a/docs/superpowers/plans/2026-04-28-f112-provenance-and-reason-trace-surfaces.md
+++ b/docs/superpowers/plans/2026-04-28-f112-provenance-and-reason-trace-surfaces.md
@@ -1,0 +1,35 @@
+# Plan: F112 Provenance And Reason Trace Surfaces
+
+## Step 1 — Type And Payload Audit
+
+- inspect the current runtime-policy audit route and dashboard insight payloads
+- define the exact read-only fields needed for student trust traces and small-group reason traces
+- confirm the frontend API contracts to extend
+
+## Step 2 — Backend Trust Payload Shaping
+
+- extend `deeptutor/services/evidence/teacher_insights.py`
+- add bounded `reason_trace` payloads for students and small groups
+- keep all fields derived from existing evidence and recommendation payloads
+- add or update dashboard API tests
+
+## Step 3 — `/agents` Runtime Policy Audit Surface
+
+- add runtime-policy-audit fetch helper to `web/lib/agent-spec-api.ts`
+- render a read-only runtime policy audit panel in `SpecPackAuthoringTab`
+- keep it capability-scoped and version-aware
+
+## Step 4 — Dashboard Trust Surfaces
+
+- extend `web/lib/dashboard-api.ts` with trust-trace types
+- render a compact trust summary on student cards
+- render a fuller trust trace on student detail
+- replace generic small-group explanation copy with reason-trace fields
+
+## Step 5 — Verification And Control-Plane Updates
+
+- run targeted backend tests
+- run targeted frontend lint
+- update `MAIN_SYSTEM_MAP.md`
+- add PR note with Mermaid diagram
+- update `ACTIVE_ASSIGNMENTS`, `TASK_REGISTRY`, and daily log

--- a/docs/superpowers/pr-notes/2026-04-28-f112-provenance-and-reason-trace-surfaces.md
+++ b/docs/superpowers/pr-notes/2026-04-28-f112-provenance-and-reason-trace-surfaces.md
@@ -1,0 +1,31 @@
+# PR Note: F112 Provenance And Reason Trace Surfaces
+
+## Summary
+
+- add bounded student and small-group trust traces to teacher insight payloads
+- surface diagnosis policy, evidence, and teacher-review framing in dashboard trust UI
+- surface runtime-policy audit details for agent specs on `/agents`
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A["Runtime policy compiler"] --> B["/api/v1/agent-specs/{agent_id}/runtime-policy-audit"]
+    B --> C["SpecPackAuthoringTab runtime audit panel"]
+    D["Teacher insight payload"] --> E["student reason_trace"]
+    D --> F["small-group reason_trace"]
+    E --> G["Student insight card/detail trust surfaces"]
+    F --> H["Small-group trust surface"]
+```
+
+## MAIN_SYSTEM_MAP
+
+- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md` to include runtime audit and teacher insight trust surfaces.
+
+## Validation
+
+- `pytest tests/api/test_dashboard_router.py -k "dashboard_insights_returns_students_and_small_groups or preserve_procedure_breakdown_taxonomy_for_small_groups or skips_small_groups_for_stale_evidence" -q`
+- `pytest tests/api/test_agent_specs_router.py -k "runtime_policy_audit" -q`
+- `./web/node_modules/.bin/eslint --config web/eslint.config.mjs ...`
+- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`

--- a/docs/superpowers/specs/2026-04-28-f112-provenance-and-reason-trace-surfaces-design.md
+++ b/docs/superpowers/specs/2026-04-28-f112-provenance-and-reason-trace-surfaces-design.md
@@ -1,0 +1,69 @@
+# Spec: F112 Provenance And Reason Trace Surfaces
+
+## Problem
+
+The product already has bounded trust ingredients:
+
+- runtime-policy audit for agent specs
+- diagnosis evidence strings
+- teacher-review framing on diagnosis and recommendations
+
+But those signals are not surfaced clearly enough in teacher-facing UI. Teachers can see conclusions and actions, yet they cannot quickly inspect why a recommendation exists or which teacher-authored policy slices are actually shaping an agent.
+
+## Decision
+
+Implement three bounded trust surfaces:
+
+1. `Runtime policy audit panel` in `/agents`
+   - fetch existing `/api/v1/agent-specs/{agent_id}/runtime-policy-audit`
+   - show capability, spec version, applied slices, missing slices, knowledge policy, source priority, and slice sources
+
+2. `Student trust trace` in dashboard detail
+   - show diagnosis policy
+   - show teacher-review-required framing
+   - show structured evidence chips already present in the payload
+   - show bounded recommendation rationale and abstain state when present
+
+3. `Small-group reason trace`
+   - derive a compact shared reason trace from grouped student payloads
+   - show topic, diagnosis type, source action type, confidence tag, and a few real supporting evidence snippets
+
+## Non-goals
+
+- full chain-of-thought exposure
+- freeform explainability generation
+- changing runtime behavior or diagnosis semantics
+- classroom management or roster UX
+
+## File-Level Design
+
+### Backend
+
+- `deeptutor/services/evidence/teacher_insights.py`
+  - add bounded `reason_trace` blocks for student and small-group payloads
+  - derive them only from existing payload fields
+
+### Frontend
+
+- `web/lib/agent-spec-api.ts`
+  - add runtime-policy-audit fetch contract
+- `web/components/agents/SpecPackAuthoringTab.tsx`
+  - render read-only runtime policy audit panel
+- `web/lib/dashboard-api.ts`
+  - type the new trust-trace fields
+- `web/components/dashboard/StudentInsightDetail.tsx`
+  - render a `Trust trace` section
+- `web/components/dashboard/StudentInsightCard.tsx`
+  - render a compact trust summary
+- `web/components/dashboard/SmallGroupInsightCard.tsx`
+  - replace generic grouping explanation with bounded reason-trace fields
+
+## Risks
+
+- Overclaiming explainability by adding too much prose.
+- Accidentally mixing frontend-only summaries with backend truth.
+
+## Mitigation
+
+- Keep all new trace fields structured and derived.
+- Label trust surfaces as bounded evidence and teacher-review context, not proof of correctness.

--- a/docs/superpowers/tasks/2026-04-28-f112-provenance-and-reason-trace-surfaces.md
+++ b/docs/superpowers/tasks/2026-04-28-f112-provenance-and-reason-trace-surfaces.md
@@ -1,0 +1,52 @@
+# Task Packet: F112_PROVENANCE_AND_REASON_TRACE_SURFACES
+
+- Task ID: `F112_PROVENANCE_AND_REASON_TRACE_SURFACES`
+- Commit tag: `F112`
+- Owner: `Codex Session A`
+- Status: `in-progress`
+- Branch: `pod-a/provenance-reason-traces`
+
+## Objective
+
+Expose bounded provenance and reason traces for teacher-facing trust without overclaiming full explainability.
+
+## Scope
+
+- Reuse existing runtime-policy audit data for `/agents`.
+- Reuse existing diagnosis evidence and teacher-review framing for dashboard trust surfaces.
+- Add only bounded read-only payload shaping where current APIs do not provide enough structure.
+
+## Owned Files
+
+- `web/components/dashboard/`
+- `web/components/agents/`
+- `web/app/(workspace)/agents/`
+- `web/lib/dashboard-api.ts`
+- `web/lib/agent-spec-api.ts`
+- `deeptutor/services/evidence/teacher_insights.py`
+- bounded read-only dashboard/agent-spec API tests
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- `docs/superpowers/pr-notes/`
+- `ai_first/daily/2026-04-28.md`
+
+## Do-Not-Touch
+
+- `deeptutor/services/session/`
+- mutable runtime execution semantics
+- class-roster lifecycle or teacher-ownership write paths
+- broader `/agents` authoring workflow beyond a bounded audit/trust surface
+
+## Acceptance Criteria
+
+1. `/agents` can show a bounded runtime-policy audit surface for the selected spec pack.
+2. Student insight detail shows a bounded trust trace built from real evidence fields and teacher-review framing.
+3. Small-group cards show a bounded reason trace derived from existing grouped evidence, not generic copy only.
+4. No new claim implies full explainability or autonomous correctness.
+5. `MAIN_SYSTEM_MAP.md` and PR note describe the new trust surfaces.
+
+## Validation
+
+- targeted dashboard/agent-spec API tests
+- targeted frontend lint for touched files
+- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`

--- a/tests/api/test_dashboard_router.py
+++ b/tests/api/test_dashboard_router.py
@@ -492,10 +492,15 @@ async def test_dashboard_insights_returns_students_and_small_groups(
     assert response.status_code == 200
     payload = response.json()
     assert payload["students"][0]["student_id"] in {"student-a", "student-b"}
+    assert payload["students"][0]["reason_trace"]["diagnosis_policy"] == "rule_assisted_teacher_review"
+    assert payload["students"][0]["reason_trace"]["teacher_review_required"] is True
+    assert payload["students"][0]["reason_trace"]["evidence"]
     assert payload["small_groups"][0]["topic"] == "fractions subtraction"
     assert sorted(payload["small_groups"][0]["student_ids"]) == ["student-a", "student-b"]
     assert payload["small_groups"][0]["recommended_action"] == "small_group_support"
     assert payload["small_groups"][0]["confidence_tag"] in {"medium", "high"}
+    assert payload["small_groups"][0]["reason_trace"]["grouping_rule"] == "same_topic_same_diagnosis_same_recommended_move"
+    assert payload["small_groups"][0]["reason_trace"]["shared_evidence"]
 
 
 @pytest.mark.asyncio

--- a/web/components/agents/SpecPackAuthoringTab.tsx
+++ b/web/components/agents/SpecPackAuthoringTab.tsx
@@ -9,6 +9,8 @@ import {
   createAgentSpec,
   exportAgentSpec,
   getAgentSpec,
+  getAgentSpecRuntimePolicyAudit,
+  type RuntimePolicyAuditPayload,
   listAgentSpecs,
   type AgentSpecDetail,
   type AgentSpecUpsertPayload,
@@ -79,6 +81,9 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
   const [activeManualFile, setActiveManualFile] = useState<ManualFile>("CURRICULUM.md");
   const [saving, setSaving] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const [auditCapability, setAuditCapability] = useState<"chat" | "deep_question" | "deep_solve">("chat");
+  const [runtimeAudit, setRuntimeAudit] = useState<RuntimePolicyAuditPayload | null>(null);
+  const [auditLoading, setAuditLoading] = useState(false);
 
   async function reloadList(preferredId?: string) {
     const items = await listAgentSpecs();
@@ -109,6 +114,24 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
       }
     })();
   }, []);
+
+  useEffect(() => {
+    if (!draft.agent_id) {
+      setRuntimeAudit(null);
+      return;
+    }
+    void (async () => {
+      setAuditLoading(true);
+      try {
+        const payload = await getAgentSpecRuntimePolicyAudit(draft.agent_id, auditCapability);
+        setRuntimeAudit(payload);
+      } catch {
+        setRuntimeAudit(null);
+      } finally {
+        setAuditLoading(false);
+      }
+    })();
+  }, [draft.agent_id, auditCapability]);
 
   const runtimeSummary = useMemo(
     () => [
@@ -395,6 +418,76 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
             <SummaryRow label={t("What students will feel")} value={runtimeSummary.join(" • ")} />
             <SummaryRow label={t("Version")} value={draft.version > 0 ? `v${draft.version}` : t("New")} />
           </div>
+        </div>
+
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                {t("Runtime policy audit")}
+              </p>
+              <h3 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
+                {t("What policy actually reaches the agent")}
+              </h3>
+            </div>
+            <select
+              value={auditCapability}
+              onChange={(event) => setAuditCapability(event.target.value as "chat" | "deep_question" | "deep_solve")}
+              className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1 text-[12px] text-[var(--foreground)]"
+            >
+              <option value="chat">chat</option>
+              <option value="deep_question">deep_question</option>
+              <option value="deep_solve">deep_solve</option>
+            </select>
+          </div>
+          {!draft.agent_id ? (
+            <p className="mt-3 text-[12px] text-[var(--muted-foreground)]">
+              {t("Save the spec pack first to inspect the compiled runtime policy.")}
+            </p>
+          ) : auditLoading ? (
+            <div className="mt-4 flex items-center gap-2 text-[12px] text-[var(--muted-foreground)]">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              {t("Loading runtime policy audit…")}
+            </div>
+          ) : runtimeAudit ? (
+            <div className="mt-4 space-y-3 text-[12px]">
+              <SummaryRow label={t("Capability")} value={runtimeAudit.capability} />
+              <SummaryRow
+                label={t("Spec version")}
+                value={runtimeAudit.agent_spec_version != null ? `v${runtimeAudit.agent_spec_version}` : t("Latest")}
+              />
+              <SummaryRow label={t("Knowledge policy")} value={runtimeAudit.runtime_policy.knowledge_policy} />
+              <SummaryRow
+                label={t("Source priority")}
+                value={runtimeAudit.runtime_policy.source_priority.join(" > ")}
+              />
+              <SummaryRow
+                label={t("Applied slices")}
+                value={runtimeAudit.runtime_policy.debug.applied_slices.join(", ") || t("None")}
+              />
+              <SummaryRow
+                label={t("Missing slices")}
+                value={runtimeAudit.runtime_policy.debug.missing_slices.join(", ") || t("None")}
+              />
+              <div className="rounded-xl border border-[var(--border)] bg-[var(--background)]/50 p-3">
+                <p className="text-[11px] uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+                  {t("Slice sources")}
+                </p>
+                <div className="mt-2 space-y-2">
+                  {Object.entries(runtimeAudit.runtime_policy.debug.slice_sources).map(([slice, source]) => (
+                    <div key={slice} className="flex items-start justify-between gap-3">
+                      <span className="font-medium text-[var(--foreground)]">{slice}</span>
+                      <span className="text-right text-[var(--muted-foreground)]">{source}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-3 text-[12px] text-[var(--muted-foreground)]">
+              {t("No runtime audit is available for this spec yet.")}
+            </p>
+          )}
         </div>
 
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">

--- a/web/components/dashboard/SmallGroupInsightCard.tsx
+++ b/web/components/dashboard/SmallGroupInsightCard.tsx
@@ -38,6 +38,7 @@ export function SmallGroupInsightCard({
   const [interventionAssignment, setInterventionAssignment] = useState<InterventionAssignmentRecord | null>(
     group.intervention_assignment ?? null,
   );
+  const reasonTrace = group.reason_trace;
 
   return (
     <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
@@ -57,11 +58,31 @@ export function SmallGroupInsightCard({
           toneClassName="text-emerald-700"
         />
         <div className="mt-3 text-[12px] text-emerald-900/80">
-          {t("Why these students are grouped: they show the same dominant learning signal.")}
+          {reasonTrace
+            ? t("Why these students are grouped: same topic, diagnosis, and suggested move.")
+            : t("Why these students are grouped: they show the same dominant learning signal.")}
         </div>
         <div className="mt-3 text-[12px] text-[var(--muted-foreground)]">
           {t("Students: {{students}}", { students: group.student_ids.join(", ") })}
         </div>
+        {reasonTrace ? (
+          <div className="mt-3 rounded-2xl border border-emerald-200 bg-white/80 p-3 text-[12px] text-emerald-900/80">
+            <div className="font-medium">
+              {t("Trust trace: {{confidence}} confidence", { confidence: reasonTrace.confidence_tag })}
+            </div>
+            <div className="mt-1">
+              {t("Rule: {{rule}}", { rule: reasonTrace.grouping_rule })}
+            </div>
+            {reasonTrace.shared_evidence?.length ? (
+              <ul className="mt-2 space-y-1">
+                {reasonTrace.shared_evidence.map((fact) => (
+                  <li key={`${group.target_id ?? group.topic}-${fact}`}>• {fact}</li>
+                ))}
+              </ul>
+            ) : null}
+            <div className="mt-2 text-emerald-900/70">{reasonTrace.teacher_review_note}</div>
+          </div>
+        ) : null}
         <div className="mt-3">
           <RecommendationFeedbackComposer
             triggerLabel={

--- a/web/components/dashboard/StudentInsightCard.tsx
+++ b/web/components/dashboard/StudentInsightCard.tsx
@@ -53,6 +53,7 @@ export function StudentInsightCard({
   );
   const latestAction = teacherActions[0] ?? null;
   const latestAssignment = interventionAssignments[0] ?? null;
+  const trustTrace = student.reason_trace;
 
   return (
     <article className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm">
@@ -132,6 +133,19 @@ export function StudentInsightCard({
               {diagnosisFeedback.teacher_note ? <div className="mt-1">{diagnosisFeedback.teacher_note}</div> : null}
             </div>
           ) : null}
+          {trustTrace ? (
+            <div className="mt-3 rounded-2xl border border-amber-200/70 bg-white/80 p-3 text-[12px] text-amber-900/80">
+              <div className="font-medium">
+                {t("Trust trace: {{policy}}", { policy: trustTrace.diagnosis_policy || t("teacher-reviewed") })}
+              </div>
+              <div className="mt-1">
+                {trustTrace.teacher_review_required
+                  ? t("Teacher review is required before treating this as a classroom fact.")
+                  : t("This signal does not currently require an extra teacher review step.")}
+              </div>
+              {trustTrace.evidence?.[0] ? <div className="mt-1">{trustTrace.evidence[0]}</div> : null}
+            </div>
+          ) : null}
         </section>
 
         <section className="rounded-2xl bg-emerald-50 p-3">
@@ -147,6 +161,12 @@ export function StudentInsightCard({
               ? t("Why this move: {{reason}}", { reason: diagnosis.evidence[0] })
               : t("Why this move: based on the strongest recent learning signal.")}
           </div>
+          {trustTrace?.recommendation_rationale ? (
+            <div className="mt-2 rounded-2xl border border-emerald-200 bg-white/75 p-3 text-[12px] text-emerald-900/80">
+              <div className="font-medium">{t("Recommendation rationale")}</div>
+              <div className="mt-1">{trustTrace.recommendation_rationale}</div>
+            </div>
+          ) : null}
           <div className="mt-3">
             <RecommendationFeedbackComposer
               triggerLabel={

--- a/web/components/dashboard/StudentInsightDetail.tsx
+++ b/web/components/dashboard/StudentInsightDetail.tsx
@@ -77,6 +77,7 @@ export function StudentInsightDetail({
 
   const diagnosis = student?.inferred[0];
   const recommendation = student?.recommended_actions[0];
+  const trustTrace = student?.reason_trace ?? null;
 
   if (!student) {
     return (
@@ -165,6 +166,28 @@ export function StudentInsightDetail({
                 )}
               </div>
             ) : null}
+            {trustTrace ? (
+              <div className="mt-4 rounded-2xl border border-amber-200 bg-white/80 p-4 text-[12px] text-amber-900/80">
+                <div className="font-medium">
+                  {t("Trust trace: {{policy}}", { policy: trustTrace.diagnosis_policy || t("teacher-reviewed") })}
+                </div>
+                <div className="mt-2">
+                  {trustTrace.teacher_review_required
+                    ? t("This diagnosis is a teacher-reviewable hypothesis, not an autonomous final judgment.")
+                    : t("This signal can be reviewed directly in context.")}
+                </div>
+                {trustTrace.teacher_review_note ? (
+                  <div className="mt-2">{trustTrace.teacher_review_note}</div>
+                ) : null}
+                {trustTrace.abstained ? (
+                  <div className="mt-2">
+                    {t("Abstain reason: {{reason}}", {
+                      reason: trustTrace.abstain_reason || t("evidence was too weak"),
+                    })}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </section>
       </div>
@@ -187,6 +210,12 @@ export function StudentInsightDetail({
               ? t("Why this move: {{reason}}", { reason: diagnosis.evidence[0] })
               : t("Why this move: based on the strongest recent learning signal.")}
           </div>
+          {trustTrace?.recommendation_rationale ? (
+            <div className="mt-4 rounded-2xl border border-emerald-200 bg-white/80 p-3 text-[12px] text-emerald-900/80">
+              <div className="font-medium">{t("Recommendation rationale")}</div>
+              <div className="mt-1">{trustTrace.recommendation_rationale}</div>
+            </div>
+          ) : null}
           <div className="mt-4 space-y-2 text-[12px] text-[var(--muted-foreground)]">
             <div>{t("Topic: {{topic}}", { topic: recommendation?.topic ?? diagnosis?.topic ?? t("Unknown") })}</div>
             <div>
@@ -198,6 +227,16 @@ export function StudentInsightDetail({
               <div>{t("Support level: {{value}}", { value: student.student_state.support_level })}</div>
             ) : null}
           </div>
+          {trustTrace?.evidence?.length ? (
+            <div className="mt-4 rounded-2xl border border-emerald-200 bg-white/80 p-3 text-[12px] text-emerald-900/80">
+              <div className="font-medium">{t("Evidence used")}</div>
+              <ul className="mt-2 space-y-1">
+                {trustTrace.evidence.map((fact) => (
+                  <li key={`${student.student_id}-trust-${fact}`}>• {fact}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
           {recommendation ? (
             <div className="mt-4">
               <RecommendationFeedbackComposer

--- a/web/lib/agent-spec-api.ts
+++ b/web/lib/agent-spec-api.ts
@@ -61,6 +61,30 @@ export interface AgentSpecUpsertPayload {
   files: Record<string, string>;
 }
 
+export interface RuntimePolicyAuditPayload {
+  agent_spec_id: string;
+  agent_spec_version: number | null;
+  capability: string;
+  runtime_policy: {
+    capability: string;
+    agent_spec_id: string;
+    agent_spec_version: number | null;
+    slices: Record<string, string>;
+    sources: Record<string, string>;
+    knowledge_policy: string;
+    source_priority: string[];
+    teacher_kb_context: string;
+    debug: {
+      applied_slices: string[];
+      missing_slices: string[];
+      slice_sources: Record<string, string>;
+      agent_spec_id: string;
+      agent_spec_version: number | null;
+      has_teacher_kb_context: boolean;
+    };
+  };
+}
+
 async function expectJson<T>(response: Response): Promise<T> {
   if (!response.ok) {
     const message = await response.text();
@@ -104,4 +128,15 @@ export async function exportAgentSpec(agentId: string): Promise<Blob> {
     throw new Error(`Export failed: ${response.status}`);
   }
   return response.blob();
+}
+
+export async function getAgentSpecRuntimePolicyAudit(
+  agentId: string,
+  capability = "chat",
+): Promise<RuntimePolicyAuditPayload> {
+  const response = await fetch(
+    apiUrl(`/api/v1/agent-specs/${agentId}/runtime-policy-audit?capability=${encodeURIComponent(capability)}`),
+    { cache: "no-store" },
+  );
+  return expectJson<RuntimePolicyAuditPayload>(response);
 }

--- a/web/lib/dashboard-api.ts
+++ b/web/lib/dashboard-api.ts
@@ -305,7 +305,19 @@ export interface TeacherInsightStudent {
     confidence_tag: string;
     topic: string;
     evidence: string[];
+    teacher_review_note?: string;
   }>;
+  reason_trace?: {
+    diagnosis_policy: string;
+    teacher_review_required: boolean;
+    confidence_tag: string;
+    topic: string;
+    evidence: string[];
+    teacher_review_note: string;
+    recommendation_rationale: string;
+    abstained: boolean;
+    abstain_reason: string;
+  } | null;
   diagnosis_feedback?: DiagnosisFeedbackRecord | null;
   recommended_actions: Array<{
     action_id: string;
@@ -455,6 +467,18 @@ export interface DashboardInsights {
     diagnosis_type: string;
     student_ids: string[];
     recommended_action: string;
+    source_action_type?: string;
+    confidence_tag?: string;
+    reason_trace?: {
+      topic: string;
+      diagnosis_type: string;
+      source_action_type: string;
+      confidence_tag: string;
+      grouping_rule: string;
+      shared_evidence: string[];
+      teacher_review_note: string;
+      supporting_student_ids: string[];
+    } | null;
     target_id?: string;
     recommendation_ack?: RecommendationAckRecord | null;
     recommendation_feedback?: RecommendationFeedbackRecord | null;


### PR DESCRIPTION
## Summary
- add bounded student and small-group trust traces to teacher insight payloads
- surface diagnosis policy, evidence, and teacher-review framing in dashboard trust UI
- surface runtime-policy audit details for agent specs on `/agents`

## Validation
- pytest tests/api/test_dashboard_router.py -k "dashboard_insights_returns_students_and_small_groups or preserve_procedure_breakdown_taxonomy_for_small_groups or skips_small_groups_for_stale_evidence" -q
- pytest tests/api/test_agent_specs_router.py -k "runtime_policy_audit" -q
- ./web/node_modules/.bin/eslint --config web/eslint.config.mjs <touched files>  # passes with existing Next.js pages-path warning only
- python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
- git diff --check

## Architecture
- Updated `ai_first/architecture/MAIN_SYSTEM_MAP.md`
- PR note: `docs/superpowers/pr-notes/2026-04-28-f112-provenance-and-reason-trace-surfaces.md`
