### PR TITLE
feat(validation): add pilot feedback ingestion seam [F122]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local-mac
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-pilot-feedback-ingestion`
 - Task: `F122_PILOT_FEEDBACK_INGESTION_PATH`
-- Status: `planning`
+- Status: `in-progress`
 - Branch: `pod-b/pilot-feedback-ingestion-path`
 - Task packet: `docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md`
-- Owned files: `deeptutor/api/routers/system.py`, `deeptutor/services/evidence/`, bounded `deeptutor/services/session/sqlite_store.py`, `tests/api/test_system_router.py`, bounded `tests/services/session/test_sqlite_store.py`, bounded `docs/contest/`, bounded `ai_first/competition/`, `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`
+- Owned files: `deeptutor/api/routers/system.py`, `deeptutor/services/evidence/`, `tests/api/test_system_router.py`, `tests/services/evidence/`, bounded `docs/contest/`, bounded `ai_first/competition/`, `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`
 - PR: `none yet`
 - Last update: `2026-04-28`
-- Next action: `write F122 task packet, spec, and implementation plan before any code changes`
+- Next action: `run final targeted verification, then stage the implementation and open a Draft PR`
 - Blocker: `none`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local-mac
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-pilot-feedback-ingestion`
 - Task: `F122_PILOT_FEEDBACK_INGESTION_PATH`
-- Status: `in-progress`
+- Status: `ready-review`
 - Branch: `pod-b/pilot-feedback-ingestion-path`
 - Task packet: `docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md`
 - Owned files: `deeptutor/api/routers/system.py`, `deeptutor/services/evidence/`, `tests/api/test_system_router.py`, `tests/services/evidence/`, bounded `docs/contest/`, bounded `ai_first/competition/`, `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`
-- PR: `none yet`
+- PR: `#200`
 - Last update: `2026-04-28`
-- Next action: `run final targeted verification, then stage the implementation and open a Draft PR`
+- Next action: `watch CI on PR #200 and merge once checks are green`
 - Blocker: `none`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task is currently assigned on `main`.
-The next product work should start from a fresh Session A or Session B branch/worktree after the AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Session B AI
+- Machine: local-mac
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-pilot-feedback-ingestion`
+- Task: `F122_PILOT_FEEDBACK_INGESTION_PATH`
+- Status: `planning`
+- Branch: `pod-b/pilot-feedback-ingestion-path`
+- Task packet: `docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md`
+- Owned files: `deeptutor/api/routers/system.py`, `deeptutor/services/evidence/`, bounded `deeptutor/services/session/sqlite_store.py`, `tests/api/test_system_router.py`, bounded `tests/services/session/test_sqlite_store.py`, bounded `docs/contest/`, bounded `ai_first/competition/`, `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`
+- PR: `none yet`
+- Last update: `2026-04-28`
+- Next action: `write F122 task packet, spec, and implementation plan before any code changes`
+- Blocker: `none`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-28T05:24:00Z",
+    "last_updated": "2026-04-28T05:35:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -83,8 +83,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F122_PILOT_FEEDBACK_INGESTION_PATH"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -93,10 +95,9 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 4,
+      "count": 3,
       "tasks": [
         "F112_PROVENANCE_AND_REASON_TRACE_SURFACES",
-        "F122_PILOT_FEEDBACK_INGESTION_PATH",
         "F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION",
         "F124_EVIDENCE_AUTOMATION_REFRESH"
       ]
@@ -1766,10 +1767,10 @@
       "dependencies": [
         "R6_CLAIM_CALIBRATION_PILOT"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "validation-ops",
-      "notes": "Should preserve the current explicit no-pilot-yet stance until real external feedback exists."
+      "notes": "Active on branch pod-b/pilot-feedback-ingestion-path in worktree .worktrees/pod-b-pilot-feedback-ingestion. Planning and implementation must preserve the explicit no-pilot-yet stance until real external feedback exists."
     },
     {
       "id": "F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -175,6 +175,13 @@ flowchart TD
   PromptManager --> VietnameseFallback["vi → en fallback chain"]
   Localization --> LanguageSettings["Settings: en/zh/vi"]
 
+  Product --> ValidationOps["Validation Ops"]
+  ValidationOps --> ValidationStatus["Contest validation status surfaces"]
+  ValidationStatus --> PilotStatusDoc["docs/contest/PILOT_STATUS.md"]
+  ValidationStatus --> PilotStatusAPI["GET /api/v1/system/pilot-feedback-status"]
+  ValidationStatus --> PilotFeedbackAPI["POST/GET /api/v1/system/pilot-feedback"]
+  PilotFeedbackAPI --> PilotFeedbackStore["Pilot feedback records (bounded validation-ops storage)"]
+
   Project --> Data["Data Layer"]
   Data --> SQLite["data/user/chat_history.db"]
   Data --> KnowledgeBases["data/knowledge_bases"]

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -59,6 +59,8 @@
 - Task: `F122_PILOT_FEEDBACK_INGESTION_PATH`
 - Done: Claimed the new Session B worktree in `ACTIVE_ASSIGNMENTS.md` and moved `F122` to `in-progress` in `TASK_REGISTRY.json`.
 - Done: Wrote the task packet, design spec, and implementation plan for a bounded validation-ops seam that can ingest future external walkthrough or pilot feedback without changing the current no-pilot-yet claim.
-- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; placeholder scan on the new F122 packet/spec/plan; `git diff --check`
+- Done: Added a dedicated `pilot_feedback` evidence helper plus `POST/GET /api/v1/system/pilot-feedback` and `GET /api/v1/system/pilot-feedback-status` so future feedback can be stored without touching teacher-facing dashboard UX.
+- Done: Updated `docs/contest/PILOT_STATUS.md`, `docs/contest/HUMAN_REVIEW_HANDOFF.md`, and `ai_first/architecture/MAIN_SYSTEM_MAP.md` so the contest read path references the new bounded validation-ops seam while keeping the current empty-state claim explicit.
+- Tests: `pytest tests/services/evidence/test_pilot_feedback.py tests/api/test_system_router.py -q`; `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; placeholder scan on the new F122 packet/spec/plan; `git diff --check`
 - Blockers: None.
-- Next: implement the smallest test-backed feedback storage and system-status seam inside the owned validation-ops files only.
+- Next: write the PR note, run final verification on the full owned slice, and prepare the branch for Draft PR flow.

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -52,3 +52,13 @@
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; `git diff --check`
 - Blockers: None.
 - Next: start a fresh Session A or Session B branch/worktree for `F112`, `F122`, or `F123` instead of reviving `F121`.
+
+## Session B Pilot Feedback Ingestion Path
+
+- Branch: `pod-b/pilot-feedback-ingestion-path`
+- Task: `F122_PILOT_FEEDBACK_INGESTION_PATH`
+- Done: Claimed the new Session B worktree in `ACTIVE_ASSIGNMENTS.md` and moved `F122` to `in-progress` in `TASK_REGISTRY.json`.
+- Done: Wrote the task packet, design spec, and implementation plan for a bounded validation-ops seam that can ingest future external walkthrough or pilot feedback without changing the current no-pilot-yet claim.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; placeholder scan on the new F122 packet/spec/plan; `git diff --check`
+- Blockers: None.
+- Next: implement the smallest test-backed feedback storage and system-status seam inside the owned validation-ops files only.

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -61,6 +61,7 @@
 - Done: Wrote the task packet, design spec, and implementation plan for a bounded validation-ops seam that can ingest future external walkthrough or pilot feedback without changing the current no-pilot-yet claim.
 - Done: Added a dedicated `pilot_feedback` evidence helper plus `POST/GET /api/v1/system/pilot-feedback` and `GET /api/v1/system/pilot-feedback-status` so future feedback can be stored without touching teacher-facing dashboard UX.
 - Done: Updated `docs/contest/PILOT_STATUS.md`, `docs/contest/HUMAN_REVIEW_HANDOFF.md`, and `ai_first/architecture/MAIN_SYSTEM_MAP.md` so the contest read path references the new bounded validation-ops seam while keeping the current empty-state claim explicit.
+- Done: Opened Draft PR `#200`, completed local self-review, and prepared the lane to move into review once the review-status control-plane update is pushed.
 - Tests: `pytest tests/services/evidence/test_pilot_feedback.py tests/api/test_system_router.py -q`; `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; placeholder scan on the new F122 packet/spec/plan; `git diff --check`
 - Blockers: None.
-- Next: write the PR note, run final verification on the full owned slice, and prepare the branch for Draft PR flow.
+- Next: keep PR `#200` green and mergeable, then run the post-merge AI-first sync on a fresh docs branch.

--- a/deeptutor/api/routers/system.py
+++ b/deeptutor/api/routers/system.py
@@ -6,14 +6,20 @@ Manages system status checks and model connection tests
 from datetime import datetime
 import time
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from deeptutor.services.evidence.pilot_feedback import (
+    build_pilot_feedback_status,
+    create_pilot_feedback,
+    list_pilot_feedback,
+)
 from deeptutor.services.config import resolve_search_runtime_config
 from deeptutor.services.embedding import get_embedding_client, get_embedding_config
 from deeptutor.services.llm import complete as llm_complete
 from deeptutor.services.llm import get_llm_config, get_token_limit_kwargs
 from deeptutor.services.search import web_search
+from deeptutor.services.session import get_sqlite_session_store
 
 router = APIRouter()
 
@@ -24,6 +30,39 @@ class TestResponse(BaseModel):
     model: str | None = None
     response_time_ms: float | None = None
     error: str | None = None
+
+
+class PilotFeedbackCreateRequest(BaseModel):
+    evidence_level: str
+    source_label: str
+    participant_role: str = ""
+    feedback_date: str
+    scope_note: str
+    finding_summary: str
+    recommendation_note: str = ""
+    artifact_ref: str = ""
+    verified_by: str = ""
+
+
+@router.get("/pilot-feedback-status")
+async def get_pilot_feedback_status():
+    return build_pilot_feedback_status(get_sqlite_session_store())
+
+
+@router.get("/pilot-feedback")
+async def get_pilot_feedback():
+    return {"items": list_pilot_feedback(get_sqlite_session_store())}
+
+
+@router.post("/pilot-feedback")
+async def create_pilot_feedback_record(payload: PilotFeedbackCreateRequest):
+    try:
+        return create_pilot_feedback(
+            get_sqlite_session_store(),
+            **payload.model_dump(),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/runtime-topology")

--- a/deeptutor/services/evidence/__init__.py
+++ b/deeptutor/services/evidence/__init__.py
@@ -12,6 +12,11 @@ from .intervention_assignments import (
     update_intervention_assignment_status,
 )
 from .intervention_effectiveness import summarize_intervention_effectiveness
+from .pilot_feedback import (
+    build_pilot_feedback_status,
+    create_pilot_feedback,
+    list_pilot_feedback,
+)
 from .recommendation_acks import (
     create_recommendation_ack,
     list_recommendation_acks,
@@ -32,10 +37,12 @@ from .teacher_insights import build_teacher_insights_payload
 
 __all__ = [
     "build_student_diagnosis",
+    "build_pilot_feedback_status",
     "build_teacher_insights_payload",
     "classify_evidence_sufficiency",
     "create_diagnosis_feedback",
     "create_intervention_assignment",
+    "create_pilot_feedback",
     "create_recommendation_ack",
     "create_recommendation_feedback",
     "create_teacher_override",
@@ -43,6 +50,7 @@ __all__ = [
     "extract_observations_from_review",
     "list_diagnosis_feedback",
     "list_intervention_assignments",
+    "list_pilot_feedback",
     "list_recommendation_acks",
     "list_recommendation_feedback",
     "list_teacher_overrides",

--- a/deeptutor/services/evidence/pilot_feedback.py
+++ b/deeptutor/services/evidence/pilot_feedback.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import sqlite3
+from typing import Any
+from uuid import uuid4
+
+_ALLOWED_LEVELS = {"walkthrough", "limited_external_feedback", "pilot"}
+
+
+def _now_ts() -> int:
+    return int(datetime.now(tz=timezone.utc).timestamp())
+
+
+def _connect(db_path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_table(db_path) -> None:
+    with _connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pilot_feedback (
+                id TEXT PRIMARY KEY,
+                evidence_level TEXT NOT NULL,
+                source_label TEXT NOT NULL,
+                participant_role TEXT NOT NULL,
+                feedback_date TEXT NOT NULL,
+                scope_note TEXT NOT NULL,
+                finding_summary TEXT NOT NULL,
+                recommendation_note TEXT NOT NULL,
+                artifact_ref TEXT NOT NULL,
+                verified_by TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_pilot_feedback_date
+                ON pilot_feedback(feedback_date DESC, updated_at DESC)
+            """
+        )
+        conn.commit()
+
+
+def _row_to_record(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "evidence_level": row["evidence_level"],
+        "source_label": row["source_label"],
+        "participant_role": row["participant_role"],
+        "feedback_date": row["feedback_date"],
+        "scope_note": row["scope_note"],
+        "finding_summary": row["finding_summary"],
+        "recommendation_note": row["recommendation_note"],
+        "artifact_ref": row["artifact_ref"],
+        "verified_by": row["verified_by"],
+        "created_at": int(row["created_at"]),
+        "updated_at": int(row["updated_at"]),
+    }
+
+
+def list_pilot_feedback(store: Any) -> list[dict[str, Any]]:
+    _ensure_table(store.db_path)
+    with _connect(store.db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT id, evidence_level, source_label, participant_role, feedback_date,
+                   scope_note, finding_summary, recommendation_note, artifact_ref,
+                   verified_by, created_at, updated_at
+            FROM pilot_feedback
+            ORDER BY feedback_date DESC, updated_at DESC, created_at DESC, id DESC
+            """
+        ).fetchall()
+    return [_row_to_record(row) for row in rows]
+
+
+def create_pilot_feedback(
+    store: Any,
+    *,
+    evidence_level: str,
+    source_label: str,
+    participant_role: str = "",
+    feedback_date: str,
+    scope_note: str,
+    finding_summary: str,
+    recommendation_note: str = "",
+    artifact_ref: str = "",
+    verified_by: str = "",
+) -> dict[str, Any]:
+    if evidence_level not in _ALLOWED_LEVELS:
+        raise ValueError("invalid evidence_level")
+
+    cleaned_source = source_label.strip()
+    cleaned_role = participant_role.strip()
+    cleaned_date = feedback_date.strip()
+    cleaned_scope = scope_note.strip()
+    cleaned_finding = finding_summary.strip()
+    cleaned_recommendation = recommendation_note.strip()
+    cleaned_artifact = artifact_ref.strip()
+    cleaned_verified = verified_by.strip()
+
+    if not cleaned_source or not cleaned_date or not cleaned_scope or not cleaned_finding:
+        raise ValueError("missing required pilot feedback field")
+
+    now = _now_ts()
+    record = {
+        "id": f"pilot-feedback:{uuid4().hex}",
+        "evidence_level": evidence_level,
+        "source_label": cleaned_source,
+        "participant_role": cleaned_role,
+        "feedback_date": cleaned_date,
+        "scope_note": cleaned_scope,
+        "finding_summary": cleaned_finding,
+        "recommendation_note": cleaned_recommendation,
+        "artifact_ref": cleaned_artifact,
+        "verified_by": cleaned_verified,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    _ensure_table(store.db_path)
+    with _connect(store.db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO pilot_feedback (
+                id, evidence_level, source_label, participant_role, feedback_date,
+                scope_note, finding_summary, recommendation_note, artifact_ref,
+                verified_by, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record["id"],
+                record["evidence_level"],
+                record["source_label"],
+                record["participant_role"],
+                record["feedback_date"],
+                record["scope_note"],
+                record["finding_summary"],
+                record["recommendation_note"],
+                record["artifact_ref"],
+                record["verified_by"],
+                record["created_at"],
+                record["updated_at"],
+            ),
+        )
+        conn.commit()
+    return deepcopy(record)
+
+
+def build_pilot_feedback_status(store: Any) -> dict[str, Any]:
+    items = list_pilot_feedback(store)
+    if not items:
+        return {
+            "status": "no_pilot_evidence_yet",
+            "record_count": 0,
+            "levels_present": [],
+            "latest_feedback_date": None,
+            "items": [],
+        }
+
+    levels_present = sorted({item["evidence_level"] for item in items})
+    latest_feedback_date = max(item["feedback_date"] for item in items)
+    return {
+        "status": "feedback_records_available",
+        "record_count": len(items),
+        "levels_present": levels_present,
+        "latest_feedback_date": latest_feedback_date,
+        "items": items,
+    }
+

--- a/docs/contest/HUMAN_REVIEW_HANDOFF.md
+++ b/docs/contest/HUMAN_REVIEW_HANDOFF.md
@@ -38,7 +38,7 @@ Before submission, quickly verify:
 - screenshots are clear and contain no private data
 - `docs/contest/VALIDATION_REPORT.md` still matches the intended demo environment
 - hybrid authoring claims stay calibrated: `/agents` authoring can be shown, and bounded automated proof now exists for the unified Tutor turn path; do not rewrite that as universal live binding across every entry point
-- pilot or external-feedback language stays honest: use [`PILOT_STATUS.md`](./PILOT_STATUS.md) instead of implying classroom validation that the repository does not contain
+- pilot or external-feedback language stays honest: use [`PILOT_STATUS.md`](./PILOT_STATUS.md) and keep `/api/v1/system/pilot-feedback-status` aligned with any real stored feedback instead of implying classroom validation that the repository does not contain
 - optional video is either not required or has been recorded separately using `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`
 
 ### 4. Final package sign-off

--- a/docs/contest/PILOT_STATUS.md
+++ b/docs/contest/PILOT_STATUS.md
@@ -4,6 +4,8 @@
 
 No pilot evidence yet is included in this repository.
 
+The repository now includes a bounded validation-ops ingestion seam at `/api/v1/system/pilot-feedback` and `/api/v1/system/pilot-feedback-status`, but that seam is still empty unless real external walkthrough or pilot feedback records are intentionally added later.
+
 ## What Exists Instead
 
 - structured walkthrough validation of the contest MVP flow
@@ -18,3 +20,5 @@ These artifacts show the current merged capability and repeatable demo behavior 
 ## Next Stronger Validation Step
 
 The next stronger step after the contest would be a small teacher walkthrough or limited pilot with clearly documented scope, dates, and feedback boundaries.
+
+If that happens, record it through the bounded pilot-feedback seam first and then update this document to summarize the stored evidence honestly.

--- a/docs/superpowers/plans/2026-04-28-f122-pilot-feedback-ingestion-path.md
+++ b/docs/superpowers/plans/2026-04-28-f122-pilot-feedback-ingestion-path.md
@@ -1,0 +1,27 @@
+# F122 Implementation Plan
+
+## Objective
+
+Add a bounded validation-ops seam for future pilot or external walkthrough feedback, while preserving the repository's explicit current `no_pilot_evidence_yet` stance.
+
+## Steps
+
+1. Add failing tests first
+   - store/service tests for dedicated pilot-feedback persistence and validation
+   - system API tests for honest empty-state status and record listing behavior
+2. Isolate feedback ingestion logic
+   - add a focused helper under `deeptutor/services/evidence/`
+   - use a dedicated SQLite table or similarly isolated storage path
+   - keep labels and required fields explicit and claim-safe
+3. Expose a bounded ops surface
+   - extend a non-dashboard router such as `system.py`
+   - return a compact status payload that still says `no_pilot_evidence_yet` when there are zero records
+4. Update bounded docs proof
+   - refresh `docs/contest/PILOT_STATUS.md` and related handoff wording only as needed to reference the new seam
+   - write the PR note with a Mermaid diagram
+   - update `MAIN_SYSTEM_MAP.md` if the new validation-ops seam becomes a stable subsystem boundary
+5. Verify
+   - run targeted store/service and system API tests
+   - run `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+   - run a registry consistency check
+   - run `git diff --check`

--- a/docs/superpowers/plans/2026-04-28-f122-pilot-feedback-ingestion-path.md
+++ b/docs/superpowers/plans/2026-04-28-f122-pilot-feedback-ingestion-path.md
@@ -7,11 +7,11 @@ Add a bounded validation-ops seam for future pilot or external walkthrough feedb
 ## Steps
 
 1. Add failing tests first
-   - store/service tests for dedicated pilot-feedback persistence and validation
+   - service tests for dedicated pilot-feedback persistence and validation
    - system API tests for honest empty-state status and record listing behavior
 2. Isolate feedback ingestion logic
    - add a focused helper under `deeptutor/services/evidence/`
-   - use a dedicated SQLite table or similarly isolated storage path
+   - use a dedicated SQLite table or similarly isolated storage path managed by that helper
    - keep labels and required fields explicit and claim-safe
 3. Expose a bounded ops surface
    - extend a non-dashboard router such as `system.py`

--- a/docs/superpowers/pr-notes/2026-04-28-f122-pilot-feedback-ingestion-path.md
+++ b/docs/superpowers/pr-notes/2026-04-28-f122-pilot-feedback-ingestion-path.md
@@ -1,0 +1,24 @@
+# F122 Pilot Feedback Ingestion Path Architecture Note
+
+## Summary
+
+`F122` adds a bounded validation-ops seam for future external walkthrough or pilot feedback. It does not change teacher-facing dashboard UX and it does not upgrade the repository's current proof level by itself. The empty state remains explicit through `PILOT_STATUS.md` and `/api/v1/system/pilot-feedback-status`.
+
+## Structure
+
+```mermaid
+flowchart TD
+  HumanReview["Human review / contest ops"] --> PilotDoc["docs/contest/PILOT_STATUS.md"]
+  HumanReview --> PilotStatusAPI["GET /api/v1/system/pilot-feedback-status"]
+  HumanReview --> PilotWriteAPI["POST /api/v1/system/pilot-feedback"]
+  PilotWriteAPI --> PilotHelper["services/evidence/pilot_feedback.py"]
+  PilotStatusAPI --> PilotHelper
+  PilotHelper --> PilotStore["SQLite pilot_feedback table"]
+  PilotHelper --> EmptyState["status = no_pilot_evidence_yet when no records exist"]
+```
+
+## Notes
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
+- The route is intentionally system/ops-facing, not a dashboard or classroom workflow surface.
+- The contract is safe to leave empty; no seeded pilot data is required or implied.

--- a/docs/superpowers/specs/2026-04-28-f122-pilot-feedback-ingestion-path-design.md
+++ b/docs/superpowers/specs/2026-04-28-f122-pilot-feedback-ingestion-path-design.md
@@ -1,0 +1,82 @@
+# F122 Design: Pilot Feedback Ingestion Path
+
+## Problem
+
+The repository already has honest contest wording that says no pilot evidence is currently bundled, but it does not have a bounded product-side place to ingest and preserve future walkthrough or pilot feedback once that feedback exists. Without an explicit seam, the likely failure modes are scattered notes, claim drift across contest docs, or ad hoc storage mixed into unrelated teacher/product surfaces.
+
+## Design Direction
+
+Keep this slice narrow and ops-facing. The system should add a dedicated feedback-ingestion seam that can safely hold future external walkthrough or pilot feedback records, while keeping the current empty state explicit and reviewable. The feature should improve future evidence hygiene, not imply that real pilot evidence already exists.
+
+Recommended record shape:
+
+- feedback id
+- evidence tier such as `walkthrough`, `limited_external_feedback`, or `pilot`
+- source label and optional participant role
+- activity date or date range
+- short scope note
+- bounded findings or recommendation notes
+- claim-safety metadata such as `verified_by`, `artifact_ref`, or `status`
+
+## Proposed Contract
+
+1. Add a focused feedback store/helper under `deeptutor/services/evidence/` with explicit validation and list/read behavior.
+2. Persist records in a dedicated SQLite table or similarly isolated storage seam rather than hiding them in generic session preferences.
+3. Expose a bounded system/ops surface that can:
+   - report the current pilot-feedback status
+   - remain explicit about `no_pilot_evidence_yet` when no records exist
+   - list stored records without turning them into teacher-facing product UX
+4. Update contest and human-review docs so they point to the new status/ingestion seam while keeping claims calibrated.
+
+## Approach Options
+
+### Option A — Docs-only placeholder
+
+Keep `PILOT_STATUS.md` as the only source of truth and add no backend path.
+
+Pros:
+- smallest change
+- zero runtime risk
+
+Cons:
+- future real feedback still has no structured storage path
+- encourages manual drift between docs and actual evidence records
+
+### Option B — Dedicated validation-ops feedback seam
+
+Add a small storage/helper layer plus a bounded system-facing API/status surface.
+
+Pros:
+- honest empty state today, usable ingestion path later
+- keeps evidence handling separate from dashboard and tutoring flows
+- testable without inventing real pilot data
+
+Cons:
+- adds one small persistence/API seam to maintain
+
+### Option C — Reuse generic session preferences or dashboard metadata
+
+Store pilot notes inside existing session or dashboard data models.
+
+Pros:
+- fewer new files
+
+Cons:
+- wrong boundary
+- easy to couple future external evidence with teacher product workflow
+- harder to reason about claim safety
+
+## Recommendation
+
+Use **Option B**. It gives the repository a real ingestion path without broadening into classroom UX or making unsupported evidence claims.
+
+## Scope Boundary
+
+- in scope: dedicated feedback storage/helper, bounded system-facing status or ingestion API, contest/handoff wording updates, tests that prove empty-state honesty and record persistence
+- out of scope: teacher dashboard UX, public pilot claims, analytics over feedback, or synthetic/example pilot data presented as real evidence
+
+## Proof Plan
+
+- service or store tests prove the system can persist and return feedback records with explicit validation
+- system API tests prove empty state remains `no_pilot_evidence_yet` when no records exist and becomes structured only when real records are stored
+- bounded docs updates prove the contest read path points to the seam without changing the underlying no-pilot-yet claim

--- a/docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md
+++ b/docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md
@@ -2,7 +2,7 @@
 
 - Task ID: `F122_PILOT_FEEDBACK_INGESTION_PATH`
 - Commit tag: `F122`
-- Status: `Planning`
+- Status: `In Progress`
 - Branch recommendation: `pod-b/pilot-feedback-ingestion-path`
 
 ## Goal
@@ -13,9 +13,8 @@ Prepare a bounded ingestion and status path for future external walkthrough or p
 
 - `deeptutor/api/routers/system.py`
 - `deeptutor/services/evidence/`
-- bounded `deeptutor/services/session/sqlite_store.py`
 - `tests/api/test_system_router.py`
-- bounded `tests/services/session/test_sqlite_store.py`
+- `tests/services/evidence/`
 - bounded `docs/contest/`
 - bounded `ai_first/competition/`
 - `docs/superpowers/specs/`

--- a/docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md
+++ b/docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md
@@ -2,7 +2,7 @@
 
 - Task ID: `F122_PILOT_FEEDBACK_INGESTION_PATH`
 - Commit tag: `F122`
-- Status: `In Progress`
+- Status: `Ready for review`
 - Branch recommendation: `pod-b/pilot-feedback-ingestion-path`
 
 ## Goal

--- a/docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md
+++ b/docs/superpowers/tasks/2026-04-28-f122-pilot-feedback-ingestion-path.md
@@ -1,0 +1,38 @@
+# F122 Pilot Feedback Ingestion Path
+
+- Task ID: `F122_PILOT_FEEDBACK_INGESTION_PATH`
+- Commit tag: `F122`
+- Status: `Planning`
+- Branch recommendation: `pod-b/pilot-feedback-ingestion-path`
+
+## Goal
+
+Prepare a bounded ingestion and status path for future external walkthrough or pilot feedback so the repository can store real feedback later without overstating what current evidence proves today.
+
+## Owned Files
+
+- `deeptutor/api/routers/system.py`
+- `deeptutor/services/evidence/`
+- bounded `deeptutor/services/session/sqlite_store.py`
+- `tests/api/test_system_router.py`
+- bounded `tests/services/session/test_sqlite_store.py`
+- bounded `docs/contest/`
+- bounded `ai_first/competition/`
+- `docs/superpowers/specs/`
+- `docs/superpowers/plans/`
+- `docs/superpowers/pr-notes/`
+
+## Do Not Touch
+
+- teacher-facing dashboard presentation files
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- tutoring runtime, capability binding, and agent-spec surfaces
+- recommendation, diagnosis, and classroom workflow UX beyond bounded contest/ops wording
+
+## Constraints
+
+- preserve the explicit current stance that no pilot evidence is bundled yet unless real feedback is actually added
+- avoid fabricated quotes, participant counts, outcomes, or classroom-validated wording
+- keep the ingestion seam separate from teacher-facing product UX
+- prefer a narrow validation-ops API or storage contract over broad workflow expansion

--- a/tests/api/test_system_router.py
+++ b/tests/api/test_system_router.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - optional dependency in lightweight envs
+    FastAPI = None
+    TestClient = None
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+pytestmark = pytest.mark.skipif(FastAPI is None or TestClient is None, reason="fastapi not installed")
+
+
+def _build_app(store: SQLiteSessionStore, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from deeptutor.api.routers import system
+
+    app = FastAPI()
+    app.include_router(system.router, prefix="/api/v1/system")
+    monkeypatch.setattr(system, "get_sqlite_session_store", lambda: store)
+    return app
+
+
+def test_system_pilot_feedback_status_stays_explicit_when_empty(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        response = client.get("/api/v1/system/pilot-feedback-status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "no_pilot_evidence_yet",
+        "record_count": 0,
+        "levels_present": [],
+        "latest_feedback_date": None,
+        "items": [],
+    }
+
+
+def test_system_pilot_feedback_create_and_list_round_trip(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+
+    with TestClient(_build_app(store, monkeypatch)) as client:
+        create_response = client.post(
+            "/api/v1/system/pilot-feedback",
+            json={
+                "evidence_level": "limited_external_feedback",
+                "source_label": "Teacher review meeting",
+                "participant_role": "teacher",
+                "feedback_date": "2026-04-28",
+                "scope_note": "two-teacher demo review",
+                "finding_summary": "Reviewers understood the flow and asked for clearer classroom boundary notes.",
+                "recommendation_note": "Preserve the no-pilot-yet wording until broader external use exists.",
+                "artifact_ref": "docs/contest/PILOT_STATUS.md",
+                "verified_by": "submission-team",
+            },
+        )
+        list_response = client.get("/api/v1/system/pilot-feedback")
+        status_response = client.get("/api/v1/system/pilot-feedback-status")
+
+    assert create_response.status_code == 200
+    created = create_response.json()
+    assert created["evidence_level"] == "limited_external_feedback"
+    assert created["verified_by"] == "submission-team"
+
+    assert list_response.status_code == 200
+    assert list_response.json()["items"][0]["source_label"] == "Teacher review meeting"
+
+    assert status_response.status_code == 200
+    assert status_response.json()["status"] == "feedback_records_available"
+    assert status_response.json()["record_count"] == 1
+    assert status_response.json()["levels_present"] == ["limited_external_feedback"]

--- a/tests/services/evidence/test_pilot_feedback.py
+++ b/tests/services/evidence/test_pilot_feedback.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from deeptutor.services.session.sqlite_store import SQLiteSessionStore
+
+from deeptutor.services.evidence.pilot_feedback import (
+    build_pilot_feedback_status,
+    create_pilot_feedback,
+    list_pilot_feedback,
+)
+
+
+def test_pilot_feedback_status_defaults_to_no_pilot_evidence(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+
+    status = build_pilot_feedback_status(store)
+
+    assert status == {
+        "status": "no_pilot_evidence_yet",
+        "record_count": 0,
+        "levels_present": [],
+        "latest_feedback_date": None,
+        "items": [],
+    }
+
+
+def test_pilot_feedback_records_round_trip_with_claim_safe_metadata(tmp_path) -> None:
+    store = SQLiteSessionStore(tmp_path / "chat_history.db")
+
+    record = create_pilot_feedback(
+        store,
+        evidence_level="walkthrough",
+        source_label="Teacher walkthrough",
+        participant_role="teacher",
+        feedback_date="2026-04-28",
+        scope_note="single-teacher structured walkthrough",
+        finding_summary="The MVP flow is clear, but the evidence boundary should stay explicit.",
+        recommendation_note="Add a clearer note about evidence freshness before a wider demo.",
+        artifact_ref="docs/contest/PILOT_STATUS.md",
+        verified_by="internal-review",
+    )
+
+    listed = list_pilot_feedback(store)
+    status = build_pilot_feedback_status(store)
+
+    assert record["evidence_level"] == "walkthrough"
+    assert listed[0]["source_label"] == "Teacher walkthrough"
+    assert listed[0]["artifact_ref"] == "docs/contest/PILOT_STATUS.md"
+    assert status["status"] == "feedback_records_available"
+    assert status["record_count"] == 1
+    assert status["levels_present"] == ["walkthrough"]
+    assert status["latest_feedback_date"] == "2026-04-28"
+


### PR DESCRIPTION
# F122 Pilot Feedback Ingestion Path Architecture Note

## Summary

`F122` adds a bounded validation-ops seam for future external walkthrough or pilot feedback. It does not change teacher-facing dashboard UX and it does not upgrade the repository's current proof level by itself. The empty state remains explicit through `PILOT_STATUS.md` and `/api/v1/system/pilot-feedback-status`.

## Structure

```mermaid
flowchart TD
  HumanReview["Human review / contest ops"] --> PilotDoc["docs/contest/PILOT_STATUS.md"]
  HumanReview --> PilotStatusAPI["GET /api/v1/system/pilot-feedback-status"]
  HumanReview --> PilotWriteAPI["POST /api/v1/system/pilot-feedback"]
  PilotWriteAPI --> PilotHelper["services/evidence/pilot_feedback.py"]
  PilotStatusAPI --> PilotHelper
  PilotHelper --> PilotStore["SQLite pilot_feedback table"]
  PilotHelper --> EmptyState["status = no_pilot_evidence_yet when no records exist"]
```

## Notes

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
- The route is intentionally system/ops-facing, not a dashboard or classroom workflow surface.
- The contract is safe to leave empty; no seeded pilot data is required or implied.
