### PR TITLE
feat(validation): expand casepack evaluation dataset [F123]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task is currently assigned on `main`.
-The next product work should start from a fresh Session A or Session B branch/worktree after the AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Codex Session B
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-casepack-eval-dataset`
+- Task: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
+- Status: `brainstorming`
+- Branch: `pod-b/casepack-eval-dataset`
+- Task packet: `docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
+- Owned files: `docs/contest/`, `ai_first/evidence/`, bounded `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`, optional bounded schema/helper under `tests/` if casepack validation is added
+- PR: `draft-not-opened`
+- Last update: `2026-04-28`
+- Next action: `write packet, spec, and plan for a machine-readable validation casepack that stays outside runtime product scope`
+- Blocker: `none`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-casepack-eval-dataset`
 - Task: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
-- Status: `brainstorming`
+- Status: `draft-pr-open`
 - Branch: `pod-b/casepack-eval-dataset`
 - Task packet: `docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
 - Owned files: `docs/contest/`, `ai_first/evidence/`, bounded `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`, optional bounded schema/helper under `tests/` if casepack validation is added
-- PR: `draft-not-opened`
+- PR: `draft-to-open`
 - Last update: `2026-04-28`
-- Next action: `write packet, spec, and plan for a machine-readable validation casepack that stays outside runtime product scope`
+- Next action: `push branch, open Draft PR, and keep the validation-only lane mergeable`
 - Blocker: `none`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -85,8 +85,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -95,9 +97,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 2,
+      "count": 1,
       "tasks": [
-        "F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION",
         "F124_EVIDENCE_AUTOMATION_REFRESH"
       ]
     }
@@ -1792,10 +1793,10 @@
       "dependencies": [
         "R2_DIAGNOSIS_CREDIBILITY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "validation-ops",
-      "notes": "Provides stronger repeatable fixtures for later automation and model-quality work."
+      "notes": "Active on branch pod-b/casepack-eval-dataset in worktree .worktrees/pod-b-casepack-eval-dataset. This lane is building a reusable machine-readable validation casepack for judge-safe evidence review without widening runtime product scope."
     },
     {
       "id": "F124_EVIDENCE_AUTOMATION_REFRESH",

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1796,7 +1796,7 @@
       "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "validation-ops",
-      "notes": "Active on branch pod-b/casepack-eval-dataset in worktree .worktrees/pod-b-casepack-eval-dataset. This lane is building a reusable machine-readable validation casepack for judge-safe evidence review without widening runtime product scope."
+      "notes": "Active on branch pod-b/casepack-eval-dataset in worktree .worktrees/pod-b-casepack-eval-dataset. The branch now contains a reusable machine-readable validation casepack, contest-facing guide, and bounded schema test; open it as a Draft PR and keep runtime product scope unchanged."
     },
     {
       "id": "F124_EVIDENCE_AUTOMATION_REFRESH",

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -5,10 +5,10 @@
 - Branch: `pod-b/casepack-eval-dataset`
 - Task: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
 - Done: Opened a fresh Session B validation-ops lane to grow diagnosis prose into a reusable machine-readable validation casepack without widening runtime product scope.
-- Done: Defined the initial scope around a JSON casepack, contest-facing guide, and bounded schema validation test.
-- Tests: planning stage only so far; execution validation runs after the first artifact batch lands.
+- Done: Added `ai_first/evidence/casepack.json`, `docs/contest/CASEPACK_AND_EVALUATION_DATASET.md`, contest-doc cross-links, and a bounded `tests/evidence/test_casepack_dataset.py` schema check.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `python -m json.tool ai_first/evidence/casepack.json >/dev/null`; `pytest tests/evidence/test_casepack_dataset.py -q`; `git diff --check`
 - Blockers: None.
-- Next: add the casepack JSON, contest guide, and validation test, then open a Draft PR.
+- Next: push the branch, open a Draft PR, and keep the validation-only lane mergeable.
 
 ## Session B Intervention Effectiveness
 

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,15 @@
 # Daily Log: 2026-04-28
 
+## Session B Casepack And Evaluation Dataset Expansion
+
+- Branch: `pod-b/casepack-eval-dataset`
+- Task: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
+- Done: Opened a fresh Session B validation-ops lane to grow diagnosis prose into a reusable machine-readable validation casepack without widening runtime product scope.
+- Done: Defined the initial scope around a JSON casepack, contest-facing guide, and bounded schema validation test.
+- Tests: planning stage only so far; execution validation runs after the first artifact batch lands.
+- Blockers: None.
+- Next: add the casepack JSON, contest guide, and validation test, then open a Draft PR.
+
 ## Session B Intervention Effectiveness
 
 - Branch: `pod-b/intervention-effectiveness-tracking`

--- a/ai_first/evidence/casepack.json
+++ b/ai_first/evidence/casepack.json
@@ -1,0 +1,153 @@
+{
+  "version": "2026-04-28",
+  "categories": [
+    "diagnosis_credibility",
+    "recommendation_actionability",
+    "abstain_behavior",
+    "teacher_execution_loop",
+    "trust_trace"
+  ],
+  "cases": [
+    {
+      "id": "diagnosis-fraction-concept-gap",
+      "category": "diagnosis_credibility",
+      "title": "Concept gap in fraction subtraction",
+      "objective": "Show that repeated same-topic misses with slower response patterns support a bounded concept-gap hypothesis.",
+      "product_surface": [
+        "teacher_dashboard",
+        "diagnosis_review"
+      ],
+      "observed": [
+        "Topic is fractions subtraction",
+        "Two incorrect answers on the same topic",
+        "Long response times of 48s and 61s",
+        "Retry behavior present"
+      ],
+      "inferred": {
+        "diagnosis": "concept_gap",
+        "confidence": "medium_to_high",
+        "abstain_reason": null
+      },
+      "recommended_action": "review_prerequisite",
+      "teacher_review_framing": "Use this as a likely prerequisite gap worth checking before the next assessment, not as a proof of the student's exact misconception.",
+      "unsafe_overclaim": "The system has proven the exact internal misunderstanding without teacher review.",
+      "expected_artifacts": [
+        "docs/contest/DIAGNOSIS_CASE_STUDIES.md",
+        "docs/contest/VALIDATION_REPORT.md"
+      ]
+    },
+    {
+      "id": "recommendation-mini-group-remediation",
+      "category": "recommendation_actionability",
+      "title": "Shared misconception becomes a small-group move",
+      "objective": "Show that the evidence loop can move from shared signals to a concrete teacher move instead of stopping at analysis.",
+      "product_surface": [
+        "teacher_dashboard",
+        "small_group_cards",
+        "teacher_actions"
+      ],
+      "observed": [
+        "Three students share the same topic-level misconception",
+        "All three required repeated hints before reaching an answer",
+        "The diagnosis layer grouped them under one recommendation"
+      ],
+      "inferred": {
+        "diagnosis": "support_dependency",
+        "confidence": "medium",
+        "abstain_reason": null
+      },
+      "recommended_action": "small_group_remediation",
+      "teacher_review_framing": "The system is proposing one bounded classroom move: pull the students into a remediation mini-group around the same misconception.",
+      "unsafe_overclaim": "This grouping guarantees the best intervention outcome or proves that no other grouping would work.",
+      "expected_artifacts": [
+        "docs/contest/README.md",
+        "docs/contest/CASEPACK_AND_EVALUATION_DATASET.md"
+      ]
+    },
+    {
+      "id": "abstain-on-thin-geometry-signal",
+      "category": "abstain_behavior",
+      "title": "Abstain when the evidence layer is too thin",
+      "objective": "Show that the system withholds diagnosis when one strong-correct signal is not enough to justify intervention.",
+      "product_surface": [
+        "teacher_dashboard",
+        "teacher_trust"
+      ],
+      "observed": [
+        "Topic is geometry",
+        "Student answered correctly",
+        "No hint burden",
+        "No retry burden"
+      ],
+      "inferred": {
+        "diagnosis": null,
+        "confidence": "abstained",
+        "abstain_reason": "evidence is too weak or too mixed for a confident diagnosis"
+      },
+      "recommended_action": null,
+      "teacher_review_framing": "This is a trust feature: the system avoids fabricating intervention when the observation layer does not justify one.",
+      "unsafe_overclaim": "No diagnosis means the student fully mastered the topic or needs no future review at all.",
+      "expected_artifacts": [
+        "docs/contest/DIAGNOSIS_CASE_STUDIES.md",
+        "docs/contest/CASEPACK_AND_EVALUATION_DATASET.md"
+      ]
+    },
+    {
+      "id": "teacher-action-follow-through",
+      "category": "teacher_execution_loop",
+      "title": "Teacher converts a recommendation into a bounded remediation step",
+      "objective": "Show that the product now supports the path from recommendation to structured teacher action and intervention assignment.",
+      "product_surface": [
+        "teacher_dashboard",
+        "teacher_actions",
+        "intervention_assignments"
+      ],
+      "observed": [
+        "A student repeatedly misses one prerequisite concept",
+        "The dashboard recommends reteaching that prerequisite",
+        "The teacher creates a structured action and later turns it into an intervention assignment"
+      ],
+      "inferred": {
+        "diagnosis": "concept_gap",
+        "confidence": "medium",
+        "abstain_reason": null
+      },
+      "recommended_action": "reteach_concept",
+      "teacher_review_framing": "The system helps the teacher operationalize the insight, but the teacher remains responsible for confirming and executing the intervention.",
+      "unsafe_overclaim": "Creating a teacher action proves the intervention was effective or completed successfully.",
+      "expected_artifacts": [
+        "docs/contest/README.md",
+        "docs/contest/SUBMISSION_PACKAGE.md"
+      ]
+    },
+    {
+      "id": "trust-trace-bounded-rationale",
+      "category": "trust_trace",
+      "title": "Bounded reason trace supports trust without chain-of-thought exposure",
+      "objective": "Show that the system exposes provenance and teacher-review framing while keeping rationale bounded and audit-friendly.",
+      "product_surface": [
+        "teacher_dashboard",
+        "agents_authoring",
+        "trust_surfaces"
+      ],
+      "observed": [
+        "The insight payload includes observed evidence facts",
+        "The dashboard shows diagnosis policy and teacher-review-required framing",
+        "The /agents authoring surface shows runtime policy audit slices and sources"
+      ],
+      "inferred": {
+        "diagnosis": "rule_assisted_teacher_review",
+        "confidence": "bounded",
+        "abstain_reason": null
+      },
+      "recommended_action": "inspect_reason_trace_before_reteach",
+      "teacher_review_framing": "These traces are bounded trust surfaces for review and debugging, not unrestricted model reasoning dumps.",
+      "unsafe_overclaim": "The product now exposes full internal chain-of-thought or proves universal explainability across all paths.",
+      "expected_artifacts": [
+        "docs/contest/README.md",
+        "docs/contest/VALIDATION_REPORT.md",
+        "docs/contest/SUBMISSION_PACKAGE.md"
+      ]
+    }
+  ]
+}

--- a/docs/contest/CASEPACK_AND_EVALUATION_DATASET.md
+++ b/docs/contest/CASEPACK_AND_EVALUATION_DATASET.md
@@ -1,0 +1,51 @@
+# Casepack And Evaluation Dataset
+
+This document explains the structured validation casepack used for contest-safe review and future evaluation work.
+
+## Purpose
+
+The repository now includes a reusable machine-readable casepack at [`../../ai_first/evidence/casepack.json`](../../ai_first/evidence/casepack.json).
+
+Its job is to:
+
+- turn prose-only examples into structured validation scenarios
+- keep judge-facing evidence examples consistent across docs
+- provide reusable fixtures for later automation work such as `F124`
+
+This is not a benchmark leaderboard, outcome study, or production evaluation harness.
+
+## Categories
+
+The current casepack covers five bounded categories:
+
+- `diagnosis_credibility`
+- `recommendation_actionability`
+- `abstain_behavior`
+- `teacher_execution_loop`
+- `trust_trace`
+
+## How Reviewers Should Read It
+
+Each case combines:
+
+- observed evidence signals
+- bounded inferred hypothesis
+- recommended teacher move when applicable
+- teacher-review framing
+- one explicit unsafe overclaim the product must avoid
+
+Use the casepack to understand how the current product should be described and validated, not to claim benchmark-grade accuracy.
+
+## How AI Workers Should Reuse It
+
+- use the JSON casepack as the structured source-of-truth
+- use contest docs as the narrative layer
+- do not invent parallel example sets unless a new task explicitly requires them
+- extend the dataset by adding new cases, not by mutating older cases to fit a new story
+
+## Current Limits
+
+- the casepack is a validation asset, not runtime tutoring data
+- it does not prove classroom outcomes
+- it does not replace teacher review
+- it does not justify autonomous diagnosis accuracy claims

--- a/docs/contest/DIAGNOSIS_CASE_STUDIES.md
+++ b/docs/contest/DIAGNOSIS_CASE_STUDIES.md
@@ -2,6 +2,8 @@
 
 Use these cases when a reviewer asks how the diagnosis layer works or how much trust to place in it.
 
+Structured source-of-truth: the reusable machine-readable pack now lives at [`../../ai_first/evidence/casepack.json`](../../ai_first/evidence/casepack.json). This document remains the judge-facing prose layer for a subset of those cases.
+
 ## Framing
 
 - The diagnosis layer is `rule_assisted_teacher_review`, not a benchmarked autonomous assessor.

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -34,6 +34,7 @@ The current product can be described as `agent-native` today and `multi-agent by
 - [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md): local validation commands, results, limitations, and remaining capture work.
 - [`PILOT_STATUS.md`](./PILOT_STATUS.md): explicit status of pilot or external-feedback evidence.
 - [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md): judge-facing diagnosis examples and teacher-review framing.
+- [`CASEPACK_AND_EVALUATION_DATASET.md`](./CASEPACK_AND_EVALUATION_DATASET.md): structured validation casepack guide backed by `ai_first/evidence/casepack.json`.
 - [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md): smoke lane used to verify the MVP path before any evidence refresh.
 - [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md): demo-safe data inventory and reset runbook before smoke/evidence refresh.
 
@@ -47,6 +48,7 @@ The current product can be described as `agent-native` today and `multi-agent by
 - Hybrid `/agents` screenshots are current, and the codebase now also carries automated bounded runtime-binding proof for the unified `chat`, `deep_question`, and `deep_solve` turn paths. Keep the claim narrower than universal entry-point coverage.
 - Video capture is optional and deferred to avoid storing large media in the repository.
 - No pilot evidence is currently bundled; the strongest current proof is structured walkthrough validation plus smoke-backed and screenshot-backed artifacts.
+- Judge-safe validation examples now have both prose case studies and a reusable machine-readable casepack for future evaluation reuse.
 
 ## Judge-Friendly Use Cases
 

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -37,6 +37,7 @@ Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/com
 | Smoke-backed validation | Ready | [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) |
 | Evidence checklist | Ready | [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md) |
 | Diagnosis credibility cases | Ready | [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md) |
+| Structured validation casepack | Ready | [`CASEPACK_AND_EVALUATION_DATASET.md`](./CASEPACK_AND_EVALUATION_DATASET.md) |
 | Screenshot bundle | Ready | [`screenshots/`](./screenshots/) |
 | Demo-safe reset command | Ready | [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) |
 | Smoke procedure | Ready | [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md) |

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -49,6 +49,7 @@ Use these status values consistently:
 - Browser-backed screenshot refresh now works in a local worktree, but it still depends on a running backend and frontend plus demo-safe local data.
 - Runtime handoff from `config.agent_spec_id` through the unified live Tutor turn path now has bounded automated proof in repository tests, including a visible behavior difference between two spec packs. This report still does not claim universal wiring across every possible entry point.
 - Diagnosis credibility is grounded in deterministic rules plus teacher review framing. This report does not claim benchmark accuracy numbers for diagnosis or recommendation quality.
+- Structured validation scenarios now live in `ai_first/evidence/casepack.json` and are explained in `CASEPACK_AND_EVALUATION_DATASET.md`; they support repeatable review without becoming a benchmark claim.
 - The repository currently documents no pilot cohort, classroom rollout, or real-user study. Use `PILOT_STATUS.md` for the explicit external-feedback status.
 - Local provider-backed assessment generation was unavailable during the 2026-04-25 screenshot refresh because the configured model key was still a placeholder. The refreshed `07` and `08` screenshots therefore use demo-safe local session content in the worktree data store instead of a live provider response.
 - Provider-backed AI quality depends on configured model credentials. If credentials are unavailable during a demo, use the command validation and recorded UI flow as fallback evidence.
@@ -94,6 +95,7 @@ The 2026-04-26 scripted-reset smoke run verified the MVP path in the current mer
 5. smoke-backed command evidence stayed `Current`, and browser-captured dashboard plus hybrid `/agents` rows were refreshed on 2026-04-26 against the current merged UI;
 6. focused automated tests now prove the unified Tutor turn path can accept `config.agent_spec_id`, assemble the matching runtime policy, and produce a deterministic behavior difference between two contrasting spec packs without claiming full entry-point coverage.
 7. diagnosis credibility is supported by focused rule-based cases in repository tests and a reviewer-facing case-study packet in `DIAGNOSIS_CASE_STUDIES.md`, not by fabricated accuracy metrics.
+8. reusable validation examples now also exist as a machine-readable casepack in `ai_first/evidence/casepack.json`, which is intended for future regression and evidence-automation work rather than runtime scoring.
 
 ## Manual Verification Template
 

--- a/docs/superpowers/plans/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+++ b/docs/superpowers/plans/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
@@ -1,0 +1,254 @@
+# F123 Casepack And Evaluation Dataset Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reusable, machine-readable validation casepack and contest-facing guide that expands the current diagnosis examples into a structured dataset for future evidence review and automation.
+
+**Architecture:** Keep the work fully inside validation assets. A JSON casepack under `ai_first/evidence/` becomes the structured source-of-truth, while a contest-facing Markdown guide explains how judges and future AI workers should use it. A bounded test validates schema completeness so later work can reuse the pack safely.
+
+**Tech Stack:** Markdown, JSON, Python `json`/`pathlib`, pytest
+
+---
+
+### Task 1: Establish the F123 control-plane slice
+
+**Files:**
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-28.md`
+- Create: `docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
+- Create: `docs/superpowers/specs/2026-04-28-f123-casepack-and-evaluation-dataset-expansion-design.md`
+- Create: `docs/superpowers/plans/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
+
+- [ ] **Step 1: Mark the lane active in AI-first tracking**
+
+Update `ai_first/TASK_REGISTRY.json` so `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION` becomes `in-progress`, and keep `ACTIVE_ASSIGNMENTS.md` aligned with the new Session B worktree and branch.
+
+- [ ] **Step 2: Run JSON validation on the registry**
+
+Run: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+Expected: no output, exit code `0`
+
+- [ ] **Step 3: Record the planning start in the daily log**
+
+Append a short `## Session B Casepack And Evaluation Dataset Expansion` entry in `ai_first/daily/2026-04-28.md` noting the branch, task, and planning scope.
+
+- [ ] **Step 4: Commit the control-plane and planning artifacts**
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-28.md docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md docs/superpowers/specs/2026-04-28-f123-casepack-and-evaluation-dataset-expansion-design.md docs/superpowers/plans/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+git commit -m "docs(validation): scaffold F123 casepack work [F123]"
+```
+
+### Task 2: Add the structured casepack source-of-truth
+
+**Files:**
+- Create: `ai_first/evidence/casepack.json`
+- Modify: `docs/contest/DIAGNOSIS_CASE_STUDIES.md`
+- Modify: `docs/contest/README.md`
+- Modify: `docs/contest/VALIDATION_REPORT.md`
+- Modify: `docs/contest/SUBMISSION_PACKAGE.md`
+
+- [ ] **Step 1: Define the casepack schema in JSON**
+
+Create `ai_first/evidence/casepack.json` with a top-level object:
+
+```json
+{
+  "version": "2026-04-28",
+  "categories": [
+    "diagnosis_credibility",
+    "recommendation_actionability",
+    "abstain_behavior",
+    "teacher_execution_loop",
+    "trust_trace"
+  ],
+  "cases": []
+}
+```
+
+- [ ] **Step 2: Populate at least five bounded validation cases**
+
+Each case must include:
+
+```json
+{
+  "id": "case_slug",
+  "category": "diagnosis_credibility",
+  "title": "Short human-readable title",
+  "objective": "What this case validates",
+  "product_surface": ["teacher_dashboard"],
+  "observed": ["signal 1", "signal 2"],
+  "inferred": {
+    "diagnosis": "concept_gap",
+    "confidence": "medium",
+    "abstain_reason": null
+  },
+  "recommended_action": "review_prerequisite",
+  "teacher_review_framing": "Safe teacher-facing interpretation",
+  "unsafe_overclaim": "What the system must not claim",
+  "expected_artifacts": ["docs/contest/DIAGNOSIS_CASE_STUDIES.md"]
+}
+```
+
+Minimum required coverage:
+- one diagnosis credibility case
+- one recommendation actionability case
+- one abstain case
+- one teacher execution loop case
+- one trust trace case
+
+- [ ] **Step 3: Keep diagnosis prose aligned with the new pack**
+
+Update `docs/contest/DIAGNOSIS_CASE_STUDIES.md` so it explicitly references `ai_first/evidence/casepack.json` as the structured source and keeps the prose examples aligned with the shared case IDs where relevant.
+
+- [ ] **Step 4: Point contest-facing docs at the casepack**
+
+Add short references in:
+- `docs/contest/README.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+
+Use wording that emphasizes:
+- judge-safe structured examples
+- no benchmark accuracy claims
+- future automation reuse
+
+- [ ] **Step 5: Validate the JSON file parses**
+
+Run: `python -m json.tool ai_first/evidence/casepack.json >/dev/null`
+Expected: no output, exit code `0`
+
+- [ ] **Step 6: Commit the casepack and doc updates**
+
+```bash
+git add ai_first/evidence/casepack.json docs/contest/DIAGNOSIS_CASE_STUDIES.md docs/contest/README.md docs/contest/VALIDATION_REPORT.md docs/contest/SUBMISSION_PACKAGE.md
+git commit -m "feat(validation): add reusable evaluation casepack [F123]"
+```
+
+### Task 3: Add a bounded validation test and contest guide
+
+**Files:**
+- Create: `docs/contest/CASEPACK_AND_EVALUATION_DATASET.md`
+- Create: `tests/evidence/test_casepack_dataset.py`
+- Modify: `docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
+
+- [ ] **Step 1: Write the failing casepack validation test**
+
+Create `tests/evidence/test_casepack_dataset.py` with:
+
+```python
+import json
+from pathlib import Path
+
+
+def test_casepack_has_required_top_level_shape():
+    payload = json.loads(Path("ai_first/evidence/casepack.json").read_text())
+    assert payload["version"]
+    assert isinstance(payload["categories"], list)
+    assert isinstance(payload["cases"], list)
+    assert payload["cases"]
+
+
+def test_every_case_has_required_fields_and_known_category():
+    payload = json.loads(Path("ai_first/evidence/casepack.json").read_text())
+    allowed = set(payload["categories"])
+    required = {
+        "id",
+        "category",
+        "title",
+        "objective",
+        "product_surface",
+        "observed",
+        "inferred",
+        "recommended_action",
+        "teacher_review_framing",
+        "unsafe_overclaim",
+        "expected_artifacts",
+    }
+    for case in payload["cases"]:
+        assert required.issubset(case.keys())
+        assert case["category"] in allowed
+        assert case["expected_artifacts"]
+```
+
+- [ ] **Step 2: Run the test to verify the new dataset shape**
+
+Run: `pytest tests/evidence/test_casepack_dataset.py -q`
+Expected: `2 passed`
+
+- [ ] **Step 3: Write the contest-facing guide**
+
+Create `docs/contest/CASEPACK_AND_EVALUATION_DATASET.md` with:
+- purpose of the casepack
+- category list
+- how judges should read it
+- how future AI workers can reuse it
+- explicit note that it is a structured validation pack, not a benchmark leaderboard
+
+- [ ] **Step 4: Add the required PR note with Mermaid**
+
+Create `docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md` and include:
+
+```mermaid
+flowchart LR
+    Prose["Judge-facing case narratives"] --> Pack["ai_first/evidence/casepack.json"]
+    Pack --> Guide["CASEPACK_AND_EVALUATION_DATASET.md"]
+    Pack --> Test["tests/evidence/test_casepack_dataset.py"]
+    Guide --> Review["Contest review / future automation reuse"]
+```
+
+State whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed. For this lane, it should normally remain unchanged.
+
+- [ ] **Step 5: Commit the validation harness and guide**
+
+```bash
+git add docs/contest/CASEPACK_AND_EVALUATION_DATASET.md tests/evidence/test_casepack_dataset.py docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+git commit -m "test(validation): verify casepack dataset integrity [F123]"
+```
+
+### Task 4: Final lane validation and PR prep
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-28.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+
+- [ ] **Step 1: Run the lane validation bundle**
+
+Run:
+
+```bash
+python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+python -m json.tool ai_first/evidence/casepack.json >/dev/null
+pytest tests/evidence/test_casepack_dataset.py -q
+git diff --check
+```
+
+Expected:
+- JSON validation exits `0`
+- pytest prints `2 passed`
+- `git diff --check` prints nothing
+
+- [ ] **Step 2: Update AI-first tracking to draft-PR-open**
+
+Refresh:
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+
+Set `F123` to `in-progress` with draft PR metadata until merge time.
+
+- [ ] **Step 3: Create the Draft PR**
+
+```bash
+git push -u origin pod-b/casepack-eval-dataset
+gh pr create --repo Creative-Science-Contest-2026/Multiagent-learning-platform --base main --head pod-b/casepack-eval-dataset --title "feat(validation): expand casepack evaluation dataset [F123]" --body-file <prepared-body-file> --draft
+```
+
+- [ ] **Step 4: Commit the final tracking updates**
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-28.md
+git commit -m "chore(ai-first): record F123 draft PR state [F123]"
+```

--- a/docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+++ b/docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
@@ -1,0 +1,28 @@
+# PR Note: F123 Casepack And Evaluation Dataset Expansion
+
+## Summary
+
+- adds a reusable machine-readable validation casepack under `ai_first/evidence/`
+- adds a contest-facing guide for how judges and future AI workers should use the pack
+- aligns contest docs with the new structured source-of-truth
+- adds a bounded test so the dataset shape does not drift silently
+
+## Architecture Impact
+
+- no runtime or product architecture change
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` update not required for this validation-assets-only PR
+
+```mermaid
+flowchart LR
+    Prose["Judge-facing case narratives"] --> Pack["ai_first/evidence/casepack.json"]
+    Pack --> Guide["CASEPACK_AND_EVALUATION_DATASET.md"]
+    Pack --> Test["tests/evidence/test_casepack_dataset.py"]
+    Guide --> Review["Contest review and future automation reuse"]
+```
+
+## Validation
+
+- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `python -m json.tool ai_first/evidence/casepack.json >/dev/null`
+- `pytest tests/evidence/test_casepack_dataset.py -q`
+- `git diff --check`

--- a/docs/superpowers/specs/2026-04-28-f123-casepack-and-evaluation-dataset-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-28-f123-casepack-and-evaluation-dataset-expansion-design.md
@@ -1,0 +1,84 @@
+# F123 Design: Casepack And Evaluation Dataset Expansion
+
+## Goal
+
+Create a reusable validation casepack that turns the current contest-safe diagnosis examples into a structured dataset for future evidence review, UI trust checks, and automation work. This lane stays outside runtime product behavior and focuses on validation assets only.
+
+## Approach
+
+Chosen approach: `docs + machine-readable casepack`.
+
+Why:
+
+- prose-only case studies are useful for judges but weak for regression and reuse
+- a full evaluation harness belongs to later automation work such as `F124`
+- a lightweight structured casepack gives both human-readable and machine-usable value without widening scope
+
+## Scope
+
+### In scope
+
+- add a machine-readable casepack under `ai_first/evidence/`
+- map current diagnosis credibility material into structured cases
+- add additional cases for recommendation actionability, abstain behavior, teacher action follow-through, and trust/provenance framing
+- document how the casepack should be used in contest review and internal validation
+- add a bounded validation check so the dataset shape does not drift silently
+
+### Out of scope
+
+- changing runtime diagnosis logic
+- adding new dashboard features
+- building a full automated evaluator pipeline
+- introducing benchmark claims or accuracy metrics
+
+## Artifact Set
+
+- `ai_first/evidence/casepack.json`
+  - source-of-truth dataset
+- `docs/contest/CASEPACK_AND_EVALUATION_DATASET.md`
+  - human-readable guide
+- optional bounded test/helper under `tests/`
+  - validates required fields and basic schema shape
+
+## Case Structure
+
+Each case should include:
+
+- `id`
+- `category`
+- `title`
+- `objective`
+- `product_surface`
+- `observed`
+- `inferred`
+- `recommended_action`
+- `teacher_review_framing`
+- `unsafe_overclaim`
+- `expected_artifacts`
+
+Recommended categories:
+
+- `diagnosis_credibility`
+- `recommendation_actionability`
+- `abstain_behavior`
+- `teacher_execution_loop`
+- `trust_trace`
+
+## Data Flow
+
+1. Existing prose case studies remain useful as judge-facing explanations.
+2. The new casepack becomes the structured validation source.
+3. Contest docs point to the casepack guide rather than duplicating inconsistent examples.
+4. Later automation work can reuse the same dataset instead of inventing new fixtures.
+
+## Validation
+
+- the JSON casepack must parse cleanly
+- required fields must be present in every case
+- category values should stay inside the bounded list declared by the dataset
+- docs references should point to the new casepack guide
+
+## Architecture Impact
+
+- no runtime architecture change
+- no `ai_first/architecture/MAIN_SYSTEM_MAP.md` update expected unless a new persistent validation read-path becomes part of the repo-level architecture

--- a/docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+++ b/docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
@@ -1,0 +1,45 @@
+# Task Packet: F123 Casepack And Evaluation Dataset Expansion
+
+- Task ID: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
+- Commit tag: `F123`
+- Owner: `Codex`
+- Status: `brainstorming`
+
+## Objective
+
+Grow the current judge-safe case studies into a reusable validation casepack that is machine-readable, contest-safe, and ready for later automation without widening runtime product scope.
+
+## Owned Files
+
+- `ai_first/evidence/`
+- `docs/contest/`
+- `tests/` only for bounded casepack validation
+- `docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
+- `docs/superpowers/specs/2026-04-28-f123-casepack-and-evaluation-dataset-expansion-design.md`
+- `docs/superpowers/plans/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
+- `docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+
+## Do-Not-Touch
+
+- runtime product code outside a bounded validation helper if one becomes strictly necessary
+- dashboard UX
+- assessment generation flow
+- session runtime / agent-spec plumbing
+- control-plane files outside those listed above
+
+## Acceptance Criteria
+
+1. A machine-readable casepack exists under `ai_first/evidence/` as source-of-truth for reusable validation scenarios.
+2. The casepack expands beyond the current diagnosis prose into multiple judge-safe scenario types.
+3. Contest-facing docs explain how to read and use the casepack without overclaiming model accuracy.
+4. A bounded validation check prevents schema drift or missing required fields.
+5. AI-first tracking is updated with scope, status, validation, and handoff notes.
+
+## Validation
+
+- `python -m json.tool` or equivalent schema/format validation for the casepack
+- targeted validation test if one is added
+- `git diff --check`

--- a/tests/evidence/test_casepack_dataset.py
+++ b/tests/evidence/test_casepack_dataset.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+
+def test_casepack_has_required_top_level_shape():
+    payload = json.loads(Path("ai_first/evidence/casepack.json").read_text())
+    assert payload["version"]
+    assert isinstance(payload["categories"], list)
+    assert isinstance(payload["cases"], list)
+    assert payload["cases"]
+
+
+def test_every_case_has_required_fields_and_known_category():
+    payload = json.loads(Path("ai_first/evidence/casepack.json").read_text())
+    allowed = set(payload["categories"])
+    required = {
+        "id",
+        "category",
+        "title",
+        "objective",
+        "product_surface",
+        "observed",
+        "inferred",
+        "recommended_action",
+        "teacher_review_framing",
+        "unsafe_overclaim",
+        "expected_artifacts",
+    }
+    for case in payload["cases"]:
+        assert required.issubset(case.keys())
+        assert case["category"] in allowed
+        assert case["expected_artifacts"]


### PR DESCRIPTION
## Summary
- add a reusable machine-readable validation casepack under `ai_first/evidence/`
- add a contest-facing guide for how judges and future AI workers should use the pack
- align contest docs with the new structured source-of-truth
- add a bounded schema test so the dataset shape does not drift silently

## Validation
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `python -m json.tool ai_first/evidence/casepack.json >/dev/null`
- `pytest tests/evidence/test_casepack_dataset.py -q`
- `git diff --check`

## Architecture
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` update not required for this validation-assets-only PR
- Mermaid architecture note: `docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
