### PR TITLE
feat(validation): add diagnosis validation casepack [F123]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task is currently assigned on `main`.
-The next product work should start from a fresh Session A or Session B branch/worktree after the AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Session B AI
+- Machine: local-mac
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-casepack-evaluation-dataset-expansion`
+- Task: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
+- Status: `planning`
+- Branch: `pod-b/casepack-evaluation-dataset-expansion`
+- Task packet: `docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
+- Owned files: `ai_first/evidence/`, bounded `docs/contest/`, `tests/services/evidence/`, bounded `tests/api/`, `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`
+- PR: `none yet`
+- Last update: `2026-04-28`
+- Next action: `write F123 packet/spec/plan before creating the validation casepack dataset`
+- Blocker: `none`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local-mac
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-casepack-evaluation-dataset-expansion`
 - Task: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
-- Status: `planning`
+- Status: `in-progress`
 - Branch: `pod-b/casepack-evaluation-dataset-expansion`
 - Task packet: `docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md`
 - Owned files: `ai_first/evidence/`, bounded `docs/contest/`, `tests/services/evidence/`, bounded `tests/api/`, `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`
 - PR: `none yet`
 - Last update: `2026-04-28`
-- Next action: `write F123 packet/spec/plan before creating the validation casepack dataset`
+- Next action: `run final verification, then stage the casepack slice and open a Draft PR`
 - Blocker: `none`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "last_updated": "2026-04-28T06:20:00Z",
+    "last_updated": "2026-04-28T07:05:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
     "total_tasks": 73
@@ -85,8 +85,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -95,9 +97,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 2,
+      "count": 1,
       "tasks": [
-        "F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION",
         "F124_EVIDENCE_AUTOMATION_REFRESH"
       ]
     }
@@ -1792,10 +1793,10 @@
       "dependencies": [
         "R2_DIAGNOSIS_CREDIBILITY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "validation-ops",
-      "notes": "Provides stronger repeatable fixtures for later automation and model-quality work."
+      "notes": "Active on branch pod-b/casepack-evaluation-dataset-expansion in worktree .worktrees/pod-b-casepack-evaluation-dataset-expansion. The slice should package current diagnosis/evidence examples into a reusable validation pack without broadening into benchmark claims."
     },
     {
       "id": "F124_EVIDENCE_AUTOMATION_REFRESH",

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -201,6 +201,7 @@ flowchart TD
   AIFirst --> Plans["docs/superpowers/plans"]
   AIFirst --> Tasks["docs/superpowers/tasks"]
   AIFirst --> Evidence["ai_first/evidence"]
+  Evidence --> ValidationCasepacks["Validation casepacks for diagnosis/evidence regression"]
   AIFirst --> AutoLoop["Autonomous completion loop"]
   AutoLoop --> MergeGates["Safe merge gates"]
   AutoLoop --> NextTask["Next task selection"]

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -97,3 +97,13 @@
 - Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; `git diff --check`
 - Blockers: None.
 - Next: start a fresh Session B branch/worktree for `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION` or `F124_EVIDENCE_AUTOMATION_REFRESH`.
+
+## Session B Casepack And Evaluation Dataset Expansion
+
+- Branch: `pod-b/casepack-evaluation-dataset-expansion`
+- Task: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
+- Done: Claimed the new Session B worktree in `ACTIVE_ASSIGNMENTS.md` and moved `F123` to `in-progress` in `TASK_REGISTRY.json`.
+- Done: Wrote the task packet, design spec, and implementation plan for a bounded validation casepack that reuses merged diagnosis/evidence patterns without making benchmark claims.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; placeholder scan on the new F123 packet/spec/plan; `git diff --check`
+- Blockers: None.
+- Next: implement the smallest reusable casepack dataset and consistency proof tests inside the owned validation-ops files.

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -104,6 +104,8 @@
 - Task: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
 - Done: Claimed the new Session B worktree in `ACTIVE_ASSIGNMENTS.md` and moved `F123` to `in-progress` in `TASK_REGISTRY.json`.
 - Done: Wrote the task packet, design spec, and implementation plan for a bounded validation casepack that reuses merged diagnosis/evidence patterns without making benchmark claims.
-- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; placeholder scan on the new F123 packet/spec/plan; `git diff --check`
+- Done: Added a structured diagnosis validation pack under `ai_first/evidence/casepacks/`, a contest-facing `VALIDATION_CASEPACK.md` read path, and a consistency test that checks the pack against current `build_student_diagnosis` behavior.
+- Done: Updated `docs/contest/README.md` and `ai_first/architecture/MAIN_SYSTEM_MAP.md` so the new validation asset is discoverable without broadening any product claim.
+- Tests: `pytest tests/services/evidence/test_validation_casepack.py -q`; `python -m json.tool ai_first/evidence/casepacks/diagnosis-validation-pack.json >/dev/null`; `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; registry consistency check; placeholder scan on the new F123 packet/spec/plan; `git diff --check`
 - Blockers: None.
-- Next: implement the smallest reusable casepack dataset and consistency proof tests inside the owned validation-ops files.
+- Next: write the PR note, run final verification on the full owned slice, and prepare the branch for Draft PR flow.

--- a/ai_first/evidence/casepacks/README.md
+++ b/ai_first/evidence/casepacks/README.md
@@ -1,0 +1,19 @@
+# Validation Casepacks
+
+This folder holds reusable, judge-safe validation datasets derived from merged repository behavior.
+
+## Current Pack
+
+- `diagnosis-validation-pack.json`: structured diagnosis and abstain cases anchored to the current `rule_assisted_teacher_review` behavior.
+
+## Usage
+
+- use the pack for regression-style validation and future automation work
+- treat it as a bounded validation artifact, not a benchmark leaderboard
+- update the source references when a case is added or materially changed
+
+## Rules
+
+- do not fabricate classroom outcomes or benchmark claims
+- derive cases from merged docs, tests, or smoke-backed evidence
+- keep expected outputs bounded to diagnosis type, abstain code, confidence band, and teacher-review framing

--- a/ai_first/evidence/casepacks/diagnosis-validation-pack.json
+++ b/ai_first/evidence/casepacks/diagnosis-validation-pack.json
@@ -1,0 +1,278 @@
+{
+  "pack_id": "diagnosis-validation-pack",
+  "version": 1,
+  "policy": "rule_assisted_teacher_review",
+  "description": "Reusable diagnosis and abstain cases derived from merged contest-safe evidence patterns.",
+  "cases": [
+    {
+      "case_id": "concept-gap-fractions",
+      "title": "Concept gap in fraction subtraction",
+      "validation_objective": "Prove repeated same-topic misses still resolve to a teacher-reviewable concept-gap diagnosis.",
+      "student_id": "student-a",
+      "observations": [
+        {
+          "observation_id": "obs_1",
+          "session_id": "quiz-1",
+          "student_id": "student-a",
+          "source": "assessment",
+          "topic": "fractions subtraction",
+          "question_id": "q1",
+          "is_correct": false,
+          "latency_seconds": 48,
+          "hint_count": 0,
+          "retry_count": 1,
+          "dominant_error": "concept_gap"
+        },
+        {
+          "observation_id": "obs_2",
+          "session_id": "quiz-1",
+          "student_id": "student-a",
+          "source": "assessment",
+          "topic": "fractions subtraction",
+          "question_id": "q2",
+          "is_correct": false,
+          "latency_seconds": 61,
+          "hint_count": 0,
+          "retry_count": 1,
+          "dominant_error": "concept_gap"
+        }
+      ],
+      "student_state": {
+        "student_id": "student-a",
+        "repeated_mistakes": ["fractions subtraction"],
+        "support_level": "guided",
+        "confidence_trend": "down",
+        "mastery_signals": {
+          "emerging_topics": ["fractions subtraction"],
+          "stable_topics": [],
+          "at_risk_topics": ["fractions subtraction"]
+        },
+        "support_signals": {
+          "heavy_hint_topics": ["fractions subtraction"],
+          "retry_heavy_topics": [],
+          "recent_support_burden": "elevated"
+        },
+        "misconception_signals": {
+          "dominant_errors": {
+            "fractions subtraction": "concept_gap"
+          },
+          "persistent_topics": ["fractions subtraction"]
+        }
+      },
+      "expected": {
+        "mode": "diagnosis",
+        "diagnosis_type": "concept_gap",
+        "action_type": "review_prerequisite",
+        "confidence_tags": ["medium", "high"]
+      },
+      "source_refs": [
+        "docs/contest/DIAGNOSIS_CASE_STUDIES.md#case-1-concept-gap-in-fraction-subtraction",
+        "tests/services/evidence/test_diagnosis.py"
+      ]
+    },
+    {
+      "case_id": "careless-error-arithmetic",
+      "title": "Careless error in arithmetic",
+      "validation_objective": "Prove quick incorrect arithmetic responses still route to a bounded careless-error hypothesis.",
+      "student_id": "student-c",
+      "observations": [
+        {
+          "observation_id": "obs_c1",
+          "session_id": "quiz-2",
+          "student_id": "student-c",
+          "source": "assessment",
+          "topic": "arithmetic",
+          "question_id": "q1",
+          "is_correct": false,
+          "latency_seconds": 8,
+          "hint_count": 0,
+          "retry_count": 0,
+          "dominant_error": "careless_error"
+        },
+        {
+          "observation_id": "obs_c2",
+          "session_id": "quiz-2",
+          "student_id": "student-c",
+          "source": "assessment",
+          "topic": "arithmetic",
+          "question_id": "q2",
+          "is_correct": false,
+          "latency_seconds": 10,
+          "hint_count": 0,
+          "retry_count": 0,
+          "dominant_error": "careless_error"
+        }
+      ],
+      "expected": {
+        "mode": "diagnosis",
+        "diagnosis_type": "careless_error",
+        "action_type": "retry_easier"
+      },
+      "source_refs": [
+        "docs/contest/DIAGNOSIS_CASE_STUDIES.md#case-2-careless-error-in-basic-arithmetic",
+        "tests/services/evidence/test_diagnosis.py"
+      ]
+    },
+    {
+      "case_id": "thin-evidence-geometry",
+      "title": "Thin evidence abstain",
+      "validation_objective": "Prove the diagnosis layer abstains when one strong-correct observation is insufficient.",
+      "student_id": "student-d",
+      "observations": [
+        {
+          "observation_id": "obs_ok",
+          "session_id": "quiz-3",
+          "student_id": "student-d",
+          "source": "assessment",
+          "topic": "geometry",
+          "question_id": "q1",
+          "is_correct": true,
+          "latency_seconds": 20,
+          "hint_count": 0,
+          "retry_count": 0,
+          "dominant_error": null
+        }
+      ],
+      "expected": {
+        "mode": "abstain",
+        "abstain_reason_code": "thin_evidence"
+      },
+      "source_refs": [
+        "docs/contest/DIAGNOSIS_CASE_STUDIES.md#case-3-abstain-on-strong-correct-signal",
+        "tests/services/evidence/test_diagnosis.py"
+      ]
+    },
+    {
+      "case_id": "mixed-evidence-fractions",
+      "title": "Mixed evidence abstain",
+      "validation_objective": "Prove the diagnosis layer abstains when the same-topic signal is mixed and support-heavy.",
+      "student_id": "student-m",
+      "observations": [
+        {
+          "observation_id": "obs_m1",
+          "session_id": "quiz-5",
+          "student_id": "student-m",
+          "source": "assessment",
+          "topic": "fractions subtraction",
+          "question_id": "q1",
+          "is_correct": false,
+          "latency_seconds": 34,
+          "hint_count": 0,
+          "retry_count": 0,
+          "dominant_error": null
+        },
+        {
+          "observation_id": "obs_m2",
+          "session_id": "quiz-5",
+          "student_id": "student-m",
+          "source": "assessment",
+          "topic": "fractions subtraction",
+          "question_id": "q2",
+          "is_correct": true,
+          "latency_seconds": 45,
+          "hint_count": 2,
+          "retry_count": 1,
+          "dominant_error": null
+        },
+        {
+          "observation_id": "obs_m3",
+          "session_id": "quiz-5",
+          "student_id": "student-m",
+          "source": "assessment",
+          "topic": "fractions subtraction",
+          "question_id": "q3",
+          "is_correct": true,
+          "latency_seconds": 41,
+          "hint_count": 2,
+          "retry_count": 1,
+          "dominant_error": null
+        }
+      ],
+      "expected": {
+        "mode": "abstain",
+        "abstain_reason_code": "mixed_evidence"
+      },
+      "source_refs": [
+        "tests/services/evidence/test_diagnosis.py"
+      ]
+    },
+    {
+      "case_id": "stale-evidence-equations",
+      "title": "Stale evidence abstain",
+      "validation_objective": "Prove old evidence stays bounded by the stale-evidence abstain gate even if repeated misses exist.",
+      "student_id": "student-old",
+      "observations": [
+        {
+          "observation_id": "obs_old1",
+          "session_id": "quiz-6",
+          "student_id": "student-old",
+          "source": "assessment",
+          "topic": "equations",
+          "question_id": "q1",
+          "is_correct": false,
+          "latency_seconds": 52,
+          "hint_count": 0,
+          "retry_count": 1,
+          "dominant_error": "concept_gap"
+        },
+        {
+          "observation_id": "obs_old2",
+          "session_id": "quiz-6",
+          "student_id": "student-old",
+          "source": "assessment",
+          "topic": "equations",
+          "question_id": "q2",
+          "is_correct": false,
+          "latency_seconds": 57,
+          "hint_count": 0,
+          "retry_count": 1,
+          "dominant_error": "concept_gap"
+        }
+      ],
+      "student_state": {
+        "student_id": "student-old",
+        "repeated_mistakes": ["equations"],
+        "support_level": "guided",
+        "confidence_trend": "down",
+        "recency_summary": {
+          "total_observations": 2,
+          "window_size": 24,
+          "bucket_counts": {
+            "last_24h": 0,
+            "last_7d": 0,
+            "last_30d": 0,
+            "older": 2
+          },
+          "recent_incorrect": 2,
+          "weighted_topic_misses": {
+            "equations": 0.18
+          }
+        },
+        "mastery_signals": {
+          "emerging_topics": [],
+          "stable_topics": [],
+          "at_risk_topics": ["equations"]
+        },
+        "support_signals": {
+          "heavy_hint_topics": [],
+          "retry_heavy_topics": [],
+          "recent_support_burden": "steady"
+        },
+        "misconception_signals": {
+          "dominant_errors": {
+            "equations": "concept_gap"
+          },
+          "persistent_topics": ["equations"]
+        }
+      },
+      "expected": {
+        "mode": "abstain",
+        "abstain_reason_code": "stale_evidence"
+      },
+      "source_refs": [
+        "tests/services/evidence/test_diagnosis.py"
+      ]
+    }
+  ]
+}
+

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -34,6 +34,7 @@ The current product can be described as `agent-native` today and `multi-agent by
 - [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md): local validation commands, results, limitations, and remaining capture work.
 - [`PILOT_STATUS.md`](./PILOT_STATUS.md): explicit status of pilot or external-feedback evidence.
 - [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md): judge-facing diagnosis examples and teacher-review framing.
+- [`VALIDATION_CASEPACK.md`](./VALIDATION_CASEPACK.md): reusable structured casepack for diagnosis and abstain validation.
 - [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md): smoke lane used to verify the MVP path before any evidence refresh.
 - [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md): demo-safe data inventory and reset runbook before smoke/evidence refresh.
 

--- a/docs/contest/VALIDATION_CASEPACK.md
+++ b/docs/contest/VALIDATION_CASEPACK.md
@@ -1,0 +1,29 @@
+# Validation Casepack
+
+This repository includes a reusable validation casepack for diagnosis credibility and abstain behavior.
+
+## What It Is
+
+- a structured pack under `ai_first/evidence/casepacks/diagnosis-validation-pack.json`
+- derived from merged diagnosis case studies and service-test patterns
+- meant for repeatable internal validation, future automation, and reviewer explanation
+
+## What It Is Not
+
+- not a public benchmark
+- not classroom outcome proof
+- not a substitute for teacher review
+
+## Current Coverage
+
+- concept-gap diagnosis
+- careless-error diagnosis
+- thin-evidence abstain
+- mixed-evidence abstain
+- stale-evidence abstain
+
+## Read Path
+
+1. `docs/contest/DIAGNOSIS_CASE_STUDIES.md`
+2. `ai_first/evidence/casepacks/diagnosis-validation-pack.json`
+3. `tests/services/evidence/test_validation_casepack.py`

--- a/docs/superpowers/plans/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+++ b/docs/superpowers/plans/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
@@ -1,0 +1,28 @@
+# F123 Implementation Plan
+
+## Objective
+
+Create a reusable validation casepack from existing diagnosis and evidence patterns, with lightweight proof tests and bounded documentation.
+
+## Steps
+
+1. Add the planning/control-plane checkpoint
+   - claim the Session B assignment
+   - move `F123` to `in-progress`
+   - write the packet, spec, and plan
+2. Build the casepack dataset
+   - add a structured file under `ai_first/evidence/`
+   - include bounded expected outcomes and traceability fields
+   - keep the pack small and high-signal
+3. Add proof tests
+   - validate dataset structure
+   - validate expected outcomes against the current diagnosis helper where appropriate
+4. Update bounded docs proof
+   - add a short casepack usage/readme doc
+   - add a PR note with Mermaid
+   - update `MAIN_SYSTEM_MAP.md` only if the evidence layer gains a durable new validation asset boundary
+5. Verify
+   - run targeted validation tests
+   - run `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+   - run a registry consistency check
+   - run `git diff --check`

--- a/docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+++ b/docs/superpowers/pr-notes/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
@@ -1,0 +1,20 @@
+# F123 Casepack And Evaluation Dataset Expansion Architecture Note
+
+## Summary
+
+`F123` adds a reusable validation casepack for diagnosis credibility and abstain behavior. It does not change product runtime or teacher-facing UX. The pack lives under AI-first evidence assets and is verified against current diagnosis behavior by a lightweight regression-style test.
+
+## Structure
+
+```mermaid
+flowchart TD
+  CaseStudies["docs/contest/DIAGNOSIS_CASE_STUDIES.md"] --> Casepack["ai_first/evidence/casepacks/diagnosis-validation-pack.json"]
+  Tests["tests/services/evidence/test_validation_casepack.py"] --> Casepack
+  Tests --> Diagnosis["build_student_diagnosis"]
+  ContestReadme["docs/contest/VALIDATION_CASEPACK.md"] --> Casepack
+```
+
+## Notes
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
+- The casepack is a bounded validation artifact, not a benchmark leaderboard.

--- a/docs/superpowers/specs/2026-04-28-f123-casepack-and-evaluation-dataset-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-28-f123-casepack-and-evaluation-dataset-expansion-design.md
@@ -1,0 +1,75 @@
+# F123 Design: Casepack And Evaluation Dataset Expansion
+
+## Problem
+
+The repository already has useful contest artifacts such as diagnosis case studies, smoke evidence, and service tests, but those examples are scattered across docs and test files. That makes later validation work harder: future workers have to reconstruct a reusable dataset from prose, code, and screenshots instead of extending one explicit validation pack.
+
+## Design Direction
+
+Keep this slice in validation-ops. The system should package a small, explicit casepack that reuses existing merged evidence patterns without claiming benchmark accuracy or classroom outcome proof. The pack should be readable by humans, stable for tests, and easy to extend later by `F124` automation.
+
+Recommended casepack structure:
+
+- case id and short label
+- validation objective
+- observation payloads derived from existing evidence patterns
+- optional student-state context
+- expected bounded outcome such as diagnosis type, abstain code, confidence band, or teacher-review framing
+- links back to contest docs or test sources for traceability
+
+## Proposed Contract
+
+1. Add a dedicated structured dataset under `ai_first/evidence/` for a small number of high-signal validation cases.
+2. Cover at least the current credibility-critical patterns already used in docs and tests:
+   - concept gap
+   - careless error
+   - thin evidence abstain
+   - mixed evidence abstain
+   - stale evidence abstain
+3. Add a lightweight validation test that proves the pack remains internally consistent and aligned with existing expected diagnosis outcomes.
+4. Add one bounded contest-facing doc or readme that explains how to use the casepack without turning it into a public benchmark claim.
+
+## Approach Options
+
+### Option A — Keep prose case studies only
+
+Pros:
+- smallest change
+
+Cons:
+- not reusable as structured validation input
+- future automation still has to reconstruct data manually
+
+### Option B — Add a structured validation casepack plus consistency tests
+
+Pros:
+- reusable for future automation and smoke-adjacent checks
+- keeps proof explicit and bounded
+- stays outside product runtime
+
+Cons:
+- introduces one more evidence asset to maintain
+
+### Option C — Build a broader benchmark harness now
+
+Pros:
+- more ambitious evaluation story
+
+Cons:
+- exceeds bounded scope
+- risks overclaiming model quality
+
+## Recommendation
+
+Use **Option B**. It creates a reusable evaluation asset without broadening into benchmarking or product behavior changes.
+
+## Scope Boundary
+
+- in scope: structured validation casepack, traceability/readme doc, consistency tests, bounded contest doc linkage
+- out of scope: new diagnosis logic, dashboard UX, benchmark scoring claims, or broad automation tooling
+
+## Proof Plan
+
+- tests prove the casepack is structurally valid and mapped to expected bounded outcomes
+- docs prove where the pack fits in the contest and AI-first evidence read path
+- PR note explains that the casepack is a reusable validation artifact, not a benchmark leaderboard

--- a/docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+++ b/docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
@@ -2,7 +2,7 @@
 
 - Task ID: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
 - Commit tag: `F123`
-- Status: `Planning`
+- Status: `In Progress`
 - Branch recommendation: `pod-b/casepack-evaluation-dataset-expansion`
 
 ## Goal

--- a/docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
+++ b/docs/superpowers/tasks/2026-04-28-f123-casepack-and-evaluation-dataset-expansion.md
@@ -1,0 +1,35 @@
+# F123 Casepack And Evaluation Dataset Expansion
+
+- Task ID: `F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION`
+- Commit tag: `F123`
+- Status: `Planning`
+- Branch recommendation: `pod-b/casepack-evaluation-dataset-expansion`
+
+## Goal
+
+Grow the current judge-safe diagnosis and evidence examples into a reusable validation casepack so future model, dashboard, and automation work can rely on one bounded dataset instead of scattered narrative examples.
+
+## Owned Files
+
+- `ai_first/evidence/`
+- bounded `docs/contest/`
+- `tests/services/evidence/`
+- bounded `tests/api/`
+- `docs/superpowers/specs/`
+- `docs/superpowers/plans/`
+- `docs/superpowers/pr-notes/`
+
+## Do Not Touch
+
+- teacher-facing dashboard presentation files
+- `web/components/dashboard/`
+- `web/app/(workspace)/dashboard/`
+- tutoring/runtime-policy/agent-spec implementation files
+- diagnosis or evidence business rules unless a bounded validator helper is strictly needed
+
+## Constraints
+
+- keep the pack judge-safe and derived from existing merged behavior, not fabricated benchmark claims
+- prefer structured docs/data assets over new product runtime
+- if tests are added, they should validate pack structure or consistency, not redefine diagnosis behavior
+- preserve current contest claim calibration and teacher-review framing

--- a/tests/services/evidence/test_validation_casepack.py
+++ b/tests/services/evidence/test_validation_casepack.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from deeptutor.services.evidence.diagnosis import build_student_diagnosis
+
+
+def _load_casepack() -> dict:
+    root = Path(__file__).resolve().parents[3]
+    path = root / "ai_first" / "evidence" / "casepacks" / "diagnosis-validation-pack.json"
+    return json.loads(path.read_text())
+
+
+def test_validation_casepack_has_expected_shape_and_traceability() -> None:
+    payload = _load_casepack()
+
+    assert payload["pack_id"] == "diagnosis-validation-pack"
+    assert payload["version"] == 1
+    assert payload["policy"] == "rule_assisted_teacher_review"
+    assert len(payload["cases"]) >= 5
+
+    for case in payload["cases"]:
+        assert case["case_id"]
+        assert case["title"]
+        assert case["validation_objective"]
+        assert isinstance(case["observations"], list)
+        assert case["expected"]["mode"] in {"diagnosis", "abstain"}
+        assert case["source_refs"]
+
+
+def test_validation_casepack_cases_match_current_diagnosis_behavior() -> None:
+    payload = _load_casepack()
+
+    for case in payload["cases"]:
+        result = build_student_diagnosis(
+            student_id=case["student_id"],
+            observations=case["observations"],
+            student_state=case.get("student_state"),
+        )
+        expected = case["expected"]
+
+        if expected["mode"] == "diagnosis":
+            assert result["observed"]["abstained"] is False
+            assert result["inferred"][0]["diagnosis_type"] == expected["diagnosis_type"]
+            assert result["recommended_actions"][0]["action_type"] == expected["action_type"]
+            if "confidence_tags" in expected:
+                assert result["inferred"][0]["confidence_tag"] in expected["confidence_tags"]
+        else:
+            assert result["observed"]["abstained"] is True
+            assert result["observed"]["abstain_reason_code"] == expected["abstain_reason_code"]
+            assert result["inferred"] == []
+            assert result["recommended_actions"] == []
+


### PR DESCRIPTION
# F123 Casepack And Evaluation Dataset Expansion Architecture Note

## Summary

`F123` adds a reusable validation casepack for diagnosis credibility and abstain behavior. It does not change product runtime or teacher-facing UX. The pack lives under AI-first evidence assets and is verified against current diagnosis behavior by a lightweight regression-style test.

## Structure

```mermaid
flowchart TD
  CaseStudies["docs/contest/DIAGNOSIS_CASE_STUDIES.md"] --> Casepack["ai_first/evidence/casepacks/diagnosis-validation-pack.json"]
  Tests["tests/services/evidence/test_validation_casepack.py"] --> Casepack
  Tests --> Diagnosis["build_student_diagnosis"]
  ContestReadme["docs/contest/VALIDATION_CASEPACK.md"] --> Casepack
```

## Notes

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
- The casepack is a bounded validation artifact, not a benchmark leaderboard.
