### PR TITLE
feat(validation): automate evidence refresh status [F124]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine: local
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-evidence-automation-refresh`
 - Task: `F124_EVIDENCE_AUTOMATION_REFRESH`
-- Status: `brainstorming`
+- Status: `draft-pr-open`
 - Branch: `pod-b/evidence-automation-refresh`
 - Task packet: `docs/superpowers/tasks/2026-04-28-f124-evidence-automation-refresh.md`
 - Owned files: `scripts/contest/`, `docs/contest/`, `ai_first/evidence/`, bounded `tests/` for automation helpers, `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`
-- PR: `draft-not-opened`
+- PR: `draft-to-open`
 - Last update: `2026-04-28`
-- Next action: `write packet, spec, and plan for a bounded evidence automation helper that preserves manual screenshot/video semantics`
+- Next action: `push branch, open Draft PR, and keep the validation-ops lane mergeable`
 - Blocker: `none`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task is currently assigned on `main`.
-The next product work should start from a fresh Session A or Session B branch/worktree after the AI loop selects the next future-backlog task.
+### Assignment
+
+- Owner: Codex Session B
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/pod-b-evidence-automation-refresh`
+- Task: `F124_EVIDENCE_AUTOMATION_REFRESH`
+- Status: `brainstorming`
+- Branch: `pod-b/evidence-automation-refresh`
+- Task packet: `docs/superpowers/tasks/2026-04-28-f124-evidence-automation-refresh.md`
+- Owned files: `scripts/contest/`, `docs/contest/`, `ai_first/evidence/`, bounded `tests/` for automation helpers, `docs/superpowers/{tasks,specs,plans,pr-notes}/`, `ai_first/{ACTIVE_ASSIGNMENTS.md,TASK_REGISTRY.json,daily/2026-04-28.md}`
+- PR: `draft-not-opened`
+- Last update: `2026-04-28`
+- Next action: `write packet, spec, and plan for a bounded evidence automation helper that preserves manual screenshot/video semantics`
+- Blocker: `none`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -86,8 +86,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "F124_EVIDENCE_AUTOMATION_REFRESH"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -96,9 +98,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 1,
+      "count": 0,
       "tasks": [
-        "F124_EVIDENCE_AUTOMATION_REFRESH"
       ]
     }
   },
@@ -1818,10 +1819,10 @@
       "dependencies": [
         "F123_CASEPACK_AND_EVALUATION_DATASET_EXPANSION"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "validation-ops",
-      "notes": "This should improve repeatability without changing the product's proof level by itself."
+      "notes": "Active on branch pod-b/evidence-automation-refresh in worktree .worktrees/pod-b-evidence-automation-refresh. This lane is automating command-backed evidence refresh status while keeping screenshot and video evidence explicitly manual."
     }
   ],
   "github_issues_template": {

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1822,7 +1822,7 @@
       "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime-data",
       "layer": "validation-ops",
-      "notes": "Active on branch pod-b/evidence-automation-refresh in worktree .worktrees/pod-b-evidence-automation-refresh. This lane is automating command-backed evidence refresh status while keeping screenshot and video evidence explicitly manual."
+      "notes": "Active on branch pod-b/evidence-automation-refresh in worktree .worktrees/pod-b-evidence-automation-refresh. The branch now contains a bounded evidence-refresh helper, a machine-readable status artifact, and contest-doc wiring that preserves manual screenshot and video semantics."
     }
   ],
   "github_issues_template": {

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -6,9 +6,10 @@
 - Task: `F124_EVIDENCE_AUTOMATION_REFRESH`
 - Done: Opened the final remaining Session B future-backlog lane to automate command-backed contest evidence refresh without widening product proof claims.
 - Done: Scoped the lane around a bounded orchestration helper, a machine-readable status artifact, and contest docs that preserve manual screenshot/video semantics.
-- Tests: planning stage only so far; execution validation runs after the helper and artifact land.
+- Done: Added `scripts/contest/refresh_evidence_status.py`, `ai_first/evidence/evidence_status.json`, contest-doc wiring, and a bounded `tests/scripts/test_refresh_evidence_status.py` helper test.
+- Tests: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `python -m json.tool ai_first/evidence/evidence_status.json >/dev/null`; `pytest tests/scripts/test_refresh_evidence_status.py -q`; `git diff --check`
 - Blockers: None.
-- Next: add the helper, output artifact, and bounded tests, then open a Draft PR.
+- Next: push the branch, open a Draft PR, and keep the validation-ops lane mergeable.
 
 ## Session B Casepack And Evaluation Dataset Expansion
 

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,15 @@
 # Daily Log: 2026-04-28
 
+## Session B Evidence Automation Refresh
+
+- Branch: `pod-b/evidence-automation-refresh`
+- Task: `F124_EVIDENCE_AUTOMATION_REFRESH`
+- Done: Opened the final remaining Session B future-backlog lane to automate command-backed contest evidence refresh without widening product proof claims.
+- Done: Scoped the lane around a bounded orchestration helper, a machine-readable status artifact, and contest docs that preserve manual screenshot/video semantics.
+- Tests: planning stage only so far; execution validation runs after the helper and artifact land.
+- Blockers: None.
+- Next: add the helper, output artifact, and bounded tests, then open a Draft PR.
+
 ## Session B Casepack And Evaluation Dataset Expansion
 
 - Branch: `pod-b/casepack-eval-dataset`

--- a/ai_first/evidence/evidence_status.json
+++ b/ai_first/evidence/evidence_status.json
@@ -1,0 +1,26 @@
+{
+  "generated_at": "2026-04-28T00:00:00+00:00",
+  "project_root": ".",
+  "api_base": "http://localhost:8001",
+  "proof_level": "validated_prototype",
+  "checks": [
+    {
+      "name": "demo_reset",
+      "command": "python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001",
+      "status": "planned",
+      "summary": "execution skipped",
+      "manual_followup_required": false
+    },
+    {
+      "name": "system_status",
+      "command": "curl -s http://localhost:8001/api/v1/system/status",
+      "status": "planned",
+      "summary": "execution skipped",
+      "manual_followup_required": false
+    }
+  ],
+  "manual_artifacts": {
+    "screenshots": "manual",
+    "video": "manual"
+  }
+}

--- a/docs/contest/DEMO_DATA_RESET.md
+++ b/docs/contest/DEMO_DATA_RESET.md
@@ -49,6 +49,12 @@ The command:
 - prints the ids and local paths it touched;
 - can be run repeatedly without duplicating demo sessions.
 
+After reset plus smoke, the automation helper can write a machine-readable command-evidence snapshot:
+
+```bash
+python3 -m scripts.contest.refresh_evidence_status --project-root . --api-base http://localhost:8001
+```
+
 Generated local `data/` changes are not committed.
 
 ## Manual UI Reset

--- a/docs/contest/EVIDENCE_CHECKLIST.md
+++ b/docs/contest/EVIDENCE_CHECKLIST.md
@@ -31,6 +31,8 @@ Use this section to calibrate claims when showing teacher authoring plus evidenc
 
 Refresh these automatically after every successful smoke pass.
 
+Automation source-of-truth for command-backed freshness: `../../ai_first/evidence/evidence_status.json`
+
 | Command | Refresh mode | Status | Source |
 | --- | --- | --- | --- |
 | `python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001` | Auto before smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
@@ -41,6 +43,8 @@ Refresh these automatically after every successful smoke pass.
 | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-assessment-demo` | Auto after smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
 | `curl -s http://127.0.0.1:8001/api/v1/sessions/contest-tutor-demo` | Auto after smoke | Current | Passed on 2026-04-26; see `VALIDATION_REPORT.md`. |
 | `cd web && npm ci && npm run build` | Auto after smoke | Current | Passed on 2026-04-26 in lane 6, with the existing lockfile warning. |
+
+Screenshots and optional video remain manual even when command-backed evidence is refreshed through automation.
 
 ## Optional Video
 

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -35,6 +35,7 @@ The current product can be described as `agent-native` today and `multi-agent by
 - [`PILOT_STATUS.md`](./PILOT_STATUS.md): explicit status of pilot or external-feedback evidence.
 - [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md): judge-facing diagnosis examples and teacher-review framing.
 - [`CASEPACK_AND_EVALUATION_DATASET.md`](./CASEPACK_AND_EVALUATION_DATASET.md): structured validation casepack guide backed by `ai_first/evidence/casepack.json`.
+- `../../ai_first/evidence/evidence_status.json`: machine-readable status snapshot for command-backed evidence refresh.
 - [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md): smoke lane used to verify the MVP path before any evidence refresh.
 - [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md): demo-safe data inventory and reset runbook before smoke/evidence refresh.
 
@@ -49,6 +50,7 @@ The current product can be described as `agent-native` today and `multi-agent by
 - Video capture is optional and deferred to avoid storing large media in the repository.
 - No pilot evidence is currently bundled; the strongest current proof is structured walkthrough validation plus smoke-backed and screenshot-backed artifacts.
 - Judge-safe validation examples now have both prose case studies and a reusable machine-readable casepack for future evaluation reuse.
+- Command-backed evidence refresh now also has a machine-readable status artifact; screenshots and video remain manual artifacts.
 
 ## Judge-Friendly Use Cases
 

--- a/docs/contest/SMOKE_RUNBOOK.md
+++ b/docs/contest/SMOKE_RUNBOOK.md
@@ -10,6 +10,12 @@ If local demo data may be stale, missing, or private, run `DEMO_DATA_RESET.md` b
 python3 -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
 ```
 
+After a successful command-backed smoke pass, the bounded automation helper can refresh the structured status artifact:
+
+```bash
+python3 -m scripts.contest.refresh_evidence_status --project-root . --api-base http://localhost:8001
+```
+
 Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTION_QUEUE.md` and `ai_first/daily/YYYY-MM-DD.md`.
 
 ## Stage 1: Backend

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -14,6 +14,8 @@ This report validates prototype behavior and contest evidence only. It is not a 
 
 Latest smoke-backed refresh: 2026-04-26
 
+Structured command-backed status artifact: `../../ai_first/evidence/evidence_status.json`
+
 | Evidence group | Refresh mode | Status | Latest source |
 | --- | --- | --- | --- |
 | Backend and API reachability | Auto after smoke | Current | Scripted-reset smoke run recorded in `ai_first/daily/2026-04-26.md`. |
@@ -50,6 +52,7 @@ Use these status values consistently:
 - Runtime handoff from `config.agent_spec_id` through the unified live Tutor turn path now has bounded automated proof in repository tests, including a visible behavior difference between two spec packs. This report still does not claim universal wiring across every possible entry point.
 - Diagnosis credibility is grounded in deterministic rules plus teacher review framing. This report does not claim benchmark accuracy numbers for diagnosis or recommendation quality.
 - Structured validation scenarios now live in `ai_first/evidence/casepack.json` and are explained in `CASEPACK_AND_EVALUATION_DATASET.md`; they support repeatable review without becoming a benchmark claim.
+- Command-backed evidence refresh can now be summarized through `ai_first/evidence/evidence_status.json`; this improves repeatability but does not automate screenshot or video capture.
 - The repository currently documents no pilot cohort, classroom rollout, or real-user study. Use `PILOT_STATUS.md` for the explicit external-feedback status.
 - Local provider-backed assessment generation was unavailable during the 2026-04-25 screenshot refresh because the configured model key was still a placeholder. The refreshed `07` and `08` screenshots therefore use demo-safe local session content in the worktree data store instead of a live provider response.
 - Provider-backed AI quality depends on configured model credentials. If credentials are unavailable during a demo, use the command validation and recorded UI flow as fallback evidence.

--- a/docs/superpowers/plans/2026-04-28-f124-evidence-automation-refresh.md
+++ b/docs/superpowers/plans/2026-04-28-f124-evidence-automation-refresh.md
@@ -1,0 +1,208 @@
+# F124 Evidence Automation Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a bounded automation helper that refreshes command-backed contest evidence status into a reusable machine-readable artifact without changing proof level or pretending manual evidence is automated.
+
+**Architecture:** Add one orchestration script under `scripts/contest/` that reuses the existing reset flow, runs a fixed set of command-backed checks, and writes `ai_first/evidence/evidence_status.json`. Contest docs then point to that artifact for command evidence while keeping screenshots and video explicitly manual.
+
+**Tech Stack:** Python, JSON, pytest, existing local CLI and HTTP checks
+
+---
+
+### Task 1: Establish the F124 control-plane slice
+
+**Files:**
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-28.md`
+- Create: `docs/superpowers/tasks/2026-04-28-f124-evidence-automation-refresh.md`
+- Create: `docs/superpowers/specs/2026-04-28-f124-evidence-automation-refresh-design.md`
+- Create: `docs/superpowers/plans/2026-04-28-f124-evidence-automation-refresh.md`
+
+- [ ] **Step 1: Mark F124 active in AI-first tracking**
+
+Set `F124_EVIDENCE_AUTOMATION_REFRESH` to `in-progress` in `ai_first/TASK_REGISTRY.json` and record the active worktree/branch in `ai_first/ACTIVE_ASSIGNMENTS.md`.
+
+- [ ] **Step 2: Validate the registry update**
+
+Run: `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+Expected: no output, exit code `0`
+
+- [ ] **Step 3: Record lane start in the daily log**
+
+Add a short section to `ai_first/daily/2026-04-28.md` noting that this lane is automating command-backed evidence refresh only.
+
+- [ ] **Step 4: Commit the planning/control-plane setup**
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-28.md docs/superpowers/tasks/2026-04-28-f124-evidence-automation-refresh.md docs/superpowers/specs/2026-04-28-f124-evidence-automation-refresh-design.md docs/superpowers/plans/2026-04-28-f124-evidence-automation-refresh.md
+git commit -m "docs(validation): scaffold F124 evidence automation lane [F124]"
+```
+
+### Task 2: Build the bounded orchestration helper
+
+**Files:**
+- Create: `scripts/contest/refresh_evidence_status.py`
+- Create: `ai_first/evidence/evidence_status.json`
+- Test: `tests/scripts/test_refresh_evidence_status.py`
+
+- [ ] **Step 1: Write the failing tests for plan assembly and artifact shape**
+
+Create `tests/scripts/test_refresh_evidence_status.py` with:
+
+```python
+from scripts.contest.refresh_evidence_status import build_check_plan, build_status_artifact
+
+
+def test_build_check_plan_contains_expected_core_checks():
+    plan = build_check_plan(api_base="http://localhost:8001", include_frontend=False)
+    names = [item["name"] for item in plan]
+    assert names == [
+        "demo_reset",
+        "system_status",
+        "knowledge_list",
+        "dashboard_overview",
+        "dashboard_recent",
+        "assessment_session",
+        "tutor_session",
+    ]
+
+
+def test_build_status_artifact_marks_manual_followups():
+    checks = [
+        {"name": "system_status", "command": "curl ...", "status": "passed", "summary": "ok"},
+    ]
+    artifact = build_status_artifact(
+        project_root=".",
+        api_base="http://localhost:8001",
+        checks=checks,
+    )
+    assert artifact["checks"][0]["manual_followup_required"] is False
+    assert artifact["manual_artifacts"]["screenshots"] == "manual"
+    assert artifact["manual_artifacts"]["video"] == "manual"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/scripts/test_refresh_evidence_status.py -q`
+Expected: fail because the helper does not exist yet
+
+- [ ] **Step 3: Implement the helper with pure functions first**
+
+Create `scripts/contest/refresh_evidence_status.py` with:
+- `build_check_plan(api_base: str, include_frontend: bool) -> list[dict]`
+- `build_status_artifact(project_root: str, api_base: str, checks: list[dict]) -> dict`
+- `main()` CLI that can:
+  - optionally run reset first
+  - run the command checks
+  - write `ai_first/evidence/evidence_status.json`
+
+Reuse the existing safety style from `scripts/contest/reset_demo_data.py` for local API validation.
+
+- [ ] **Step 4: Seed an initial artifact file**
+
+Write `ai_first/evidence/evidence_status.json` using the same output shape the helper produces. The seeded artifact should clearly indicate it is a local automation snapshot, not a deployment proof.
+
+- [ ] **Step 5: Re-run the helper tests**
+
+Run: `pytest tests/scripts/test_refresh_evidence_status.py -q`
+Expected: `2 passed`
+
+- [ ] **Step 6: Commit the helper and test**
+
+```bash
+git add scripts/contest/refresh_evidence_status.py ai_first/evidence/evidence_status.json tests/scripts/test_refresh_evidence_status.py
+git commit -m "feat(validation): add evidence refresh helper [F124]"
+```
+
+### Task 3: Wire contest docs to the new artifact
+
+**Files:**
+- Modify: `docs/contest/README.md`
+- Modify: `docs/contest/VALIDATION_REPORT.md`
+- Modify: `docs/contest/EVIDENCE_CHECKLIST.md`
+- Modify: `docs/contest/SMOKE_RUNBOOK.md`
+- Modify: `docs/contest/DEMO_DATA_RESET.md`
+- Create: `docs/superpowers/pr-notes/2026-04-28-f124-evidence-automation-refresh.md`
+
+- [ ] **Step 1: Add the artifact to contest evidence docs**
+
+Update docs so they reference `ai_first/evidence/evidence_status.json` as the source-of-truth for command-backed evidence refresh status.
+
+- [ ] **Step 2: Preserve the auto/manual boundary**
+
+In `README.md`, `VALIDATION_REPORT.md`, and `EVIDENCE_CHECKLIST.md`, make the distinction explicit:
+- command evidence = automation-supported
+- screenshots = manual capture
+- video = manual capture
+
+- [ ] **Step 3: Update runbooks to mention the helper**
+
+In `SMOKE_RUNBOOK.md` and `DEMO_DATA_RESET.md`, add a short note showing how the new helper fits after reset/smoke:
+
+```bash
+python3 -m scripts.contest.refresh_evidence_status --project-root . --api-base http://localhost:8001
+```
+
+- [ ] **Step 4: Add the required PR note with Mermaid**
+
+Create `docs/superpowers/pr-notes/2026-04-28-f124-evidence-automation-refresh.md` with a Mermaid diagram such as:
+
+```mermaid
+flowchart LR
+    Reset["reset_demo_data.py"] --> Refresh["refresh_evidence_status.py"]
+    Refresh --> Artifact["ai_first/evidence/evidence_status.json"]
+    Artifact --> Docs["contest docs use structured status"]
+    Docs --> Human["human still captures screenshots/video"]
+```
+
+State whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed. For this lane it should normally remain unchanged.
+
+- [ ] **Step 5: Commit the docs integration**
+
+```bash
+git add docs/contest/README.md docs/contest/VALIDATION_REPORT.md docs/contest/EVIDENCE_CHECKLIST.md docs/contest/SMOKE_RUNBOOK.md docs/contest/DEMO_DATA_RESET.md docs/superpowers/pr-notes/2026-04-28-f124-evidence-automation-refresh.md
+git commit -m "docs(validation): wire evidence automation artifact [F124]"
+```
+
+### Task 4: Final validation and Draft PR
+
+**Files:**
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-28.md`
+
+- [ ] **Step 1: Run the lane validation bundle**
+
+Run:
+
+```bash
+python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+python -m json.tool ai_first/evidence/evidence_status.json >/dev/null
+pytest tests/scripts/test_refresh_evidence_status.py -q
+git diff --check
+```
+
+Expected:
+- JSON commands exit `0`
+- pytest prints `2 passed`
+- `git diff --check` prints nothing
+
+- [ ] **Step 2: Update tracking to draft-PR-open**
+
+Refresh `ACTIVE_ASSIGNMENTS.md`, `TASK_REGISTRY.json`, and the daily log so `F124` is clearly active with a Draft PR.
+
+- [ ] **Step 3: Push and open the Draft PR**
+
+```bash
+git push -u origin pod-b/evidence-automation-refresh
+gh pr create --repo Creative-Science-Contest-2026/Multiagent-learning-platform --base main --head pod-b/evidence-automation-refresh --title "feat(validation): automate evidence refresh status [F124]" --body-file <prepared-body-file> --draft
+```
+
+- [ ] **Step 4: Commit the final tracking update**
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-28.md
+git commit -m "chore(ai-first): record F124 draft PR state [F124]"
+```

--- a/docs/superpowers/pr-notes/2026-04-28-f124-evidence-automation-refresh.md
+++ b/docs/superpowers/pr-notes/2026-04-28-f124-evidence-automation-refresh.md
@@ -1,0 +1,28 @@
+# PR Note: F124 Evidence Automation Refresh
+
+## Summary
+
+- adds a bounded helper to refresh command-backed evidence status
+- writes a reusable machine-readable artifact under `ai_first/evidence/`
+- updates contest docs to treat command evidence as automation-supported while keeping screenshots and video manual
+- adds a small helper test for plan assembly and artifact shape
+
+## Architecture Impact
+
+- no runtime or product architecture changes
+- no `ai_first/architecture/MAIN_SYSTEM_MAP.md` update required for this validation-ops-only PR
+
+```mermaid
+flowchart LR
+    Reset["reset_demo_data.py"] --> Refresh["refresh_evidence_status.py"]
+    Refresh --> Artifact["ai_first/evidence/evidence_status.json"]
+    Artifact --> Docs["contest docs read structured status"]
+    Docs --> Human["screenshots and video remain manual"]
+```
+
+## Validation
+
+- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `python -m json.tool ai_first/evidence/evidence_status.json >/dev/null`
+- `pytest tests/scripts/test_refresh_evidence_status.py -q`
+- `git diff --check`

--- a/docs/superpowers/specs/2026-04-28-f124-evidence-automation-refresh-design.md
+++ b/docs/superpowers/specs/2026-04-28-f124-evidence-automation-refresh-design.md
@@ -1,0 +1,80 @@
+# F124 Design: Evidence Automation Refresh
+
+## Goal
+
+Automate the command-backed portion of contest evidence refresh so the validated-prototype claim is easier to maintain without pretending screenshots or video can be fully automated.
+
+## Approach
+
+Chosen approach: `wrapper script + generated status artifact`.
+
+Why:
+
+- a wrapper alone still leaves humans and AI workers to manually summarize status
+- full screenshot or video automation is out of scope and not reliable in this environment
+- a status artifact gives later docs lanes and AI workers one structured source for evidence freshness
+
+## Scope
+
+### In scope
+
+- add a bounded orchestration helper under `scripts/contest/`
+- run the existing demo-reset path plus selected command-backed checks
+- generate a machine-readable artifact under `ai_first/evidence/`
+- update contest docs to use the artifact as the source-of-truth for command-backed evidence refresh
+- add a bounded test for helper output shape or execution-plan assembly
+
+### Out of scope
+
+- browser screenshot automation
+- optional video automation
+- changing proof level or product claims
+- modifying runtime product behavior
+
+## Artifact Set
+
+- `scripts/contest/refresh_evidence_status.py`
+- `ai_first/evidence/evidence_status.json`
+- bounded test under `tests/`
+- doc refresh in `docs/contest/`
+
+## Command Coverage
+
+The first automation pass should cover:
+
+- demo reset command
+- system status endpoint
+- knowledge list endpoint
+- dashboard overview endpoint
+- dashboard recent endpoint
+- contest assessment session fetch
+- contest tutor session fetch
+- optional frontend build check behind an explicit flag
+
+## Data Shape
+
+The generated artifact should include:
+
+- `generated_at`
+- `api_base`
+- `project_root`
+- `checks`
+- per-check fields:
+  - `name`
+  - `command`
+  - `status`
+  - `summary`
+  - `manual_followup_required`
+
+## Documentation Behavior
+
+Contest docs should explain:
+
+- command-backed evidence can be refreshed with the helper
+- screenshot and video evidence remain manual
+- the helper updates operational repeatability, not the product's proof level
+
+## Architecture Impact
+
+- no runtime architecture change
+- no `ai_first/architecture/MAIN_SYSTEM_MAP.md` update expected unless the helper becomes part of a broader persistent ops architecture later

--- a/docs/superpowers/tasks/2026-04-28-f124-evidence-automation-refresh.md
+++ b/docs/superpowers/tasks/2026-04-28-f124-evidence-automation-refresh.md
@@ -1,0 +1,46 @@
+# Task Packet: F124 Evidence Automation Refresh
+
+- Task ID: `F124_EVIDENCE_AUTOMATION_REFRESH`
+- Commit tag: `F124`
+- Owner: `Codex`
+- Status: `brainstorming`
+
+## Objective
+
+Automate the command-backed evidence refresh path so contest validation status is easier to regenerate and review without overstating what remains manual.
+
+## Owned Files
+
+- `scripts/contest/`
+- `docs/contest/`
+- `ai_first/evidence/`
+- bounded `tests/` for automation helpers
+- `docs/superpowers/tasks/2026-04-28-f124-evidence-automation-refresh.md`
+- `docs/superpowers/specs/2026-04-28-f124-evidence-automation-refresh-design.md`
+- `docs/superpowers/plans/2026-04-28-f124-evidence-automation-refresh.md`
+- `docs/superpowers/pr-notes/2026-04-28-f124-evidence-automation-refresh.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+
+## Do-Not-Touch
+
+- runtime product code
+- screenshot capture automation
+- video capture automation
+- dashboard or tutoring UX
+- control-plane files outside those listed above
+
+## Acceptance Criteria
+
+1. A bounded evidence-refresh helper exists under `scripts/contest/`.
+2. The helper can produce a machine-readable evidence status artifact under `ai_first/evidence/`.
+3. Contest docs clearly distinguish auto-refreshed command evidence from manual screenshot/video evidence.
+4. A bounded test validates helper output shape or execution-plan assembly.
+5. AI-first tracking reflects scope, validation, and handoff status.
+
+## Validation
+
+- bounded helper test or artifact validation
+- `python -m json.tool` for generated JSON artifact if used
+- `git diff --check`

--- a/scripts/contest/refresh_evidence_status.py
+++ b/scripts/contest/refresh_evidence_status.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def build_check_plan(api_base: str, include_frontend: bool) -> list[dict]:
+    plan = [
+        {
+            "name": "demo_reset",
+            "command": f"python3 -m scripts.contest.reset_demo_data --project-root . --api-base {api_base}",
+            "manual_followup_required": False,
+        },
+        {
+            "name": "system_status",
+            "command": f"curl -s {api_base}/api/v1/system/status",
+            "manual_followup_required": False,
+        },
+        {
+            "name": "knowledge_list",
+            "command": f"curl -s {api_base}/api/v1/knowledge/list",
+            "manual_followup_required": False,
+        },
+        {
+            "name": "dashboard_overview",
+            "command": f"curl -s {api_base}/api/v1/dashboard/overview",
+            "manual_followup_required": False,
+        },
+        {
+            "name": "dashboard_recent",
+            "command": f"curl -s {api_base}/api/v1/dashboard/recent",
+            "manual_followup_required": False,
+        },
+        {
+            "name": "assessment_session",
+            "command": f"curl -s {api_base}/api/v1/sessions/contest-assessment-demo",
+            "manual_followup_required": False,
+        },
+        {
+            "name": "tutor_session",
+            "command": f"curl -s {api_base}/api/v1/sessions/contest-tutor-demo",
+            "manual_followup_required": False,
+        },
+    ]
+    if include_frontend:
+        plan.append(
+            {
+                "name": "frontend_build",
+                "command": "cd web && npm ci && npm run build",
+                "manual_followup_required": False,
+            }
+        )
+    return plan
+
+
+def build_status_artifact(project_root: str, api_base: str, checks: list[dict]) -> dict:
+    normalized_checks = []
+    for check in checks:
+        normalized_checks.append(
+            {
+                "name": check["name"],
+                "command": check["command"],
+                "status": check["status"],
+                "summary": check["summary"],
+                "manual_followup_required": check.get("manual_followup_required", False),
+            }
+        )
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "project_root": project_root,
+        "api_base": api_base,
+        "proof_level": "validated_prototype",
+        "checks": normalized_checks,
+        "manual_artifacts": {
+            "screenshots": "manual",
+            "video": "manual",
+        },
+    }
+
+
+def run_check(command: str, cwd: Path) -> dict:
+    result = subprocess.run(
+        command,
+        shell=True,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    summary = result.stdout.strip() or result.stderr.strip() or "no output"
+    return {
+        "status": "passed" if result.returncode == 0 else "failed",
+        "summary": summary[:500],
+    }
+
+
+def write_artifact(project_root: Path, artifact: dict) -> Path:
+    target = project_root / "ai_first" / "evidence" / "evidence_status.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(artifact, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Refresh command-backed contest evidence status.")
+    parser.add_argument("--project-root", default=".", help="Repository root.")
+    parser.add_argument("--api-base", default="http://localhost:8001", help="Local API base.")
+    parser.add_argument("--include-frontend", action="store_true", help="Include frontend build validation.")
+    parser.add_argument(
+        "--skip-execution",
+        action="store_true",
+        help="Only emit the current artifact shape without running commands.",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.project_root).expanduser().resolve()
+    plan = build_check_plan(api_base=args.api_base, include_frontend=args.include_frontend)
+
+    checks = []
+    for item in plan:
+        if args.skip_execution:
+            checks.append(
+                {
+                    "name": item["name"],
+                    "command": item["command"],
+                    "status": "planned",
+                    "summary": "execution skipped",
+                    "manual_followup_required": item["manual_followup_required"],
+                }
+            )
+            continue
+        outcome = run_check(item["command"], root)
+        checks.append(
+            {
+                "name": item["name"],
+                "command": item["command"],
+                "status": outcome["status"],
+                "summary": outcome["summary"],
+                "manual_followup_required": item["manual_followup_required"],
+            }
+        )
+
+    artifact = build_status_artifact(
+        project_root=str(root),
+        api_base=args.api_base,
+        checks=checks,
+    )
+    path = write_artifact(root, artifact)
+    print(json.dumps({"artifact_path": str(path), "checks": len(checks)}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_refresh_evidence_status.py
+++ b/tests/scripts/test_refresh_evidence_status.py
@@ -1,0 +1,37 @@
+from scripts.contest.refresh_evidence_status import (
+    build_check_plan,
+    build_status_artifact,
+)
+
+
+def test_build_check_plan_contains_expected_core_checks():
+    plan = build_check_plan(api_base="http://localhost:8001", include_frontend=False)
+    names = [item["name"] for item in plan]
+    assert names == [
+        "demo_reset",
+        "system_status",
+        "knowledge_list",
+        "dashboard_overview",
+        "dashboard_recent",
+        "assessment_session",
+        "tutor_session",
+    ]
+
+
+def test_build_status_artifact_marks_manual_followups():
+    checks = [
+        {
+            "name": "system_status",
+            "command": "curl -s http://localhost:8001/api/v1/system/status",
+            "status": "passed",
+            "summary": "ok",
+        },
+    ]
+    artifact = build_status_artifact(
+        project_root=".",
+        api_base="http://localhost:8001",
+        checks=checks,
+    )
+    assert artifact["checks"][0]["manual_followup_required"] is False
+    assert artifact["manual_artifacts"]["screenshots"] == "manual"
+    assert artifact["manual_artifacts"]["video"] == "manual"


### PR DESCRIPTION
## Summary
- add a bounded helper to refresh command-backed contest evidence status
- write a machine-readable status artifact under `ai_first/evidence/`
- update contest docs so command evidence is automation-supported while screenshots and video remain manual
- add a small helper test for plan assembly and artifact shape

## Validation
- `python -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `python -m json.tool ai_first/evidence/evidence_status.json >/dev/null`
- `pytest tests/scripts/test_refresh_evidence_status.py -q`
- `git diff --check`

## Architecture
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` update not required for this validation-ops-only PR
- Mermaid architecture note: `docs/superpowers/pr-notes/2026-04-28-f124-evidence-automation-refresh.md`
