### PR TITLE
test: stabilize baseline pytest collection blocker [OPS-PYTEST]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,11 +34,11 @@ Rules:
 - Machine:
 - Worktree: `.worktrees/fix-baseline-pytest-collection-blocker`
 - Task: `OPS_PYTEST_COLLECTION_BLOCKER`
-- Status: in-progress
+- Status: in-review
 - Branch: `fix/baseline-pytest-collection-blocker`
 - Task packet: `docs/superpowers/tasks/2026-04-28-baseline-pytest-collection-blocker.md`
 - Owned files: test package markers, task packet, PR note, active assignment, and daily log
-- PR:
+- PR: `#209`
 - Last update: 2026-04-28
-- Next action: commit the collection-fix lane and use it to unblock merge work on other branches that currently stop at pytest collection
+- Next action: monitor Draft PR `#209`, confirm required checks, and merge this lane before resuming submission-close merge work
 - Blocker: post-collection baseline remains at 23 failing tests on current `main`, but the import-mismatch collector blocker is resolved

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -28,5 +28,17 @@ Rules:
 
 ## Active
 
-No active AI implementation task is currently assigned on `main`.
-The current future-backlog loop is complete on `main`; any further AI product work should start from a fresh packet or a newly approved backlog addition.
+### Assignment
+
+- Owner: Session-specific
+- Machine:
+- Worktree: `.worktrees/fix-baseline-pytest-collection-blocker`
+- Task: `OPS_PYTEST_COLLECTION_BLOCKER`
+- Status: in-progress
+- Branch: `fix/baseline-pytest-collection-blocker`
+- Task packet: `docs/superpowers/tasks/2026-04-28-baseline-pytest-collection-blocker.md`
+- Owned files: test package markers, task packet, PR note, active assignment, and daily log
+- PR:
+- Last update: 2026-04-28
+- Next action: commit the collection-fix lane and use it to unblock merge work on other branches that currently stop at pytest collection
+- Blocker: post-collection baseline remains at 23 failing tests on current `main`, but the import-mismatch collector blocker is resolved

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,16 @@
 # Daily Log: 2026-04-28
 
+## OPS_PYTEST_COLLECTION_BLOCKER
+
+- Branch: `fix/baseline-pytest-collection-blocker`
+- Task: `OPS_PYTEST_COLLECTION_BLOCKER`
+- Done: Opened a fresh fix lane from `origin/main` to isolate the baseline `pytest` collection blocker from the submission-close planning branch.
+- Done: Added a focused task packet, PR note, and active assignment before touching the `tests/` tree.
+- Done: Added minimal test package markers so duplicate basenames under `tests/agents/` and `tests/services/llm/` no longer collide during default pytest collection.
+- Tests: `pytest --collect-only -q` now succeeds with `361 tests collected`; `pytest -q` now reaches full execution and reports the pre-existing post-collection baseline of `23 failed, 337 passed, 1 skipped`; `git diff --check`
+- Blockers: none yet
+- Next: commit this scoped collection fix, then return to the submission-close branch and decide whether to merge this fix first or open a Draft PR for it.
+
 ## Session B Evidence Automation Refresh
 
 - Branch: `pod-b/evidence-automation-refresh`

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -7,9 +7,10 @@
 - Done: Opened a fresh fix lane from `origin/main` to isolate the baseline `pytest` collection blocker from the submission-close planning branch.
 - Done: Added a focused task packet, PR note, and active assignment before touching the `tests/` tree.
 - Done: Added minimal test package markers so duplicate basenames under `tests/agents/` and `tests/services/llm/` no longer collide during default pytest collection.
+- Done: Pushed branch `fix/baseline-pytest-collection-blocker` and opened Draft PR `#209`.
 - Tests: `pytest --collect-only -q` now succeeds with `361 tests collected`; `pytest -q` now reaches full execution and reports the pre-existing post-collection baseline of `23 failed, 337 passed, 1 skipped`; `git diff --check`
 - Blockers: none yet
-- Next: commit this scoped collection fix, then return to the submission-close branch and decide whether to merge this fix first or open a Draft PR for it.
+- Next: wait for PR `#209` checks, merge this lane, then return to the submission-close branch and resume the merge path there.
 
 ## Session B Evidence Automation Refresh
 

--- a/docs/superpowers/pr-notes/2026-04-28-baseline-pytest-collection-blocker.md
+++ b/docs/superpowers/pr-notes/2026-04-28-baseline-pytest-collection-blocker.md
@@ -1,0 +1,22 @@
+# PR Note: Baseline Pytest Collection Blocker
+
+## Summary
+
+- add minimal test package markers to prevent duplicate basename collisions during pytest collection
+- keep the fix scoped to `tests/` layout stabilization
+- document that post-collection baseline failures remain out of scope for this branch
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  A[tests/agents/math_animator/test_request_config.py] --> P[pytest import namespace]
+  B[tests/agents/research/test_request_config.py] --> P
+  C[tests/services/llm/test_utils.py] --> P
+  D[tests/agents/math_animator/test_utils.py] --> P
+  P --> F[Package markers prevent basename collisions]
+```
+
+## Main System Map
+
+- Not updated. This fix affects test discovery only.

--- a/docs/superpowers/tasks/2026-04-28-baseline-pytest-collection-blocker.md
+++ b/docs/superpowers/tasks/2026-04-28-baseline-pytest-collection-blocker.md
@@ -1,0 +1,77 @@
+# Feature Pod Task: Baseline Pytest Collection Blocker
+
+Task ID: `OPS_PYTEST_COLLECTION_BLOCKER`
+Commit tag: `OPS-PYTEST`
+Owner: Session-specific
+Branch: `fix/baseline-pytest-collection-blocker`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Fix the current baseline `pytest` collection failure on `main` so the full suite can at least collect tests consistently before any higher-level workflow or docs branch is merged.
+
+## User-visible outcome
+
+- `pytest -q` no longer stops at collection time with `import file mismatch`.
+- Duplicate test basenames under `tests/` no longer collide in default pytest import mode.
+
+## Owned files/modules
+
+- `tests/__init__.py`
+- `tests/agents/__init__.py`
+- `tests/agents/math_animator/__init__.py`
+- `tests/agents/research/__init__.py`
+- `tests/services/llm/__init__.py`
+- `docs/superpowers/tasks/2026-04-28-baseline-pytest-collection-blocker.md`
+- `docs/superpowers/pr-notes/2026-04-28-baseline-pytest-collection-blocker.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-28.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `docs/contest/`
+- `requirements/`
+- lockfiles
+
+## API/data contract
+
+- This fix changes test-package layout only.
+- It must not change runtime/product behavior.
+- It must not switch global pytest import mode as a side effect.
+
+## Acceptance criteria
+
+- `pytest --collect-only -q` completes without `import file mismatch`.
+- The fix is limited to package markers or equally small test-layout stabilization.
+- Any remaining failing tests are post-collection baseline failures, not collection blockers.
+
+## Required tests
+
+- `pytest --collect-only -q`
+- `pytest -q`
+- `git diff --check`
+
+## Manual verification
+
+- Confirm the previous `test_request_config` and `test_utils` import mismatch no longer appears.
+- Confirm no runtime/product files changed.
+
+## Parallel-work notes
+
+- Keep this lane separate from `docs/submission-close-master`.
+- Do not widen this into fixing the 23 post-collection baseline failures.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should not change because this is test-layout stabilization only.
+
+## Handoff notes
+
+- This lane exists only to remove the collection blocker.
+- If the suite still has logic/config failures after collection succeeds, report them separately instead of silently expanding scope.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package marker for stable pytest module imports."""

--- a/tests/agents/__init__.py
+++ b/tests/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Agent test package marker for stable pytest module imports."""

--- a/tests/agents/math_animator/__init__.py
+++ b/tests/agents/math_animator/__init__.py
@@ -1,0 +1,1 @@
+"""Math animator test package marker for stable pytest module imports."""

--- a/tests/agents/research/__init__.py
+++ b/tests/agents/research/__init__.py
@@ -1,0 +1,1 @@
+"""Research test package marker for stable pytest module imports."""

--- a/tests/services/llm/__init__.py
+++ b/tests/services/llm/__init__.py
@@ -1,0 +1,1 @@
+"""LLM service test package marker for stable pytest module imports."""


### PR DESCRIPTION
## Summary
- add a focused task packet and PR note for the baseline pytest collection blocker lane
- add minimal `tests/` package markers so duplicate basename tests no longer collide during default pytest collection
- update AI-first active assignment and daily log for the fix lane

## Validation
- `pytest --collect-only -q` -> passes with `361 tests collected`
- `pytest -q` -> no longer fails at collection; current main baseline continues into `23 failed, 337 passed, 1 skipped`
- `git diff --check`

## Main System Map
- Not updated; this branch changes test discovery and workflow docs only, not runtime/product architecture.