### PR TITLE
[OPS-A] Freeze Session A submission scope and claim contract

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -49,14 +49,14 @@ Rules:
 - Machine:
 - Worktree: `.worktrees/submission-close-a`
 - Task: `OPS_SUBMISSION_CLOSE_A`
-- Status: in-progress
+- Status: in-review
 - Branch: `docs/submission-close-session-a`
 - Task packet: `docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md`
 - Owned files: submission narrative and package docs
-- PR:
+- PR: `#211`
 - Last update: 2026-04-28
-- Next action: execute `C202_SUBMISSION_SCOPE_FREEZE`, then `C203_CLAIM_AND_PROOF_CONTRACT_FREEZE`
-- Blocker:
+- Next action: keep Draft PR `#211` aligned with Session B proof refresh, then advance the remaining Session A packaging work that does not require validation-owned edits
+- Blocker: `PR-CLOSE-09` remains blocked on Session B validation/evidence outputs
 
 ### Planned Assignment
 

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,28 +34,28 @@ Rules:
 - Machine:
 - Worktree: `.worktrees/submission-close-master`
 - Task: `OPS_SUBMISSION_CLOSE_MASTER`
-- Status: in-review
+- Status: merged
 - Branch: `docs/submission-close-master`
 - Task packet: `docs/superpowers/tasks/2026-04-28-submission-close-master-coordination.md`
 - Owned files: submission-close spec, plan, task packets, and AI-first mirrors
 - PR: `#210`
 - Last update: 2026-04-28
-- Next action: monitor Draft PR `#210`, merge it when CI is green, then launch Session A, Session B, and Session C from fresh worktrees off `main`
+- Next action: keep Session A active, launch Session B and Session C only when their assigned worktrees and scopes are ready
 - Blocker: current `main` no longer has the pytest collection mismatch, but the full baseline suite still contains post-collection failures outside this docs-planning lane
 
-### Planned Assignment
+### Assignment
 
 - Owner: Session A
 - Machine:
 - Worktree: `.worktrees/submission-close-a`
 - Task: `OPS_SUBMISSION_CLOSE_A`
-- Status: planned
+- Status: in-progress
 - Branch: `docs/submission-close-session-a`
 - Task packet: `docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md`
 - Owned files: submission narrative and package docs
 - PR:
 - Last update: 2026-04-28
-- Next action: start `PR-CLOSE-01`
+- Next action: execute `C202_SUBMISSION_SCOPE_FREEZE`, then `C203_CLAIM_AND_PROOF_CONTRACT_FREEZE`
 - Blocker:
 
 ### Planned Assignment

--- a/ai_first/competition/fork-modifications.md
+++ b/ai_first/competition/fork-modifications.md
@@ -8,7 +8,9 @@ This repository is a contest-focused fork of `HKUDS/DeepTutor`, which remains cr
 
 The fork narrows the broad DeepTutor platform into a stable VnExpress Sáng kiến Khoa học 2026 MVP for the Education field. The submission story is:
 
-Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention.
+
+The dashboard remains the teacher-facing operating surface for reviewing diagnosis and choosing interventions, but it should not replace the five-step contest loop as the official product scope.
 
 ## Major Modifications Added in This Fork
 
@@ -43,6 +45,7 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 - teacher analytics and activity views
 - student progress dashboard and learning-path sequencing
 - filtering and recent-session visibility for review workflows
+- teacher-reviewable diagnosis and intervention follow-up context
 
 ### 6. Contest-readiness and operating layer
 
@@ -66,3 +69,9 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 ## Submission Use
 
 This note exists to satisfy the submission-checklist item `Fork modifications described` with a concise, repo-backed explanation of how this fork differs from upstream HKUDS/DeepTutor for the contest MVP.
+
+Scope guardrail for submission wording:
+
+- position the fork as a teacher-controlled adaptive tutoring prototype
+- treat marketplace, export, replay, and offline helpers as supporting proof
+- do not present the current repository as a full classroom deployment or autonomous multi-agent system

--- a/ai_first/competition/pitch-notes.md
+++ b/ai_first/competition/pitch-notes.md
@@ -2,7 +2,7 @@
 
 ## One-line pitch
 
-An AI-first learning platform where Vietnamese teachers turn their own materials into classroom-ready tutoring, practice, and follow-up insight without giving up control over how the AI teaches.
+A teacher-controlled adaptive tutoring platform where Vietnamese teachers turn their own materials into classroom-ready practice, tutoring, diagnosis review, and follow-up intervention without giving up control over how the AI teaches.
 
 Current status: validated prototype with smoke-backed demo evidence, not a deployed classroom system.
 
@@ -12,7 +12,7 @@ Teachers already have lesson materials and teaching instincts, but they do not h
 
 ## Solution
 
-The platform turns teacher-owned materials into Knowledge Packs, drafts assessments for teacher review, supports student tutoring, and gives teachers an evidence-first dashboard. Teachers can also set the tutor's class fit, support style, and guardrails on `/agents`, so the system adapts to how they want students to be helped, not just what content is covered.
+The platform turns teacher-owned materials into Knowledge Packs, drafts assessments for teacher review, supports student tutoring, surfaces diagnosis signals for teacher review, and helps the teacher choose the next intervention. Teachers can also set the tutor's class fit, support style, and guardrails on `/agents`, so the system adapts to how they want students to be helped, not just what content is covered.
 
 Teacher-facing use cases:
 
@@ -37,7 +37,15 @@ Architecture direction: agent-native today, with future multi-agent role separat
 1. Teacher creates a Knowledge Pack.
 2. Teacher generates questions from the pack.
 3. Student studies with Tutor Agent grounded in the pack.
-4. Teacher views dashboard evidence and teacher-reviewable diagnosis suggestions.
+4. Teacher reviews diagnosis signals and recommendation context.
+5. Teacher decides the next intervention using dashboard evidence.
+
+Official scope freeze:
+
+- Core loop: `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`
+- Operator surface: the dashboard helps the teacher inspect and act on the loop
+- Claim level: validated prototype, not classroom deployment
+- Architecture claim: agent-native today, multi-agent by design as a future direction
 
 Behavior-diff story for judges:
 

--- a/ai_first/competition/product-description.md
+++ b/ai_first/competition/product-description.md
@@ -10,7 +10,7 @@ Education
 
 ## Short Description
 
-Multiagent Learning Platform is an AI-first learning platform that helps Vietnamese teachers turn their own teaching materials into reusable Knowledge Packs, draft assessments, support student tutoring, and review learning progress through one connected workflow while still deciding how the AI should teach.
+Multiagent Learning Platform is a teacher-controlled adaptive tutoring platform that helps Vietnamese teachers turn their own teaching materials into reusable Knowledge Packs, draft assessments, support student tutoring, review AI-assisted diagnosis, and decide the next intervention while still controlling how the AI should teach.
 
 Current proof level: a validated prototype with contest-safe walkthrough validation, smoke-backed checks, and refreshed UI evidence.
 
@@ -20,9 +20,11 @@ Teachers often already have lesson materials, exercises, and teaching experience
 
 ## Solution
 
-The platform keeps teachers in control of the source knowledge. A teacher creates or imports a Knowledge Pack, uses AI to generate an assessment, lets students learn with a Tutor Agent grounded in that same pack, and then reviews the resulting activity in a teacher dashboard. This creates one practical loop:
+The platform keeps teachers in control of the source knowledge. A teacher creates or imports a Knowledge Pack, uses AI to generate an assessment, lets students learn with a Tutor Agent grounded in that same pack, reviews teacher-facing diagnosis signals, and then decides the next intervention. This creates one practical loop:
 
-Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention.
+
+The teacher dashboard remains the operating surface that helps the teacher inspect that loop, but the product claim should stay anchored to the five-step learning cycle above rather than a generic reporting story.
 
 Within that loop, diagnosis and recommendation outputs are positioned as evidence-backed, confidence-tagged, teacher-reviewed hypotheses rather than autonomous final judgments. The `/agents` flow adds one more teacher-control layer: the teacher can decide who the tutor is for, how it should respond when students are wrong or stuck, and which classroom guardrails it must respect.
 
@@ -38,8 +40,30 @@ Within that loop, diagnosis and recommendation outputs are positioned as evidenc
 2. Marketplace import and batch import for reusable packs.
 3. AI-generated assessments with review insights, timing metrics, and export support.
 4. Tutor Agent sessions with context badges, follow-up prompts, and replay support.
-5. Teacher dashboard analytics for recent activity, student-facing learning progress, and teacher-reviewable diagnosis/recommendation signals.
+5. Teacher-reviewable diagnosis and intervention workflow surfaced through dashboard analytics, recent activity, and teacher-facing learning signals.
 6. Contest-ready evidence bundle with smoke-backed validation, screenshots, and demo-safe reset workflow.
+
+## Submission Scope Freeze
+
+In-scope contest story:
+
+- teacher-controlled adaptive tutoring for Vietnamese classrooms
+- the five-step learning loop: `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`
+- teacher-owned control over tutor identity, teaching style, and guardrails through `/agents`
+- validated-prototype proof through smoke-backed walkthroughs, screenshots, and contest docs
+
+Secondary but not core proof:
+
+- marketplace reuse and batch import
+- assessment export, replay, and timing support
+- offline-ready fallback and sync-resilience helpers
+
+Out of current claim scope:
+
+- classroom outcome evidence
+- school-scale deployment
+- fully autonomous multi-agent operation without teacher review
+- universal runtime proof across every capability and entry point
 
 ## Why It Is Useful in Vietnam
 
@@ -50,7 +74,7 @@ Within that loop, diagnosis and recommendation outputs are positioned as evidenc
 
 ## Innovation
 
-The platform combines agent workflows, retrieval grounded in teacher-approved materials, assessment generation, tutoring, and dashboard review into one connected product path instead of isolated tools. Its practical novelty is not only “using AI,” but using AI while preserving teacher control over source content, teaching style, and evidence review.
+The platform combines agent workflows, retrieval grounded in teacher-approved materials, assessment generation, tutoring, diagnosis support, and intervention decision support into one connected product path instead of isolated tools. Its practical novelty is not only “using AI,” but using AI while preserving teacher control over source content, teaching style, and evidence review.
 
 Its future direction can be described as multi-agent by design, because the architecture is prepared for stronger role separation later. The current merged product should still be described as an agent-native validated prototype rather than a full autonomous multi-agent deployment.
 

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -9,9 +9,10 @@
 - Done: Added a claim-and-proof contract, operator read path, and explicit human review gates without editing Session B validation/evidence files.
 - Done: Added the required PR note with Mermaid and updated the Session A task packet with progress notes.
 - Done: Pushed `docs/submission-close-session-a` and opened Draft PR `#211` for the Session A submission scope freeze lane.
+- Done: Tightened the operator/gate wording after PR creation so the submission package now shows pending dependencies and the human handoff now shows a gate-status snapshot.
 - Tests: `rg -n "Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention|validated prototype|teacher-controlled adaptive tutoring" ai_first/competition docs/contest docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md`; `git diff --check`
 - Blockers: `PR-CLOSE-09 Final Package Readiness` remains blocked on Session B outputs, especially validation/evidence freshness under `PR-CLOSE-05`.
-- Next: keep Draft PR `#211` synchronized with Session B proof refresh, then finish any remaining Session A package wording that stays inside owned scope.
+- Next: keep Draft PR `#211` synchronized with Session B proof refresh, then run the final Session A consistency pass only after Session B-owned evidence files are refreshed or explicitly deferred.
 
 ## OPS_SUBMISSION_CLOSE_MASTER
 

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,17 @@
 # Daily Log: 2026-04-28
 
+## OPS_SUBMISSION_CLOSE_A
+
+- Branch: `docs/submission-close-session-a`
+- Task: `OPS_SUBMISSION_CLOSE_A`
+- Done: Created the dedicated Session A worktree from refreshed `origin/main` and recorded the lane as active in `ai_first/ACTIVE_ASSIGNMENTS.md`.
+- Done: Froze the contest narrative around `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention` across the owned submission and competition docs.
+- Done: Added a claim-and-proof contract, operator read path, and explicit human review gates without editing Session B validation/evidence files.
+- Done: Added the required PR note with Mermaid and updated the Session A task packet with progress notes.
+- Tests: `rg -n "Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention|validated prototype|teacher-controlled adaptive tutoring" ai_first/competition docs/contest docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md`; `git diff --check`
+- Blockers: `PR-CLOSE-09 Final Package Readiness` remains blocked on Session B outputs, especially validation/evidence freshness under `PR-CLOSE-05`.
+- Next: review the docs-only diff, then wait for Session B proof refresh before any final package-readiness wording.
+
 ## OPS_SUBMISSION_CLOSE_MASTER
 
 - Branch: `docs/submission-close-master`

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -8,9 +8,10 @@
 - Done: Froze the contest narrative around `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention` across the owned submission and competition docs.
 - Done: Added a claim-and-proof contract, operator read path, and explicit human review gates without editing Session B validation/evidence files.
 - Done: Added the required PR note with Mermaid and updated the Session A task packet with progress notes.
+- Done: Pushed `docs/submission-close-session-a` and opened Draft PR `#211` for the Session A submission scope freeze lane.
 - Tests: `rg -n "Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention|validated prototype|teacher-controlled adaptive tutoring" ai_first/competition docs/contest docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md`; `git diff --check`
 - Blockers: `PR-CLOSE-09 Final Package Readiness` remains blocked on Session B outputs, especially validation/evidence freshness under `PR-CLOSE-05`.
-- Next: review the docs-only diff, then wait for Session B proof refresh before any final package-readiness wording.
+- Next: keep Draft PR `#211` synchronized with Session B proof refresh, then finish any remaining Session A package wording that stays inside owned scope.
 
 ## OPS_SUBMISSION_CLOSE_MASTER
 

--- a/docs/contest/HUMAN_REVIEW_HANDOFF.md
+++ b/docs/contest/HUMAN_REVIEW_HANDOFF.md
@@ -12,6 +12,16 @@ Use this file as the shortest manual review path before the final VnExpress Sán
 
 ## Human Review Gates
 
+## Gate Status Snapshot
+
+| Gate | Owner | Status | Blocking condition |
+| --- | --- | --- | --- |
+| Product wording and category fit | submission operator / final reviewer | Pending | final human wording review not yet recorded |
+| Intellectual property commitment | submission operator / project owner | Pending | external confirmation not yet recorded |
+| Evidence sanity check | submission operator | Pending | Session B proof refresh remains authoritative |
+| Optional video decision | submission operator | Pending | final submission requirements not yet confirmed |
+| Final package sign-off | final reviewer | Blocked | Gates 1-4 must complete first |
+
 ### Gate 1. Product wording and category fit
 
 Status: pending human review
@@ -83,6 +93,8 @@ Use `docs/contest/SUBMISSION_PACKAGE.md` as the final read path and then mark th
 4. `ai_first/competition/fork-modifications.md`
 5. `docs/contest/VALIDATION_REPORT.md`
 6. `docs/contest/screenshots/`
+
+If any wording here disagrees with Session B-owned freshness files, prefer the Session B file and update this handoff later rather than overriding proof status locally.
 
 ## Expected End State
 

--- a/docs/contest/HUMAN_REVIEW_HANDOFF.md
+++ b/docs/contest/HUMAN_REVIEW_HANDOFF.md
@@ -4,18 +4,18 @@ Use this file as the shortest manual review path before the final VnExpress Sán
 
 ## What Is Already Ready
 
-- end-to-end MVP story is documented in `docs/contest/SUBMISSION_PACKAGE.md`
+- the official product loop and claim contract are documented in `docs/contest/SUBMISSION_PACKAGE.md`
 - smoke-backed validation is recorded in `docs/contest/VALIDATION_REPORT.md`
 - screenshot evidence is current in `docs/contest/screenshots/`
-- AI-verifiable submission items are checked in `ai_first/competition/submission-checklist.md`
-- supporting contest text exists in:
-  - `ai_first/competition/product-description.md`
-  - `ai_first/competition/fork-modifications.md`
-  - `ai_first/competition/pitch-notes.md`
+- AI-verifiable submission items are tracked in `ai_first/competition/submission-checklist.md`
+- supporting contest text exists in `ai_first/competition/product-description.md`, `ai_first/competition/fork-modifications.md`, and `ai_first/competition/pitch-notes.md`
 
-## Remaining Human-Owned Decisions
+## Human Review Gates
 
-### 1. Product description review
+### Gate 1. Product wording and category fit
+
+Status: pending human review
+Owner: submission operator / final reviewer
 
 Confirm wording, claim calibration, and category fit for Education using:
 
@@ -23,7 +23,16 @@ Confirm wording, claim calibration, and category fit for Education using:
 - `ai_first/competition/pitch-notes.md`
 - `ai_first/competition/vnexpress-rules-summary.md`
 
-### 2. Intellectual property commitment
+Acceptance rule:
+
+- keep the product framed as a teacher-controlled adaptive tutoring prototype
+- keep the official loop at `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`
+- reject any wording that implies school-scale deployment or autonomous final judgment
+
+### Gate 2. Intellectual property commitment
+
+Status: pending human confirmation
+Owner: submission operator / project owner
 
 Review the contest IP commitment outside the repository submission flow and confirm the maintained facts still match:
 
@@ -31,7 +40,10 @@ Review the contest IP commitment outside the repository submission flow and conf
 - upstream attribution retained in `README.md` and `AGENTS.md`
 - contest-specific fork modifications summarized in `ai_first/competition/fork-modifications.md`
 
-### 3. Evidence sanity check
+### Gate 3. Evidence sanity check
+
+Status: pending final manual pass
+Owner: submission operator
 
 Before submission, quickly verify:
 
@@ -41,7 +53,25 @@ Before submission, quickly verify:
 - pilot or external-feedback language stays honest: use [`PILOT_STATUS.md`](./PILOT_STATUS.md) and keep `/api/v1/system/pilot-feedback-status` aligned with any real stored feedback instead of implying classroom validation that the repository does not contain
 - optional video is either not required or has been recorded separately using `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`
 
-### 4. Final package sign-off
+Acceptance rule:
+
+- if Session B refreshes validation or evidence wording, use its files as authoritative
+- if a screenshot or validation artifact is stale, do not silently mark the package ready
+
+### Gate 4. Optional video decision
+
+Status: pending human decision
+Owner: submission operator
+
+Decide one of:
+
+- no video is required for the submission path
+- video is required and will be recorded outside the repository using `docs/contest/VIDEO_CAPTURE_RUNBOOK.md`
+
+### Gate 5. Final package sign-off
+
+Status: pending after Gates 1-4
+Owner: final reviewer
 
 Use `docs/contest/SUBMISSION_PACKAGE.md` as the final read path and then mark the remaining human checklist items in the actual submission workflow.
 
@@ -56,4 +86,8 @@ Use `docs/contest/SUBMISSION_PACKAGE.md` as the final read path and then mark th
 
 ## Expected End State
 
-After human review, the only repo state change that may still be useful is marking the final manual submission/sign-off outcome if the team wants a last archival docs sync.
+After human review, the repo should have one visible answer for three questions:
+
+- what the product claims
+- what evidence supports those claims
+- which manual gates were still human-only at sign-off

--- a/docs/contest/HUMAN_REVIEW_HANDOFF.md
+++ b/docs/contest/HUMAN_REVIEW_HANDOFF.md
@@ -18,7 +18,7 @@ Use this file as the shortest manual review path before the final VnExpress Sán
 | --- | --- | --- | --- |
 | Product wording and category fit | submission operator / final reviewer | Pending | final human wording review not yet recorded |
 | Intellectual property commitment | submission operator / project owner | Pending | external confirmation not yet recorded |
-| Evidence sanity check | submission operator | Pending | Session B proof refresh remains authoritative |
+| Evidence sanity check | submission operator | Pending | final human sanity pass not yet recorded; Session B proof refresh is now merged and authoritative |
 | Optional video decision | submission operator | Pending | final submission requirements not yet confirmed |
 | Final package sign-off | final reviewer | Blocked | Gates 1-4 must complete first |
 
@@ -67,6 +67,7 @@ Acceptance rule:
 
 - if Session B refreshes validation or evidence wording, use its files as authoritative
 - if a screenshot or validation artifact is stale, do not silently mark the package ready
+- the current authoritative refresh is the merged 2026-04-28 Session B smoke/evidence pass, while screenshot capture dates remain 2026-04-25 and 2026-04-26
 
 ### Gate 4. Optional video decision
 
@@ -95,6 +96,7 @@ Use `docs/contest/SUBMISSION_PACKAGE.md` as the final read path and then mark th
 6. `docs/contest/screenshots/`
 
 If any wording here disagrees with Session B-owned freshness files, prefer the Session B file and update this handoff later rather than overriding proof status locally.
+This handoff now assumes the Session B refresh merged successfully; the remaining work is human review and optional submission-only decisions.
 
 ## Expected End State
 

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -4,23 +4,49 @@ This folder is the entry point for VnExpress Sang kien Khoa hoc 2026 demo eviden
 
 Current framing: this repository is a validated prototype with smoke-backed evidence and contest-safe walkthrough artifacts. It is not positioned as a deployed classroom system.
 
+Official contest framing: a teacher-controlled adaptive tutoring platform for Vietnamese classrooms.
+
 ## MVP Story
 
-Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention.
+
+The teacher dashboard is the operating surface that helps a teacher inspect diagnosis and choose interventions. It supports the loop; it is not a substitute for the loop.
+
+## Submission Scope Freeze
+
+Core submission scope:
+
+- teacher-controlled adaptive tutoring for Vietnamese classrooms
+- a single five-step loop: `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`
+- teacher-owned tutor control through `/agents` identity, style, and guardrails
+- validated-prototype proof through smoke-backed walkthroughs, screenshots, and submission docs
+
+Secondary proof that can be mentioned but should not replace the core story:
+
+- marketplace reuse and batch import
+- export, replay, timing, and offline-resilience helpers
+- architecture readiness for deeper role separation later
+
+Out of scope for contest claims:
+
+- classroom outcome evidence
+- school-scale deployment claims
+- autonomous diagnosis without teacher review
+- universal capability coverage beyond the currently documented proof paths
 
 ## Hybrid Proof Scope
 
 This evidence bundle now supports a hybrid contest narrative:
 
 - Teacher authoring proof: the teacher can structure Agent Specs on `/agents` and export a spec pack.
-- Learning evidence-loop proof: Knowledge Pack -> assessment -> tutoring follow-up -> dashboard activity.
+- Learning evidence-loop proof: `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`, with dashboard activity as the teacher-facing operating surface around the last two stages.
 
 Teacher-value framing for presenters:
 
 - `IDENTITY` lets a teacher choose who the tutor is for: subject, grade band, tone, and language.
 - `SOUL` lets a teacher decide how the tutor reacts when a student is wrong, stuck, or discouraged.
 - `RULES` lets a teacher keep classroom boundaries such as no direct answers, hint limits, or escalation expectations.
-- The dashboard is not only reporting activity; it helps the teacher decide what to reteach, who needs follow-up, and which students can be grouped around the same misconception.
+- The dashboard is not only reporting activity; it helps the teacher review diagnosis, decide what to reteach, who needs follow-up, and which students can be grouped around the same misconception.
 
 The repository now includes bounded proof that the unified live turn paths for `chat`, `deep_question`, and `deep_solve` can carry `config.agent_spec_id` into runtime policy assembly. Do not expand that claim into universal coverage across every capability or entry point unless a fresh verification run proves those additional paths.
 

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -4,11 +4,32 @@ Use this as the short review path before submitting the VnExpress Sang kien Khoa
 
 ## Submission Story
 
-Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with Tutor Agent -> Teacher sees dashboard.
+Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention.
 
 One-line pitch:
 
-An AI-first learning platform where Vietnamese teachers turn their own materials into tutoring, practice, and follow-up insight while staying in control of how the AI teaches.
+A teacher-controlled adaptive tutoring platform where Vietnamese teachers turn their own materials into practice, tutoring, diagnosis review, and follow-up intervention while staying in control of how the AI teaches.
+
+## Scope Freeze
+
+Primary contest scope:
+
+- one official product loop: `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`
+- teacher control over source knowledge, tutor behavior, and intervention choice
+- validated prototype proof only
+
+Secondary supporting scope:
+
+- `/agents` authoring as teacher-control proof
+- marketplace reuse, batch import, export, replay, and offline helpers
+- dashboard evidence as the operator surface around diagnosis and intervention
+
+Out-of-scope claims:
+
+- classroom outcome proof
+- school-scale deployment
+- autonomous final judgment without teacher review
+- universal runtime-binding proof across every entry point
 
 Hybrid proof calibration:
 
@@ -19,6 +40,17 @@ Hybrid proof calibration:
 - Assessment claims should stay at: AI can draft questions and feedback, but teacher review is the primary safety gate before student-facing reuse.
 - Overall product framing should stay at: validated prototype, not school-scale deployment.
 - Architecture framing should stay at: agent-native today, prepared for deeper multi-agent role separation later.
+
+## Claim And Proof Contract
+
+Use these pairings when preparing the final package:
+
+| Claim | Allowed proof source | Guardrail |
+| --- | --- | --- |
+| Teacher-controlled adaptive tutoring loop | [`docs/contest/README.md`](./README.md), [`ai_first/competition/product-description.md`](../../ai_first/competition/product-description.md), screenshots, smoke-backed demo flow | Keep the loop at `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention` |
+| `/agents` improves teacher control | `/agents` screenshots, pitch notes, bounded runtime-binding wording already documented in this package | Do not expand bounded proof into universal entry-point coverage |
+| Diagnosis and recommendations help teacher follow-up | [`DIAGNOSIS_CASE_STUDIES.md`](./DIAGNOSIS_CASE_STUDIES.md), dashboard screenshots, validation-backed walkthrough | Present them as teacher-reviewed hypotheses, not autonomous grading |
+| Submission package is reviewable end to end | this file, [`HUMAN_REVIEW_HANDOFF.md`](./HUMAN_REVIEW_HANDOFF.md), checklist, validation report | Keep Session B validation status authoritative |
 
 Teacher-value shorthand for Q&A:
 
@@ -62,6 +94,17 @@ The latest smoke-backed refresh passed on 2026-04-26 after running the scripted 
 - frontend production build with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
 
 Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` and `#128` for smoke-backed evidence, and `#99` plus `#130` for the screenshot bundle. This validation record supports a validated prototype claim. It does not, by itself, establish classroom deployment or outcome evidence.
+
+## Operator Read Path
+
+Read in this order before final submission:
+
+1. [`docs/contest/SUBMISSION_PACKAGE.md`](./SUBMISSION_PACKAGE.md)
+2. [`docs/contest/HUMAN_REVIEW_HANDOFF.md`](./HUMAN_REVIEW_HANDOFF.md)
+3. [`ai_first/competition/product-description.md`](../../ai_first/competition/product-description.md)
+4. [`ai_first/competition/fork-modifications.md`](../../ai_first/competition/fork-modifications.md)
+5. [`docs/contest/VALIDATION_REPORT.md`](./VALIDATION_REPORT.md)
+6. [`docs/contest/EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md)
 
 ## Human Review Checklist
 

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -84,16 +84,16 @@ Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/com
 
 ## Latest Validation
 
-The latest smoke-backed refresh passed on 2026-04-26 after running the scripted local reset. It verified:
+The latest command-backed smoke refresh passed on 2026-04-28 after running the scripted local reset. It verified:
 
 - demo-safe Knowledge Pack `contest-demo-quadratics`;
 - assessment session `contest-assessment-demo`;
 - tutor session `contest-tutor-demo`;
 - dashboard overview and recent activity including the contest sessions;
-- dashboard evidence-first and `/agents` authoring screenshots were recaptured on 2026-04-26;
-- frontend production build with `NEXT_PUBLIC_API_BASE=http://localhost:8001`.
+- frontend production build with `NEXT_PUBLIC_API_BASE=http://localhost:8001`;
+- retained screenshot freshness authority from the last real browser captures on 2026-04-25 and 2026-04-26.
 
-Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` and `#128` for smoke-backed evidence, and `#99` plus `#130` for the screenshot bundle. This validation record supports a validated prototype claim. It does not, by itself, establish classroom deployment or outcome evidence.
+Detailed command evidence lives in [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md). The refresh lanes are `#96` and `#128` for the earlier smoke-backed evidence foundation, `#99` plus `#130` for the screenshot bundle, and `#212` for the latest Session B validation/evidence refresh. This validation record supports a validated prototype claim. It does not, by itself, establish classroom deployment or outcome evidence.
 
 ## Operator Read Path
 
@@ -106,16 +106,16 @@ Read in this order before final submission:
 5. [`docs/contest/VALIDATION_REPORT.md`](./VALIDATION_REPORT.md)
 6. [`docs/contest/EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md)
 
-## Pending Dependencies
+## Validation Authority
 
-These items are intentionally outside Session A ownership and remain authoritative in their own files:
+These items remain authoritative outside the Session A narrative files and are already merged through the Session B refresh:
 
 | Dependency | Source of truth | Current handling |
 | --- | --- | --- |
-| Core-loop revalidation wording | [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) | Session B-owned |
-| Smoke/reset contract wording | [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md), [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) | Session B-owned |
-| Evidence freshness rows | [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md), [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) | Session B-owned |
-| Final package readiness call | this file plus the files above | blocked until Session B refresh completes |
+| Core-loop revalidation wording | [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) | current after Session B refresh on 2026-04-28 |
+| Smoke/reset contract wording | [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md), [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) | current after Session B refresh on 2026-04-28 |
+| Evidence freshness rows | [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md), [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) | current after Session B refresh on 2026-04-28 |
+| Final package readiness call | this file plus the files above | unblocked for human review; keep Session B files authoritative if wording diverges |
 
 ## Human Review Checklist
 
@@ -131,6 +131,7 @@ Before final submission, a human should review:
 AI-verifiable checklist items are tracked in [`ai_first/competition/submission-checklist.md`](../../ai_first/competition/submission-checklist.md). Human-only items stay unchecked until a final manual review happens.
 Use [`HUMAN_REVIEW_HANDOFF.md`](./HUMAN_REVIEW_HANDOFF.md) for the shortest remaining manual review path.
 If the submission requires video, use [`VIDEO_CAPTURE_RUNBOOK.md`](./VIDEO_CAPTURE_RUNBOOK.md) before recording.
+The package is now ready for final human review, not automatic final sign-off.
 
 ## Known Limitations
 

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -34,7 +34,7 @@ Out-of-scope claims:
 Hybrid proof calibration:
 
 - Teacher authoring capability on `/agents` is part of the merged product story.
-- Contest evidence-loop proof remains anchored to smoke-backed Knowledge Pack -> assessment -> tutor -> dashboard artifacts.
+- Contest evidence-loop proof remains anchored to smoke-backed `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention` walkthrough artifacts, with the dashboard serving as the teacher-facing operating surface around the last two stages.
 - You may claim bounded automated proof that the unified Tutor turn path accepts `config.agent_spec_id` and changes behavior across two contrasting spec packs. Do not expand that into universal live turn-time binding unless broader paths are re-verified in the target demo environment.
 - Diagnosis claims should stay at: rule-assisted, confidence-tagged, teacher-reviewed hypothesis layer. Do not present the diagnosis engine as a benchmarked autonomous assessor.
 - Assessment claims should stay at: AI can draft questions and feedback, but teacher review is the primary safety gate before student-facing reuse.
@@ -105,6 +105,17 @@ Read in this order before final submission:
 4. [`ai_first/competition/fork-modifications.md`](../../ai_first/competition/fork-modifications.md)
 5. [`docs/contest/VALIDATION_REPORT.md`](./VALIDATION_REPORT.md)
 6. [`docs/contest/EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md)
+
+## Pending Dependencies
+
+These items are intentionally outside Session A ownership and remain authoritative in their own files:
+
+| Dependency | Source of truth | Current handling |
+| --- | --- | --- |
+| Core-loop revalidation wording | [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) | Session B-owned |
+| Smoke/reset contract wording | [`SMOKE_RUNBOOK.md`](./SMOKE_RUNBOOK.md), [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) | Session B-owned |
+| Evidence freshness rows | [`EVIDENCE_CHECKLIST.md`](./EVIDENCE_CHECKLIST.md), [`VALIDATION_REPORT.md`](./VALIDATION_REPORT.md) | Session B-owned |
+| Final package readiness call | this file plus the files above | blocked until Session B refresh completes |
 
 ## Human Review Checklist
 

--- a/docs/superpowers/pr-notes/2026-04-28-session-a-submission-scope-freeze.md
+++ b/docs/superpowers/pr-notes/2026-04-28-session-a-submission-scope-freeze.md
@@ -1,0 +1,28 @@
+# PR Note: Session A Submission Scope Freeze
+
+## Summary
+
+This PR freezes the contest narrative around one teacher-controlled adaptive tutoring loop, adds a bounded claim-and-proof contract for submission wording, and converts the final manual review path into explicit gates without touching validation-owned evidence files.
+
+## Architecture Impact
+
+- No runtime or product modules changed.
+- Contest-facing docs now share one authoritative loop and one operator read path.
+- Session B remains the source of truth for validation and evidence freshness.
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  Scope["Scope Freeze"]
+  Claim["Claim And Proof Contract"]
+  Operator["Operator Read Path"]
+  Gates["Human Review Gates"]
+  Validation["Session B Validation Files"]
+
+  Scope --> Claim
+  Claim --> Operator
+  Operator --> Gates
+  Validation --> Operator
+  Validation --> Gates
+```

--- a/docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md
+++ b/docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md
@@ -65,6 +65,7 @@ Freeze the contest submission story, claims, operator-facing read path, and manu
 - 2026-04-28: `PR-CLOSE-01` and `PR-CLOSE-02` are being executed together as a docs-only scope and claim freeze across the owned narrative files.
 - 2026-04-28: `PR-CLOSE-06`, `PR-CLOSE-07`, and `PR-CLOSE-08` are limited to skeleton/operator-gate wording until Session B refreshes validation-owned proof files.
 - 2026-04-28: Draft PR `#211` was opened for the current docs-only Session A freeze set.
+- 2026-04-28: Session A merged `origin/main` after Session B landed, re-read the authoritative validation/evidence files, and executed `PR-CLOSE-09 Final Package Readiness` inside the owned package/handoff docs.
 
 ## Handoff Notes
 
@@ -74,13 +75,14 @@ Freeze the contest submission story, claims, operator-facing read path, and manu
   - `PR-CLOSE-01 Submission Scope Freeze`
   - `PR-CLOSE-02 Claim and Proof Contract Freeze`
   - narrative/operator/gate portions of `PR-CLOSE-06`, `PR-CLOSE-07`, and `PR-CLOSE-08`
+  - `PR-CLOSE-09 Final Package Readiness` after Session B merged its proof refresh
 - Deliberately not edited because they are outside owned scope:
   - `docs/contest/VALIDATION_REPORT.md`
   - `docs/contest/SMOKE_RUNBOOK.md`
   - `docs/contest/DEMO_DATA_RESET.md`
   - `docs/contest/EVIDENCE_CHECKLIST.md`
-- Known dependency gap:
-  - Session B-owned validation and evidence files still carry the authoritative proof freshness state and may still use older loop wording until their lane refreshes them.
-- Safe next step for Session A after Session B lands:
-  - re-read `docs/contest/VALIDATION_REPORT.md` and `docs/contest/EVIDENCE_CHECKLIST.md`
-  - only then decide whether `PR-CLOSE-09 Final Package Readiness` can be declared without widening any claims
+- Current dependency rule:
+  - Session B-owned validation and evidence files remain authoritative for proof freshness, smoke wording, and screenshot dates.
+- Safe next step for Session A:
+  - keep PR `#211` aligned with the merged Session B files
+  - hand the package to a human reviewer without widening any claims beyond the validated-prototype contract

--- a/docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md
+++ b/docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md
@@ -64,3 +64,4 @@ Freeze the contest submission story, claims, operator-facing read path, and manu
 - 2026-04-28: Session A started from `.worktrees/submission-close-a` on branch `docs/submission-close-session-a`.
 - 2026-04-28: `PR-CLOSE-01` and `PR-CLOSE-02` are being executed together as a docs-only scope and claim freeze across the owned narrative files.
 - 2026-04-28: `PR-CLOSE-06`, `PR-CLOSE-07`, and `PR-CLOSE-08` are limited to skeleton/operator-gate wording until Session B refreshes validation-owned proof files.
+- 2026-04-28: Draft PR `#211` was opened for the current docs-only Session A freeze set.

--- a/docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md
+++ b/docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md
@@ -58,3 +58,9 @@ Freeze the contest submission story, claims, operator-facing read path, and manu
 - Keep all claims at validated-prototype level unless Session B refreshes stronger evidence.
 - Do not silently widen the product story beyond `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`.
 - Keep the final operator read path link-heavy and conflict-light.
+
+## Session A Progress Notes
+
+- 2026-04-28: Session A started from `.worktrees/submission-close-a` on branch `docs/submission-close-session-a`.
+- 2026-04-28: `PR-CLOSE-01` and `PR-CLOSE-02` are being executed together as a docs-only scope and claim freeze across the owned narrative files.
+- 2026-04-28: `PR-CLOSE-06`, `PR-CLOSE-07`, and `PR-CLOSE-08` are limited to skeleton/operator-gate wording until Session B refreshes validation-owned proof files.

--- a/docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md
+++ b/docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md
@@ -65,3 +65,22 @@ Freeze the contest submission story, claims, operator-facing read path, and manu
 - 2026-04-28: `PR-CLOSE-01` and `PR-CLOSE-02` are being executed together as a docs-only scope and claim freeze across the owned narrative files.
 - 2026-04-28: `PR-CLOSE-06`, `PR-CLOSE-07`, and `PR-CLOSE-08` are limited to skeleton/operator-gate wording until Session B refreshes validation-owned proof files.
 - 2026-04-28: Draft PR `#211` was opened for the current docs-only Session A freeze set.
+
+## Handoff Notes
+
+- Current PR: `#211`
+- Current branch head: Session A has already pushed the docs-only freeze set to `origin/docs/submission-close-session-a`.
+- Completed inside owned scope:
+  - `PR-CLOSE-01 Submission Scope Freeze`
+  - `PR-CLOSE-02 Claim and Proof Contract Freeze`
+  - narrative/operator/gate portions of `PR-CLOSE-06`, `PR-CLOSE-07`, and `PR-CLOSE-08`
+- Deliberately not edited because they are outside owned scope:
+  - `docs/contest/VALIDATION_REPORT.md`
+  - `docs/contest/SMOKE_RUNBOOK.md`
+  - `docs/contest/DEMO_DATA_RESET.md`
+  - `docs/contest/EVIDENCE_CHECKLIST.md`
+- Known dependency gap:
+  - Session B-owned validation and evidence files still carry the authoritative proof freshness state and may still use older loop wording until their lane refreshes them.
+- Safe next step for Session A after Session B lands:
+  - re-read `docs/contest/VALIDATION_REPORT.md` and `docs/contest/EVIDENCE_CHECKLIST.md`
+  - only then decide whether `PR-CLOSE-09 Final Package Readiness` can be declared without widening any claims


### PR DESCRIPTION
## Summary
- freeze the Session A contest narrative around `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`
- add a bounded claim-and-proof contract plus operator read path in the submission package
- convert the manual close path into explicit human review gates without editing Session B validation-owned files

## Why
Session A owns the narrative and packaging skeleton for the submission-close train. This PR establishes one source of truth for product framing so Session B can validate against a stable contract instead of drifting wording.

## Validation
- `git diff --check`
- `rg -n "Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention|validated prototype|teacher-controlled adaptive tutoring" ai_first/competition docs/contest docs/superpowers/tasks/2026-04-28-session-a-submission-scope-and-narrative.md`

## Notes
- Session B-owned validation/evidence files still carry older loop wording and remain authoritative for proof freshness until that lane refreshes them.
- `PR-CLOSE-09 Final Package Readiness` remains blocked on Session B outputs, especially `PR-CLOSE-05`.