### PR TITLE
feat(ui): polish core loop visibility [C212]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -91,14 +91,14 @@ Rules:
 ### Planned Assignment
 
 - Owner: Session C
-- Machine:
+- Machine: local
 - Worktree: `.worktrees/submission-close-c`
-- Task: `OPS_SUBMISSION_CLOSE_C`
-- Status: planned
+- Task: `C212_CORE_LOOP_VISIBILITY_POLISH`
+- Status: in-progress
 - Branch: `fix/submission-close-session-c`
-- Task packet: `docs/superpowers/tasks/2026-04-28-session-c-runtime-fix-and-polish.md`
-- Owned files: runtime fixes and optional polish only
+- Task packet: `docs/superpowers/tasks/2026-04-28-c212-core-loop-visibility-polish.md`
+- Owned files: core-loop visibility polish on contest-facing frontend surfaces
 - PR:
 - Last update: 2026-04-28
-- Next action: remain on standby unless a human explicitly opens optional Phase 2 polish or a new blocker appears
+- Next action: implement `PR-POLISH-02` on the bounded Knowledge, Assessment, Tutor, and Dashboard surfaces, then validate with lint and build
 - Blocker:

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -2115,9 +2115,10 @@
       "dependencies": [
         "C210_FINAL_PACKAGE_READINESS"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-c-polish",
-      "layer": "optional-polish"
+      "layer": "optional-polish",
+      "notes": "Activated on branch fix/submission-close-session-c on 2026-04-28. Scope is bounded to loop-visibility labels on existing Knowledge, Assessment, Tutor, and Dashboard surfaces."
     },
     {
       "id": "C213_DIFFERENTIATION_WORDING_SWEEP",

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,16 @@
 # Daily Log: 2026-04-28
 
+## C212_CORE_LOOP_VISIBILITY_POLISH
+
+- Branch: `fix/submission-close-session-c`
+- Task: `C212_CORE_LOOP_VISIBILITY_POLISH`
+- Done: Opened the Session C worktree from `origin/main`, created a dedicated spec, plan, and task packet, and moved the task to `in-progress`.
+- Done: Added a shared contest-loop visibility strip and inserted it into the Knowledge, Assessment Review, Tutor Chat, and Dashboard screens.
+- Done: Added the required PR note and kept the polish inside bounded frontend surfaces without changing submission docs or runtime behavior.
+- Tests: pending frontend lint/build pass for the touched files; `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: none yet
+- Next: run targeted frontend validation, then open the Session C optional-polish PR if checks are green.
+
 ## OPS_POST_SUBMISSION_CLOSE_SYNC
 
 - Branch: `docs/post-submission-close-sync`

--- a/docs/superpowers/plans/2026-04-28-c212-core-loop-visibility-polish.md
+++ b/docs/superpowers/plans/2026-04-28-c212-core-loop-visibility-polish.md
@@ -1,0 +1,89 @@
+# C212 Core Loop Visibility Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bounded, reusable contest-loop visibility strip to the key Knowledge, Assessment, Tutor, and Dashboard screens so the five-step submission story is visible in-product.
+
+**Architecture:** Build one shared React component for the loop strip, then place it in the four scoped screens using screen-specific current-step and helper text props. Keep styling consistent with existing card headers and avoid any routing, data, or backend changes.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript, Tailwind utility classes, lucide-react, existing `react-i18next` usage.
+
+---
+
+## File Structure
+
+- Create: `web/components/contest/CoreLoopVisibilityStrip.tsx`
+  Responsibility: render the five-step contest loop with current-step and next-step emphasis.
+- Modify: `web/app/(utility)/knowledge/page.tsx`
+  Responsibility: show the loop at the source-knowledge stage.
+- Modify: `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+  Responsibility: show the loop at the assessment stage.
+- Modify: `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+  Responsibility: show the loop at the tutor stage in a compact layout.
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+  Responsibility: show the loop at the diagnosis stage and frame intervention as the next move.
+
+## Task 1: Create the shared visibility strip
+
+**Files:**
+- Create: `web/components/contest/CoreLoopVisibilityStrip.tsx`
+
+- [ ] Define a fixed ordered step list with the labels `Knowledge Pack`, `Assessment`, `Tutor`, `Diagnosis`, and `Intervention`.
+- [ ] Implement typed props for `currentStep`, optional `nextStep`, optional `compact`, and optional `helperText`.
+- [ ] Render a label, helper text, and step pills with three visual states: active, next, and inactive.
+- [ ] Keep the component wrapping cleanly on mobile by using flex-wrap and compact text sizing.
+
+## Task 2: Add the strip to Knowledge
+
+**Files:**
+- Modify: `web/app/(utility)/knowledge/page.tsx`
+
+- [ ] Import the shared strip.
+- [ ] Add the strip to the page header area with `currentStep="Knowledge Pack"` and `nextStep="Assessment"`.
+- [ ] Use helper text that frames the page as the teacher-owned source material stage.
+
+## Task 3: Add the strip to Assessment review
+
+**Files:**
+- Modify: `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+
+- [ ] Import the shared strip.
+- [ ] Insert it below the main header and above the existing three summary cards.
+- [ ] Set `currentStep="Assessment"` and `nextStep="Tutor"` with helper text that preserves the teacher review safety framing.
+
+## Task 4: Add the strip to Tutor chat
+
+**Files:**
+- Modify: `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+
+- [ ] Import the shared strip.
+- [ ] Place it below the slim chat header and above the message list.
+- [ ] Use `compact` mode with `currentStep="Tutor"` and `nextStep="Diagnosis"` so the chat screen keeps its minimal density.
+
+## Task 5: Add the strip to Dashboard
+
+**Files:**
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+
+- [ ] Import the shared strip.
+- [ ] Place it inside the hero card above the existing workflow summary blocks.
+- [ ] Set `currentStep="Diagnosis"` and `nextStep="Intervention"` with helper text that keeps the dashboard framed as a teacher action surface.
+
+## Task 6: Validation and PR metadata
+
+**Files:**
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-28.md`
+- Create: `docs/superpowers/pr-notes/2026-04-28-c212-core-loop-visibility-polish.md`
+
+- [ ] Mark Session C active for `C212`.
+- [ ] Move `C212_CORE_LOOP_VISIBILITY_POLISH` to `in-progress`.
+- [ ] Record the implementation and validation commands in the daily log.
+- [ ] Add the required PR note with a Mermaid diagram and state that `MAIN_SYSTEM_MAP.md` was not updated.
+
+## Validation
+
+- [ ] Run: `cd web && npx eslint app/'(utility)'/knowledge/page.tsx app/'(workspace)'/dashboard/page.tsx app/'(workspace)'/dashboard/assessments/[sessionId]/page.tsx app/'(workspace)'/agents/[botId]/chat/page.tsx components/contest/*.tsx`
+- [ ] Run: `cd web && npm run build`
+- [ ] Run: `git diff --check`

--- a/docs/superpowers/pr-notes/2026-04-28-c212-core-loop-visibility-polish.md
+++ b/docs/superpowers/pr-notes/2026-04-28-c212-core-loop-visibility-polish.md
@@ -1,0 +1,28 @@
+# PR Note: C212 Core Loop Visibility Polish
+
+## Summary
+
+- add a shared contest-loop visibility strip for existing product screens
+- show the five-step loop on Knowledge, Assessment, Tutor, and Dashboard
+- keep the polish bounded to UI framing without changing runtime behavior or submission docs
+
+## Architecture Impact
+
+- No backend or runtime contracts changed.
+- No submission-doc claims changed.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR is bounded UI polish only.
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  K["Knowledge Pack"] --> A["Assessment"]
+  A --> T["Tutor"]
+  T --> D["Diagnosis"]
+  D --> I["Intervention"]
+
+  K --> UI["Shared loop strip"]
+  A --> UI
+  T --> UI
+  D --> UI
+```

--- a/docs/superpowers/specs/2026-04-28-c212-core-loop-visibility-polish-design.md
+++ b/docs/superpowers/specs/2026-04-28-c212-core-loop-visibility-polish-design.md
@@ -1,0 +1,102 @@
+# C212 Core Loop Visibility Polish Design
+
+Date: 2026-04-28
+Status: Approved by execution assumption
+Task: `C212_CORE_LOOP_VISIBILITY_POLISH`
+
+## Goal
+
+Make the contest loop `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention` more visible across the existing product surfaces without redesigning the app or changing submission claims.
+
+## Assumption
+
+Because the user explicitly asked to continue without more questions, this design assumes the safest bounded Phase 2 option:
+
+- emphasize the loop with inline status labels on existing screens;
+- do not add a new cross-app wizard, route, or persistent global shell;
+- do not rewrite Session A or Session B submission docs from this lane.
+
+## Scope
+
+This polish is limited to four contest-facing surfaces already central to the demo path:
+
+1. `web/app/(utility)/knowledge/page.tsx`
+2. `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+3. `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+4. `web/app/(workspace)/dashboard/page.tsx`
+
+Plus one new shared component under `web/components/`.
+
+## Non-goals
+
+- no new product claims;
+- no new API or backend logic;
+- no route structure changes;
+- no large visual redesign;
+- no contest-doc wording edits from this lane;
+- no screenshot or evidence refresh inside this PR.
+
+## UX approach
+
+Add one reusable “core loop visibility” strip that:
+
+- lists the five contest steps in order;
+- highlights the current step on the current screen;
+- optionally shows which step comes next;
+- uses the existing card/border/muted styling language so the polish looks native to the repo;
+- wraps cleanly on mobile instead of forcing a long horizontal scroller.
+
+## Screen mapping
+
+### Knowledge page
+
+- Current step: `Knowledge Pack`
+- Purpose: establish the teacher-owned source of truth
+- Placement: inside the top page header region, before the rest of the management UI
+
+### Assessment review page
+
+- Current step: `Assessment`
+- Purpose: show that the teacher is reviewing the second step in the same contest loop
+- Placement: directly below the page header and above the “Next Steps / Knowledge Pack / Overall Score” summary cards
+
+### Tutor chat page
+
+- Current step: `Tutor`
+- Purpose: make the tutoring stage legible even in a minimal chat shell
+- Placement: below the tutor header and above the message list
+
+### Dashboard page
+
+- Current step: `Diagnosis`
+- Secondary callout: `Intervention` as the next teacher-facing move
+- Purpose: show the dashboard as the teacher action surface around the final two loop stages
+- Placement: inside the hero header card above the existing workflow summary
+
+## Component contract
+
+Create a shared component that accepts:
+
+- `currentStep`
+- optional `nextStep`
+- optional `compact`
+- optional short screen-specific helper text
+
+The component should render:
+
+- a small uppercase contest-loop label;
+- a short helper sentence;
+- five step pills with active/inactive/next styling.
+
+## Acceptance criteria
+
+- A teacher or judge can identify the current contest-loop step within a few seconds on each touched screen.
+- The loop wording stays exactly aligned with Session A: `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`.
+- The dashboard still reads as a teacher action surface, not as an autonomous final judgment engine.
+- The polish remains mobile-safe and visually consistent with the existing UI.
+
+## Validation plan
+
+- run targeted lint on touched frontend files;
+- run a production frontend build;
+- verify no TypeScript or formatting regressions are introduced.

--- a/docs/superpowers/tasks/2026-04-28-c212-core-loop-visibility-polish.md
+++ b/docs/superpowers/tasks/2026-04-28-c212-core-loop-visibility-polish.md
@@ -1,0 +1,63 @@
+# Feature Pod Task: C212 Core Loop Visibility Polish
+
+Task ID: `C212_CORE_LOOP_VISIBILITY_POLISH`
+Commit tag: `C212`
+Owner: Session C
+Branch: `fix/submission-close-session-c`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Make the five-step contest loop more visible across existing teacher-facing product screens with bounded UI polish only.
+
+## User-visible outcome
+
+- Knowledge, Assessment, Tutor, and Dashboard screens visibly map to the same contest loop.
+- The current step is obvious without reading contest docs first.
+- The dashboard still reads as diagnosis/intervention support, not autonomous judgment.
+
+## Owned files/modules
+
+- `docs/superpowers/specs/2026-04-28-c212-core-loop-visibility-polish-design.md`
+- `docs/superpowers/plans/2026-04-28-c212-core-loop-visibility-polish.md`
+- `docs/superpowers/tasks/2026-04-28-c212-core-loop-visibility-polish.md`
+- `docs/superpowers/pr-notes/2026-04-28-c212-core-loop-visibility-polish.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+- `web/components/contest/`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx`
+- `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+
+## Do-not-touch files/modules
+
+- `docs/contest/`
+- `ai_first/competition/`
+- `deeptutor/`
+- `web/app/(workspace)/dashboard/student/page.tsx`
+- `web/components/dashboard/TeacherInsightPanel.tsx`
+- lockfiles unless a dependency change becomes strictly necessary
+
+## Constraints
+
+- Keep the exact loop wording: `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`.
+- Do not add new routes, APIs, or stateful flows.
+- Do not widen the polish beyond the four scoped screens and one shared component family.
+- Keep mobile layout safe and avoid a forced horizontal scroll strip.
+
+## Required tests
+
+- `cd web && npx eslint app/'(utility)'/knowledge/page.tsx app/'(workspace)'/dashboard/page.tsx app/'(workspace)'/dashboard/assessments/[sessionId]/page.tsx app/'(workspace)'/agents/[botId]/chat/page.tsx components/contest/*.tsx`
+- `cd web && npm run build`
+- `git diff --check`
+
+## PR ownership
+
+- `PR-POLISH-02 Core Loop Visibility Polish`
+
+## Architecture note
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not expected to change unless implementation escapes bounded UI polish.

--- a/web/app/(utility)/knowledge/page.tsx
+++ b/web/app/(utility)/knowledge/page.tsx
@@ -36,6 +36,7 @@ import {
   invalidateNotebookCaches,
   listNotebooks,
 } from "@/lib/notebook-api";
+import { CoreLoopVisibilityStrip } from "@/components/contest/CoreLoopVisibilityStrip";
 
 const MarkdownRenderer = dynamic(() => import("@/components/common/MarkdownRenderer"), {
   ssr: false,
@@ -759,7 +760,7 @@ export default function KnowledgePage() {
       return t("This knowledge base is currently {{status}} and cannot accept uploads yet.", { status: status.replaceAll("_", " ") });
     }
     return null;
-  }, [uploadTargetKb]);
+  }, [t, uploadTargetKb]);
 
   const uploadDisabled =
     !uploadTarget || !uploadFiles.length || !!uploadingKb || Boolean(uploadBlockedReason);
@@ -804,6 +805,12 @@ export default function KnowledgePage() {
             ))}
           </div>
         </div>
+
+        <CoreLoopVisibilityStrip
+          currentStep="Knowledge Pack"
+          nextStep="Assessment"
+          helperText={t("Start with teacher-owned source material so every later step stays grounded in the same classroom knowledge pack.")}
+        />
 
         {pageError && (
           <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">

--- a/web/app/(workspace)/agents/[botId]/chat/page.tsx
+++ b/web/app/(workspace)/agents/[botId]/chat/page.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { ArrowLeft, Bot, Loader2, Send } from "lucide-react";
 import { apiUrl, wsUrl } from "@/lib/api";
 import AssistantResponse from "@/components/common/AssistantResponse";
+import { CoreLoopVisibilityStrip } from "@/components/contest/CoreLoopVisibilityStrip";
 
 interface BotInfo {
   bot_id: string;
@@ -140,6 +141,17 @@ export default function BotChatPage() {
         {bot?.running && (
           <span className="h-2 w-2 rounded-full bg-emerald-500" />
         )}
+      </div>
+
+      <div className="border-b border-[var(--border)] px-5 py-3">
+        <div className="mx-auto max-w-[720px]">
+          <CoreLoopVisibilityStrip
+            compact
+            currentStep="Tutor"
+            nextStep="Diagnosis"
+            helperText={t("Tutor replies are one step in the same classroom loop before the teacher reviews diagnosis and chooses the next intervention.")}
+          />
+        </div>
       </div>
 
       {/* Messages */}

--- a/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
+++ b/web/app/(workspace)/dashboard/assessments/[sessionId]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { AssessmentRubricReviewCard } from "@/components/assessment/AssessmentRubricReviewCard";
 import { ProgressIndicator } from "@/components/assessment/ProgressIndicator";
 import { LearningJourneySummary } from "@/components/assessment/LearningJourneySummary";
+import { CoreLoopVisibilityStrip } from "@/components/contest/CoreLoopVisibilityStrip";
 
 function formatTime(value: number): string {
   if (!value) return "";
@@ -161,6 +162,12 @@ export default function AssessmentReviewPage() {
             {exporting ? t("Exporting PDF...") : t("Export PDF")}
           </button>
         </header>
+
+        <CoreLoopVisibilityStrip
+          currentStep="Assessment"
+          nextStep="Tutor"
+          helperText={t("This review keeps the assessment stage visible before students move into tutor support and later teacher diagnosis.")}
+        />
 
         <section className="grid gap-3 md:grid-cols-3">
           <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-sm">

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Activity, ArrowRight, BookOpen, CheckCircle2, Filter, Loader2, PenLine, Search, Users } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { TeacherInsightPanel } from "@/components/dashboard/TeacherInsightPanel";
+import { CoreLoopVisibilityStrip } from "@/components/contest/CoreLoopVisibilityStrip";
 import {
   getDashboardInsights,
   getDashboardOverview,
@@ -142,6 +143,13 @@ export default function DashboardPage() {
               {t("Open student progress")}
               <ArrowRight size={15} />
             </Link>
+          </div>
+          <div className="mt-4">
+            <CoreLoopVisibilityStrip
+              currentStep="Diagnosis"
+              nextStep="Intervention"
+              helperText={t("This dashboard turns observed activity into teacher-reviewed diagnosis and the next intervention decision, not autonomous final judgment.")}
+            />
           </div>
           <div className="mt-4 grid gap-3 md:grid-cols-3">
             <div className="rounded-xl bg-[var(--background)] px-4 py-3">

--- a/web/components/contest/CoreLoopVisibilityStrip.tsx
+++ b/web/components/contest/CoreLoopVisibilityStrip.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+export type CoreLoopStep =
+  | "Knowledge Pack"
+  | "Assessment"
+  | "Tutor"
+  | "Diagnosis"
+  | "Intervention";
+
+const CORE_LOOP_STEPS: CoreLoopStep[] = [
+  "Knowledge Pack",
+  "Assessment",
+  "Tutor",
+  "Diagnosis",
+  "Intervention",
+];
+
+interface CoreLoopVisibilityStripProps {
+  currentStep: CoreLoopStep;
+  nextStep?: CoreLoopStep;
+  helperText?: string;
+  compact?: boolean;
+}
+
+export function CoreLoopVisibilityStrip({
+  currentStep,
+  nextStep,
+  helperText,
+  compact = false,
+}: CoreLoopVisibilityStripProps) {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      className={`rounded-2xl border border-[var(--border)] bg-[var(--background)]/70 ${
+        compact ? "px-3 py-3" : "px-4 py-4"
+      }`}
+    >
+      <div className="flex flex-col gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+          {t("Contest loop")}
+        </div>
+        <p className={`${compact ? "text-[12px]" : "text-[13px]"} text-[var(--muted-foreground)]`}>
+          {helperText || t("Follow the same five-step classroom loop across the product.")}
+        </p>
+      </div>
+
+      <div className={`mt-3 flex flex-wrap gap-2 ${compact ? "text-[11px]" : "text-[12px]"}`}>
+        {CORE_LOOP_STEPS.map((step) => {
+          const isCurrent = step === currentStep;
+          const isNext = step === nextStep;
+
+          return (
+            <span
+              key={step}
+              className={`inline-flex items-center rounded-full border px-3 py-1.5 font-medium transition-colors ${
+                isCurrent
+                  ? "border-[var(--foreground)] bg-[var(--foreground)] text-[var(--background)]"
+                  : isNext
+                    ? "border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-200"
+                    : "border-[var(--border)] bg-[var(--card)] text-[var(--muted-foreground)]"
+              }`}
+            >
+              {step}
+            </span>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
# PR Note: C212 Core Loop Visibility Polish

## Summary

- add a shared contest-loop visibility strip for existing product screens
- show the five-step loop on Knowledge, Assessment, Tutor, and Dashboard
- keep the polish bounded to UI framing without changing runtime behavior or submission docs

## Architecture Impact

- No backend or runtime contracts changed.
- No submission-doc claims changed.
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this PR is bounded UI polish only.

## Mermaid

```mermaid
flowchart LR
  K["Knowledge Pack"] --> A["Assessment"]
  A --> T["Tutor"]
  T --> D["Diagnosis"]
  D --> I["Intervention"]

  K --> UI["Shared loop strip"]
  A --> UI
  T --> UI
  D --> UI
```
