### PR TITLE
fix: align adaptive tutor framing

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -88,17 +88,17 @@ Rules:
 - Next action: keep the 2026-04-28 command-backed validation refresh as the authoritative proof baseline unless a later smoke pass replaces it
 - Blocker:
 
-### Planned Assignment
+### Active Assignment
 
 - Owner: Session C
 - Machine: local
 - Worktree: `.worktrees/submission-close-c`
-- Task: `C212_CORE_LOOP_VISIBILITY_POLISH`
+- Task: `C213_DIFFERENTIATION_WORDING_SWEEP`
 - Status: in-progress
-- Branch: `fix/submission-close-session-c`
-- Task packet: `docs/superpowers/tasks/2026-04-28-c212-core-loop-visibility-polish.md`
-- Owned files: core-loop visibility polish on contest-facing frontend surfaces
+- Branch: `fix/submission-close-c213`
+- Task packet: `docs/superpowers/tasks/2026-04-28-c213-differentiation-wording-sweep.md`
+- Owned files: contest-facing wording-only polish on bounded frontend surfaces plus required AI-first mirrors
 - PR:
 - Last update: 2026-04-28
-- Next action: implement `PR-POLISH-02` on the bounded Knowledge, Assessment, Tutor, and Dashboard surfaces, then validate with lint and build
+- Next action: implement the wording sweep on Knowledge, Dashboard, Tutor, and Spec Pack authoring surfaces, then validate with lint and build
 - Blocker:

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -2115,10 +2115,10 @@
       "dependencies": [
         "C210_FINAL_PACKAGE_READINESS"
       ],
-      "status": "in-progress",
+      "status": "completed",
       "recommended_session_bucket": "session-c-polish",
       "layer": "optional-polish",
-      "notes": "Activated on branch fix/submission-close-session-c on 2026-04-28. Scope is bounded to loop-visibility labels on existing Knowledge, Assessment, Tutor, and Dashboard surfaces."
+      "notes": "Merged to main through PR #214 on 2026-04-28. Scope stayed bounded to loop-visibility labels on existing Knowledge, Assessment, Tutor, and Dashboard surfaces."
     },
     {
       "id": "C213_DIFFERENTIATION_WORDING_SWEEP",
@@ -2139,9 +2139,10 @@
       "dependencies": [
         "C210_FINAL_PACKAGE_READINESS"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-c-polish",
-      "layer": "optional-polish"
+      "layer": "optional-polish",
+      "notes": "Activated on branch fix/submission-close-c213 on 2026-04-28. Scope is bounded to contest-facing wording only on existing frontend surfaces and required AI-first mirrors."
     },
     {
       "id": "C214_JUDGE_FACING_VISUAL_ASSET_POLISH",

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,15 @@
 # Daily Log: 2026-04-28
 
+## C213_DIFFERENTIATION_WORDING_SWEEP
+
+- Branch: `fix/submission-close-c213`
+- Task: `C213_DIFFERENTIATION_WORDING_SWEEP`
+- Done: Opened a fresh Session C optional-polish lane from updated `origin/main` and created the dedicated spec, plan, task packet, and PR note for the wording sweep.
+- Done: Moved the AI-first mirrors forward so `C212` is recorded completed and `C213` is tracked as the active wording-only polish task.
+- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: none yet
+- Next: apply the bounded wording pass to Dashboard, Tutor, Knowledge, and Spec Pack authoring surfaces, then run frontend lint/build validation.
+
 ## C212_CORE_LOOP_VISIBILITY_POLISH
 
 - Branch: `fix/submission-close-session-c`
@@ -7,9 +17,9 @@
 - Done: Opened the Session C worktree from `origin/main`, created a dedicated spec, plan, and task packet, and moved the task to `in-progress`.
 - Done: Added a shared contest-loop visibility strip and inserted it into the Knowledge, Assessment Review, Tutor Chat, and Dashboard screens.
 - Done: Added the required PR note and kept the polish inside bounded frontend surfaces without changing submission docs or runtime behavior.
-- Tests: pending frontend lint/build pass for the touched files; `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`; `cd web && npx eslint "app/(utility)/knowledge/page.tsx" "app/(workspace)/dashboard/page.tsx" "app/(workspace)/dashboard/assessments/[sessionId]/page.tsx" "app/(workspace)/agents/[botId]/chat/page.tsx" "components/contest/*.tsx"`; `cd web && npm run build`
 - Blockers: none yet
-- Next: run targeted frontend validation, then open the Session C optional-polish PR if checks are green.
+- Next: merged to `main` through PR `#214`; if Session C continues, open the next optional polish lane from refreshed `origin/main`.
 
 ## OPS_POST_SUBMISSION_CLOSE_SYNC
 

--- a/docs/superpowers/plans/2026-04-28-c213-differentiation-wording-sweep.md
+++ b/docs/superpowers/plans/2026-04-28-c213-differentiation-wording-sweep.md
@@ -1,0 +1,116 @@
+# C213 Differentiation Wording Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align contest-facing UI copy with the teacher-controlled adaptive tutor framing without changing behavior.
+
+**Architecture:** This plan is a wording-only sweep across existing frontend surfaces plus the required AI-first tracking mirrors. The implementation keeps existing components and flows intact, changing only contest-facing text and control-plane task status.
+
+**Tech Stack:** Next.js, React, TypeScript, Tailwind CSS, Markdown AI-first operating docs
+
+---
+
+### Task 1: Open the `C213` lane contract
+
+**Files:**
+- Create: `docs/superpowers/tasks/2026-04-28-c213-differentiation-wording-sweep.md`
+- Create: `docs/superpowers/pr-notes/2026-04-28-c213-differentiation-wording-sweep.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-28.md`
+
+- [ ] **Step 1: Write the lane packet and PR note**
+
+```md
+Task ID: C213_DIFFERENTIATION_WORDING_SWEEP
+Commit tag: C213
+Scope: wording-only sweep on bounded contest-facing frontend surfaces
+```
+
+- [ ] **Step 2: Move the AI-first mirrors to the active lane**
+
+Run: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+Expected: command exits successfully after `C212` is recorded as completed and `C213` is recorded as in-progress.
+
+- [ ] **Step 3: Record the daily log handoff**
+
+```md
+## C213_DIFFERENTIATION_WORDING_SWEEP
+- Branch: `fix/submission-close-c213`
+- Task: `C213_DIFFERENTIATION_WORDING_SWEEP`
+- Done: opened bounded wording-only polish lane
+```
+
+### Task 2: Reframe the contest-facing copy
+
+**Files:**
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+- Modify: `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+- Modify: `web/app/(utility)/knowledge/page.tsx`
+- Modify: `web/components/agents/SpecPackAuthoringTab.tsx`
+- Modify: `web/components/contest/CoreLoopVisibilityStrip.tsx`
+
+- [ ] **Step 1: Update the dashboard hero and helper text**
+
+```tsx
+{t("Teacher-controlled adaptive loop")}
+{t("Teacher-reviewed signals, adaptive next steps")}
+{t("Review observed evidence first, then choose the clearest adaptive classroom move for each student or group.")}
+```
+
+- [ ] **Step 2: Update tutor chat framing**
+
+```tsx
+helperText={t("Tutor replies provide adaptive practice inside the same teacher-controlled loop before diagnosis review and intervention selection.")}
+{t("Continue guided tutoring with {{name}}", { name: bot?.name ?? botId })}
+```
+
+- [ ] **Step 3: Update knowledge and spec-pack framing**
+
+```tsx
+helperText={t("Start with teacher-owned source material so the adaptive tutor, assessment, and teacher review all stay grounded in the same classroom knowledge pack.")}
+{t("Shape the adaptive tutor for this class")}
+{t("No spec packs yet. Start with a teacher-controlled adaptive tutor.")}
+```
+
+- [ ] **Step 4: Keep the shared strip default aligned**
+
+```tsx
+{helperText || t("Track the same teacher-guided adaptive loop across the product.")}
+```
+
+### Task 3: Validate and prepare review
+
+**Files:**
+- Modify: `docs/superpowers/tasks/2026-04-28-c213-differentiation-wording-sweep.md`
+
+- [ ] **Step 1: Run targeted validation**
+
+Run: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+Expected: PASS
+
+Run: `git diff --check`
+Expected: no output
+
+Run: `cd web && npx eslint "app/(utility)/knowledge/page.tsx" "app/(workspace)/dashboard/page.tsx" "app/(workspace)/agents/[botId]/chat/page.tsx" "components/agents/SpecPackAuthoringTab.tsx" "components/contest/CoreLoopVisibilityStrip.tsx"`
+Expected: PASS
+
+Run: `cd web && npm run build`
+Expected: production build succeeds
+
+- [ ] **Step 2: Update the task packet with validation evidence and merge status**
+
+```md
+Validation:
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`
+- `cd web && npx eslint ...`
+- `cd web && npm run build`
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ai_first/TASK_REGISTRY.json ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks/2026-04-28-c213-differentiation-wording-sweep.md docs/superpowers/pr-notes/2026-04-28-c213-differentiation-wording-sweep.md web/app/(workspace)/dashboard/page.tsx web/app/(workspace)/agents/[botId]/chat/page.tsx web/app/(utility)/knowledge/page.tsx web/components/agents/SpecPackAuthoringTab.tsx web/components/contest/CoreLoopVisibilityStrip.tsx
+git commit -m "fix(copy): align adaptive tutor framing [C213]"
+```

--- a/docs/superpowers/pr-notes/2026-04-28-c213-differentiation-wording-sweep.md
+++ b/docs/superpowers/pr-notes/2026-04-28-c213-differentiation-wording-sweep.md
@@ -1,0 +1,22 @@
+# PR Note: C213 Differentiation Wording Sweep
+
+## Summary
+
+- aligns bounded contest-facing UI copy with the teacher-controlled adaptive tutor framing
+- keeps the same routes, components, and runtime behavior
+- updates AI-first mirrors so `C212` is recorded completed and `C213` is tracked as the active optional polish lane
+
+## Architecture impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
+- reason: this lane changes wording only and does not alter routes, components, data flow, or runtime contracts
+
+## Mermaid
+
+```mermaid
+flowchart LR
+    K["Knowledge Pack wording"] --> A["Assessment framing unchanged"]
+    A --> T["Tutor wording"]
+    T --> D["Dashboard wording"]
+    D --> I["Teacher-reviewed intervention framing"]
+```

--- a/docs/superpowers/specs/2026-04-28-c213-differentiation-wording-sweep-design.md
+++ b/docs/superpowers/specs/2026-04-28-c213-differentiation-wording-sweep-design.md
@@ -1,0 +1,63 @@
+# C213 Differentiation Wording Sweep Design
+
+## Goal
+
+Tighten contest-facing product copy so the web app consistently reads as a teacher-controlled adaptive tutoring workflow rather than a fully autonomous tutor.
+
+## Scope
+
+- Contest-facing wording only on already-merged UI surfaces.
+- No route changes, no data-model changes, no runtime behavior changes.
+- Small AI-first control-plane updates required to record `C212` completion and `C213` activation.
+
+## Owned files
+
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/components/agents/SpecPackAuthoringTab.tsx`
+- `web/components/contest/CoreLoopVisibilityStrip.tsx`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+- `docs/superpowers/tasks/2026-04-28-c213-differentiation-wording-sweep.md`
+- `docs/superpowers/pr-notes/2026-04-28-c213-differentiation-wording-sweep.md`
+
+## Do-not-touch
+
+- Backend/runtime code outside the listed frontend files
+- Contest submission package docs
+- Lockfiles, generated files, and screenshots
+
+## Copy strategy
+
+1. Keep existing information architecture and component placement.
+2. Replace broad or generic tutoring language with teacher-guided, classroom-loop framing.
+3. Emphasize that tutoring output is evidence inside a larger review-and-intervention workflow.
+4. Avoid stronger product claims than the submission package already supports.
+
+## Surface decisions
+
+### Dashboard
+
+- Reframe the hero from generic workflow language to teacher-reviewed adaptive action language.
+- Keep the loop strip, but sharpen helper text around teacher judgment.
+
+### Tutor chat
+
+- Reframe the empty state and loop helper so the tutor is positioned as guided practice, not the final decision-maker.
+
+### Knowledge
+
+- Reframe the loop helper so Knowledge Packs read as teacher-owned grounding for later adaptive steps.
+
+### Spec pack authoring
+
+- Reframe setup copy so teachers are clearly shaping an adaptive tutor for a class with explicit boundaries.
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`
+- `cd web && npx eslint "app/(utility)/knowledge/page.tsx" "app/(workspace)/dashboard/page.tsx" "app/(workspace)/agents/[botId]/chat/page.tsx" "components/agents/SpecPackAuthoringTab.tsx" "components/contest/CoreLoopVisibilityStrip.tsx"`
+- `cd web && npm run build`

--- a/docs/superpowers/tasks/2026-04-28-c213-differentiation-wording-sweep.md
+++ b/docs/superpowers/tasks/2026-04-28-c213-differentiation-wording-sweep.md
@@ -1,0 +1,51 @@
+# 2026-04-28 C213 Differentiation Wording Sweep
+
+- Task ID: `C213_DIFFERENTIATION_WORDING_SWEEP`
+- Commit tag: `C213`
+- Branch: `fix/submission-close-c213`
+- Worktree: `.worktrees/submission-close-c`
+- Status: `in-progress`
+
+## Goal
+
+Align contest-facing product wording with the teacher-controlled adaptive tutor framing across the bounded UI surfaces already used in the submission flow.
+
+## Owned files
+
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/components/agents/SpecPackAuthoringTab.tsx`
+- `web/components/contest/CoreLoopVisibilityStrip.tsx`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+- `docs/superpowers/specs/2026-04-28-c213-differentiation-wording-sweep-design.md`
+- `docs/superpowers/plans/2026-04-28-c213-differentiation-wording-sweep.md`
+- `docs/superpowers/pr-notes/2026-04-28-c213-differentiation-wording-sweep.md`
+
+## Do-not-touch
+
+- Backend and runtime logic
+- Contest submission package docs
+- Screenshots, evidence inventory, and visual assets
+- Lockfiles and generated files
+
+## Execution notes
+
+- Keep the sweep wording-only.
+- Preserve existing layout and component structure.
+- Prefer language that highlights teacher review, adaptive support, and classroom grounding.
+- Do not widen product claims beyond current submission proof.
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`
+- `cd web && npx eslint "app/(utility)/knowledge/page.tsx" "app/(workspace)/dashboard/page.tsx" "app/(workspace)/agents/[botId]/chat/page.tsx" "components/agents/SpecPackAuthoringTab.tsx" "components/contest/CoreLoopVisibilityStrip.tsx"`
+- `cd web && npm run build`
+
+## Handoff
+
+- Wording now consistently frames the product as a teacher-controlled adaptive tutor loop across Dashboard, Tutor, Knowledge, and Spec Pack authoring surfaces.
+- No runtime behavior, routes, or submission-package docs were changed.

--- a/web/app/(utility)/knowledge/page.tsx
+++ b/web/app/(utility)/knowledge/page.tsx
@@ -809,7 +809,7 @@ export default function KnowledgePage() {
         <CoreLoopVisibilityStrip
           currentStep="Knowledge Pack"
           nextStep="Assessment"
-          helperText={t("Start with teacher-owned source material so every later step stays grounded in the same classroom knowledge pack.")}
+          helperText={t("Start with teacher-owned source material so the adaptive tutor, assessment, and teacher review all stay grounded in the same classroom knowledge pack.")}
         />
 
         {pageError && (

--- a/web/app/(workspace)/agents/[botId]/chat/page.tsx
+++ b/web/app/(workspace)/agents/[botId]/chat/page.tsx
@@ -149,7 +149,7 @@ export default function BotChatPage() {
             compact
             currentStep="Tutor"
             nextStep="Diagnosis"
-            helperText={t("Tutor replies are one step in the same classroom loop before the teacher reviews diagnosis and chooses the next intervention.")}
+            helperText={t("Tutor replies provide adaptive practice inside the same teacher-controlled loop before diagnosis review and intervention selection.")}
           />
         </div>
       </div>
@@ -163,10 +163,10 @@ export default function BotChatPage() {
                 <Bot size={22} />
               </div>
               <p className="text-[14px] font-medium text-[var(--foreground)]">
-                {t("Chat with {{name}}", { name: bot?.name ?? botId })}
+                {t("Continue guided tutoring with {{name}}", { name: bot?.name ?? botId })}
               </p>
               <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
-                {t("Send a message to start the conversation.")}
+                {t("Use the tutor to probe understanding, then bring that evidence back to teacher review.")}
               </p>
             </div>
           )}

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -127,13 +127,13 @@ export default function DashboardPage() {
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
               <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
-                {t("Teacher Workflow")}
+                {t("Teacher-controlled adaptive loop")}
               </p>
               <h1 className="mt-2 text-[28px] font-semibold tracking-tight text-[var(--foreground)]">
-                {t("Observed, diagnosed, and ready for action")}
+                {t("Teacher-reviewed signals, adaptive next steps")}
               </h1>
               <p className="mt-2 max-w-[680px] text-[14px] leading-6 text-[var(--muted-foreground)]">
-                {t("Review observed facts first, then decide the clearest next classroom move for each student or group.")}
+                {t("Review observed evidence first, then choose the clearest adaptive classroom move for each student or group.")}
               </p>
             </div>
             <Link
@@ -148,7 +148,7 @@ export default function DashboardPage() {
             <CoreLoopVisibilityStrip
               currentStep="Diagnosis"
               nextStep="Intervention"
-              helperText={t("This dashboard turns observed activity into teacher-reviewed diagnosis and the next intervention decision, not autonomous final judgment.")}
+              helperText={t("This dashboard turns assessment and tutoring signals into teacher-reviewed diagnosis and the next classroom move; it does not replace teacher judgment.")}
             />
           </div>
           <div className="mt-4 grid gap-3 md:grid-cols-3">

--- a/web/components/agents/SpecPackAuthoringTab.tsx
+++ b/web/components/agents/SpecPackAuthoringTab.tsx
@@ -221,7 +221,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
               {t("Class tutoring setup")}
             </p>
             <h2 className="mt-1 text-[16px] font-semibold text-[var(--foreground)]">
-              {t("Shape how the tutor teaches this class")}
+              {t("Shape the adaptive tutor for this class")}
             </h2>
           </div>
           <button
@@ -238,7 +238,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
           </div>
         ) : packs.length === 0 ? (
           <div className="rounded-xl border border-dashed border-[var(--border)] p-4 text-[13px] text-[var(--muted-foreground)]">
-            {t("No spec packs yet. Start with a new teacher-defined agent.")}
+            {t("No spec packs yet. Start with a teacher-controlled adaptive tutor.")}
           </div>
         ) : (
           <div className="space-y-2">
@@ -282,7 +282,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
                 {t("Choose class fit, support style, and guardrails")}
               </h2>
               <p className="mt-2 max-w-[680px] text-[13px] text-[var(--muted-foreground)]">
-                {t("IDENTITY sets who this tutor is for, SOUL shapes how it responds when students are wrong or stuck, and RULES keep help within your classroom boundaries.")}
+                {t("IDENTITY defines who this adaptive tutor supports, SOUL shapes how it coaches when students are wrong or stuck, and RULES keep every response inside your classroom boundaries.")}
               </p>
             </div>
             <div className="flex items-center gap-2">
@@ -435,9 +435,9 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
               onChange={(event) => setAuditCapability(event.target.value as "chat" | "deep_question" | "deep_solve")}
               className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1 text-[12px] text-[var(--foreground)]"
             >
-              <option value="chat">chat</option>
-              <option value="deep_question">deep_question</option>
-              <option value="deep_solve">deep_solve</option>
+              <option value="chat">{t("chat")}</option>
+              <option value="deep_question">{t("deep_question")}</option>
+              <option value="deep_solve">{t("deep_solve")}</option>
             </select>
           </div>
           {!draft.agent_id ? (

--- a/web/components/contest/CoreLoopVisibilityStrip.tsx
+++ b/web/components/contest/CoreLoopVisibilityStrip.tsx
@@ -43,7 +43,7 @@ export function CoreLoopVisibilityStrip({
           {t("Contest loop")}
         </div>
         <p className={`${compact ? "text-[12px]" : "text-[13px]"} text-[var(--muted-foreground)]`}>
-          {helperText || t("Follow the same five-step classroom loop across the product.")}
+          {helperText || t("Track the same teacher-guided adaptive loop across the product.")}
         </p>
       </div>
 


### PR DESCRIPTION
# PR Note: C213 Differentiation Wording Sweep

## Summary

- aligns bounded contest-facing UI copy with the teacher-controlled adaptive tutor framing
- keeps the same routes, components, and runtime behavior
- updates AI-first mirrors so `C212` is recorded completed and `C213` is tracked as the active optional polish lane

## Architecture impact

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
- reason: this lane changes wording only and does not alter routes, components, data flow, or runtime contracts

## Mermaid

```mermaid
flowchart LR
    K["Knowledge Pack wording"] --> A["Assessment framing unchanged"]
    A --> T["Tutor wording"]
    T --> D["Dashboard wording"]
    D --> I["Teacher-reviewed intervention framing"]
```
