### PR TITLE
docs: polish judge-facing evidence guidance

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -93,12 +93,12 @@ Rules:
 - Owner: Session C
 - Machine: local
 - Worktree: `.worktrees/submission-close-c`
-- Task: `C213_DIFFERENTIATION_WORDING_SWEEP`
+- Task: `C214_JUDGE_FACING_VISUAL_ASSET_POLISH`
 - Status: in-progress
-- Branch: `fix/submission-close-c213`
-- Task packet: `docs/superpowers/tasks/2026-04-28-c213-differentiation-wording-sweep.md`
-- Owned files: contest-facing wording-only polish on bounded frontend surfaces plus required AI-first mirrors
+- Branch: `fix/submission-close-c214`
+- Task packet: `docs/superpowers/tasks/2026-04-28-c214-judge-facing-visual-asset-polish.md`
+- Owned files: docs and evidence-inventory polish for judge-facing screenshot presentation plus required AI-first mirrors
 - PR:
 - Last update: 2026-04-28
-- Next action: implement the wording sweep on Knowledge, Dashboard, Tutor, and Spec Pack authoring surfaces, then validate with lint and build
+- Next action: tighten screenshot captions, judge-view order, and evidence guidance without recapturing assets or widening claims
 - Blocker:

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -2139,10 +2139,10 @@
       "dependencies": [
         "C210_FINAL_PACKAGE_READINESS"
       ],
-      "status": "in-progress",
+      "status": "completed",
       "recommended_session_bucket": "session-c-polish",
       "layer": "optional-polish",
-      "notes": "Activated on branch fix/submission-close-c213 on 2026-04-28. Scope is bounded to contest-facing wording only on existing frontend surfaces and required AI-first mirrors."
+      "notes": "Merged to main through PR #215 on 2026-04-28. Scope stayed bounded to contest-facing wording only on existing frontend surfaces and required AI-first mirrors."
     },
     {
       "id": "C214_JUDGE_FACING_VISUAL_ASSET_POLISH",
@@ -2162,9 +2162,10 @@
       "dependencies": [
         "C210_FINAL_PACKAGE_READINESS"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-c-polish",
-      "layer": "optional-polish"
+      "layer": "optional-polish",
+      "notes": "Activated on branch fix/submission-close-c214 on 2026-04-28. Scope is bounded to docs and evidence inventory wording/order only; no screenshot recapture or runtime edits."
     },
     {
       "id": "C215_POST_POLISH_EVIDENCE_RECAPTURE",

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,14 +1,24 @@
 # Daily Log: 2026-04-28
 
+## C214_JUDGE_FACING_VISUAL_ASSET_POLISH
+
+- Branch: `fix/submission-close-c214`
+- Task: `C214_JUDGE_FACING_VISUAL_ASSET_POLISH`
+- Done: Opened a fresh docs/evidence lane from updated `origin/main` after `C213` merged, and created the dedicated spec, plan, task packet, and PR note for judge-facing visual guidance polish.
+- Done: Moved the AI-first mirrors forward so `C213` is recorded completed and `C214` is tracked as the active docs-only polish task.
+- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Blockers: none yet
+- Next: refine screenshot captions, judge-view order, and visual guidance across the contest evidence docs, then run docs validation.
+
 ## C213_DIFFERENTIATION_WORDING_SWEEP
 
 - Branch: `fix/submission-close-c213`
 - Task: `C213_DIFFERENTIATION_WORDING_SWEEP`
 - Done: Opened a fresh Session C optional-polish lane from updated `origin/main` and created the dedicated spec, plan, task packet, and PR note for the wording sweep.
 - Done: Moved the AI-first mirrors forward so `C212` is recorded completed and `C213` is tracked as the active wording-only polish task.
-- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`; `cd web && npx eslint "app/(utility)/knowledge/page.tsx" "app/(workspace)/dashboard/page.tsx" "app/(workspace)/agents/[botId]/chat/page.tsx" "components/agents/SpecPackAuthoringTab.tsx" "components/contest/CoreLoopVisibilityStrip.tsx"`; `cd web && npm run build`
 - Blockers: none yet
-- Next: apply the bounded wording pass to Dashboard, Tutor, Knowledge, and Spec Pack authoring surfaces, then run frontend lint/build validation.
+- Next: merged to `main` through PR `#215`; if Session C continues, move to the next optional polish lane or stop at human review.
 
 ## C212_CORE_LOOP_VISIBILITY_POLISH
 

--- a/ai_first/evidence/screenshots.md
+++ b/ai_first/evidence/screenshots.md
@@ -1,15 +1,27 @@
 # Screenshots and Video Checklist
 
+## Judge-facing order
+
+Use the existing screenshot set in this order when a reviewer wants the shortest visual proof path:
+
+1. Teacher control on `/agents`
+2. Knowledge Pack grounding
+3. Assessment generation and feedback
+4. Tutor support
+5. Dashboard review and next action
+
+Keep the narration at validated-prototype scope. The screenshots support teacher control, adaptive support, and teacher-reviewed follow-up. They do not support classroom outcome claims or autonomous teacher replacement.
+
 ## Screenshot freshness
 
-| Artifact | Status | Last real capture | Notes |
+| Artifact | Status | Last real capture | Judge-facing caption | Notes |
 | --- | --- | --- | --- |
-| Knowledge Pack creation | Current | 2026-04-25 | No Session B recapture on 2026-04-28. |
-| Assessment Builder result | Current | 2026-04-25 | Uses demo-safe local session content. |
-| Student Tutor conversation | Current | 2026-04-25 | Uses seeded demo response. |
-| Teacher Dashboard | Current | 2026-04-26 | Evidence-first dashboard workflow recaptured after the dashboard polish merge. |
-| `/agents` authoring proof | Current | 2026-04-26 | Pair with bounded runtime-binding automated proof. |
-| Main architecture Mermaid map rendered | Pending review | N/A | Session A owns the narrative/submission package refresh. |
+| `/agents` authoring proof | Current | 2026-04-26 | Teacher defines who the tutor is for, how it coaches, and what boundaries it must follow. | Pair with bounded runtime-binding automated proof. |
+| Knowledge Pack creation | Current | 2026-04-25 | Teacher sets the learning context and sharing boundary before any AI step begins. | No Session B recapture on 2026-04-28. |
+| Assessment Builder result | Current | 2026-04-25 | The assessment is grounded in the same teacher-approved knowledge pack. | Uses demo-safe local session content. |
+| Student Tutor conversation | Current | 2026-04-25 | The tutor gives adaptive help while staying inside the same classroom loop. | Uses seeded demo response. |
+| Teacher Dashboard | Current | 2026-04-26 | The teacher reviews signals and chooses the next classroom move. | Evidence-first dashboard workflow recaptured after the dashboard polish merge. |
+| Main architecture Mermaid map rendered | Pending review | N/A | Architecture/read path exists if a reviewer asks how the system is organized. | Session A owns the narrative/submission package refresh. |
 
 ## Video freshness
 

--- a/docs/contest/EVIDENCE_CHECKLIST.md
+++ b/docs/contest/EVIDENCE_CHECKLIST.md
@@ -6,26 +6,34 @@ Use this checklist after running the demo locally.
 
 Refresh these only when the UI changed or when the latest smoke-backed validation marks them stale or blocked.
 
-| Area | Evidence | Refresh mode | Status | Notes |
-| --- | --- | --- | --- | --- |
-| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Browser capture | Current | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass`; see `01-knowledge-pack-metadata.png`. |
-| Knowledge Pack | Metadata still visible after reload | Browser capture | Current | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass`; see `02-knowledge-pack-after-reload.png`. |
-| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Browser capture | Current | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass`; see `04-assessment-config.png`. |
-| Assessment | Generated questions visible | Browser capture | Current | Refreshed on 2026-04-25 with demo-safe local session content in the screenshot worktree; see `07-assessment-generated-questions.png`. |
-| Assessment | Common-mistake or feedback guidance visible | Browser capture | Current | Refreshed on 2026-04-25 with demo-safe local session content in the screenshot worktree; see `08-assessment-common-mistakes.png`. |
-| Tutor Agent | Student asks a follow-up question | Browser capture | Current | Refreshed on 2026-04-25; the student turn is visible in `06-tutor-agent-answer.png`. |
-| Tutor Agent | Tutor response with learning context | Browser capture | Current | Refreshed on 2026-04-25; the tutor answer is visible in `06-tutor-agent-answer.png`. |
-| Dashboard | Evidence-first teacher insight overview visible | Browser capture | Current | Refreshed on 2026-04-26 in `docs/evidence-dashboard-agents-recapture`; see `05-dashboard-evidence-first-overview.png`. |
-| Dashboard | Recent activity still visible below the teacher insight workflow | Browser capture | Current | Refreshed on 2026-04-26 in `docs/evidence-dashboard-agents-recapture`; see `09-dashboard-recent-activity-evidence-first.png`. |
+Recommended judge-view order:
+
+1. `/agents` authoring proof for teacher control
+2. Knowledge Pack grounding
+3. Assessment generation and feedback
+4. Tutor support
+5. Dashboard review and next action
+
+| Area | Evidence | Refresh mode | Status | Judge-facing caption | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Knowledge Pack | Metadata form filled with demo-safe subject, grade, curriculum, objectives, owner, and sharing status | Browser capture | Current | Teacher sets the trusted learning context before assessment or tutoring begins. | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass`; see `01-knowledge-pack-metadata.png`. |
+| Knowledge Pack | Metadata still visible after reload | Browser capture | Current | The configured classroom context persists after reload rather than living only in one transient form. | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass`; see `02-knowledge-pack-after-reload.png`. |
+| Assessment | Quiz or assessment configuration using the demo subject or Knowledge Pack | Browser capture | Current | Assessment drafting stays grounded in the same teacher-approved pack. | Refreshed on 2026-04-25 in `docs/t037-contest-screenshot-refresh-pass`; see `04-assessment-config.png`. |
+| Assessment | Generated questions visible | Browser capture | Current | The platform can draft practice items from the chosen classroom source. | Refreshed on 2026-04-25 with demo-safe local session content in the screenshot worktree; see `07-assessment-generated-questions.png`. |
+| Assessment | Common-mistake or feedback guidance visible | Browser capture | Current | Assessment output includes feedback signals the teacher can reuse or review. | Refreshed on 2026-04-25 with demo-safe local session content in the screenshot worktree; see `08-assessment-common-mistakes.png`. |
+| Tutor Agent | Student asks a follow-up question | Browser capture | Current | The student can continue from assessment into adaptive tutoring on the same topic. | Refreshed on 2026-04-25; the student turn is visible in `06-tutor-agent-answer.png`. |
+| Tutor Agent | Tutor response with learning context | Browser capture | Current | The tutor gives support inside the same classroom loop rather than acting as a final judge. | Refreshed on 2026-04-25; the tutor answer is visible in `06-tutor-agent-answer.png`. |
+| Dashboard | Evidence-first teacher insight overview visible | Browser capture | Current | The teacher sees reviewed signals and recommended next moves in one operating surface. | Refreshed on 2026-04-26 in `docs/evidence-dashboard-agents-recapture`; see `05-dashboard-evidence-first-overview.png`. |
+| Dashboard | Recent activity still visible below the teacher insight workflow | Browser capture | Current | The teacher can trace the supporting activity behind the dashboard recommendation layer. | Refreshed on 2026-04-26 in `docs/evidence-dashboard-agents-recapture`; see `09-dashboard-recent-activity-evidence-first.png`. |
 
 ## Hybrid Proof Screenshots
 
 Use this section to calibrate claims when showing teacher authoring plus evidence loop in one demo.
 
-| Area | Evidence | Refresh mode | Status | Notes |
-| --- | --- | --- | --- | --- |
-| Agent Specs authoring | Structured `IDENTITY`, `SOUL`, and `RULES` sections visible on `/agents` | Browser capture | Current | Refreshed on 2026-04-26 in `docs/evidence-dashboard-agents-recapture`; see `10-agents-spec-pack-authoring.png`. Pair with the bounded runtime-binding test proof when discussing live Tutor behavior. |
-| Agent Specs authoring | Export action visible from authoring tab | Browser capture | Current | Refreshed on 2026-04-26 in `docs/evidence-dashboard-agents-recapture`; see `11-agents-spec-pack-export.png`. Live runtime impact is now supported by automated bounded proof for the unified Tutor turn path. |
+| Area | Evidence | Refresh mode | Status | Judge-facing caption | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Agent Specs authoring | Structured `IDENTITY`, `SOUL`, and `RULES` sections visible on `/agents` | Browser capture | Current | Teacher control is explicit: audience, teaching style, and guardrails are configurable before tutoring starts. | Refreshed on 2026-04-26 in `docs/evidence-dashboard-agents-recapture`; see `10-agents-spec-pack-authoring.png`. Pair with the bounded runtime-binding test proof when discussing live Tutor behavior. |
+| Agent Specs authoring | Export action visible from authoring tab | Browser capture | Current | Tutor setup is portable and reviewable as a spec pack rather than hidden prompt state. | Refreshed on 2026-04-26 in `docs/evidence-dashboard-agents-recapture`; see `11-agents-spec-pack-export.png`. Live runtime impact is now supported by automated bounded proof for the unified Tutor turn path. |
 
 ## Required Command Evidence
 

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -113,16 +113,18 @@ Run [`DEMO_DATA_RESET.md`](./DEMO_DATA_RESET.md) first when local demo data may 
 
 ## Screenshot Index
 
-- [`01-knowledge-pack-metadata.png`](./screenshots/01-knowledge-pack-metadata.png)
-- [`02-knowledge-pack-after-reload.png`](./screenshots/02-knowledge-pack-after-reload.png)
-- [`04-assessment-config.png`](./screenshots/04-assessment-config.png)
-- [`07-assessment-generated-questions.png`](./screenshots/07-assessment-generated-questions.png)
-- [`08-assessment-common-mistakes.png`](./screenshots/08-assessment-common-mistakes.png)
-- [`06-tutor-agent-answer.png`](./screenshots/06-tutor-agent-answer.png)
-- [`05-dashboard-evidence-first-overview.png`](./screenshots/05-dashboard-evidence-first-overview.png)
-- [`09-dashboard-recent-activity-evidence-first.png`](./screenshots/09-dashboard-recent-activity-evidence-first.png)
-- [`10-agents-spec-pack-authoring.png`](./screenshots/10-agents-spec-pack-authoring.png)
-- [`11-agents-spec-pack-export.png`](./screenshots/11-agents-spec-pack-export.png)
+Recommended review order for judges:
+
+1. [`10-agents-spec-pack-authoring.png`](./screenshots/10-agents-spec-pack-authoring.png) - teacher sets audience, coaching style, and guardrails
+2. [`11-agents-spec-pack-export.png`](./screenshots/11-agents-spec-pack-export.png) - tutor setup is portable and reviewable
+3. [`01-knowledge-pack-metadata.png`](./screenshots/01-knowledge-pack-metadata.png) - teacher sets trusted classroom source material
+4. [`02-knowledge-pack-after-reload.png`](./screenshots/02-knowledge-pack-after-reload.png) - the configured context persists
+5. [`04-assessment-config.png`](./screenshots/04-assessment-config.png) - assessment drafting stays grounded in the same pack
+6. [`07-assessment-generated-questions.png`](./screenshots/07-assessment-generated-questions.png) - the platform drafts practice items from that context
+7. [`08-assessment-common-mistakes.png`](./screenshots/08-assessment-common-mistakes.png) - assessment output includes feedback signals
+8. [`06-tutor-agent-answer.png`](./screenshots/06-tutor-agent-answer.png) - the tutor gives adaptive support on the same topic
+9. [`05-dashboard-evidence-first-overview.png`](./screenshots/05-dashboard-evidence-first-overview.png) - the teacher reviews signals and next actions
+10. [`09-dashboard-recent-activity-evidence-first.png`](./screenshots/09-dashboard-recent-activity-evidence-first.png) - the teacher can inspect the activity underneath the dashboard layer
 
 ## Evidence Flow
 

--- a/docs/contest/SUBMISSION_PACKAGE.md
+++ b/docs/contest/SUBMISSION_PACKAGE.md
@@ -82,6 +82,18 @@ Primary pitch source: [`ai_first/competition/pitch-notes.md`](../../ai_first/com
 | Final checklist | Partially verified | [`ai_first/competition/submission-checklist.md`](../../ai_first/competition/submission-checklist.md) |
 | Optional video | Deferred | Record only if final submission requires a video artifact. |
 
+## Recommended Judge Visual Order
+
+If a reviewer wants the shortest screenshot-driven proof path, present the visual bundle in this order:
+
+1. `/agents` authoring to establish teacher control
+2. Knowledge Pack metadata to establish grounded source material
+3. Assessment screenshots to show AI-generated practice and feedback
+4. Tutor screenshot to show adaptive support on the same topic
+5. Dashboard screenshots to show teacher-reviewed diagnosis and next action
+
+Use the screenshots as validated-prototype support only. They show teacher control, adaptive support, and review surfaces; they do not establish classroom outcome proof or autonomous teacher replacement.
+
 ## Latest Validation
 
 The latest command-backed smoke refresh passed on 2026-04-28 after running the scripted local reset. It verified:

--- a/docs/superpowers/plans/2026-04-28-c214-judge-facing-visual-asset-polish.md
+++ b/docs/superpowers/plans/2026-04-28-c214-judge-facing-visual-asset-polish.md
@@ -1,0 +1,86 @@
+# C214 Judge-Facing Visual Asset Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve judge-facing screenshot captions and presentation order without changing evidence artifacts or product scope.
+
+**Architecture:** This is a docs-only evidence packaging pass. The plan updates the evidence entry points and AI-first mirrors so the same screenshot set reads more clearly as teacher control plus adaptive loop proof.
+
+**Tech Stack:** Markdown docs, AI-first operating files
+
+---
+
+### Task 1: Open the `C214` docs lane
+
+**Files:**
+- Create: `docs/superpowers/tasks/2026-04-28-c214-judge-facing-visual-asset-polish.md`
+- Create: `docs/superpowers/pr-notes/2026-04-28-c214-judge-facing-visual-asset-polish.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-28.md`
+
+- [ ] **Step 1: Record `C213` as completed and `C214` as active**
+
+Run: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+Expected: PASS after the task-state transition.
+
+- [ ] **Step 2: Write the lane packet and PR note**
+
+```md
+Task ID: C214_JUDGE_FACING_VISUAL_ASSET_POLISH
+Commit tag: C214
+Scope: docs and evidence inventory only
+```
+
+### Task 2: Improve judge-facing screenshot guidance
+
+**Files:**
+- Modify: `docs/contest/README.md`
+- Modify: `docs/contest/EVIDENCE_CHECKLIST.md`
+- Modify: `docs/contest/SUBMISSION_PACKAGE.md`
+- Modify: `ai_first/evidence/screenshots.md`
+
+- [ ] **Step 1: Add recommended judge-view order**
+
+```md
+1. Teacher control
+2. Knowledge grounding
+3. Assessment evidence
+4. Tutor support
+5. Dashboard review
+```
+
+- [ ] **Step 2: Add caption intent to the screenshot inventory**
+
+```md
+Judge-facing caption: "Teacher sets the learning context and sharing boundary before any AI step begins."
+```
+
+- [ ] **Step 3: Keep claims bounded**
+
+```md
+Use the screenshot set to support the validated prototype story only; do not imply classroom outcome proof or autonomous teacher replacement.
+```
+
+### Task 3: Validate and prepare merge
+
+**Files:**
+- Modify: `docs/superpowers/tasks/2026-04-28-c214-judge-facing-visual-asset-polish.md`
+
+- [ ] **Step 1: Run docs validation**
+
+Run: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+Expected: PASS
+
+Run: `rg -n "judge-facing|caption|visual order|teacher control|adaptive loop" docs/contest ai_first/evidence docs/superpowers/tasks docs/superpowers/pr-notes`
+Expected: matches the new caption/order guidance
+
+Run: `git diff --check`
+Expected: no output
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ai_first/ACTIVE_ASSIGNMENTS.md ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-28.md docs/contest/README.md docs/contest/EVIDENCE_CHECKLIST.md docs/contest/SUBMISSION_PACKAGE.md ai_first/evidence/screenshots.md docs/superpowers/tasks/2026-04-28-c214-judge-facing-visual-asset-polish.md docs/superpowers/pr-notes/2026-04-28-c214-judge-facing-visual-asset-polish.md
+git commit -m "docs(evidence): polish judge-facing asset guidance [C214]"
+```

--- a/docs/superpowers/pr-notes/2026-04-28-c214-judge-facing-visual-asset-polish.md
+++ b/docs/superpowers/pr-notes/2026-04-28-c214-judge-facing-visual-asset-polish.md
@@ -1,0 +1,22 @@
+# PR Note: C214 Judge-Facing Visual Asset Polish
+
+## Summary
+
+- improves judge-facing screenshot captions and visual order guidance without changing any evidence artifact
+- keeps the screenshot bundle and validation dates unchanged
+- syncs the AI-first mirrors so `C213` is completed and `C214` is the active optional polish lane
+
+## Architecture impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
+- reason: this lane changes docs and evidence presentation only
+
+## Mermaid
+
+```mermaid
+flowchart LR
+    A["Teacher control proof"] --> B["Knowledge grounding"]
+    B --> C["Assessment evidence"]
+    C --> D["Tutor support"]
+    D --> E["Dashboard review"]
+```

--- a/docs/superpowers/specs/2026-04-28-c214-judge-facing-visual-asset-polish-design.md
+++ b/docs/superpowers/specs/2026-04-28-c214-judge-facing-visual-asset-polish-design.md
@@ -1,0 +1,36 @@
+# C214 Judge-Facing Visual Asset Polish Design
+
+## Goal
+
+Make the existing screenshot bundle easier for judges to scan by clarifying caption intent, presentation order, and where each artifact fits in the contest story.
+
+## Scope
+
+- Docs and evidence inventory only.
+- No new screenshots, no browser recapture, no product/runtime changes.
+- Include the required AI-first mirror updates so `C213` can be recorded completed while `C214` is active.
+
+## Owned files
+
+- `docs/contest/README.md`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `ai_first/evidence/screenshots.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+- `docs/superpowers/tasks/2026-04-28-c214-judge-facing-visual-asset-polish.md`
+- `docs/superpowers/pr-notes/2026-04-28-c214-judge-facing-visual-asset-polish.md`
+
+## Do-not-touch
+
+- Screenshot files themselves
+- Validation report command results
+- Runtime code, frontend code, and contest claim boundaries
+
+## Approach
+
+1. Keep the current screenshot inventory unchanged.
+2. Add judge-facing caption intent and recommended narrative order.
+3. Emphasize which screenshots prove teacher control, adaptive tutoring, and teacher review.
+4. Keep all claims anchored to already-documented evidence.

--- a/docs/superpowers/tasks/2026-04-28-c214-judge-facing-visual-asset-polish.md
+++ b/docs/superpowers/tasks/2026-04-28-c214-judge-facing-visual-asset-polish.md
@@ -1,0 +1,42 @@
+# 2026-04-28 C214 Judge-Facing Visual Asset Polish
+
+- Task ID: `C214_JUDGE_FACING_VISUAL_ASSET_POLISH`
+- Commit tag: `C214`
+- Branch: `fix/submission-close-c214`
+- Worktree: `.worktrees/submission-close-c`
+- Status: `in-progress`
+
+## Goal
+
+Clarify how judges should read the existing screenshot bundle by tightening caption language, visual order, and supporting evidence notes.
+
+## Owned files
+
+- `docs/contest/README.md`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `ai_first/evidence/screenshots.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+- `docs/superpowers/specs/2026-04-28-c214-judge-facing-visual-asset-polish-design.md`
+- `docs/superpowers/plans/2026-04-28-c214-judge-facing-visual-asset-polish.md`
+- `docs/superpowers/pr-notes/2026-04-28-c214-judge-facing-visual-asset-polish.md`
+
+## Do-not-touch
+
+- Screenshot image files
+- Runtime/frontend code
+- Validation command outputs
+- Contest claim boundaries
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `rg -n "judge-facing|Judge-facing caption|Recommended judge-view order|Recommended Judge Visual Order|teacher control|adaptive support" docs/contest ai_first/evidence docs/superpowers/tasks docs/superpowers/pr-notes`
+- `git diff --check`
+
+## Handoff
+
+- The screenshot set is unchanged; only caption intent, visual order, and judge-facing explanation were tightened.
+- Claims remain bounded to validated-prototype proof and existing evidence dates.


### PR DESCRIPTION
# PR Note: C214 Judge-Facing Visual Asset Polish

## Summary

- improves judge-facing screenshot captions and visual order guidance without changing any evidence artifact
- keeps the screenshot bundle and validation dates unchanged
- syncs the AI-first mirrors so `C213` is completed and `C214` is the active optional polish lane

## Architecture impact

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
- reason: this lane changes docs and evidence presentation only

## Mermaid

```mermaid
flowchart LR
    A["Teacher control proof"] --> B["Knowledge grounding"]
    B --> C["Assessment evidence"]
    C --> D["Tutor support"]
    D --> E["Dashboard review"]
```
