### PR TITLE
docs: add post-phase2 browser recapture packet

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -102,3 +102,18 @@ Rules:
 - Last update: 2026-04-28
 - Next action: keep 2026-04-28 command-backed smoke evidence current, and treat browser screenshot recapture as a separate future packet if needed
 - Blocker:
+
+### Assignment
+
+- Owner: Browser recapture packet lane
+- Machine: local
+- Worktree: `.worktrees/submission-close-c`
+- Task: `OPS_BROWSER_RECAPTURE_AFTER_PHASE2`
+- Status: packet-ready
+- Branch: `docs/post-phase2-browser-recapture-packet`
+- Task packet: `docs/superpowers/tasks/2026-04-28-browser-recapture-after-phase2.md`
+- Owned files: workflow docs and AI-first mirrors for the next browser/manual evidence lane
+- PR:
+- Last update: 2026-04-28
+- Next action: use this packet from `main` when the team decides to refresh the stale browser screenshot rows
+- Blocker: browser capture is not being executed in this packet lane

--- a/ai_first/CURRENT_STATE.md
+++ b/ai_first/CURRENT_STATE.md
@@ -31,7 +31,7 @@ Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention.
 - Latest merged docs/control-plane PRs: `#210`, `#212`, and `#211` completed submission-close Phase 1 on 2026-04-28.
 - Current branch for this sync: `docs/post-submission-close-sync`
 - Product MVP path status: the core contest flow, the Wave 1 evidence spine, the command-backed 2026-04-28 smoke refresh, the optional Phase 2 polish train (`C212-C215`), and the final human-review package path are all merged to `main` as a validated prototype.
-- Current purpose: keep a correct terminal wait state while the remaining submission work is human review, optional video, optional browser screenshot recapture, final sign-off, or a newly opened packet from `main`.
+- Current purpose: keep a correct terminal wait state while the remaining submission work is human review, optional video, optional browser screenshot recapture via the explicit post-Phase-2 packet, final sign-off, or a newly opened packet from `main`.
 - Historical note: preserve `ai_first/2026-04-12-deeptutor-slimming/` as background analysis, not as the operating contract.
 
 ## Active Design
@@ -59,7 +59,7 @@ Do not revert unrelated changes.
 
 ## Active Execution
 
-- Current open task packet: none by default after the Phase 2 sync lands; start a fresh packet from `main` for any further AI-owned work
+- Current open task packet: none active by default after the Phase 2 sync; if browser freshness must be restored, start from `docs/superpowers/tasks/2026-04-28-browser-recapture-after-phase2.md`
 - Current open GitHub issue:
 - Latest completed smoke run result: the 2026-04-28 scripted-reset smoke pass succeeded with backend online through the CLI server path, frontend build passed after `npm ci`, Knowledge Pack demo data present, assessment/tutor session evidence present, and dashboard activity available.
 - Recently completed merged work: submission-close master coordination and package readiness merged through PRs `#210`, `#212`, and `#211`, followed by optional Phase 2 polish through PRs `#214`, `#215`, `#216`, and `#217`.
@@ -68,7 +68,7 @@ Do not revert unrelated changes.
 
 ## Current Next Task
 
-Wait for human review of the submission package, IP commitment, optional video decision, and final sign-off unless a fresh browser-recapture or follow-up packet is explicitly opened from `main`.
+Wait for human review of the submission package, IP commitment, optional video decision, and final sign-off unless the browser-recapture packet or another follow-up packet is explicitly opened from `main`.
 
 ## Autonomous Merge Policy
 

--- a/ai_first/EXECUTION_QUEUE.md
+++ b/ai_first/EXECUTION_QUEUE.md
@@ -59,7 +59,7 @@ The authoritative control plane is still `ai_first/AI_OPERATING_PROMPT.md`.
 ## Next recommended task
 
 - Complete the remaining human review gates: product wording confirmation, IP commitment, optional video decision, and final sign-off.
-- If the screenshot bundle must become fully current again, open a fresh browser-recapture packet from `main`; do not silently treat stale browser captures as current.
+- If the screenshot bundle must become fully current again, use `docs/superpowers/tasks/2026-04-28-browser-recapture-after-phase2.md` from `main`; do not silently treat stale browser captures as current.
 - Otherwise, open a new packet only if the human explicitly wants more post-submission work from `main`.
 
 If a requested task appears to span multiple packets, stop and ask the human to resolve the lane boundary before editing.
@@ -75,7 +75,7 @@ If a requested task appears to span multiple packets, stop and ask the human to 
 
 ## AI-owned blockers
 
-- None currently. Submission-close Phase 1 and the optional Phase 2 polish are merged, so the next AI-owned work requires either a fresh browser-recapture packet or a new approved backlog extension.
+- None currently. Submission-close Phase 1 and the optional Phase 2 polish are merged, and the next AI-owned work is already packetized as `docs/superpowers/tasks/2026-04-28-browser-recapture-after-phase2.md` if the stale browser rows must be refreshed.
 
 ## Human-review blockers
 

--- a/ai_first/NEXT_ACTIONS.md
+++ b/ai_first/NEXT_ACTIONS.md
@@ -10,8 +10,9 @@ This file is a compatibility snapshot. The authoritative action list lives in `a
 2. Decide whether an optional contest video artifact is required.
 3. Decide whether stale browser screenshots need one fresh manual recapture pass before submission.
 4. Complete final package sign-off using the current `docs/contest/` read path.
-5. Treat any future smoke failure as the next product task before opening another lane.
-6. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new AI lane or docs sync.
+5. If browser screenshot freshness must be restored, use `docs/superpowers/tasks/2026-04-28-browser-recapture-after-phase2.md` from `main`.
+6. Treat any future smoke failure as the next product task before opening another lane.
+7. Use `ai_first/ACTIVE_ASSIGNMENTS.md` before starting any new AI lane or docs sync.
 
 ## After Milestone 0
 
@@ -33,4 +34,4 @@ Use this file only as a compact queue mirror. Do not rely on it for the full ope
 2. Use the matching packet before code edits.
 3. If no packet exists and the remaining work is human-only, stop instead of inventing a new AI lane.
 4. Keep contest wording at validated-prototype level unless a stronger repository artifact is added.
-5. If screenshot freshness must be restored, open a fresh browser-recapture packet instead of editing evidence mirrors ad hoc.
+5. Use the post-Phase-2 browser recapture packet instead of editing evidence mirrors ad hoc.

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -21,6 +21,16 @@
 - Blockers: none yet
 - Next: run compact mirror validation, then push and merge the docs-only sync lane.
 
+## OPS_BROWSER_RECAPTURE_AFTER_PHASE2
+
+- Branch: `docs/post-phase2-browser-recapture-packet`
+- Task: `OPS_BROWSER_RECAPTURE_AFTER_PHASE2`
+- Done: Added the next explicit packet for manual/browser screenshot recapture after the merged Phase 2 polish train instead of leaving the recapture step as an implicit note.
+- Done: Updated the compact AI-first mirrors so they point to the new recapture packet when the team wants to restore stale browser rows to `Current`.
+- Tests: pending packet-lane validation
+- Blockers: this packet does not execute browser capture itself
+- Next: validate the packet/mirror wording, then merge the docs-only packet lane.
+
 ## C214_JUDGE_FACING_VISUAL_ASSET_POLISH
 
 - Branch: `fix/submission-close-c214`

--- a/docs/superpowers/pr-notes/2026-04-28-browser-recapture-after-phase2-packet.md
+++ b/docs/superpowers/pr-notes/2026-04-28-browser-recapture-after-phase2-packet.md
@@ -1,0 +1,22 @@
+# PR Note: Browser Recapture After Phase 2 Packet
+
+## Summary
+
+- adds the next execution packet for manual/browser screenshot recapture after the merged Phase 2 polish train
+- updates the AI-first mirrors so the repo points to a concrete recapture lane instead of a generic future intent
+- keeps current evidence truth unchanged: command-backed proof is current, affected browser screenshots remain stale until recaptured
+
+## Architecture impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
+- reason: this lane only adds workflow/packet guidance for evidence recapture
+
+## Mermaid
+
+```mermaid
+flowchart LR
+    A["2026-04-28 command smoke"] --> B["Current"]
+    C["Phase 2 UI/copy merges"] --> D["Browser rows stale"]
+    D --> E["New browser recapture packet"]
+    E --> F["Future manual/browser refresh"]
+```

--- a/docs/superpowers/tasks/2026-04-28-browser-recapture-after-phase2.md
+++ b/docs/superpowers/tasks/2026-04-28-browser-recapture-after-phase2.md
@@ -1,0 +1,93 @@
+# Feature Pod Task: Browser Recapture After Phase 2 Polish
+
+Task ID: `OPS_BROWSER_RECAPTURE_AFTER_PHASE2`
+Commit tag: `OPS-BROWSER`
+Owner: Session-specific
+Branch: `docs/post-phase2-browser-recapture`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Recapture the browser screenshot evidence that is now stale after the merged Phase 2 polish train (`#214`, `#215`, `#216`, `#217`) so the contest package can move the affected rows from `Stale` back to `Current`.
+
+## User-visible outcome
+
+- Contest docs can truthfully mark the current Knowledge, Tutor, Dashboard, and `/agents` screenshot rows as `Current`.
+- Reviewers see the latest teacher-controlled adaptive wording and loop framing rather than pre-polish browser captures.
+- The contest package keeps command-backed proof and browser-backed proof aligned without widening claims.
+
+## Owned files/modules
+
+- `docs/contest/screenshots/*`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- `docs/contest/README.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `docs/contest/DEMO_SCRIPT.md`
+- `ai_first/evidence/screenshots.md`
+- `docs/superpowers/tasks/2026-04-28-browser-recapture-after-phase2.md`
+- `docs/superpowers/pr-notes/*`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/daily/2026-04-28.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/services/`
+- `deeptutor/api/routers/`
+- `web/app/`
+- `web/components/`
+- `ai_first/AI_OPERATING_PROMPT.md` unless the browser-recapture workflow itself changes operating rules
+
+## Evidence contract
+
+- Reuse the latest command-backed smoke baseline from 2026-04-28 unless the local app must be restarted for capture confidence.
+- Recapture only the rows that are currently stale:
+  - Knowledge Pack metadata form
+  - Knowledge Pack after reload
+  - Tutor question and response
+  - Dashboard overview
+  - Dashboard recent activity
+  - `/agents` structured authoring
+  - `/agents` export action
+- Assessment screenshot rows already remain `Current`; do not recapture them unless the UI changed again before capture.
+- Only move `Stale` -> `Current` after new screenshots are produced, linked, and visually checked.
+
+## Acceptance criteria
+
+- Every stale screenshot row has a fresh artifact in `docs/contest/screenshots/`.
+- Contest evidence docs reference the new capture date and capture lane.
+- Hybrid `/agents` claims remain bounded to authoring/export proof plus the already-documented runtime-binding guardrail.
+- This lane does not change product/runtime code.
+
+## Required tests
+
+- `rg -n "Stale|Current|browser recapture|Knowledge Pack|Tutor Agent|Dashboard|/agents|screenshots" docs/contest ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## Manual verification
+
+- Open each new screenshot and confirm it matches the current merged UI.
+- Confirm no private data or credentials appear in the captures.
+- Confirm Knowledge and Tutor screenshots reflect the new loop framing from `#214` and `#215`.
+- Confirm Dashboard screenshots reflect the new teacher-reviewed signals framing from `#214` and `#215`.
+- Confirm `/agents` screenshots reflect the updated adaptive tutor wording from `#215`.
+
+## Parallel-work notes
+
+- This lane is docs/evidence-only and browser-heavy.
+- If browser capture is unavailable, leave rows `Stale` and document the blocker explicitly instead of inventing artifacts.
+- Do not “fix” UI or backend issues from this lane; capture the current merged behavior only.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged.
+
+## Handoff notes
+
+- `#217` intentionally split command-backed freshness from browser-backed freshness; this lane is the follow-up that can restore the browser rows to `Current`.
+- Start from `origin/main`, use demo-safe data, and only update screenshot dates after the fresh artifacts exist.


### PR DESCRIPTION
# PR Note: Browser Recapture After Phase 2 Packet

## Summary

- adds the next execution packet for manual/browser screenshot recapture after the merged Phase 2 polish train
- updates the AI-first mirrors so the repo points to a concrete recapture lane instead of a generic future intent
- keeps current evidence truth unchanged: command-backed proof is current, affected browser screenshots remain stale until recaptured

## Architecture impact

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated
- reason: this lane only adds workflow/packet guidance for evidence recapture

## Mermaid

```mermaid
flowchart LR
    A["2026-04-28 command smoke"] --> B["Current"]
    C["Phase 2 UI/copy merges"] --> D["Browser rows stale"]
    D --> E["New browser recapture packet"]
    E --> F["Future manual/browser refresh"]
```
