### PR TITLE
docs(ai-first): repair C211 terminal registry state [OPS-C211-REGFIX]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,6 +30,21 @@ Rules:
 
 ### Assignment
 
+- Owner: Control-plane repair lane
+- Machine: local
+- Worktree: `.worktrees/post-submission-close-sync`
+- Task: `OPS_C211_REGISTRY_REPAIR`
+- Status: in-progress
+- Branch: `docs/post-submission-close-terminal-repair`
+- Task packet: `docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md`
+- Owned files: `TASK_REGISTRY.json`, active-assignment mirror, daily log, and repair PR note only
+- PR:
+- Last update: 2026-04-28
+- Next action: mark `C211` completed in the registry, validate the repair, and open a docs-only PR
+- Blocker: none
+
+### Assignment
+
 - Owner: Post-221 sync lane
 - Machine: local
 - Worktree: `.worktrees/submission-close-c`

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,13 +34,13 @@ Rules:
 - Machine: local
 - Worktree: `.worktrees/post-submission-close-sync`
 - Task: `OPS_C211_REGISTRY_REPAIR`
-- Status: in-progress
+- Status: ready-for-review
 - Branch: `docs/post-submission-close-terminal-repair`
 - Task packet: `docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md`
 - Owned files: `TASK_REGISTRY.json`, active-assignment mirror, daily log, and repair PR note only
-- PR:
+- PR: `#225`
 - Last update: 2026-04-28
-- Next action: mark `C211` completed in the registry, validate the repair, and open a docs-only PR
+- Next action: merge the docs-only registry repair PR once checks are clear and no blocking review remains
 - Blocker: none
 
 ### Assignment

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -2092,10 +2092,10 @@
       "dependencies": [
         "C210_FINAL_PACKAGE_READINESS"
       ],
-      "status": "in-progress",
+      "status": "completed",
       "recommended_session_bucket": "session-c-polish",
       "layer": "optional-polish",
-      "notes": "Activated on branch fix/submission-close-c211 on 2026-04-28. Scope is bounded to teacher-entry product wording and setup surfaces only."
+      "notes": "Merged to main through PR #219 on 2026-04-28. Scope stayed bounded to teacher-entry wording and setup surfaces only."
     },
     {
       "id": "C212_CORE_LOOP_VISIBILITY_POLISH",

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -6,9 +6,10 @@
 - Task: `OPS_C211_REGISTRY_REPAIR`
 - Done: Opened a docs-only control-plane repair lane from `origin/main` after confirming that the merged AI-first mirrors already reflected `C211`, but `ai_first/TASK_REGISTRY.json` still incorrectly marked it `in-progress`.
 - Done: Added a tiny repair packet and PR note, recorded the lane in `ACTIVE_ASSIGNMENTS.md`, and corrected the authoritative registry entry to `completed` with merged PR `#219` in the notes.
+- Done: Pushed `docs/post-submission-close-terminal-repair` and opened Draft PR `#225` for the bounded registry repair.
 - Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `rg -n "C211_TEACHER_FIRST_ENTRY_POLISH|#219|completed|in-progress" ai_first/TASK_REGISTRY.json ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md docs/superpowers/pr-notes/2026-04-28-c211-registry-terminal-repair.md`; `git diff --check`
 - Blockers: none
-- Next: push the repair branch, open a docs-only PR, and merge it once checks are clear.
+- Next: complete self-review, move PR `#225` to Ready, and merge it once checks are clear.
 
 ## C215_POST_POLISH_EVIDENCE_RECAPTURE
 

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,15 @@
 # Daily Log: 2026-04-28
 
+## OPS_C211_REGISTRY_REPAIR
+
+- Branch: `docs/post-submission-close-terminal-repair`
+- Task: `OPS_C211_REGISTRY_REPAIR`
+- Done: Opened a docs-only control-plane repair lane from `origin/main` after confirming that the merged AI-first mirrors already reflected `C211`, but `ai_first/TASK_REGISTRY.json` still incorrectly marked it `in-progress`.
+- Done: Added a tiny repair packet and PR note, recorded the lane in `ACTIVE_ASSIGNMENTS.md`, and corrected the authoritative registry entry to `completed` with merged PR `#219` in the notes.
+- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `rg -n "C211_TEACHER_FIRST_ENTRY_POLISH|#219|completed|in-progress" ai_first/TASK_REGISTRY.json ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md docs/superpowers/pr-notes/2026-04-28-c211-registry-terminal-repair.md`; `git diff --check`
+- Blockers: none
+- Next: push the repair branch, open a docs-only PR, and merge it once checks are clear.
+
 ## C215_POST_POLISH_EVIDENCE_RECAPTURE
 
 - Branch: `fix/submission-close-c215`

--- a/docs/superpowers/pr-notes/2026-04-28-c211-registry-terminal-repair.md
+++ b/docs/superpowers/pr-notes/2026-04-28-c211-registry-terminal-repair.md
@@ -1,0 +1,22 @@
+# PR Note: C211 Registry Terminal Repair
+
+## Summary
+
+- mark `C211_TEACHER_FIRST_ENTRY_POLISH` completed in the authoritative task registry
+- record the tiny control-plane repair lane in the daily log and active-assignment board
+- leave runtime, evidence, and browser-capture state unchanged
+
+## Architecture Impact
+
+- No runtime or product modules changed.
+- This PR only repairs AI-first task-tracking metadata.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because no system contract changed.
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  A["PR #219 merged"] --> B["ACTIVE_ASSIGNMENTS says merged"]
+  A --> C["TASK_REGISTRY still in-progress"]
+  C --> D["Registry repair PR"]
+```

--- a/docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md
+++ b/docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md
@@ -1,0 +1,48 @@
+## Feature Pod Task: C211 Registry Terminal Repair
+
+Task ID: `OPS_C211_REGISTRY_REPAIR`
+Commit tag: `OPS-C211-REGFIX`
+Owner: Control-plane repair lane
+Branch: `docs/post-submission-close-terminal-repair`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Repair the last stale submission-close control-plane record so `C211_TEACHER_FIRST_ENTRY_POLISH` is marked completed after PR `#219` merged.
+
+## User-visible outcome
+
+- `ai_first/TASK_REGISTRY.json` matches the merged `C211` state already reflected elsewhere in the control plane.
+- Future workers do not see a false optional-polish task still `in-progress`.
+
+## Owned files/modules
+
+- `docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md`
+- `docs/superpowers/pr-notes/2026-04-28-c211-registry-terminal-repair.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `package-lock.json`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `.env*`
+- committed `data/` files
+
+## Output contract
+
+- Keep the repair bounded to control-plane metadata only.
+- Do not widen this lane into another evidence, browser, or runtime pass.
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `rg -n "C211_TEACHER_FIRST_ENTRY_POLISH|#219|completed|in-progress" ai_first/TASK_REGISTRY.json ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md docs/superpowers/pr-notes/2026-04-28-c211-registry-terminal-repair.md`
+- `git diff --check`


### PR DESCRIPTION
## Summary
- mark C211 completed in the authoritative task registry after merged PR #219
- add a tiny packet and PR note for the bounded control-plane repair lane
- record the lane in ACTIVE_ASSIGNMENTS and the daily log without touching runtime or evidence state

## Test Plan
- python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
- rg -n "C211_TEACHER_FIRST_ENTRY_POLISH|#219|completed|in-progress" ai_first/TASK_REGISTRY.json ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks/2026-04-28-c211-registry-terminal-repair.md docs/superpowers/pr-notes/2026-04-28-c211-registry-terminal-repair.md
- git diff --check