### PR TITLE
docs(ai-first): conclude c211 terminal state [OPS-C211-SYNC]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,13 +34,13 @@ Rules:
 - Machine: local
 - Worktree: `.worktrees/post-c211-terminal-sync`
 - Task: `OPS_POST_C211_TERMINAL_SYNC`
-- Status: in-progress
+- Status: review-ready
 - Branch: `docs/post-c211-terminal-sync`
 - Task packet: `docs/superpowers/tasks/2026-04-28-post-c211-terminal-sync.md`
 - Owned files: task registry, prompt, compact mirrors, daily log, and sync PR note
-- PR:
+- PR: `#226`
 - Last update: 2026-04-28
-- Next action: mark `C211` completed in the registry and align the remaining terminal-state mirrors
+- Next action: keep PR `#226` green and merge it once required checks pass
 - Blocker: none
 
 ### Assignment

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,6 +30,21 @@ Rules:
 
 ### Assignment
 
+- Owner: Post-C211 terminal sync lane
+- Machine: local
+- Worktree: `.worktrees/post-c211-terminal-sync`
+- Task: `OPS_POST_C211_TERMINAL_SYNC`
+- Status: in-progress
+- Branch: `docs/post-c211-terminal-sync`
+- Task packet: `docs/superpowers/tasks/2026-04-28-post-c211-terminal-sync.md`
+- Owned files: task registry, prompt, compact mirrors, daily log, and sync PR note
+- PR:
+- Last update: 2026-04-28
+- Next action: mark `C211` completed in the registry and align the remaining terminal-state mirrors
+- Blocker: none
+
+### Assignment
+
 - Owner: Post-221 sync lane
 - Machine: local
 - Worktree: `.worktrees/submission-close-c`

--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -244,7 +244,7 @@ When starting a new feature or fix:
 4. Use `ai_first/AI_FIRST_ROADMAP.md` to understand the autonomous loop and future operating direction.
 5. Keep `ai_first/EXECUTION_QUEUE.md` current after merges, blocker changes, and task selection.
 6. Keep GitHub issue state aligned with merged PRs so the queue mirrors real work, not historical leftovers.
-7. Continue from the next pending registry task in strict order after every successful merge or verification pass. Submission-close Phase 1 (`C201-C210`) is complete on `main`, so the current operational step is human review, optional video decision, or an explicitly opened optional Phase 2 polish task from `C211-C215`.
+7. Continue from the next pending registry task in strict order after every successful merge or verification pass. Submission-close Phase 1 (`C201-C210`) and the optional Phase 2 polish train (`C211-C215`) are complete on `main`, so the current operational step is human review, optional video decision, or a newly opened packet from `main`.
 8. Keep the demo-readiness smoke lane current after meaningful merges and treat smoke failures as the next task.
 9. Use `docs/contest/DEMO_DATA_RESET.md` before smoke when local demo state may be stale, missing, or private.
 10. Run the scripted reset command before the next smoke/evidence refresh so the merged utility is validated end to end.

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -2092,10 +2092,10 @@
       "dependencies": [
         "C210_FINAL_PACKAGE_READINESS"
       ],
-      "status": "in-progress",
+      "status": "completed",
       "recommended_session_bucket": "session-c-polish",
       "layer": "optional-polish",
-      "notes": "Activated on branch fix/submission-close-c211 on 2026-04-28. Scope is bounded to teacher-entry product wording and setup surfaces only."
+      "notes": "Merged to main through PR #219 on 2026-04-28. Scope stayed bounded to teacher-entry product wording and setup surfaces only."
     },
     {
       "id": "C212_CORE_LOOP_VISIBILITY_POLISH",

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -288,3 +288,13 @@
 - Tests: `rg -n "#221|browser recapture|human review|optional video|OPS_POST_221_BROWSER_RECAPTURE_SYNC" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
 - Blockers: None.
 - Next: move PR `#222` to Ready for review, watch CI, and merge it after checks are green.
+
+## Post-C211 Terminal Sync
+
+- Branch: `docs/post-c211-terminal-sync`
+- Task: `OPS_POST_C211_TERMINAL_SYNC`
+- Done: Opened a docs-only sync lane from updated `origin/main` after confirming `#219`, `#221`, and `#222` were merged while `TASK_REGISTRY.json` still left `C211` in progress.
+- Done: Marked `C211_TEACHER_FIRST_ENTRY_POLISH` completed in the registry and removed the last prompt wording that still treated optional Phase 2 as an unopened future step.
+- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `rg -n "C211|#219|#221|#222|human review|optional video|browser recapture|OPS_POST_C211_TERMINAL_SYNC" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
+- Blockers: None.
+- Next: open the docs-only PR, merge it if CI is green, then leave the repo in human-review state unless a new packet is explicitly opened from `main`.

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -295,6 +295,7 @@
 - Task: `OPS_POST_C211_TERMINAL_SYNC`
 - Done: Opened a docs-only sync lane from updated `origin/main` after confirming `#219`, `#221`, and `#222` were merged while `TASK_REGISTRY.json` still left `C211` in progress.
 - Done: Marked `C211_TEACHER_FIRST_ENTRY_POLISH` completed in the registry and removed the last prompt wording that still treated optional Phase 2 as an unopened future step.
+- Done: Opened Draft PR `#226` for `docs/post-c211-terminal-sync` after local validation.
 - Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `rg -n "C211|#219|#221|#222|human review|optional video|browser recapture|OPS_POST_C211_TERMINAL_SYNC" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
 - Blockers: None.
-- Next: open the docs-only PR, merge it if CI is green, then leave the repo in human-review state unless a new packet is explicitly opened from `main`.
+- Next: move PR `#226` to Ready for review, watch CI, and merge it if checks are green.

--- a/docs/superpowers/pr-notes/2026-04-28-post-c211-terminal-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-28-post-c211-terminal-sync.md
@@ -1,0 +1,33 @@
+# PR Note: Post-C211 Terminal Sync
+
+## Summary
+
+This PR closes the last control-plane inconsistency after the optional Phase 2 polish train and the browser-evidence refresh merged. It marks `C211` completed in the registry, removes stale “pending optional polish” language from compact mirrors, and restores one coherent terminal wait state.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  C211["PR #219 merged"]
+  Browser["PRs #221 + #222 merged"]
+  Registry["TASK_REGISTRY.json"]
+  Mirrors["Prompt + queue + snapshots"]
+  Terminal["Human review / optional video"]
+
+  C211 --> Registry
+  Browser --> Mirrors
+  Registry --> Terminal
+  Mirrors --> Terminal
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This lane only syncs task tracking and operating mirrors.
+
+## Validation
+
+```bash
+python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null
+rg -n "C211|#219|#221|#222|human review|optional video|browser recapture|OPS_POST_C211_TERMINAL_SYNC" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S
+git diff --check
+```

--- a/docs/superpowers/tasks/2026-04-28-post-c211-terminal-sync.md
+++ b/docs/superpowers/tasks/2026-04-28-post-c211-terminal-sync.md
@@ -1,0 +1,56 @@
+# Feature Pod Task: Post-C211 Terminal Sync
+
+Task ID: `OPS_POST_C211_TERMINAL_SYNC`
+Commit tag: `OPS-C211-SYNC`
+Owner: Docs sync lane
+Branch: `docs/post-c211-terminal-sync`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Sync the task registry and remaining AI-first mirrors after PR `#219` and the later browser-evidence/control-plane merges so `main` lands in one coherent terminal state.
+
+## User-visible outcome
+
+- `C211_TEACHER_FIRST_ENTRY_POLISH` is marked `completed` in `ai_first/TASK_REGISTRY.json`.
+- The prompt, queue, and compact mirrors no longer describe optional Phase 2 or browser recapture as pending work.
+- The repository ends in the correct wait state: human review, optional video, or a newly opened packet from `main`.
+
+## Owned files/modules
+
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-28.md`
+- `docs/superpowers/tasks/2026-04-28-post-c211-terminal-sync.md`
+- `docs/superpowers/pr-notes/2026-04-28-post-c211-terminal-sync.md`
+
+## Do-not-touch files/modules
+
+- `docs/contest/*`
+- `docs/contest/screenshots/*`
+- `web/`
+- `deeptutor/`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+- Any runtime or evidence artifact files outside the mirrors above
+
+## Acceptance criteria
+
+- Registry marks `C211` completed with merged-PR notes.
+- Active assignments no longer show any Phase 2 lane as active or review-ready.
+- Prompt and queue describe the current state as human review plus optional video only.
+
+## Required tests
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `rg -n "C211|#219|#221|#222|human review|optional video|browser recapture|OPS_POST_C211_TERMINAL_SYNC" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged.


### PR DESCRIPTION
## Summary
- mark `C211_TEACHER_FIRST_ENTRY_POLISH` completed in `TASK_REGISTRY.json`
- remove the last prompt wording that still treated optional Phase 2 as unopened future work
- add a focused sync packet and PR note for the final C211/control-plane cleanup

## Validation
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `rg -n "C211|#219|#221|#222|human review|optional video|browser recapture|OPS_POST_C211_TERMINAL_SYNC" ai_first docs/superpowers/tasks docs/superpowers/pr-notes -S`
- `git diff --check`

## Architecture
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated; control-plane and registry sync only
