### PR TITLE
docs(ai-first): finalize active-assignment merge sync [OPS-227-SYNC]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,13 +34,13 @@ Rules:
 - Machine: local
 - Worktree: `.worktrees/post-active-assignments-terminal-sync`
 - Task: `OPS_ACTIVE_ASSIGNMENTS_TERMINAL_SYNC`
-- Status: ready-for-review
+- Status: merged
 - Branch: `docs/post-active-assignments-terminal-sync`
 - Task packet: `docs/superpowers/tasks/2026-04-28-post-active-assignments-terminal-sync.md`
 - Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, daily log, and sync task/PR note only
 - PR: `#227`
 - Last update: 2026-04-28
-- Next action: preserve the merged `#225` terminal state in `ACTIVE_ASSIGNMENTS.md` so it no longer contradicts the authoritative prompt
+- Next action: preserve the merged `#227` active-assignment sync as part of the terminal-state baseline
 - Blocker: none
 
 ### Assignment

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,15 @@
 # Daily Log: 2026-04-28
 
+## OPS_POST_227_ACTIVE_ASSIGNMENTS_SYNC
+
+- Branch: `docs/post-227-active-assignments-merge-sync`
+- Task: `OPS_POST_227_ACTIVE_ASSIGNMENTS_SYNC`
+- Done: Opened a final docs-only sync lane from refreshed `origin/main` after confirming that PR `#227` had merged but `ai_first/ACTIVE_ASSIGNMENTS.md` still recorded that lane as `ready-for-review`.
+- Done: Updated the merged `OPS_ACTIVE_ASSIGNMENTS_TERMINAL_SYNC` entry to terminal-state truth without reopening broader submission-close scope.
+- Tests: pending local docs-only validation
+- Blockers: none
+- Next: run the grep/diff checks, then push the minimal merge-sync PR.
+
 ## OPS_ACTIVE_ASSIGNMENTS_TERMINAL_SYNC
 
 - Branch: `docs/post-active-assignments-terminal-sync`

--- a/docs/superpowers/pr-notes/2026-04-28-post-227-active-assignments-merge-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-28-post-227-active-assignments-merge-sync.md
@@ -1,0 +1,28 @@
+# PR Note: Post-227 Active-Assignments Merge Sync
+
+## Summary
+
+This PR closes the last self-referential control-plane drift after PR `#227` merged. It updates only the active-assignment mirror and required packet/log so the merged lane is recorded as merged rather than still awaiting review.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Merge["PR #227 merged"]
+  Assignments["ACTIVE_ASSIGNMENTS.md"]
+  Terminal["No active AI-owned blocker"]
+
+  Merge --> Assignments
+  Assignments --> Terminal
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This lane only finalizes a control-plane mirror after a docs-only merge.
+
+## Validation
+
+```bash
+rg -n "OPS_ACTIVE_ASSIGNMENTS_TERMINAL_SYNC|OPS_POST_227_ACTIVE_ASSIGNMENTS_SYNC|#227|ready-for-review|merged" ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks docs/superpowers/pr-notes -S
+git diff --check
+```

--- a/docs/superpowers/tasks/2026-04-28-post-227-active-assignments-merge-sync.md
+++ b/docs/superpowers/tasks/2026-04-28-post-227-active-assignments-merge-sync.md
@@ -1,0 +1,50 @@
+# Feature Pod Task: Post-227 Active-Assignments Merge Sync
+
+Task ID: `OPS_POST_227_ACTIVE_ASSIGNMENTS_SYNC`
+Commit tag: `OPS-227-SYNC`
+Owner: Docs sync lane
+Branch: `docs/post-227-active-assignments-merge-sync`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Finalize the short-lived coordination mirror after PR `#227` merged so `ai_first/ACTIVE_ASSIGNMENTS.md` no longer describes that lane as still in review.
+
+## User-visible outcome
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md` records PR `#227` as merged.
+- The active-assignment mirror no longer contains any `ready-for-review` submission-close repair lane that has already landed on `main`.
+- The repository stays in the same terminal state already declared by the authoritative prompt and queue.
+
+## Owned files/modules
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-28.md`
+- `docs/superpowers/tasks/2026-04-28-post-227-active-assignments-merge-sync.md`
+- `docs/superpowers/pr-notes/2026-04-28-post-227-active-assignments-merge-sync.md`
+
+## Do-not-touch files/modules
+
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/TASK_REGISTRY.json`
+- `docs/contest/*`
+- `web/`
+- `deeptutor/`
+
+## Acceptance criteria
+
+- The `OPS_ACTIVE_ASSIGNMENTS_TERMINAL_SYNC` entry is recorded as merged with PR `#227`.
+- No stale `ready-for-review` state remains for that merged lane.
+- No broader submission-close scope is reopened.
+
+## Required tests
+
+- `rg -n "OPS_ACTIVE_ASSIGNMENTS_TERMINAL_SYNC|OPS_POST_227_ACTIVE_ASSIGNMENTS_SYNC|#227|ready-for-review|merged" ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged.


### PR DESCRIPTION
# PR Note: Post-227 Active-Assignments Merge Sync

## Summary

This PR closes the last self-referential control-plane drift after PR `#227` merged. It updates only the active-assignment mirror and required packet/log so the merged lane is recorded as merged rather than still awaiting review.

## Mermaid Diagram

```mermaid
flowchart LR
  Merge["PR #227 merged"]
  Assignments["ACTIVE_ASSIGNMENTS.md"]
  Terminal["No active AI-owned blocker"]

  Merge --> Assignments
  Assignments --> Terminal
```

## Architecture Impact

`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This lane only finalizes a control-plane mirror after a docs-only merge.

## Validation

```bash
rg -n "OPS_ACTIVE_ASSIGNMENTS_TERMINAL_SYNC|OPS_POST_227_ACTIVE_ASSIGNMENTS_SYNC|#227|ready-for-review|merged" ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks docs/superpowers/pr-notes -S
git diff --check
```
