### PR TITLE
docs(ai-first): sync post-229 active assignment truth [OPS-POST-229]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,13 +34,13 @@ Rules:
 - Machine: local
 - Worktree: `.worktrees/post-terminal-state-sync`
 - Task: `OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC`
-- Status: in-progress
+- Status: ready-for-review
 - Branch: `docs/post-terminal-state-sync`
 - Task packet: `docs/superpowers/tasks/2026-04-28-post-229-active-assignments-merge-sync.md`
 - Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, daily log, and sync task/PR note only
-- PR:
+- PR: `#230`
 - Last update: 2026-04-28
-- Next action: update the merged `OPS_SCREENSHOT_TRUTH_SYNC` assignment to terminal-state truth and open a docs-only PR
+- Next action: merge the docs-only post-229 repair PR once checks are clear and no blocking review remains
 - Blocker: none
 
 ### Assignment

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,17 +30,32 @@ Rules:
 
 ### Assignment
 
+- Owner: Post-229 active-assignment sync lane
+- Machine: local
+- Worktree: `.worktrees/post-terminal-state-sync`
+- Task: `OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC`
+- Status: in-progress
+- Branch: `docs/post-terminal-state-sync`
+- Task packet: `docs/superpowers/tasks/2026-04-28-post-229-active-assignments-merge-sync.md`
+- Owned files: `ai_first/ACTIVE_ASSIGNMENTS.md`, daily log, and sync task/PR note only
+- PR:
+- Last update: 2026-04-28
+- Next action: update the merged `OPS_SCREENSHOT_TRUTH_SYNC` assignment to terminal-state truth and open a docs-only PR
+- Blocker: none
+
+### Assignment
+
 - Owner: Screenshot truth sync lane
 - Machine: local
 - Worktree: `.worktrees/post-screenshot-truth-sync`
 - Task: `OPS_SCREENSHOT_TRUTH_SYNC`
-- Status: ready-for-review
+- Status: merged
 - Branch: `docs/post-screenshot-truth-sync`
 - Task packet: `docs/superpowers/tasks/2026-04-28-post-screenshot-truth-sync.md`
 - Owned files: authoritative prompt, compact mirrors, daily log, and sync task/PR note only
-- PR:
+- PR: `#229`
 - Last update: 2026-04-28
-- Next action: align AI-first mirrors with the authoritative contest evidence docs that still mark browser screenshot rows stale
+- Next action: preserve the merged screenshot-truth sync as the current control-plane baseline for stale browser-backed evidence rows
 - Blocker: none
 
 ### Assignment

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -1,5 +1,15 @@
 # Daily Log: 2026-04-28
 
+## OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC
+
+- Branch: `docs/post-terminal-state-sync`
+- Task: `OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC`
+- Done: Opened a final docs-only sync lane from refreshed `origin/main` after confirming that PR `#229` had merged but `ai_first/ACTIVE_ASSIGNMENTS.md` still recorded `OPS_SCREENSHOT_TRUTH_SYNC` as `ready-for-review`.
+- Done: Added the bounded sync packet and PR note, recorded this repair lane in `ACTIVE_ASSIGNMENTS.md`, and updated the merged screenshot-truth lane to terminal-state truth.
+- Tests: `rg -n "OPS_SCREENSHOT_TRUTH_SYNC|OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC|#229|ready-for-review|merged" ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
+- Blockers: none
+- Next: push the docs-only repair branch, open a PR, and merge it once checks are clear.
+
 ## OPS_SCREENSHOT_TRUTH_SYNC
 
 - Branch: `docs/post-screenshot-truth-sync`

--- a/ai_first/daily/2026-04-28.md
+++ b/ai_first/daily/2026-04-28.md
@@ -6,9 +6,10 @@
 - Task: `OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC`
 - Done: Opened a final docs-only sync lane from refreshed `origin/main` after confirming that PR `#229` had merged but `ai_first/ACTIVE_ASSIGNMENTS.md` still recorded `OPS_SCREENSHOT_TRUTH_SYNC` as `ready-for-review`.
 - Done: Added the bounded sync packet and PR note, recorded this repair lane in `ACTIVE_ASSIGNMENTS.md`, and updated the merged screenshot-truth lane to terminal-state truth.
+- Done: Pushed `docs/post-terminal-state-sync` and opened Draft PR `#230` for the bounded post-229 repair.
 - Tests: `rg -n "OPS_SCREENSHOT_TRUTH_SYNC|OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC|#229|ready-for-review|merged" ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks docs/superpowers/pr-notes -S`; `git diff --check`
 - Blockers: none
-- Next: push the docs-only repair branch, open a PR, and merge it once checks are clear.
+- Next: complete self-review, move PR `#230` to Ready, and merge it once checks are clear.
 
 ## OPS_SCREENSHOT_TRUTH_SYNC
 

--- a/docs/superpowers/pr-notes/2026-04-28-post-229-active-assignments-merge-sync.md
+++ b/docs/superpowers/pr-notes/2026-04-28-post-229-active-assignments-merge-sync.md
@@ -1,0 +1,20 @@
+# PR Note: Post-229 Active Assignments Merge Sync
+
+## Summary
+
+- mark `OPS_SCREENSHOT_TRUTH_SYNC` merged after PR `#229`
+- record the tiny post-merge repair lane in the daily log
+- leave prompt, queue, contest evidence, and runtime files unchanged
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  A["PR #229 merged"] --> B["ACTIVE_ASSIGNMENTS still ready-for-review"]
+  B --> C["Post-229 sync lane"]
+  C --> D["Merged terminal-state mirror"]
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This lane only repairs the active-assignment mirror and daily log.

--- a/docs/superpowers/tasks/2026-04-28-post-229-active-assignments-merge-sync.md
+++ b/docs/superpowers/tasks/2026-04-28-post-229-active-assignments-merge-sync.md
@@ -1,0 +1,46 @@
+## Feature Pod Task: Post-229 Active Assignments Merge Sync
+
+Task ID: `OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC`
+Commit tag: `OPS-POST-229`
+Owner: Active-assignment merge sync lane
+Branch: `docs/post-terminal-state-sync`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Repair the active-assignment mirror after PR `#229` merged so `OPS_SCREENSHOT_TRUTH_SYNC` is no longer shown as `ready-for-review`.
+
+## User-visible outcome
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md` reflects that `OPS_SCREENSHOT_TRUTH_SYNC` is merged.
+- The daily log records the tiny terminal-state repair lane.
+- No broader submission-close files are reopened.
+
+## Owned files/modules
+
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-28.md`
+- `docs/superpowers/tasks/2026-04-28-post-229-active-assignments-merge-sync.md`
+- `docs/superpowers/pr-notes/2026-04-28-post-229-active-assignments-merge-sync.md`
+
+## Do-not-touch files/modules
+
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/CURRENT_STATE.md`
+- `ai_first/EXECUTION_QUEUE.md`
+- `ai_first/NEXT_ACTIONS.md`
+- `ai_first/TASK_REGISTRY.json`
+- `docs/contest/*`
+- `web/`
+- `deeptutor/`
+
+## Acceptance criteria
+
+- No stale `ready-for-review` state remains for merged PR `#229`.
+- The repair stays bounded to active-assignment and daily-log truth only.
+
+## Required tests
+
+- `rg -n "OPS_SCREENSHOT_TRUTH_SYNC|OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC|#229|ready-for-review|merged" ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks docs/superpowers/pr-notes -S`
+- `git diff --check`


### PR DESCRIPTION
## Summary
- mark OPS_SCREENSHOT_TRUTH_SYNC merged after PR #229
- add a tiny post-229 sync packet and PR note for the bounded repair lane
- record the repair in ACTIVE_ASSIGNMENTS and the daily log only

## Test Plan
- rg -n "OPS_SCREENSHOT_TRUTH_SYNC|OPS_POST_229_ACTIVE_ASSIGNMENTS_SYNC|#229|ready-for-review|merged" ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-28.md docs/superpowers/tasks docs/superpowers/pr-notes -S
- git diff --check