### PR TITLE
docs: tighten runtime task depth contract

### DIFF
--- a/ai_first/AI_OPERATING_PROMPT.md
+++ b/ai_first/AI_OPERATING_PROMPT.md
@@ -54,6 +54,34 @@ Before edits:
 - Every commit must include the active task identifier from the task packet or task registry.
 - Do not broaden scope just because the repo contains more files; stay inside the task packet or bootstrap contract.
 
+## Runtime-change design gate
+
+- Any task that changes runtime behavior must read `.github/skills/brainstorming/SKILL.md` before implementation.
+- Docs-only, mirror-only, and other non-runtime control-plane updates are exempt from this gate.
+- Runtime implementation may start only after the worker records a bounded design artifact in one of these places:
+  - a dedicated spec under `docs/superpowers/specs/`, or
+  - a `Design before implementation` section inside the active task packet.
+- The design artifact must state at minimum:
+  - current behavior
+  - intended behavior change
+  - 2 candidate approaches with the chosen approach and reason
+  - concrete files or modules expected to change
+  - tests to add or update
+- For runtime tasks, reading the brainstorming skill is necessary but not sufficient. If no bounded design artifact exists yet, do not edit runtime code.
+- Runtime tasks must record a codebase survey before implementation that covers:
+  - entry points or handlers
+  - primary service or use-case modules
+  - shared contracts, schemas, or types
+  - adjacent or reused flows that may share the same logic
+  - the closest existing tests
+- Runtime tasks must declare the expected impact surface before implementation:
+  - files or modules likely to change
+  - files or modules reviewed but expected to remain unchanged
+  - validation paths that must be checked before the task can stop
+- Large runtime tasks must optimize for impact-surface coverage, not just minimal edits. The worker must inspect the relevant sibling paths and explain why each affected area was changed or intentionally left unchanged.
+- A runtime task is not complete if it only changes surface text, styling, or shallow wiring while leaving the underlying behavior, impact-surface review, test coverage, and design artifact unchanged.
+- A runtime task is also not complete if the worker edits a narrow cluster of files but does not show that the broader affected code paths were inspected.
+
 ## Commit message convention
 
 - Treat the task packet as the source of truth for commit tagging.
@@ -157,11 +185,13 @@ When starting work, do the following in order:
 2. Confirm the task ID and commit tag.
 3. Confirm owned files and do-not-touch files.
 4. Check whether the change is docs-only, workflow-only, or a runtime change.
-5. Read the minimum additional context needed.
-6. Make the smallest useful change.
-7. Run the relevant test or validation command.
-8. Update this file if the repo-level operating model changed.
-9. Update the daily log and handoff notes.
+5. If the change is a runtime change, read `.github/skills/brainstorming/SKILL.md` and write the bounded design artifact before editing code.
+6. If the change is a runtime change, complete the required codebase survey and declare the expected impact surface before editing code.
+7. Read the minimum additional context needed.
+8. Make the smallest useful change that still covers the declared impact surface.
+9. Run the relevant test or validation command.
+10. Update this file if the repo-level operating model changed.
+11. Update the daily log and handoff notes.
 
 ## Completion rules
 
@@ -171,10 +201,11 @@ Before handing off:
 2. Record tests and failures.
 3. Update `ai_first/daily/YYYY-MM-DD.md`.
 4. Update this file if status, workflow, or next actions changed.
-5. Confirm the PR is Ready for review (not Draft) before requesting merge.
-6. Confirm all required CI checks are green before merge.
-7. Check whether the PR is eligible for autonomous merge under the merge policy.
-8. Add handoff notes with changed files, risks, merge status, and the next recommended read path.
+5. For runtime tasks, confirm the declared impact surface was inspected and explain any reviewed files or modules that were intentionally left unchanged.
+6. Confirm the PR is Ready for review (not Draft) before requesting merge.
+7. Confirm all required CI checks are green before merge.
+8. Check whether the PR is eligible for autonomous merge under the merge policy.
+9. Add handoff notes with changed files, risks, merge status, and the next recommended read path.
 ## Task Tracking System
 
 The project uses a structured task registry to track MVP gaps, priorities, and progress:

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -7,7 +7,9 @@
 - Done: Tightened the AI-first control plane so every runtime-behavior task must read `.github/skills/brainstorming/SKILL.md` and produce a bounded design artifact before editing code, while docs-only and mirror-only work remains exempt.
 - Done: Updated the feature task template to require a `Design before implementation` section that captures current behavior, intended behavior, approaches considered, chosen path, owned runtime files, and test impact.
 - Done: Tightened the runtime-task contract further so workers must record required code reading, declare the expected impact surface, and justify reviewed sibling paths before claiming completion.
+- Done: Added the bounded task packet and PR architecture note for the docs-only runtime-depth-contract lane so the operating change can ship through the standard PR path.
 - Tests: `rg -n "Runtime-change design gate|codebase survey|impact surface|Required code reading|Impact surface and stop conditions" ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md`; `git diff --check -- ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md`
+- Tests: `rg -n "Runtime-change design gate|codebase survey|impact surface|Required code reading|Impact surface and stop conditions" ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md`; `git diff --check -- ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md`
 - Blockers: none
 - Next: use the tightened packet sections on the next runtime task so the worker must survey the broader code path before implementation.
 

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -1,0 +1,20 @@
+# Daily Log: 2026-04-30
+
+## AI-first Operating Rule Tightening
+
+- Branch: `main`
+- Task: `OPS_RUNTIME_BRAINSTORMING_GATE`
+- Done: Tightened the AI-first control plane so every runtime-behavior task must read `.github/skills/brainstorming/SKILL.md` and produce a bounded design artifact before editing code, while docs-only and mirror-only work remains exempt.
+- Done: Updated the feature task template to require a `Design before implementation` section that captures current behavior, intended behavior, approaches considered, chosen path, owned runtime files, and test impact.
+- Done: Tightened the runtime-task contract further so workers must record required code reading, declare the expected impact surface, and justify reviewed sibling paths before claiming completion.
+- Tests: `rg -n "Runtime-change design gate|codebase survey|impact surface|Required code reading|Impact surface and stop conditions" ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md`; `git diff --check -- ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md`
+- Blockers: none
+- Next: use the tightened packet sections on the next runtime task so the worker must survey the broader code path before implementation.
+
+## Human Review Needed
+
+- None yet.
+
+## Architecture Map Updates
+
+- None. Operating-rule change only.

--- a/ai_first/templates/feature-pod-task.md
+++ b/ai_first/templates/feature-pod-task.md
@@ -15,6 +15,37 @@ Active assignment:
 
 ## API/data contract
 
+## Design before implementation
+
+- Runtime behavior change: yes/no
+- If no: state why this task is docs-only, mirror-only, or otherwise non-runtime.
+- If yes: confirm `.github/skills/brainstorming/SKILL.md` was read before implementation.
+- Current behavior:
+- Intended behavior change:
+- Candidate approach A:
+- Candidate approach B:
+- Chosen approach and reason:
+- Concrete files/modules expected to change:
+- Tests to add or update:
+
+## Required code reading
+
+- Entry points/handlers to inspect:
+- Primary logic/service/use-case modules to inspect:
+- Shared contracts/schemas/types to inspect:
+- Adjacent or reused flows to inspect:
+- Existing tests to inspect:
+- Notes from codebase survey:
+
+## Impact surface and stop conditions
+
+- Expected affected areas:
+- Files/modules likely to change:
+- Files/modules that must be reviewed even if they may remain unchanged:
+- Minimum validation paths before the task can stop:
+- What would count as a shallow fix for this task:
+- Conditions that must be checked before marking done:
+
 ## Acceptance criteria
 
 ## Required tests

--- a/docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md
+++ b/docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md
@@ -1,0 +1,24 @@
+# PR Note: Runtime Task Depth Contract
+
+## Summary
+
+- require runtime tasks to read `.github/skills/brainstorming/SKILL.md` before implementation
+- require a codebase survey and declared impact surface before runtime edits begin
+- update the feature task template so large tasks cannot be closed after a shallow local edit
+
+## Architecture Impact
+
+- No runtime or product modules changed.
+- This PR tightens the AI-first control plane and task packet contract only.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because no product or system architecture changed.
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  A["Runtime task request"] --> B["Read brainstorming skill"]
+  B --> C["Record design artifact"]
+  C --> D["Survey codebase and impact surface"]
+  D --> E["Implement across validated paths"]
+  E --> F["Completion allowed only after impact-surface review"]
+```

--- a/docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md
+++ b/docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md
@@ -1,0 +1,48 @@
+## Feature Pod Task: Runtime Task Depth Contract
+
+Task ID: `OPS_RUNTIME_BRAINSTORMING_GATE`
+Commit tag: `OPS_RUNTIME_BRAINSTORMING_GATE`
+Owner: AI-first operating lane
+Branch: `docs/runtime-task-depth-contract`
+GitHub Issue:
+Active assignment:
+
+## Goal
+
+Tighten the AI-first runtime-task contract so workers must inspect the broader code path before implementation instead of stopping after a shallow local fix.
+
+## User-visible outcome
+
+- Runtime tasks must read the brainstorming skill before implementation.
+- Runtime tasks must declare a bounded design artifact, required code reading, and expected impact surface before editing code.
+- Runtime tasks cannot claim completion without showing that sibling paths and validation paths were inspected.
+
+## Owned files/modules
+
+- `ai_first/AI_OPERATING_PROMPT.md`
+- `ai_first/templates/feature-pod-task.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md`
+- `docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/`
+- `web/`
+- `.github/workflows/`
+- `requirements/`
+- `docs/package-lock.json`
+- `web/package-lock.json`
+- `.env*`
+- committed `data/` files
+
+## Output contract
+
+- Keep the change bounded to AI-first operating docs and templates.
+- Do not change runtime product code.
+- Do not change unrelated dirty files in the current worktree.
+
+## Validation
+
+- `rg -n "Runtime-change design gate|codebase survey|impact surface|Required code reading|Impact surface and stop conditions" ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md`
+- `git diff --check -- ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md`


### PR DESCRIPTION
## Summary
- require runtime tasks to read the brainstorming skill and record a bounded design artifact before editing code
- require required-code-reading and impact-surface declarations in the feature task template
- add the task packet, PR note, and daily-log trail for this docs-only operating change

## Validation
- rg -n "Runtime-change design gate|codebase survey|impact surface|Required code reading|Impact surface and stop conditions" ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md
- git diff --check -- ai_first/AI_OPERATING_PROMPT.md ai_first/templates/feature-pod-task.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-runtime-task-depth-contract.md docs/superpowers/pr-notes/2026-04-30-runtime-task-depth-contract.md

## Main System Map
- Not updated; this PR changes AI-first operating rules and templates only.