### PR TITLE
docs: add contest differentiation follow-up packets

### DIFF
--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "last_updated": "2026-04-28T11:30:00Z",
+    "last_updated": "2026-04-30T09:45:00Z",
     "project": "Multiagent Learning Platform - VnExpress Contest MVP",
     "status": "Active Development",
-    "total_tasks": 88
+    "total_tasks": 92
   },
   "task_categories": {
     "completed": {
@@ -99,7 +99,7 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 14,
+      "count": 18,
       "tasks": [
         "C202_SUBMISSION_SCOPE_FREEZE",
         "C203_CLAIM_AND_PROOF_CONTRACT_FREEZE",
@@ -114,7 +114,11 @@
         "C212_CORE_LOOP_VISIBILITY_POLISH",
         "C213_DIFFERENTIATION_WORDING_SWEEP",
         "C214_JUDGE_FACING_VISUAL_ASSET_POLISH",
-        "C215_POST_POLISH_EVIDENCE_RECAPTURE"
+        "C215_POST_POLISH_EVIDENCE_RECAPTURE",
+        "C216_CONTEST_SHELL_SCOPE_TRIM",
+        "C217_TEACHER_COCKPIT_DEFAULT_ENTRY",
+        "C218_CONTEST_BRAND_AND_CLASSROOM_TERMINOLOGY",
+        "C219_CLASSROOM_CASE_STUDY_AND_BOUNDED_METRIC_CARD"
       ]
     }
   },
@@ -2193,6 +2197,104 @@
       "recommended_session_bucket": "session-b-validation",
       "layer": "optional-polish",
       "notes": "Merged to main through PR #217 on 2026-04-28. Scope stayed bounded to evidence freshness docs after the latest Phase 2 polish merges; no new smoke run or browser recapture was performed in this lane."
+    },
+    {
+      "id": "C216_CONTEST_SHELL_SCOPE_TRIM",
+      "category": "Contest Differentiation",
+      "priority": 89,
+      "title": "Contest Shell Scope Trim",
+      "description": "Demote or hide non-core DeepTutor-derived routes from the primary contest shell so the default product path stays anchored to Knowledge Pack, Assessment, Tutor, Diagnosis, and Intervention.",
+      "scope": {
+        "frontend": "web/components/sidebar/SidebarShell.tsx, workspace shell navigation, and any bounded contest-facing route affordances needed to keep the main demo linear"
+      },
+      "affected_features": [
+        "Contest UI",
+        "Demo Operations",
+        "Information Architecture"
+      ],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": [
+        "C213_DIFFERENTIATION_WORDING_SWEEP"
+      ],
+      "status": "pending",
+      "recommended_session_bucket": "session-c-polish",
+      "layer": "optional-polish",
+      "notes": "Triggered by the 2026-04-27 contest differentiation audit: the primary shell still exposes generic `Chat`, `Co-Writer`, `Guided Learning`, `Memory`, and other inherited surfaces that dilute the contest story."
+    },
+    {
+      "id": "C217_TEACHER_COCKPIT_DEFAULT_ENTRY",
+      "category": "Contest Differentiation",
+      "priority": 90,
+      "title": "Teacher Cockpit Default Entry",
+      "description": "Replace the generic chat-first workspace landing with a teacher-first cockpit or redirect that foregrounds classroom setup, assessment, tutor setup, and students needing attention before free-form tooling.",
+      "scope": {
+        "frontend": "web/app/(workspace)/page.tsx, web/app/(workspace)/dashboard/page.tsx, and shared contest-facing summary components needed for a teacher-first entry"
+      },
+      "affected_features": [
+        "Contest UI",
+        "Teacher Experience",
+        "Dashboard Entry"
+      ],
+      "complexity": "High",
+      "estimated_hours": 6,
+      "dependencies": [
+        "C211_TEACHER_FIRST_ENTRY_POLISH",
+        "C216_CONTEST_SHELL_SCOPE_TRIM"
+      ],
+      "status": "pending",
+      "recommended_session_bucket": "session-c-polish",
+      "layer": "optional-polish",
+      "notes": "The current `/` workspace entry is still the broad multi-capability DeepTutor chat surface, which conflicts with the requested teacher-cockpit first impression."
+    },
+    {
+      "id": "C218_CONTEST_BRAND_AND_CLASSROOM_TERMINOLOGY",
+      "category": "Contest Differentiation",
+      "priority": 91,
+      "title": "Contest Brand And Classroom Terminology",
+      "description": "Add a bounded contest-facing brand and classroom-first terminology layer so judges see a Vietnamese classroom product rather than raw DeepTutor naming and generic agent-workspace labels.",
+      "scope": {
+        "frontend": "web/components/sidebar/SidebarShell.tsx, contest-facing page headers, and the relevant `web/locales/*/app.json` labels used on the primary demo path"
+      },
+      "affected_features": [
+        "Contest UI",
+        "Localization",
+        "Brand Identity"
+      ],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": [
+        "C213_DIFFERENTIATION_WORDING_SWEEP"
+      ],
+      "status": "pending",
+      "recommended_session_bucket": "session-c-polish",
+      "layer": "optional-polish",
+      "notes": "DeepTutor branding and generic labels remain visible in the current sidebar, shell header, and locale strings even after the earlier wording polish."
+    },
+    {
+      "id": "C219_CLASSROOM_CASE_STUDY_AND_BOUNDED_METRIC_CARD",
+      "category": "Contest Differentiation",
+      "priority": 92,
+      "title": "Classroom Case Study And Bounded Metric Card",
+      "description": "Package one concrete classroom case study plus a small set of non-overclaim operational metrics so the contest story stays anchored to one teacher workflow instead of a long feature list.",
+      "scope": {
+        "docs": "docs/contest/DEMO_SCRIPT.md, docs/contest/README.md, docs/contest/CASEPACK_AND_EVALUATION_DATASET.md, docs/contest/VALIDATION_REPORT.md, and any aligned `ai_first/competition/` copy"
+      },
+      "affected_features": [
+        "Contest Narrative",
+        "Demo Operations",
+        "Evidence Calibration"
+      ],
+      "complexity": "Medium",
+      "estimated_hours": 4,
+      "dependencies": [
+        "C205_DEMO_DATA_AND_SMOKE_CONTRACT_REFRESH",
+        "C207_SUBMISSION_NARRATIVE_PACK"
+      ],
+      "status": "pending",
+      "recommended_session_bucket": "session-a-docs",
+      "layer": "submission-docs",
+      "notes": "The repository already has demo-safe reset data and a validation casepack, but it still lacks one explicit judge-facing case-study card and a compact metric set such as grounded-tutor coverage, recommendation count, or intervention follow-through for that same scenario."
     }
   ],
   "github_issues_template": {
@@ -2372,6 +2474,20 @@
       "C212",
       "C213",
       "C214"
+    ],
+    "C216": [
+      "C213"
+    ],
+    "C217": [
+      "C211",
+      "C216"
+    ],
+    "C218": [
+      "C213"
+    ],
+    "C219": [
+      "C205",
+      "C207"
     ]
   },
   "milestones": {
@@ -2454,6 +2570,16 @@
         "C215"
       ],
       "target_date": "2026-05-05"
+    },
+    "DIFFERENTIATION_HARDENING": {
+      "title": "Contest Differentiation Hardening",
+      "tasks": [
+        "C216",
+        "C217",
+        "C218",
+        "C219"
+      ],
+      "target_date": "2026-05-12"
     }
   }
 }

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -17,6 +17,21 @@
 
 - None yet.
 
+## Contest Differentiation Audit
+
+- Branch: `main`
+- Task: `OPS_CONTEST_DIFFERENTIATION_AUDIT`
+- Done: Read `ai_first/contest-product-differentiation (1).md` and compared its product-positioning recommendations against the current repo state, especially the contest docs, workspace landing, sidebar shell, `/agents`, Knowledge, and Dashboard surfaces.
+- Done: Confirmed the core teacher-controlled loop is already implemented and documented, but the default web shell still exposes a generic DeepTutor-style chat-first entry, broad inherited navigation, and visible DeepTutor branding that dilute the judge-facing story.
+- Done: Added four pending follow-up tasks to `ai_first/TASK_REGISTRY.json`: `C216_CONTEST_SHELL_SCOPE_TRIM`, `C217_TEACHER_COCKPIT_DEFAULT_ENTRY`, `C218_CONTEST_BRAND_AND_CLASSROOM_TERMINOLOGY`, and `C219_CLASSROOM_CASE_STUDY_AND_BOUNDED_METRIC_CARD`.
+- Done: Created the bounded execution packet `docs/superpowers/tasks/2026-04-30-c216-contest-shell-scope-trim.md` so a follow-up AI worker can trim the contest shell without colliding with the later `C217` default-entry work or `C218` branding work.
+- Done: Created the runtime-facing packet `docs/superpowers/tasks/2026-04-30-c217-teacher-cockpit-default-entry.md` with an in-packet design contract so a follow-up worker can change the default landing flow without reopening scope on shell trim, branding, or docs-only narrative work.
+- Done: Created the wording/branding packet `docs/superpowers/tasks/2026-04-30-c218-contest-brand-and-classroom-terminology.md` so a follow-up worker can localize the contest-facing shell and primary classroom labels without widening into routing or case-study docs.
+- Done: Created the docs-only packet `docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md` so a follow-up worker can package one judge-facing classroom scenario and a bounded metric card without changing runtime behavior or evidence freshness state.
+- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check -- ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-30.md`
+- Blockers: none
+- Next: if this differentiation pass is approved, open one bounded packet at a time starting with `C216` so the demo shell and default entry match the contest narrative.
+
 ## Architecture Map Updates
 
 - None. Operating-rule change only.

--- a/docs/superpowers/pr-notes/2026-04-30-contest-differentiation-follow-up-packets.md
+++ b/docs/superpowers/pr-notes/2026-04-30-contest-differentiation-follow-up-packets.md
@@ -1,0 +1,46 @@
+# 2026-04-30 Contest Differentiation Follow-up Packets
+
+## Summary
+
+- audited `ai_first/contest-product-differentiation (1).md` against the current merged repo state
+- added four new follow-up registry tasks for contest differentiation hardening: `C216`, `C217`, `C218`, and `C219`
+- created bounded execution packets so each follow-up can be implemented independently without reopening scope
+
+## Why
+
+The current repository already implements and documents the teacher-controlled loop, but the audit showed a remaining gap between the contest narrative and the default product shell:
+
+- inherited DeepTutor-style shell and chat-first entry still dilute the first impression
+- contest-facing wording and product identity still need a bounded classroom-first sweep
+- the docs still need one compact case-study and metric framing layer for judges
+
+This PR does not implement those runtime or wording changes directly. It prepares the control plane so later AI workers can execute the differentiation follow-ups one packet at a time.
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `python3 -m json.tool web/locales/en/app.json >/dev/null`
+- `python3 -m json.tool web/locales/vi/app.json >/dev/null`
+- `git diff --check -- ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-c216-contest-shell-scope-trim.md docs/superpowers/tasks/2026-04-30-c217-teacher-cockpit-default-entry.md docs/superpowers/tasks/2026-04-30-c218-contest-brand-and-classroom-terminology.md docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md docs/superpowers/pr-notes/2026-04-30-contest-differentiation-follow-up-packets.md`
+
+## Main System Map
+
+- Not updated; this PR only changes task planning, registry state, and handoff documentation.
+
+## Mermaid
+
+```mermaid
+flowchart LR
+  Audit["contest-product-differentiation audit"]
+  Registry["TASK_REGISTRY.json"]
+  C216["C216 shell trim packet"]
+  C217["C217 teacher cockpit packet"]
+  C218["C218 terminology packet"]
+  C219["C219 case-study metric packet"]
+
+  Audit --> Registry
+  Registry --> C216
+  Registry --> C217
+  Registry --> C218
+  Registry --> C219
+```

--- a/docs/superpowers/tasks/2026-04-30-c216-contest-shell-scope-trim.md
+++ b/docs/superpowers/tasks/2026-04-30-c216-contest-shell-scope-trim.md
@@ -1,0 +1,88 @@
+# 2026-04-30 C216 Contest Shell Scope Trim
+
+- Task ID: `C216_CONTEST_SHELL_SCOPE_TRIM`
+- Commit tag: `C216`
+- Branch: `fix/contest-shell-scope-trim`
+- Worktree: `.worktrees/contest-shell-scope-trim`
+- Status: `pending`
+
+## Goal
+
+Demote inherited DeepTutor workspace routes from the primary contest shell so judges and presenters see one bounded classroom product path instead of a broad multi-tool workspace.
+
+## User-visible outcome
+
+- Primary sidebar navigation focuses on the contest loop and teacher setup path.
+- Non-core inherited surfaces no longer compete visually with Knowledge, Assessment, Tutor, Dashboard, and `/agents` during the main demo.
+- The shell still allows internal access to existing routes when needed, but the contest-first information architecture is obvious on first load.
+
+## Owned files
+
+- `web/components/sidebar/SidebarShell.tsx`
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+- `web/components/sidebar/UtilitySidebar.tsx`
+- `web/app/(workspace)/layout.tsx`
+- `web/app/(utility)/layout.tsx`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-c216-contest-shell-scope-trim.md`
+- `docs/superpowers/pr-notes/2026-04-30-c216-contest-shell-scope-trim.md`
+
+## Do-not-touch
+
+- `web/app/(workspace)/page.tsx`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/agents/page.tsx`
+- `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/locales/`
+- `deeptutor/`
+- contest submission docs under `docs/contest/`
+- lockfiles and generated files
+
+## Execution notes
+
+- Keep the change shell-only. Do not change runtime behavior, route implementations, or API contracts.
+- Do not rename the product or introduce a new default landing route here. Brand and copy cleanup belongs to `C218`; default entry changes belong to `C217`.
+- Prefer contest-first prioritization over deletion:
+  - promote `Knowledge`, `Dashboard`, and `/agents`;
+  - demote or visually isolate inherited routes such as `Chat`, `Co-Writer`, `Guided Learning`, and `Memory`;
+  - keep access to those routes only if it can remain clearly secondary.
+- Preserve mobile and collapsed-sidebar usability.
+- If the cleanest solution requires new copy strings in `web/locales/`, stop and split that need into `C218` instead of widening this task.
+
+## Acceptance criteria
+
+- The expanded sidebar no longer presents the inherited broad workspace surface as the primary product story.
+- Contest-core routes are grouped and visually prioritized ahead of inherited tools.
+- Any retained inherited routes are clearly secondary and do not dominate the first screen.
+- No route code, dashboard logic, or tutor logic changes are required.
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`
+- `cd web && npx eslint "components/sidebar/SidebarShell.tsx" "components/sidebar/WorkspaceSidebar.tsx" "components/sidebar/UtilitySidebar.tsx" "app/(workspace)/layout.tsx" "app/(utility)/layout.tsx"`
+- `cd web && npm run build`
+
+## Manual verification
+
+- Open the workspace shell and confirm the first visual read emphasizes the contest loop surfaces instead of a generic AI workspace.
+- Collapse and expand the sidebar to confirm the same prioritization still reads clearly.
+- Open at least one non-core inherited route and confirm it remains reachable without reclaiming primary visual priority.
+
+## Parallel-work notes
+
+- This packet is intentionally narrower than `C217`; do not change `/` landing behavior here.
+- This packet is intentionally narrower than `C218`; do not widen into product renaming or localization rewrites here.
+- If shell trimming reveals that a route should be hidden only in contest mode, record the smallest safe mechanism in the PR note instead of inventing a larger feature flag system.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not expected to change unless the shell routing structure materially changes.
+
+## Handoff
+
+- Next expected follow-up is `C217_TEACHER_COCKPIT_DEFAULT_ENTRY`, which can assume a cleaner contest-first shell already exists.

--- a/docs/superpowers/tasks/2026-04-30-c217-teacher-cockpit-default-entry.md
+++ b/docs/superpowers/tasks/2026-04-30-c217-teacher-cockpit-default-entry.md
@@ -1,0 +1,142 @@
+# 2026-04-30 C217 Teacher Cockpit Default Entry
+
+- Task ID: `C217_TEACHER_COCKPIT_DEFAULT_ENTRY`
+- Commit tag: `C217`
+- Branch: `fix/teacher-cockpit-default-entry`
+- Worktree: `.worktrees/teacher-cockpit-default-entry`
+- Status: `pending`
+
+## Goal
+
+Replace the generic chat-first workspace landing with a teacher-first cockpit that foregrounds classroom setup, assessment, tutoring context, and students needing attention before broad multi-tool exploration.
+
+## User-visible outcome
+
+- Opening the main workspace no longer feels like entering a generic AI chat app.
+- Teachers land on a contest-first cockpit that points them toward Knowledge Pack setup, tutor setup, assessment, and dashboard follow-up.
+- Free-form chat and inherited tool modes remain available only as secondary paths, not the default contest story.
+
+## Owned files
+
+- `web/app/(workspace)/page.tsx`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/components/sidebar/SidebarShell.tsx` only if the landing or highlighted primary route must stay aligned with the new entry
+- `web/components/contest/`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-c217-teacher-cockpit-default-entry.md`
+- `docs/superpowers/pr-notes/2026-04-30-c217-teacher-cockpit-default-entry.md`
+
+## Do-not-touch
+
+- `web/locales/`
+- `deeptutor/`
+- `web/app/(workspace)/agents/page.tsx`
+- `web/app/(workspace)/agents/[botId]/chat/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/app/(utility)/marketplace/page.tsx`
+- `web/app/(workspace)/guide/`
+- `web/app/(workspace)/co-writer/`
+- contest submission docs under `docs/contest/`
+- lockfiles and generated files
+
+## Required code reading
+
+- `web/app/(workspace)/page.tsx`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/components/sidebar/SidebarShell.tsx`
+- `web/components/contest/CoreLoopVisibilityStrip.tsx`
+
+## Design before implementation
+
+### Current behavior
+
+- `/` opens the broad DeepTutor multi-capability workspace with chat, capability pickers, tool toggles, research modes, visualization modes, notebook hooks, and session history.
+- The current page is powerful, but its first impression is a generic AI workspace rather than a teacher-facing classroom product.
+- Dashboard already carries the strongest teacher-first framing, but it is not the default landing experience.
+
+### Intended behavior change
+
+- The default workspace entry should present a teacher cockpit or teacher-first redirect that centers the contest loop:
+  - prepare classroom context;
+  - configure the class tutor;
+  - draft or review assessment activity;
+  - inspect diagnosis and next intervention.
+- The landing should reduce cognitive load and communicate one product story before exposing the broader tool surface.
+
+### Candidate approaches
+
+1. **Hard redirect from `/` to `/dashboard`**
+   - Pros: smallest change, minimal new UI.
+   - Cons: loses the chance to create a dedicated teacher-cockpit summary and may overload the dashboard with two jobs.
+
+2. **Convert `/` into a bounded teacher cockpit that links into existing Knowledge, `/agents`, assessment flow, and Dashboard**
+   - Pros: strongest first impression, preserves the contest narrative, avoids overloading one existing page with every concern.
+   - Cons: larger bounded frontend change than a redirect.
+
+### Chosen approach
+
+- Prefer **Approach 2** if it can stay inside the owned files and existing data contracts.
+- Fall back to **Approach 1** only if the cockpit would require new APIs, localization expansion, or broader page-family edits.
+
+### Expected impact surface
+
+- Likely change:
+  - `web/app/(workspace)/page.tsx`
+  - one or more bounded shared components under `web/components/contest/`
+  - possibly `web/app/(workspace)/dashboard/page.tsx` if the new cockpit reuses or extracts an existing teacher-summary block
+- Reviewed but expected unchanged:
+  - `web/app/(workspace)/agents/page.tsx`
+  - `web/app/(utility)/knowledge/page.tsx`
+  - route implementations for co-writer, guide, memory, and marketplace
+  - backend data providers and API clients
+
+### Validation paths
+
+- Main workspace opens into the teacher-first entry.
+- Knowledge, `/agents`, dashboard, and any retained chat path are still reachable.
+- No existing route breaks from the changed landing.
+- Contest loop framing remains visible on the landing or immediate next step.
+
+## Execution notes
+
+- This is a runtime-facing frontend task. Read the brainstorming skill before implementation, then stay within the design above or refine it in-place without widening scope.
+- Do not turn this task into a product rename or localization sweep; that belongs to `C218`.
+- Do not rebuild backend contracts or add new endpoints for the cockpit.
+- Prefer extracting one small shared contest component over duplicating large dashboard or chat sections.
+- If the cleanest cockpit needs new localized copy keys, stop and convert that requirement into `C218` rather than widening here.
+
+## Acceptance criteria
+
+- `/` no longer defaults to the generic multi-capability chat workspace for the contest path.
+- The new default entry clearly points to teacher setup, assessment, tutor, and dashboard follow-up.
+- Existing core contest routes remain reachable without regression.
+- No backend or API contract changes are required.
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`
+- `cd web && npx eslint "app/(workspace)/page.tsx" "app/(workspace)/dashboard/page.tsx" "components/sidebar/SidebarShell.tsx" components/contest/*.tsx`
+- `cd web && npm run build`
+
+## Manual verification
+
+- Open `/` and confirm the first read is teacher-first, not tool-first.
+- From the landing, navigate to Knowledge, `/agents`, and Dashboard without dead ends.
+- Confirm any retained path to the old broad chat workspace is secondary, intentional, and still functional.
+
+## Parallel-work notes
+
+- This packet assumes `C216` has already clarified the shell hierarchy or that the worker will adapt to any shell changes already merged.
+- Do not widen into the full brand rename or Vietnamese terminology pass from `C218`.
+- If the cockpit needs contest metrics, stories, or demo-proof callouts beyond existing surfaces, split that into `C219` instead of widening this runtime task.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if the default user entry flow materially changes beyond a bounded UI redirect/cockpit layer.
+
+## Handoff
+
+- The next expected follow-up after this packet is `C218_CONTEST_BRAND_AND_CLASSROOM_TERMINOLOGY`, unless the worker discovers the cockpit still needs only docs-side narrative support from `C219`.

--- a/docs/superpowers/tasks/2026-04-30-c218-contest-brand-and-classroom-terminology.md
+++ b/docs/superpowers/tasks/2026-04-30-c218-contest-brand-and-classroom-terminology.md
@@ -1,0 +1,96 @@
+# 2026-04-30 C218 Contest Brand And Classroom Terminology
+
+- Task ID: `C218_CONTEST_BRAND_AND_CLASSROOM_TERMINOLOGY`
+- Commit tag: `C218`
+- Branch: `fix/contest-brand-classroom-terminology`
+- Worktree: `.worktrees/contest-brand-classroom-terminology`
+- Status: `pending`
+
+## Goal
+
+Add a bounded contest-facing brand and classroom-first terminology layer so judges see a Vietnamese classroom product instead of raw DeepTutor naming and generic AI workspace labels across the primary demo path.
+
+## User-visible outcome
+
+- The contest-facing shell and headers read like classroom software rather than a framework demo.
+- Key primary-path labels use consistent classroom terminology across English and Vietnamese.
+- DeepTutor naming remains preserved where upstream credit or clearly secondary technical context requires it, but it stops dominating the first product impression.
+
+## Owned files
+
+- `web/components/sidebar/SidebarShell.tsx`
+- `web/app/(workspace)/agents/page.tsx`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/locales/en/app.json`
+- `web/locales/vi/app.json`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-c218-contest-brand-and-classroom-terminology.md`
+- `docs/superpowers/pr-notes/2026-04-30-c218-contest-brand-and-classroom-terminology.md`
+
+## Do-not-touch
+
+- `web/app/(workspace)/page.tsx`
+- `web/app/(workspace)/guide/`
+- `web/app/(workspace)/co-writer/`
+- `web/app/(utility)/marketplace/page.tsx`
+- `deeptutor/`
+- `README.md`
+- `AGENTS.md`
+- `LICENSE`
+- contest submission docs under `docs/contest/`
+- lockfiles and generated files
+
+## Execution notes
+
+- Keep the task wording-only plus shell/header brand presentation. Do not change routing, runtime logic, or API/data contracts.
+- Preserve Apache 2.0 and HKUDS/DeepTutor attribution by leaving upstream credit in repo-level docs and license surfaces untouched.
+- Focus the copy pass on the primary contest path:
+  - shell header and primary nav labels;
+  - `/agents` teacher authoring headers and action labels;
+  - Knowledge and Dashboard contest-facing headings and helper text;
+  - the matching `en` and `vi` locale keys those surfaces depend on.
+- Prefer terminology that matches the differentiation note:
+  - `Knowledge Pack` or `Gói học liệu` over generic knowledge-base language where the screen is clearly contest-facing;
+  - `Class tutor`, `Gia sư của lớp`, or equivalent teacher-centered tutor naming over generic `TutorBot` where possible;
+  - `Teacher dashboard`, `Bảng điều khiển giáo viên`, `Điểm cần can thiệp`, and other classroom-action language over generic system jargon.
+- Leave secondary or clearly non-contest technical surfaces alone if changing them would widen the sweep into a repo-wide rebrand.
+- If a label change would require route restructuring or feature hiding, stop and keep that need inside `C216` or `C217` instead of widening this packet.
+
+## Acceptance criteria
+
+- The sidebar header and primary contest-path labels no longer make DeepTutor the dominant product identity on first read.
+- Contest-facing English and Vietnamese wording is internally consistent across shell, Knowledge, Dashboard, and `/agents`.
+- Upstream DeepTutor attribution remains intact in repo/legal surfaces.
+- No route, behavior, or API changes are required.
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `python3 -m json.tool web/locales/en/app.json >/dev/null`
+- `python3 -m json.tool web/locales/vi/app.json >/dev/null`
+- `git diff --check`
+- `cd web && npx eslint "components/sidebar/SidebarShell.tsx" "app/(workspace)/agents/page.tsx" "app/(workspace)/dashboard/page.tsx" "app/(utility)/knowledge/page.tsx"`
+- `cd web && npm run build`
+
+## Manual verification
+
+- Open the shell and confirm the header, nav, and first-read labels feel classroom-first.
+- Open Knowledge, `/agents`, and Dashboard and confirm the terminology is consistent in the same language.
+- Check at least one retained repo-level DeepTutor credit surface and confirm attribution still exists unchanged.
+
+## Parallel-work notes
+
+- This packet assumes `C216` may reduce shell clutter and `C217` may change the default landing, but it must remain valid even if those tasks merge before or after it.
+- Do not widen into a full repo-wide rename; this is a contest-path terminology pass only.
+- If the worker discovers the real gap is not wording but missing case-study framing or metrics, split that need into `C219`.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not expected to change because this task is wording and presentation only.
+
+## Handoff
+
+- The next expected follow-up after this packet is `C219_CLASSROOM_CASE_STUDY_AND_BOUNDED_METRIC_CARD`, which can assume the product wording already reads like a bounded classroom offering.

--- a/docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md
+++ b/docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md
@@ -1,0 +1,92 @@
+# 2026-04-30 C219 Classroom Case Study And Bounded Metric Card
+
+- Task ID: `C219_CLASSROOM_CASE_STUDY_AND_BOUNDED_METRIC_CARD`
+- Commit tag: `C219`
+- Branch: `docs/classroom-case-study-metric-card`
+- Worktree: `.worktrees/classroom-case-study-metric-card`
+- Status: `pending`
+
+## Goal
+
+Package one explicit classroom case study plus one compact, non-overclaim metric card so the contest story stays anchored to a single teacher workflow instead of a long feature list.
+
+## User-visible outcome
+
+- Judges and human reviewers can follow one concrete classroom scenario end to end.
+- The repo exposes a small, safe metric set that clarifies what is actually evidenced today.
+- The contest narrative becomes easier to present without inventing outcome claims or benchmark language.
+
+## Owned files
+
+- `docs/contest/DEMO_SCRIPT.md`
+- `docs/contest/README.md`
+- `docs/contest/CASEPACK_AND_EVALUATION_DATASET.md`
+- `docs/contest/VALIDATION_REPORT.md`
+- `ai_first/competition/product-description.md`
+- `ai_first/competition/pitch-notes.md`
+- `ai_first/TASK_REGISTRY.json`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md`
+- `docs/superpowers/pr-notes/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md`
+
+## Do-not-touch
+
+- `web/`
+- `deeptutor/`
+- `ai_first/evidence/casepack.json`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `docs/contest/SUBMISSION_PACKAGE.md`
+- `README.md`
+- `AGENTS.md`
+- lockfiles and generated files
+
+## Execution notes
+
+- Keep the task docs-only. Do not modify runtime code, seeded demo data, screenshots, or machine-readable evidence artifacts.
+- Reuse the existing demo-safe classroom scenario centered on `contest-demo-quadratics` unless the current docs already prove a cleaner single case without adding new claims.
+- The target output is not a benchmark section. It is a bounded presenter/reviewer aid that answers:
+  - what one teacher is teaching;
+  - what one student weakness pattern looks like;
+  - what the tutor and dashboard contribute inside the same loop;
+  - what narrow metrics are currently backed by repo evidence.
+- Prefer metric language that is operational and evidence-backed, for example:
+  - demo loop stages completed in the current smoke run;
+  - count of demo-safe sessions verified;
+  - whether Knowledge Pack grounding was present in verified session payloads;
+  - whether teacher recommendation/intervention surfaces are present in the documented flow.
+- Explicitly reject metrics that would overclaim, such as diagnosis accuracy, learning gain, classroom outcome improvement, or pilot-scale effectiveness.
+- If a stronger metric would require new runtime instrumentation or refreshed browser captures, record that as a future note instead of widening this packet.
+
+## Acceptance criteria
+
+- `DEMO_SCRIPT.md` contains one explicit classroom case-study framing that presenters can reuse consistently.
+- `README.md`, `pitch-notes.md`, and `product-description.md` no longer rely only on abstract loop language; they also point to one bounded scenario.
+- `CASEPACK_AND_EVALUATION_DATASET.md` and/or `VALIDATION_REPORT.md` expose a compact metric card or equivalent section that states what is evidenced today and what is intentionally not claimed.
+- No benchmark, outcome-study, or autonomous-accuracy wording is introduced.
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`
+- `rg -n "case study|metric|bounded|non-overclaim|grounding|contest-demo-quadratics|validated prototype|not a benchmark|not a classroom outcome" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes`
+
+## Manual verification
+
+- Read `docs/contest/README.md` top to bottom and confirm a reviewer can repeat one classroom story without needing oral explanation.
+- Read `docs/contest/DEMO_SCRIPT.md` and confirm the presenter can point to one scenario, one weakness pattern, and one teacher action.
+- Read the metric section and confirm every line is backed by existing smoke or casepack evidence rather than desired future proof.
+
+## Parallel-work notes
+
+- This packet should assume `C216-C218` may independently improve shell, entry, and wording, but it must remain valid even if those tasks are not yet executed.
+- Do not recapture screenshots or rewrite evidence freshness state here; that remains separate from this narrative packaging pass.
+- If the worker concludes that the current docs already contain enough case-study material but it is scattered, solve that by consolidation and cross-linking, not by inventing new examples.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` is not expected to change because this task is documentation and evidence framing only.
+
+## Handoff
+
+- After this packet, the differentiation follow-up set is fully packetized: `C216`, `C217`, `C218`, and `C219` can now be executed independently with bounded scope.


### PR DESCRIPTION
## Summary
- audit `ai_first/contest-product-differentiation (1).md` against the current repo state
- add registry follow-up tasks `C216` through `C219` for contest differentiation hardening
- create bounded task packets and a PR architecture note so each follow-up can be executed independently

## Why
The current repo already implements the teacher-controlled loop, but the audit showed a remaining gap between the contest narrative and the first product impression. This PR prepares the control plane for four bounded follow-up lanes:
- `C216` shell scope trim
- `C217` teacher cockpit default entry
- `C218` contest brand and classroom terminology
- `C219` classroom case study and bounded metric card

## Validation
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `python3 -m json.tool web/locales/en/app.json >/dev/null`
- `python3 -m json.tool web/locales/vi/app.json >/dev/null`
- `git diff --check -- ai_first/TASK_REGISTRY.json ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-c216-contest-shell-scope-trim.md docs/superpowers/tasks/2026-04-30-c217-teacher-cockpit-default-entry.md docs/superpowers/tasks/2026-04-30-c218-contest-brand-and-classroom-terminology.md docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md docs/superpowers/pr-notes/2026-04-30-contest-differentiation-follow-up-packets.md`

## Main System Map
- Not updated; this PR is control-plane planning and docs only.