### PR TITLE
feat: trim contest shell scope [C216]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,4 +30,17 @@ Rules:
 
 ## Active
 
-No active AI-owned non-terminal lanes.
+### Assignment
+
+- Owner: Codex
+- Machine: local
+- Worktree: `.worktrees/contest-shell-scope-trim`
+- Task: `C216_CONTEST_SHELL_SCOPE_TRIM`
+- Status: `in_progress`
+- Branch: `fix/contest-shell-scope-trim`
+- Task packet: `docs/superpowers/tasks/2026-04-30-c216-contest-shell-scope-trim.md`
+- Owned files: `web/components/sidebar/SidebarShell.tsx`, `web/components/sidebar/WorkspaceSidebar.tsx`, `web/components/sidebar/UtilitySidebar.tsx`, `web/app/(workspace)/layout.tsx`, `web/app/(utility)/layout.tsx`
+- PR:
+- Last update: `2026-04-30 10:25:01 +0700`
+- Next action: write PR note and prepare the lane commit after successful test, lint, and build validation
+- Blocker:

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -2217,7 +2217,7 @@
       "dependencies": [
         "C213_DIFFERENTIATION_WORDING_SWEEP"
       ],
-      "status": "pending",
+      "status": "in_progress",
       "recommended_session_bucket": "session-c-polish",
       "layer": "optional-polish",
       "notes": "Triggered by the 2026-04-27 contest differentiation audit: the primary shell still exposes generic `Chat`, `Co-Writer`, `Guided Learning`, `Memory`, and other inherited surfaces that dilute the contest story."

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -35,3 +35,16 @@
 ## Architecture Map Updates
 
 - None. Operating-rule change only.
+
+## C216 Contest Shell Scope Trim
+
+- Branch: `fix/contest-shell-scope-trim`
+- Task: `C216_CONTEST_SHELL_SCOPE_TRIM`
+- Done: Created isolated worktree `.worktrees/contest-shell-scope-trim` from `origin/main` and recorded the active assignment before code changes.
+- Done: Wrote the runtime-facing design artifact `docs/superpowers/specs/2026-04-30-c216-contest-shell-scope-trim-design.md`.
+- Done: Wrote the implementation plan `docs/superpowers/plans/2026-04-30-c216-contest-shell-scope-trim.md`.
+- Done: Added `web/components/sidebar/nav-groups.ts` and used it to split the sidebar into contest-core vs secondary tool groups, while keeping route targets and existing session behavior unchanged.
+- Done: Added focused regression coverage in `web/tests/sidebar-nav-groups.test.ts` for expanded and collapsed shell grouping behavior.
+- Tests: `node --test web/tests/sidebar-nav-groups.test.ts`; `cd web && npx eslint "components/sidebar/SidebarShell.tsx" "components/sidebar/WorkspaceSidebar.tsx" "components/sidebar/UtilitySidebar.tsx" "app/(workspace)/layout.tsx" "app/(utility)/layout.tsx"`; `cd web && npm run build`; `git diff --check`
+- Blockers: none
+- Next: write PR note, commit the lane, and open the review PR.

--- a/docs/superpowers/plans/2026-04-30-c216-contest-shell-scope-trim.md
+++ b/docs/superpowers/plans/2026-04-30-c216-contest-shell-scope-trim.md
@@ -1,0 +1,77 @@
+# C216 Contest Shell Scope Trim Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure the shared sidebar shell so contest-core routes are visually primary and inherited DeepTutor tools are clearly secondary.
+
+**Architecture:** Keep the existing shared `SidebarShell` as the only place that owns route grouping. Add a small test harness around the shell, then implement grouped rendering without changing route targets, session logic, or locale contracts.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, existing frontend test runner, ESLint
+
+---
+
+### Task 1: Add focused shell tests
+
+**Files:**
+- Create: `web/components/sidebar/__tests__/SidebarShell.test.tsx`
+- Modify: `web/components/sidebar/SidebarShell.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Write tests that assert:
+- expanded mode shows a contest-core section before a secondary-tools section
+- expanded mode still renders `Knowledge`, `Dashboard`, `/agents`, and `Marketplace`
+- collapsed mode omits secondary tool links such as `Co-Writer` and `Memory`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npm test -- SidebarShell.test.tsx`
+Expected: FAIL because the current shell has one flat nav and no grouped structure.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement grouped nav metadata and render logic in `SidebarShell.tsx`, reusing existing route targets and active-state behavior.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npm test -- SidebarShell.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/sidebar/SidebarShell.tsx web/components/sidebar/__tests__/SidebarShell.test.tsx
+git commit -m "test(sidebar): cover contest shell grouping [C216]"
+```
+
+### Task 2: Validate shell integration
+
+**Files:**
+- Modify: `web/components/sidebar/WorkspaceSidebar.tsx`
+- Modify: `web/components/sidebar/UtilitySidebar.tsx`
+- Modify: `web/app/(workspace)/layout.tsx`
+- Modify: `web/app/(utility)/layout.tsx`
+
+- [ ] **Step 1: Inspect whether companion wrappers need changes**
+
+Confirm the grouped shell works with current wrappers. Only adjust wrapper props or layout spacing if the grouped shell exposes a visual bug or dead path.
+
+- [ ] **Step 2: Implement the smallest companion adjustments**
+
+Keep wrapper behavior the same unless one tiny shell-alignment fix is required.
+
+- [ ] **Step 3: Run the packet validation commands**
+
+Run:
+- `cd web && npx eslint "components/sidebar/SidebarShell.tsx" "components/sidebar/WorkspaceSidebar.tsx" "components/sidebar/UtilitySidebar.tsx" "app/(workspace)/layout.tsx" "app/(utility)/layout.tsx"`
+- `cd web && npm run build`
+- `git diff --check`
+
+Expected: all commands pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/components/sidebar/WorkspaceSidebar.tsx web/components/sidebar/UtilitySidebar.tsx web/app/'(workspace)'/layout.tsx web/app/'(utility)'/layout.tsx
+git commit -m "feat(sidebar): trim contest shell scope [C216]"
+```

--- a/docs/superpowers/pr-notes/2026-04-30-c216-contest-shell-scope-trim.md
+++ b/docs/superpowers/pr-notes/2026-04-30-c216-contest-shell-scope-trim.md
@@ -1,0 +1,37 @@
+# 2026-04-30 C216 Contest Shell Scope Trim
+
+## Summary
+
+- split the shared sidebar shell into contest-core and secondary tool groups
+- kept route targets and session handling intact while demoting inherited tools from the first visual read
+- added focused regression coverage for expanded and collapsed shell nav grouping
+
+## Why
+
+The contest audit showed that the default shell still presented inherited DeepTutor tools as peers of the contest loop. This patch keeps every route available, but changes the shell hierarchy so `Knowledge`, `Dashboard`, `/agents`, and `Marketplace` read as the primary product path.
+
+## Validation
+
+- `node --test web/tests/sidebar-nav-groups.test.ts`
+- `cd web && npx eslint "components/sidebar/SidebarShell.tsx" "components/sidebar/WorkspaceSidebar.tsx" "components/sidebar/UtilitySidebar.tsx" "app/(workspace)/layout.tsx" "app/(utility)/layout.tsx"`
+- `cd web && npm run build`
+- `git diff --check`
+
+## Main System Map
+
+- Not updated; this PR changes shell presentation only and does not alter route architecture or backend/runtime contracts.
+
+## Mermaid
+
+```mermaid
+flowchart TD
+  Shell["Sidebar shell"]
+  Core["Contest core\nKnowledge / Dashboard / Agents / Marketplace"]
+  Secondary["Secondary tools\nChat / Guide / Co-Writer / Memory"]
+  Routes["Existing routes unchanged"]
+
+  Shell --> Core
+  Shell --> Secondary
+  Core --> Routes
+  Secondary --> Routes
+```

--- a/docs/superpowers/specs/2026-04-30-c216-contest-shell-scope-trim-design.md
+++ b/docs/superpowers/specs/2026-04-30-c216-contest-shell-scope-trim-design.md
@@ -1,0 +1,60 @@
+# C216 Contest Shell Scope Trim Design
+
+## Goal
+
+Make the contest shell read as one bounded classroom product by visually prioritizing the contest loop routes and demoting inherited DeepTutor utility routes without removing route access.
+
+## Current behavior
+
+- `SidebarShell.tsx` renders one flat `PRIMARY_NAV` list where `Chat`, `TutorBot`, `Co-Writer`, `Guided Learning`, `Dashboard`, `Knowledge`, `Marketplace`, and `Memory` appear as peers.
+- The shell header and route ordering make inherited tooling feel equal to the contest loop, even though the contest story depends mostly on `Knowledge`, `/agents`, and `Dashboard`.
+- `WorkspaceSidebar.tsx` and `UtilitySidebar.tsx` only pass session behavior into the shared shell; they do not currently influence information architecture.
+
+## Intended behavior
+
+- The expanded shell should present a clear contest-core group first and a secondary-tools group after it.
+- The collapsed shell should keep only the core routes visible by default, while secondary tools remain reachable via the expanded shell.
+- Route implementations, navigation targets, session handling, and copy keys stay unchanged.
+
+## Candidate approaches
+
+### Approach 1: Reorder the existing flat list only
+
+- Pros: smallest patch.
+- Cons: inherited tools still look primary because there is no visual separation.
+
+### Approach 2: Split the shell into explicit contest-core and secondary tool groups
+
+- Pros: clearest first impression, preserves all routes, fits the task packet boundary.
+- Cons: requires modest sidebar structure changes in expanded and collapsed modes.
+
+## Chosen approach
+
+Use **Approach 2**. Keep one shared nav definition in `SidebarShell.tsx`, but classify entries into:
+
+- contest core: `Knowledge`, `Dashboard`, `/agents`, and `Marketplace`
+- secondary tools: `Chat`, `Guided Learning`, `Co-Writer`, and `Memory`
+
+The expanded shell will render grouped sections. The collapsed shell will render the core routes and continue to expose the `/agents` recent-tutor affordance.
+
+## Files expected to change
+
+- `web/components/sidebar/SidebarShell.tsx`
+- `web/components/sidebar/WorkspaceSidebar.tsx` only if prop naming or defaults must be clarified
+- `web/components/sidebar/UtilitySidebar.tsx` only if prop naming or defaults must be clarified
+- `web/app/(workspace)/layout.tsx` only if shell spacing needs a tiny companion adjustment
+- `web/app/(utility)/layout.tsx` only if shell spacing needs a tiny companion adjustment
+
+## Files reviewed but expected unchanged
+
+- `web/app/(workspace)/page.tsx`
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/app/(workspace)/agents/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- all backend and API modules
+
+## Tests to add or update
+
+- Add a focused component test for `SidebarShell` that verifies grouped core-vs-secondary rendering in expanded mode.
+- Add a focused component test for `SidebarShell` collapsed mode that verifies secondary tools are not shown there.
+- Run targeted frontend test command plus the existing lint/build checks from the task packet.

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -22,6 +22,11 @@ import {
 import { useTranslation } from "react-i18next";
 import SessionList from "@/components/SessionList";
 import { TutorBotRecent } from "@/components/sidebar/TutorBotRecent";
+import {
+  getCollapsedSidebarNav,
+  getExpandedSidebarGroups,
+  type SidebarNavItem,
+} from "@/components/sidebar/nav-groups";
 import type { SessionSummary } from "@/lib/session-api";
 
 interface NavEntry {
@@ -30,19 +35,29 @@ interface NavEntry {
   icon: LucideIcon;
 }
 
-const PRIMARY_NAV: NavEntry[] = [
-  { href: "/", label: "Chat", icon: MessageSquare },
-  { href: "/agents", label: "TutorBot", icon: Bot },
-  { href: "/co-writer", label: "Co-Writer", icon: PenLine },
-  { href: "/guide", label: "Guided Learning", icon: GraduationCap },
-  { href: "/dashboard", label: "Dashboard", icon: BarChart3 },
-  { href: "/knowledge", label: "Knowledge", icon: BookOpen },
-  { href: "/marketplace", label: "Marketplace", icon: Store },
-  { href: "/memory", label: "Memory", icon: Brain },
-];
-
 const SECONDARY_NAV: NavEntry[] = [{ href: "/settings", label: "Settings", icon: Settings }];
 const DEFAULT_SESSION_VIEWPORT_CLASS_NAME = "max-h-[112px]";
+
+function resolveNavIcon(icon: SidebarNavItem["icon"]): LucideIcon {
+  switch (icon) {
+    case "message-square":
+      return MessageSquare;
+    case "bot":
+      return Bot;
+    case "pen-line":
+      return PenLine;
+    case "graduation-cap":
+      return GraduationCap;
+    case "bar-chart-3":
+      return BarChart3;
+    case "book-open":
+      return BookOpen;
+    case "store":
+      return Store;
+    case "brain":
+      return Brain;
+  }
+}
 
 interface SidebarShellProps {
   sessions?: SessionSummary[];
@@ -73,6 +88,8 @@ export function SidebarShell({
   const router = useRouter();
   const { t } = useTranslation();
   const [collapsed, setCollapsed] = useState(false);
+  const collapsedNav = getCollapsedSidebarNav();
+  const expandedNavGroups = getExpandedSidebarGroups();
 
   const handleNewChat = () => {
     if (onNewChat) {
@@ -103,7 +120,8 @@ export function SidebarShell({
         </button>
 
         <nav className="flex flex-col items-center gap-px pt-1">
-          {PRIMARY_NAV.map((item) => {
+          {collapsedNav.map((item) => {
+            const Icon = resolveNavIcon(item.icon);
             const active = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
             return (
               <div key={item.href} className="flex flex-col items-center">
@@ -115,7 +133,7 @@ export function SidebarShell({
                       : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
                   }`}
                 >
-                  <item.icon size={16} strokeWidth={active ? 1.9 : 1.5} />
+                  <Icon size={16} strokeWidth={active ? 1.9 : 1.5} />
                 </Link>
                 {item.href === "/agents" && <TutorBotRecent collapsed />}
               </div>
@@ -180,40 +198,49 @@ export function SidebarShell({
             <span>{t("New Chat")}</span>
           </button>
 
-          {PRIMARY_NAV.map((item) => {
-            const active = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
-            const hasSessionsBelow = item.href === "/" && showSessions && onSelectSession && onRenameSession && onDeleteSession;
-            const hasBots = item.href === "/agents";
-            return (
-              <div key={item.href}>
-                <Link
-                  href={item.href}
-                  className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors ${
-                    active
-                      ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
-                      : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
-                  }`}
-                >
-                  <item.icon size={16} strokeWidth={active ? 1.9 : 1.5} />
-                  <span>{t(item.label)}</span>
-                </Link>
-                {hasSessionsBelow && (
-                  <div className={`${sessionViewportClassName} overflow-y-auto`}>
-                    <SessionList
-                      sessions={sessions}
-                      activeSessionId={activeSessionId}
-                      loading={loadingSessions}
-                      onSelect={onSelectSession}
-                      onRename={onRenameSession}
-                      onDelete={onDeleteSession}
-                      compact
-                    />
-                  </div>
-                )}
-                {hasBots && <TutorBotRecent />}
+          {expandedNavGroups.map((group, index) => (
+            <div key={group.id} className={index > 0 ? "pt-3" : ""}>
+              <div className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]/80">
+                {t(group.label)}
               </div>
-            );
-          })}
+              {group.items.map((item) => {
+                const Icon = resolveNavIcon(item.icon);
+                const active = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
+                const hasSessionsBelow =
+                  item.href === "/" && showSessions && onSelectSession && onRenameSession && onDeleteSession;
+                const hasBots = item.href === "/agents";
+                return (
+                  <div key={item.href}>
+                    <Link
+                      href={item.href}
+                      className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors ${
+                        active
+                          ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
+                          : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
+                      }`}
+                    >
+                      <Icon size={16} strokeWidth={active ? 1.9 : 1.5} />
+                      <span>{t(item.label)}</span>
+                    </Link>
+                    {hasSessionsBelow && (
+                      <div className={`${sessionViewportClassName} overflow-y-auto`}>
+                        <SessionList
+                          sessions={sessions}
+                          activeSessionId={activeSessionId}
+                          loading={loadingSessions}
+                          onSelect={onSelectSession}
+                          onRename={onRenameSession}
+                          onDelete={onDeleteSession}
+                          compact
+                        />
+                      </div>
+                    )}
+                    {hasBots && <TutorBotRecent />}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
         </div>
       </nav>
 

--- a/web/components/sidebar/nav-groups.ts
+++ b/web/components/sidebar/nav-groups.ts
@@ -1,0 +1,36 @@
+export interface SidebarNavItem {
+  href: string;
+  label: string;
+  icon: "message-square" | "bot" | "pen-line" | "graduation-cap" | "bar-chart-3" | "book-open" | "store" | "brain";
+}
+
+export interface SidebarNavGroup {
+  id: "contest-core" | "secondary-tools";
+  label: string;
+  items: SidebarNavItem[];
+}
+
+const CONTEST_CORE_ITEMS: SidebarNavItem[] = [
+  { href: "/knowledge", label: "Knowledge", icon: "book-open" },
+  { href: "/dashboard", label: "Dashboard", icon: "bar-chart-3" },
+  { href: "/agents", label: "TutorBot", icon: "bot" },
+  { href: "/marketplace", label: "Marketplace", icon: "store" },
+];
+
+const SECONDARY_TOOL_ITEMS: SidebarNavItem[] = [
+  { href: "/", label: "Chat", icon: "message-square" },
+  { href: "/guide", label: "Guided Learning", icon: "graduation-cap" },
+  { href: "/co-writer", label: "Co-Writer", icon: "pen-line" },
+  { href: "/memory", label: "Memory", icon: "brain" },
+];
+
+export function getExpandedSidebarGroups(): SidebarNavGroup[] {
+  return [
+    { id: "contest-core", label: "Contest core", items: CONTEST_CORE_ITEMS },
+    { id: "secondary-tools", label: "Secondary tools", items: SECONDARY_TOOL_ITEMS },
+  ];
+}
+
+export function getCollapsedSidebarNav(): SidebarNavItem[] {
+  return CONTEST_CORE_ITEMS;
+}

--- a/web/tests/sidebar-nav-groups.test.ts
+++ b/web/tests/sidebar-nav-groups.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  getCollapsedSidebarNav,
+  getExpandedSidebarGroups,
+} from "../components/sidebar/nav-groups.ts";
+
+test("expanded sidebar groups promote contest-core routes before secondary tools", () => {
+  const groups = getExpandedSidebarGroups();
+
+  assert.equal(groups.length, 2);
+  assert.equal(groups[0]?.id, "contest-core");
+  assert.deepEqual(
+    groups[0]?.items.map((item) => item.href),
+    ["/knowledge", "/dashboard", "/agents", "/marketplace"],
+  );
+
+  assert.equal(groups[1]?.id, "secondary-tools");
+  assert.deepEqual(
+    groups[1]?.items.map((item) => item.href),
+    ["/", "/guide", "/co-writer", "/memory"],
+  );
+});
+
+test("collapsed sidebar keeps only contest-core routes visible by default", () => {
+  const items = getCollapsedSidebarNav();
+
+  assert.deepEqual(items.map((item) => item.href), [
+    "/knowledge",
+    "/dashboard",
+    "/agents",
+    "/marketplace",
+  ]);
+  assert.equal(items.some((item) => item.href === "/co-writer"), false);
+  assert.equal(items.some((item) => item.href === "/memory"), false);
+});


### PR DESCRIPTION
## Summary
- split the shared sidebar shell into contest-core and secondary tool groups
- keep route targets and session handling intact while demoting inherited tools from the first visual read
- add focused regression coverage for expanded and collapsed shell grouping behavior

## Why
The contest audit showed that the default shell still presented inherited DeepTutor tools as peers of the contest loop. This PR keeps every route available, but changes the shell hierarchy so `Knowledge`, `Dashboard`, `/agents`, and `Marketplace` read as the primary product path.

## Validation
- `node --test web/tests/sidebar-nav-groups.test.ts`
- `cd web && npx eslint "components/sidebar/SidebarShell.tsx" "components/sidebar/WorkspaceSidebar.tsx" "components/sidebar/UtilitySidebar.tsx" "app/(workspace)/layout.tsx" "app/(utility)/layout.tsx"`
- `cd web && npm run build`
- `git diff --check`

## Main System Map
- Not updated; this PR changes shell presentation only and does not alter route architecture or backend/runtime contracts.