### PR TITLE
docs: close C216 lane state

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,17 +30,4 @@ Rules:
 
 ## Active
 
-### Assignment
-
-- Owner: Codex
-- Machine: local
-- Worktree: `.worktrees/contest-shell-scope-trim`
-- Task: `C216_CONTEST_SHELL_SCOPE_TRIM`
-- Status: `in_progress`
-- Branch: `fix/contest-shell-scope-trim`
-- Task packet: `docs/superpowers/tasks/2026-04-30-c216-contest-shell-scope-trim.md`
-- Owned files: `web/components/sidebar/SidebarShell.tsx`, `web/components/sidebar/WorkspaceSidebar.tsx`, `web/components/sidebar/UtilitySidebar.tsx`, `web/app/(workspace)/layout.tsx`, `web/app/(utility)/layout.tsx`
-- PR:
-- Last update: `2026-04-30 10:25:01 +0700`
-- Next action: write PR note and prepare the lane commit after successful test, lint, and build validation
-- Blocker:
+No active AI-owned non-terminal lanes.

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -2217,10 +2217,10 @@
       "dependencies": [
         "C213_DIFFERENTIATION_WORDING_SWEEP"
       ],
-      "status": "in_progress",
+      "status": "completed",
       "recommended_session_bucket": "session-c-polish",
       "layer": "optional-polish",
-      "notes": "Triggered by the 2026-04-27 contest differentiation audit: the primary shell still exposes generic `Chat`, `Co-Writer`, `Guided Learning`, `Memory`, and other inherited surfaces that dilute the contest story."
+      "notes": "Merged to main through PR #235 on 2026-04-30. The shared sidebar shell now promotes contest-core routes ahead of inherited secondary tools without changing route targets or backend contracts."
     },
     {
       "id": "C217_TEACHER_COCKPIT_DEFAULT_ENTRY",

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -45,6 +45,7 @@
 - Done: Wrote the implementation plan `docs/superpowers/plans/2026-04-30-c216-contest-shell-scope-trim.md`.
 - Done: Added `web/components/sidebar/nav-groups.ts` and used it to split the sidebar into contest-core vs secondary tool groups, while keeping route targets and existing session behavior unchanged.
 - Done: Added focused regression coverage in `web/tests/sidebar-nav-groups.test.ts` for expanded and collapsed shell grouping behavior.
+- Done: Merged PR `#235` into `main` after `Backend`, `Docs`, `Frontend`, and `Summary` checks all passed.
 - Tests: `node --test web/tests/sidebar-nav-groups.test.ts`; `cd web && npx eslint "components/sidebar/SidebarShell.tsx" "components/sidebar/WorkspaceSidebar.tsx" "components/sidebar/UtilitySidebar.tsx" "app/(workspace)/layout.tsx" "app/(utility)/layout.tsx"`; `cd web && npm run build`; `git diff --check`
 - Blockers: none
-- Next: write PR note, commit the lane, and open the review PR.
+- Next: hand off the next parallel-safe packet, preferably `C219`, or continue with `C217` after the shell cleanup merge.


### PR DESCRIPTION
## Summary
- remove the merged `C216` assignment from `ai_first/ACTIVE_ASSIGNMENTS.md`
- mark `C216_CONTEST_SHELL_SCOPE_TRIM` as completed in `ai_first/TASK_REGISTRY.json`
- update the daily log to record that PR `#235` merged and CI passed

## Why
PR `#235` merged the runtime shell trim, but the control-plane mirrors still showed the lane as active and in progress. This PR closes that post-merge state drift.

## Validation
- `git diff --check`

## Main System Map
- Not updated; control-plane cleanup only.