### PR TITLE
docs(contest): package classroom case study and metric card [C219]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,4 +30,17 @@ Rules:
 
 ## Active
 
-- None.
+### Assignment
+
+- Owner: Codex
+- Machine: local
+- Worktree: `.worktrees/classroom-case-study-and-bounded-metric-card`
+- Task: `C219_CLASSROOM_CASE_STUDY_AND_BOUNDED_METRIC_CARD`
+- Status: `in_progress`
+- Branch: `docs/classroom-case-study-and-bounded-metric-card`
+- Task packet: `docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md`
+- Owned files: `docs/contest/DEMO_SCRIPT.md`, `docs/contest/README.md`, `docs/contest/CASEPACK_AND_EVALUATION_DATASET.md`, `docs/contest/VALIDATION_REPORT.md`, `ai_first/competition/product-description.md`, `ai_first/competition/pitch-notes.md`
+- PR:
+- Last update: `2026-04-30 11:14:39 +0700`
+- Next action: consolidate the existing quadratics demo story into one explicit case study and add one bounded metric card across the contest docs.
+- Blocker:

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -2291,10 +2291,10 @@
         "C205_DEMO_DATA_AND_SMOKE_CONTRACT_REFRESH",
         "C207_SUBMISSION_NARRATIVE_PACK"
       ],
-      "status": "pending",
+      "status": "in_progress",
       "recommended_session_bucket": "session-a-docs",
       "layer": "submission-docs",
-      "notes": "The repository already has demo-safe reset data and a validation casepack, but it still lacks one explicit judge-facing case-study card and a compact metric set such as grounded-tutor coverage, recommendation count, or intervention follow-through for that same scenario."
+      "notes": "In progress on 2026-04-30. This lane consolidates the existing contest-demo-quadratics evidence into one explicit classroom case study plus a compact metric card that stays inside smoke-backed and casepack-backed proof."
     }
   ],
   "github_issues_template": {

--- a/ai_first/competition/pitch-notes.md
+++ b/ai_first/competition/pitch-notes.md
@@ -40,6 +40,17 @@ Architecture direction: agent-native today, with future multi-agent role separat
 4. Teacher reviews diagnosis signals and recommendation context.
 5. Teacher decides the next intervention using dashboard evidence.
 
+Anchor case for the pitch:
+
+- Grade 9 math teacher
+- `contest-demo-quadratics`
+- one common factoring and root-checking weakness pattern
+- one teacher-reviewed remediation move
+
+Preferred short version:
+
+> One Grade 9 teacher prepares a quadratics Knowledge Pack, drafts one assessment, lets the student ask one grounded follow-up, then reviews one dashboard recommendation before choosing one bounded remediation step.
+
 Official scope freeze:
 
 - Core loop: `Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention`
@@ -53,3 +64,12 @@ Behavior-diff story for judges:
 - `SOUL` changes how the tutor reacts when a student is wrong, stuck, or discouraged.
 - `RULES` changes the classroom boundaries: for example, whether the tutor should withhold direct answers, how much hinting is allowed, and when to stop or escalate.
 - The same student question can therefore receive a more encouraging scaffolded response in one class setup and a more Socratic push-back in another, without changing the underlying source material.
+
+Bounded metric card for spoken Q&A:
+
+- `1` anchor Knowledge Pack
+- `2` verified demo sessions tied to that pack
+- `2/2` verified sessions grounded in the same pack
+- teacher-reviewed recommendation/intervention framing present
+
+Do not translate that card into accuracy, learning-gain, or classroom-outcome claims.

--- a/ai_first/competition/product-description.md
+++ b/ai_first/competition/product-description.md
@@ -34,6 +34,17 @@ Within that loop, diagnosis and recommendation outputs are positioned as evidenc
 2. An exam-prep teacher can set a more demanding style that asks students to justify each step before the tutor gives another hint.
 3. After class, a teacher can review the dashboard to see which students need individual follow-up and which small group should revisit the same misconception together.
 
+## Anchor Classroom Case
+
+The clearest current story is one Grade 9 quadratics class:
+
+1. The teacher prepares `contest-demo-quadratics` as a Knowledge Pack for `Vietnam secondary algebra`.
+2. The platform drafts an assessment from that same pack.
+3. A student then asks for help on a common factoring mistake and how to check both roots against the original equation.
+4. The dashboard surfaces the resulting evidence trail so the teacher can decide one bounded follow-up move, such as reteaching one prerequisite or pulling a small remediation group.
+
+This is the preferred contest case because it is already backed by demo-safe reset data, smoke validation, and the narrative casepack. It should be presented as one validated prototype flow, not as outcome proof.
+
 ## Main Capabilities in the Current MVP
 
 1. Knowledge Pack management for teacher-owned learning materials and metadata.
@@ -89,6 +100,17 @@ This repository does not currently claim classroom outcome evidence or a scaled 
 - Reduces manual work needed to turn teaching materials into assessments.
 - Gives students immediate tutoring support based on the same approved knowledge source.
 - Gives teachers a faster feedback loop through dashboard activity, assessment review, and next-step intervention suggestions.
+
+## Bounded Evidence Snapshot
+
+For the current submission, the safest metric framing is operational:
+
+- `1` demo-safe Knowledge Pack anchors the contest story: `contest-demo-quadratics`
+- `2` verified demo sessions reuse that same pack: one assessment session and one tutor session
+- Knowledge Pack grounding is present in `2/2` validated sessions
+- teacher recommendation/intervention framing is present in the documented dashboard and casepack flow
+
+These are evidence-of-flow metrics, not learning-outcome metrics.
 
 ## Development Potential
 

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -81,3 +81,15 @@
 - Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `python3 -m json.tool web/locales/en/app.json >/dev/null`; `python3 -m json.tool web/locales/vi/app.json >/dev/null`; `node --test web/tests/contest-terminology.test.ts`; `cd web && npx eslint "components/sidebar/SidebarShell.tsx" "app/(workspace)/agents/page.tsx" "app/(workspace)/dashboard/page.tsx" "app/(utility)/knowledge/page.tsx"`; `cd web && npm run build`; `git diff --check`
 - Blockers: none
 - Next: hand off the remaining follow-up packet `C219`, or stop if the remaining work is intentionally human-only.
+
+## C219 Classroom Case Study And Bounded Metric Card
+
+- Branch: `docs/classroom-case-study-and-bounded-metric-card`
+- Task: `C219_CLASSROOM_CASE_STUDY_AND_BOUNDED_METRIC_CARD`
+- Done: Created isolated worktree `.worktrees/classroom-case-study-and-bounded-metric-card` from `origin/main` and recorded the active assignment before docs changes.
+- Done: Confirmed the repo-safe classroom scenario already anchored on `contest-demo-quadratics`, `contest-assessment-demo`, and `contest-tutor-demo`, with the teacher move bounded to dashboard-reviewed remediation rather than outcome claims.
+- Done: Added one explicit Grade 9 quadratics classroom case across the contest evidence entry docs, demo script, and competition-facing narrative docs.
+- Done: Added one bounded metric card tied to smoke-backed and casepack-backed proof only, explicitly excluding benchmark, learning-gain, and classroom-outcome claims.
+- Tests: `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`; `rg -n "case study|metric|bounded|non-overclaim|grounding|contest-demo-quadratics|validated prototype|not a benchmark|not a classroom outcome" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes`
+- Blockers: none
+- Next: write the PR architecture note, then commit and open the docs-only PR for review.

--- a/docs/contest/CASEPACK_AND_EVALUATION_DATASET.md
+++ b/docs/contest/CASEPACK_AND_EVALUATION_DATASET.md
@@ -14,6 +14,17 @@ Its job is to:
 
 This is not a benchmark leaderboard, outcome study, or production evaluation harness.
 
+## Anchor Story Connection
+
+For contest review, do not present the casepack as an abstract testing asset only. Tie it back to the same bounded classroom story used elsewhere in the docs:
+
+- one Grade 9 math Knowledge Pack: `contest-demo-quadratics`
+- one weakness pattern around quadratic-equation mistakes
+- one teacher review moment on the dashboard
+- one bounded classroom move such as a remediation mini-group or scaffolded reteach step
+
+The casepack is the structured support layer for that story, not a separate benchmark track.
+
 ## Categories
 
 The current casepack covers five bounded categories:
@@ -49,3 +60,20 @@ Use the casepack to understand how the current product should be described and v
 - it does not prove classroom outcomes
 - it does not replace teacher review
 - it does not justify autonomous diagnosis accuracy claims
+
+## Bounded Metric Companion
+
+When presenters need a compact metric card, keep it operational:
+
+| Safe metric type | Why it is allowed here |
+| --- | --- |
+| count of demo-safe sessions tied to one pack | directly backed by the smoke-validated demo inventory |
+| whether the same Knowledge Pack appears across assessment and tutor proof | directly backed by session payloads and dashboard validation |
+| whether the recommendation/intervention framing exists | directly backed by the casepack and diagnosis docs |
+
+Do not convert the casepack into:
+
+- accuracy percentages
+- learning-gain claims
+- autonomous diagnosis rankings
+- classroom-effectiveness claims

--- a/docs/contest/DEMO_SCRIPT.md
+++ b/docs/contest/DEMO_SCRIPT.md
@@ -10,6 +10,32 @@ Use this script to present the MVP in the same order as the project goal.
 4. Open the web workspace in a browser.
 5. Use demo-safe sample content. Do not use private student data.
 
+## Anchor Case Study
+
+Keep the full presentation anchored to one classroom-safe story:
+
+- Class: Grade 9 mathematics
+- Knowledge Pack: `contest-demo-quadratics`
+- Curriculum context: `Vietnam secondary algebra`
+- Teacher goal: help students solve quadratic equations and explain common mistakes
+- Student weakness pattern to narrate: factoring confusion plus missed root-checking
+- Teacher decision point: use dashboard signals to choose one bounded remediation step or a small-group follow-up
+
+If a presenter needs one sentence, use this:
+
+> A Grade 9 math teacher prepares one quadratics Knowledge Pack, drafts one assessment from it, lets the student ask one grounded follow-up, then uses the dashboard to decide one bounded remediation move for the same misconception cluster.
+
+## Presenter Metric Card
+
+If a judge asks for a compact proof summary during the demo, use only these bounded metrics:
+
+- `1` anchor Knowledge Pack: `contest-demo-quadratics`
+- `2` verified demo sessions: `contest-assessment-demo` and `contest-tutor-demo`
+- `2/2` verified sessions grounded in the same Knowledge Pack
+- teacher-reviewed recommendation/intervention framing present in the dashboard and casepack docs
+
+Do not expand this into diagnosis accuracy, learning gain, or classroom outcome claims.
+
 ## Hybrid Presenter Check
 
 Before the learning loop, optionally show a short teacher-authoring proof on `/agents`:
@@ -65,6 +91,11 @@ Steps:
 6. Review generated questions and common-mistake feedback.
 7. Explain that a teacher can approve, edit, or reject before student-facing reuse.
 
+Presenter framing for the anchor case:
+
+- the assessment is still about quadratic equations from the same pack
+- the weakness pattern to watch for is factoring and root-checking, not a random generic topic
+
 Evidence to capture:
 
 - Screenshot of the quiz configuration.
@@ -82,6 +113,10 @@ Steps:
 3. Ask a student-style follow-up question.
 4. Confirm the tutor response is grounded in the selected learning context.
 
+Anchor follow-up prompt example:
+
+- ask the tutor to help a student understand a common factoring mistake and why both roots still need to be checked against the original equation
+
 Evidence to capture:
 
 - Screenshot of the selected Knowledge Pack context.
@@ -98,11 +133,11 @@ Steps:
 3. Confirm small-group recommendation cards are visible when grouped signals exist.
 4. Confirm recent activity still distinguishes assessment and tutoring sessions.
 5. Confirm Knowledge Pack references appear when sessions used a selected pack.
-6. Explain one concrete teacher move, such as reteaching one concept to a small group or giving a gentler scaffold to one student next session.
-7. Reuse one of the prepared dashboard stories:
-   - repeated misses on one topic -> reteach one prerequisite with one scaffolded example
-   - quick but inconsistent answers -> ask for one reasoning step before another hint
-   - shared misconception cluster -> pull a remediation mini-group before the next check
+6. Explain one concrete teacher move for the same quadratics case: the teacher sees repeated factoring confusion and decides to reteach one prerequisite plus pull a remediation mini-group before the next check.
+7. Keep the dashboard explanation inside one bounded story:
+   - observed: repeated difficulty on one quadratics sub-skill
+   - inferred: likely misconception cluster worth teacher review
+   - teacher move: one scaffolded reteach or one mini-group follow-up
 
 Evidence to capture:
 
@@ -115,6 +150,7 @@ Evidence to capture:
 
 - Keep the demo short and linear.
 - Use one consistent sample topic across all screens.
+- Prefer the same quadratics story on every screen instead of switching examples mid-demo.
 - When explaining `/agents`, start with classroom outcomes before architecture words.
 - If an external LLM provider is unavailable, explain the unavailable credential and show the local validation report instead of inventing evidence.
 - After the demo, open `VALIDATION_REPORT.md` to show exact commands and known limitations.

--- a/docs/contest/README.md
+++ b/docs/contest/README.md
@@ -12,6 +12,38 @@ Knowledge Pack -> Assessment -> Tutor -> Diagnosis -> Intervention.
 
 The teacher dashboard is the operating surface that helps a teacher inspect diagnosis and choose interventions. It supports the loop; it is not a substitute for the loop.
 
+## Anchor Classroom Case
+
+Use one bounded classroom story throughout the contest package:
+
+- Teacher: a Grade 9 math teacher
+- Topic: quadratic equations in `Vietnam secondary algebra`
+- Shared Knowledge Pack: `contest-demo-quadratics`
+- Learning objective: solve quadratic equations and explain common mistakes
+- Student weakness pattern: repeated confusion around factoring steps and checking both roots against the original equation
+- Teacher move: review the dashboard signals, then assign one bounded remediation step or small-group follow-up instead of accepting the diagnosis as an autonomous verdict
+
+This case is intentionally narrow. It is not a claim about broad classroom coverage; it is the single demo-safe story already backed by the repository reset runbook, smoke validation, and casepack framing.
+
+## Bounded Metric Card
+
+What is evidenced today for the anchor case:
+
+| Metric | Current bounded claim | Source |
+| --- | --- | --- |
+| Demo-safe Knowledge Packs in the anchor story | `1` (`contest-demo-quadratics`) | `DEMO_DATA_RESET.md`, `VALIDATION_REPORT.md` |
+| Verified demo sessions tied to that pack | `2` (`contest-assessment-demo`, `contest-tutor-demo`) | `VALIDATION_REPORT.md` |
+| Verified command-backed loop surfaces | `4` (Knowledge Pack presence, assessment session, tutor session, dashboard review endpoints) | `VALIDATION_REPORT.md` |
+| Verified session grounding coverage | `2/2` verified sessions carry the same Knowledge Pack context | `VALIDATION_REPORT.md` |
+| Teacher-action framing present | `Yes` — recommendation, remediation, and intervention remain teacher-reviewed surfaces | `DEMO_SCRIPT.md`, `CASEPACK_AND_EVALUATION_DATASET.md`, `DIAGNOSIS_CASE_STUDIES.md` |
+
+What this metric card does **not** claim:
+
+- diagnosis accuracy percentages
+- learning-gain or classroom-outcome impact
+- pilot-scale effectiveness
+- autonomous intervention quality without teacher review
+
 ## Submission Scope Freeze
 
 Core submission scope:

--- a/docs/contest/VALIDATION_REPORT.md
+++ b/docs/contest/VALIDATION_REPORT.md
@@ -10,6 +10,34 @@ Teacher creates Knowledge Pack -> AI generates assessment -> Student learns with
 
 This report validates prototype behavior and contest evidence only. It is not a classroom outcome study or deployment report.
 
+## Anchor Case And Bounded Metrics
+
+Primary docs story for this report:
+
+- Knowledge Pack: `contest-demo-quadratics`
+- Class level: `Grade 9`
+- Curriculum: `Vietnam secondary algebra`
+- Learning objective: solve quadratic equations and explain common mistakes
+- Weakness pattern used in the demo story: factoring confusion and missed root-checking
+- Teacher decision surface: dashboard-reviewed remediation, not autonomous intervention
+
+Bounded metric card for the current evidence set:
+
+| Metric | Current value | Evidence basis |
+| --- | --- | --- |
+| Demo-safe Knowledge Packs in the anchor story | `1` | `contest-demo-quadratics` from the reset inventory and knowledge-list validation |
+| Verified demo sessions tied to that pack | `2` | `contest-assessment-demo` and `contest-tutor-demo` from local validation |
+| Verified command-backed loop checkpoints | `4` | Knowledge Pack presence, assessment session, tutor session, and dashboard review endpoints |
+| Knowledge Pack grounding coverage in verified sessions | `2/2` | both validated sessions reference `contest-demo-quadratics` |
+| Teacher recommendation/intervention framing present | `Yes` | dashboard review flow, diagnosis case studies, and casepack framing |
+
+Explicit non-claims:
+
+- no diagnosis accuracy benchmark
+- no classroom outcome metric
+- no learning-gain claim
+- no pilot effectiveness claim
+
 ## Evidence Freshness Status
 
 Latest smoke-backed refresh: 2026-04-28

--- a/docs/superpowers/pr-notes/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md
+++ b/docs/superpowers/pr-notes/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md
@@ -1,0 +1,46 @@
+# C219 Classroom Case Study And Bounded Metric Card
+
+## Summary
+
+- packages the contest docs around one explicit Grade 9 quadratics classroom case
+- adds one compact metric card that stays inside smoke-backed and casepack-backed proof
+- removes pressure to present the repository as a benchmark, pilot, or classroom-outcome study
+
+## Scope
+
+- Changed:
+  - `docs/contest/README.md`
+  - `docs/contest/DEMO_SCRIPT.md`
+  - `docs/contest/CASEPACK_AND_EVALUATION_DATASET.md`
+  - `docs/contest/VALIDATION_REPORT.md`
+  - `ai_first/competition/product-description.md`
+  - `ai_first/competition/pitch-notes.md`
+- Unchanged by design:
+  - runtime code
+  - screenshot freshness state
+  - `ai_first/evidence/casepack.json`
+  - `docs/contest/EVIDENCE_CHECKLIST.md`
+
+## Architecture
+
+```mermaid
+flowchart LR
+  A["contest-demo-quadratics"] --> B["Assessment demo"]
+  A --> C["Tutor demo"]
+  B --> D["Dashboard review"]
+  C --> D
+  D --> E["Teacher remediation move"]
+  F["Smoke-backed validation"] --> G["Bounded metric card"]
+  H["Casepack framing"] --> G
+  G --> I["Contest docs and pitch notes"]
+```
+
+## Validation
+
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`
+- `rg -n "case study|metric|bounded|non-overclaim|grounding|contest-demo-quadratics|validated prototype|not a benchmark|not a classroom outcome" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes`
+
+## Main System Map
+
+- No update required. This lane changes documentation and evidence framing only.

--- a/docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md
+++ b/docs/superpowers/tasks/2026-04-30-c219-classroom-case-study-and-bounded-metric-card.md
@@ -4,7 +4,7 @@
 - Commit tag: `C219`
 - Branch: `docs/classroom-case-study-metric-card`
 - Worktree: `.worktrees/classroom-case-study-metric-card`
-- Status: `pending`
+- Status: `in_progress`
 
 ## Goal
 
@@ -90,3 +90,4 @@ Package one explicit classroom case study plus one compact, non-overclaim metric
 ## Handoff
 
 - After this packet, the differentiation follow-up set is fully packetized: `C216`, `C217`, `C218`, and `C219` can now be executed independently with bounded scope.
+- This execution keeps the story anchored to `contest-demo-quadratics` and only adds evidence-backed flow metrics, not benchmark or classroom-outcome claims.


### PR DESCRIPTION
# C219 Classroom Case Study And Bounded Metric Card

## Summary

- packages the contest docs around one explicit Grade 9 quadratics classroom case
- adds one compact metric card that stays inside smoke-backed and casepack-backed proof
- removes pressure to present the repository as a benchmark, pilot, or classroom-outcome study

## Scope

- Changed:
  - `docs/contest/README.md`
  - `docs/contest/DEMO_SCRIPT.md`
  - `docs/contest/CASEPACK_AND_EVALUATION_DATASET.md`
  - `docs/contest/VALIDATION_REPORT.md`
  - `ai_first/competition/product-description.md`
  - `ai_first/competition/pitch-notes.md`
- Unchanged by design:
  - runtime code
  - screenshot freshness state
  - `ai_first/evidence/casepack.json`
  - `docs/contest/EVIDENCE_CHECKLIST.md`

## Architecture

```mermaid
flowchart LR
  A["contest-demo-quadratics"] --> B["Assessment demo"]
  A --> C["Tutor demo"]
  B --> D["Dashboard review"]
  C --> D
  D --> E["Teacher remediation move"]
  F["Smoke-backed validation"] --> G["Bounded metric card"]
  H["Casepack framing"] --> G
  G --> I["Contest docs and pitch notes"]
```

## Validation

- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `git diff --check`
- `rg -n "case study|metric|bounded|non-overclaim|grounding|contest-demo-quadratics|validated prototype|not a benchmark|not a classroom outcome" docs/contest ai_first/competition docs/superpowers/tasks docs/superpowers/pr-notes`

## Main System Map

- No update required. This lane changes documentation and evidence framing only.
