### PR TITLE
docs(contest): tighten final human review handoff [OPS-HANDOFF]

### DIFF
--- a/ai_first/competition/submission-checklist.md
+++ b/ai_first/competition/submission-checklist.md
@@ -38,5 +38,7 @@
 - HKUDS/DeepTutor credit retained: upstream credit remains visible in `README.md` and `AGENTS.md`.
 - No secrets committed: tracked-file grep on 2026-04-25 found only test/example placeholders, not live credentials or private keys.
 - Uploaded sample data is licensed or self-created: contest docs require demo-safe local data only via `docs/contest/DEMO_DATA_RESET.md`.
+- Screenshots captured: authoritative screenshot bundle was refreshed on 2026-04-30; see `docs/contest/EVIDENCE_CHECKLIST.md` and `docs/contest/VALIDATION_REPORT.md`.
 - Product description drafted: see `ai_first/competition/product-description.md`.
 - Fork modifications described: see `ai_first/competition/fork-modifications.md`.
+- Remaining human-only review gates: see `docs/contest/HUMAN_REVIEW_HANDOFF.md`.

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -96,6 +96,20 @@
 - Next: the contest-differentiation follow-up set is complete; only browser-freshness review or human-only submission decisions remain unless a new packet is opened.
 # 2026-04-30
 
+## Final human-review handoff refinement
+
+- Opened docs-only lane `OPS_FINAL_HUMAN_REVIEW_HANDOFF_REFINEMENT` from `origin/main` in `.worktrees/final-human-review-handoff-refinement`.
+- Added bounded packet and plan for a handoff-only refinement lane so the remaining submission work could stay explicit and human-owned.
+- Updated `docs/contest/HUMAN_REVIEW_HANDOFF.md` to reflect the post-`#243` evidence state:
+  - browser screenshots are already refreshed on 2026-04-30;
+  - evidence sanity check is now only a final human clarity/privacy pass;
+  - added a compact final sign-off record table for reviewer/date/result capture.
+- Updated `ai_first/competition/submission-checklist.md` so the verification basis explicitly points to the refreshed screenshot authority and the final handoff sheet.
+- Added the lane PR note and left runtime, evidence-refresh docs, and contest claims unchanged.
+- Validation used:
+  - `rg -n "2026-04-25|2026-04-26|stale|screenshot|IP commitment|Final package reviewed by humans|video" docs/contest/HUMAN_REVIEW_HANDOFF.md ai_first/competition/submission-checklist.md docs/superpowers/tasks docs/superpowers/plans docs/superpowers/pr-notes -S`
+  - `git diff --check`
+
 ## Browser recapture refresh
 
 - Opened docs-only lane `OPS_BROWSER_RECAPTURE_REFRESH_20260430` from `origin/main` in `.worktrees/browser-recapture-refresh-20260430`.

--- a/docs/contest/HUMAN_REVIEW_HANDOFF.md
+++ b/docs/contest/HUMAN_REVIEW_HANDOFF.md
@@ -18,7 +18,7 @@ Use this file as the shortest manual review path before the final VnExpress Sán
 | --- | --- | --- | --- |
 | Product wording and category fit | submission operator / final reviewer | Pending | final human wording review not yet recorded |
 | Intellectual property commitment | submission operator / project owner | Pending | external confirmation not yet recorded |
-| Evidence sanity check | submission operator | Pending | final human sanity pass not yet recorded; Session B proof refresh is now merged and authoritative |
+| Evidence sanity check | submission operator | Pending | final human clarity/privacy pass not yet recorded, even though browser screenshots were refreshed on 2026-04-30 |
 | Optional video decision | submission operator | Pending | final submission requirements not yet confirmed |
 | Final package sign-off | final reviewer | Blocked | Gates 1-4 must complete first |
 
@@ -67,7 +67,7 @@ Acceptance rule:
 
 - if Session B refreshes validation or evidence wording, use its files as authoritative
 - if a screenshot or validation artifact is stale, do not silently mark the package ready
-- the current authoritative refresh is the merged 2026-04-28 Session B smoke/evidence pass, while screenshot capture dates remain 2026-04-25 and 2026-04-26
+- the current authoritative refresh set is: smoke-backed command evidence on 2026-04-28 plus refreshed Knowledge, Tutor, Dashboard, and `/agents` browser screenshots on 2026-04-30
 
 ### Gate 4. Optional video decision
 
@@ -86,6 +86,18 @@ Owner: final reviewer
 
 Use `docs/contest/SUBMISSION_PACKAGE.md` as the final read path and then mark the remaining human checklist items in the actual submission workflow.
 
+## Final Sign-Off Record
+
+Use this short record when a human completes the remaining gates:
+
+| Item | Reviewer | Date | Result |
+| --- | --- | --- | --- |
+| Product wording and category fit reviewed |  |  | Pending |
+| IP commitment reviewed |  |  | Pending |
+| Evidence sanity pass completed |  |  | Pending |
+| Optional video decision recorded |  |  | Pending |
+| Final package sign-off recorded |  |  | Pending |
+
 ## Suggested Human Read Order
 
 1. `docs/contest/SUBMISSION_PACKAGE.md`
@@ -96,7 +108,7 @@ Use `docs/contest/SUBMISSION_PACKAGE.md` as the final read path and then mark th
 6. `docs/contest/screenshots/`
 
 If any wording here disagrees with Session B-owned freshness files, prefer the Session B file and update this handoff later rather than overriding proof status locally.
-This handoff now assumes the Session B refresh merged successfully; the remaining work is human review and optional submission-only decisions.
+This handoff now assumes the smoke-backed Session B validation and the later 2026-04-30 browser screenshot refresh both merged successfully; the remaining work is human review and optional submission-only decisions.
 
 ## Expected End State
 

--- a/docs/superpowers/plans/2026-04-30-final-human-review-handoff-refinement.md
+++ b/docs/superpowers/plans/2026-04-30-final-human-review-handoff-refinement.md
@@ -1,0 +1,41 @@
+# Final Human Review Handoff Refinement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** tighten the final human-review docs so the remaining manual contest gates are accurate after the refreshed browser evidence merge
+
+**Architecture:** this is a docs-only cleanup lane. Update the short human-review handoff as the primary operator gate sheet, then align the compact submission checklist so it reflects the same manual completion truth without claiming sign-off has already happened.
+
+**Tech Stack:** Markdown, git diff validation, ripgrep
+
+---
+
+### Task 1: Refresh the human gate sheet
+
+**Files:**
+- Modify: `docs/contest/HUMAN_REVIEW_HANDOFF.md`
+
+- [ ] Step 1: replace any stale screenshot-state wording with the current merged evidence state from PR `#243`
+- [ ] Step 2: compress the gate list so each remaining manual decision has a clear owner, status, and acceptance rule
+- [ ] Step 3: make the suggested read order and expected end state short enough for a final operator pass
+
+### Task 2: Align the compact submission checklist
+
+**Files:**
+- Modify: `ai_first/competition/submission-checklist.md`
+
+- [ ] Step 1: keep screenshot evidence checked as complete
+- [ ] Step 2: keep `IP commitment reviewed` and `Final package reviewed by humans` unchecked
+- [ ] Step 3: tighten the verification basis so it points reviewers at the current handoff and evidence docs
+
+### Task 3: Record and verify the lane
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-final-human-review-handoff-refinement.md`
+
+- [ ] Step 1: record the lane outcome in the daily log
+- [ ] Step 2: clear the active assignment after verification
+- [ ] Step 3: add the PR note with Mermaid diagram
+- [ ] Step 4: run the required `rg` validation and `git diff --check`

--- a/docs/superpowers/pr-notes/2026-04-30-final-human-review-handoff-refinement.md
+++ b/docs/superpowers/pr-notes/2026-04-30-final-human-review-handoff-refinement.md
@@ -1,0 +1,32 @@
+# PR Note: Final Human Review Handoff Refinement
+
+## Summary
+
+This docs-only lane tightens the final human-review path after browser evidence refresh is complete. It updates the shortest manual gate sheet and aligns the compact submission checklist so the remaining work is unambiguously human-only: wording review, IP commitment, optional video decision, and final sign-off.
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Evidence["Command evidence + refreshed screenshots"]
+  Handoff["HUMAN_REVIEW_HANDOFF.md"]
+  Checklist["submission-checklist.md"]
+  Reviewer["Human reviewer"]
+  Signoff["Final sign-off"]
+
+  Evidence --> Handoff
+  Handoff --> Checklist
+  Checklist --> Reviewer
+  Reviewer --> Signoff
+```
+
+## Architecture Impact
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` is not updated. This lane only refines final human-review docs.
+
+## Validation
+
+```bash
+rg -n "2026-04-25|2026-04-26|stale|screenshot|IP commitment|Final package reviewed by humans|video" docs/contest/HUMAN_REVIEW_HANDOFF.md ai_first/competition/submission-checklist.md docs/superpowers/tasks docs/superpowers/plans docs/superpowers/pr-notes -S
+git diff --check
+```

--- a/docs/superpowers/tasks/2026-04-30-final-human-review-handoff-refinement.md
+++ b/docs/superpowers/tasks/2026-04-30-final-human-review-handoff-refinement.md
@@ -1,0 +1,57 @@
+# Feature Pod Task: Final Human Review Handoff Refinement
+
+Task ID: `OPS_FINAL_HUMAN_REVIEW_HANDOFF_REFINEMENT`
+Commit tag: `OPS-HANDOFF`
+Owner: Session-specific
+Branch: `docs/final-human-review-handoff-refinement`
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Tighten the final human-review docs so the remaining manual gates are accurate after PR `#243` and can be completed without re-reading the whole repository history.
+
+## User-visible outcome
+
+- Human reviewers get one short, current gate sheet instead of a partially stale handoff.
+- The legal and submission checklist reflects that screenshots are already refreshed.
+- The remaining manual steps are explicit: wording review, IP commitment, optional video decision, and final sign-off.
+
+## Owned files/modules
+
+- `docs/contest/HUMAN_REVIEW_HANDOFF.md`
+- `ai_first/competition/submission-checklist.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-final-human-review-handoff-refinement.md`
+- `docs/superpowers/plans/2026-04-30-final-human-review-handoff-refinement.md`
+- `docs/superpowers/pr-notes/*`
+
+## Do-not-touch files/modules
+
+- `docs/contest/screenshots/*`
+- `docs/contest/VALIDATION_REPORT.md`
+- `docs/contest/EVIDENCE_CHECKLIST.md`
+- `ai_first/AI_OPERATING_PROMPT.md`
+- runtime/product code
+- lockfiles
+
+## Acceptance criteria
+
+- `HUMAN_REVIEW_HANDOFF.md` no longer references the pre-`#243` screenshot state.
+- `submission-checklist.md` stays bounded to human-review truth and does not overclaim sign-off completion.
+- The lane remains docs-only and does not invent any new contest claim or runtime scope.
+
+## Required tests
+
+- `rg -n "2026-04-25|2026-04-26|stale|screenshot|IP commitment|Final package reviewed by humans|video" docs/contest/HUMAN_REVIEW_HANDOFF.md ai_first/competition/submission-checklist.md docs/superpowers/tasks docs/superpowers/plans docs/superpowers/pr-notes -S`
+- `git diff --check`
+
+## Parallel-work notes
+
+- This lane is docs-only.
+- Do not reopen evidence refresh or browser capture work inside this lane.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` should remain unchanged.


### PR DESCRIPTION
## Summary
- refresh the shortest human-review gate sheet so it matches the post-#243 evidence state
- align the compact submission checklist with the refreshed screenshot authority and remaining human-only gates
- add the bounded packet, plan, and PR note for this docs-only lane

## Validation
- `rg -n "2026-04-25|2026-04-26|stale|screenshot|IP commitment|Final package reviewed by humans|video" docs/contest/HUMAN_REVIEW_HANDOFF.md ai_first/competition/submission-checklist.md docs/superpowers/tasks docs/superpowers/plans docs/superpowers/pr-notes -S`
- `git diff --check`
