### PR TITLE
fix(ui): harden contest responsive layout [C220]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,4 +30,17 @@ Rules:
 
 ## Active
 
-- None.
+### Assignment
+
+- Owner: Codex
+- Machine: local
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/contest-layout-breakage-sweep`
+- Task: `C220_CONTEST_LAYOUT_BREAKAGE_SWEEP`
+- Status: `in_progress`
+- Branch: `fix/contest-layout-breakage-sweep`
+- Task packet: `docs/superpowers/tasks/2026-04-30-c220-contest-layout-breakage-sweep.md`
+- Owned files: `web/components/agents/SpecPackAuthoringTab.tsx`, `web/app/(workspace)/agents/page.tsx`, `web/components/contest/TeacherCockpit.tsx`, `web/components/contest/CoreLoopVisibilityStrip.tsx`, `web/app/(workspace)/dashboard/page.tsx`, `web/app/(utility)/knowledge/page.tsx`, and `web/app/(utility)/marketplace/page.tsx` only if the same layout issue is confirmed there
+- PR: `not opened`
+- Last update: `2026-04-30`
+- Next action: `finish codebase survey, then implement the responsive hardening sweep`
+- Blocker: `none`

--- a/ai_first/TASK_REGISTRY.json
+++ b/ai_first/TASK_REGISTRY.json
@@ -106,8 +106,10 @@
     },
     "in_progress": {
       "description": "Features partially implemented, need completion",
-      "count": 0,
-      "tasks": []
+      "count": 1,
+      "tasks": [
+        "C220_CONTEST_LAYOUT_BREAKAGE_SWEEP"
+      ]
     },
     "blocked": {
       "description": "Tasks blocked by dependencies",
@@ -116,9 +118,8 @@
     },
     "pending": {
       "description": "Tasks not started, ordered by priority",
-      "count": 2,
+      "count": 1,
       "tasks": [
-        "C220_CONTEST_LAYOUT_BREAKAGE_SWEEP",
         "C221_CONTEST_VIETNAMESE_COVERAGE_COMPLETION"
       ]
     }
@@ -2317,10 +2318,10 @@
         "C217_TEACHER_COCKPIT_DEFAULT_ENTRY",
         "C218_CONTEST_BRAND_AND_CLASSROOM_TERMINOLOGY"
       ],
-      "status": "not-started",
+      "status": "in-progress",
       "recommended_session_bucket": "session-b-runtime",
       "layer": "post-contest-recovery",
-      "notes": "Opened from `main` on 2026-04-30 after a visual audit found severe column collapse, button overlap, and poor wrapping on `/agents`, plus follow-on layout risk across the teacher cockpit, Knowledge, and Dashboard screens."
+      "notes": "In progress on branch fix/contest-layout-breakage-sweep as of 2026-04-30. Local runtime hardening has landed for /agents plus bounded responsive guards on the teacher cockpit, Knowledge, and Dashboard; final merge status pending review."
     },
     {
       "id": "C221_CONTEST_VIETNAMESE_COVERAGE_COMPLETION",

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -1,5 +1,20 @@
 # Daily Log: 2026-04-30
 
+## C220 Contest Layout Breakage Sweep
+
+- Branch: `fix/contest-layout-breakage-sweep`
+- Task: `C220_CONTEST_LAYOUT_BREAKAGE_SWEEP`
+- Done: Created isolated worktree `.worktrees/contest-layout-breakage-sweep` from the published task-packet head and recorded the active assignment before runtime edits.
+- Done: Wrote the implementation plan `docs/superpowers/plans/2026-04-30-c220-contest-layout-breakage-sweep.md`.
+- Done: Reworked `web/components/agents/SpecPackAuthoringTab.tsx` so the spec-authoring surface no longer forces a fragile three-column layout at laptop widths; the right rail now drops below the main column until larger screens, action rows wrap, and long summary/audit values can break instead of colliding.
+- Done: Expanded the `/agents` page shell width and allowed the tab strip to wrap so the spec-authoring lane has room to breathe without truncating the contest-path header chrome.
+- Done: Added bounded responsive guards to the teacher cockpit, Knowledge header, and dashboard metric grid so the contest path tolerates longer Vietnamese copy without immediate overflow pressure.
+- Done: Left `web/app/(utility)/marketplace/page.tsx` unchanged after survey because the same collapse pattern was not required there for this sweep.
+- Tests: `cd web && npm install`; `cd web && npx eslint "components/agents/SpecPackAuthoringTab.tsx" "app/(workspace)/agents/page.tsx" "components/contest/TeacherCockpit.tsx" "components/contest/CoreLoopVisibilityStrip.tsx" "app/(workspace)/dashboard/page.tsx" "app/(utility)/knowledge/page.tsx" "app/(utility)/marketplace/page.tsx"`; `cd web && npm run build`; `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`; `git diff --check`
+- Tests: ESLint reported `0 errors, 1 warning` from an existing `react-hooks/exhaustive-deps` warning in one `page.tsx`; this lane did not add a new lint error.
+- Blockers: manual browser verification is still recommended before merge because the lane was validated through build/lint plus source-level responsive review in this session.
+- Next: capture PR note and, if no further local UI adjustment is needed, open the draft PR for review before starting `C221`.
+
 ## Contest UI Recovery Audit
 
 - Branch: `docs/contest-ui-i18n-audit-tasks`

--- a/docs/superpowers/plans/2026-04-30-c220-contest-layout-breakage-sweep.md
+++ b/docs/superpowers/plans/2026-04-30-c220-contest-layout-breakage-sweep.md
@@ -1,0 +1,49 @@
+# C220 Contest Layout Breakage Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stabilize the contest-path responsive layout, starting with `/agents` spec-pack authoring and then hardening nearby teacher-facing screens against overlap, clipping, and column collapse.
+
+**Architecture:** Keep the fix bounded to presentation. Restack the `/agents` authoring page earlier, add `min-w-0` and wrapping guards to action rows and rails, then apply smaller responsive protections to the cockpit, dashboard, and any confirmed contest-path sibling screen that shares the same failure mode.
+
+**Tech Stack:** Next.js App Router, React, Tailwind utility classes, Node test runner, ESLint
+
+---
+
+### Task 1: Harden `/agents` spec-pack authoring layout
+
+**Files:**
+- Modify: `web/components/agents/SpecPackAuthoringTab.tsx`
+- Test: existing frontend build and manual verification on `/agents`
+
+- [ ] Restack the root grid so the left rail, authoring column, and summary rail stop competing at laptop widths.
+- [ ] Add `min-w-0`, wrapping, and width guards to the top action header and right-rail summary blocks.
+- [ ] Make the runtime audit and markdown preview cards tolerate long values without forcing horizontal spill.
+- [ ] Run a focused lint/build pass after the `/agents` changes land cleanly.
+
+### Task 2: Apply bounded responsive guards to adjacent contest screens
+
+**Files:**
+- Modify: `web/components/contest/TeacherCockpit.tsx`
+- Modify: `web/components/contest/CoreLoopVisibilityStrip.tsx`
+- Modify: `web/app/(workspace)/dashboard/page.tsx`
+- Modify: `web/app/(utility)/knowledge/page.tsx`
+- Modify only if needed: `web/app/(utility)/marketplace/page.tsx`
+
+- [ ] Tighten cockpit action-card and header wrapping so longer copy does not crowd controls.
+- [ ] Verify the core-loop pill strip wraps cleanly with no clipped labels.
+- [ ] Add only the minimum responsive fixes needed on Dashboard and Knowledge if the same overflow pattern appears there.
+- [ ] Leave Marketplace untouched unless the code survey confirms the same contest-path issue.
+
+### Task 3: Validate and document lane state
+
+**Files:**
+- Modify: `ai_first/ACTIVE_ASSIGNMENTS.md`
+- Modify: `ai_first/TASK_REGISTRY.json`
+- Modify: `ai_first/daily/2026-04-30.md`
+- Modify: `docs/superpowers/pr-notes/2026-04-30-c220-contest-layout-breakage-sweep.md`
+
+- [ ] Run `cd web && npx eslint "components/agents/SpecPackAuthoringTab.tsx" "app/(workspace)/agents/page.tsx" "components/contest/TeacherCockpit.tsx" "components/contest/CoreLoopVisibilityStrip.tsx" "app/(workspace)/dashboard/page.tsx" "app/(utility)/knowledge/page.tsx" "app/(utility)/marketplace/page.tsx"`.
+- [ ] Run `cd web && npm run build`.
+- [ ] Run `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null` and `git diff --check`.
+- [ ] Update the task registry, daily log, and PR note with the validated impact surface and any residual follow-up for `C221`.

--- a/docs/superpowers/pr-notes/2026-04-30-c220-contest-layout-breakage-sweep.md
+++ b/docs/superpowers/pr-notes/2026-04-30-c220-contest-layout-breakage-sweep.md
@@ -1,0 +1,49 @@
+# C220 Contest Layout Breakage Sweep
+
+## Summary
+
+- stabilizes the `/agents` spec-pack authoring screen by restacking the layout earlier and adding wrap guards to controls and summary content
+- widens the `/agents` shell and wraps the tab row so the teacher-setup path remains readable on laptop widths
+- applies smaller responsive protections to the teacher cockpit, Knowledge header, and dashboard metrics without changing routes or backend contracts
+
+## Scope
+
+- Changed:
+  - `web/components/agents/SpecPackAuthoringTab.tsx`
+  - `web/app/(workspace)/agents/page.tsx`
+  - `web/components/contest/TeacherCockpit.tsx`
+  - `web/app/(utility)/knowledge/page.tsx`
+  - `web/app/(workspace)/dashboard/page.tsx`
+  - `docs/superpowers/plans/2026-04-30-c220-contest-layout-breakage-sweep.md`
+  - `ai_first/ACTIVE_ASSIGNMENTS.md`
+  - `ai_first/TASK_REGISTRY.json`
+  - `ai_first/daily/2026-04-30.md`
+- Reviewed but intentionally unchanged:
+  - `web/components/contest/CoreLoopVisibilityStrip.tsx`
+  - `web/app/(utility)/marketplace/page.tsx`
+  - locale files and backend contracts
+
+## Architecture
+
+```mermaid
+flowchart LR
+  A["/agents authoring shell"] --> B["2-column on xl"]
+  B --> C["3-column only on 2xl"]
+  A --> D["wrap action row"]
+  A --> E["break long summary values"]
+  F["Teacher cockpit"] --> G["min-w-0 and copy wrap guards"]
+  H["Knowledge header"] --> I["stack controls before overflow"]
+  J["Dashboard cards"] --> K["2-up before 4-up"]
+```
+
+## Validation
+
+- `cd web && npm install`
+- `cd web && npx eslint "components/agents/SpecPackAuthoringTab.tsx" "app/(workspace)/agents/page.tsx" "components/contest/TeacherCockpit.tsx" "components/contest/CoreLoopVisibilityStrip.tsx" "app/(workspace)/dashboard/page.tsx" "app/(utility)/knowledge/page.tsx" "app/(utility)/marketplace/page.tsx"`
+- `cd web && npm run build`
+- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
+- `git diff --check`
+
+## Main System Map
+
+- No update required. This lane changes responsive presentation only, not the system architecture or route contracts.

--- a/docs/superpowers/tasks/2026-04-30-c220-contest-layout-breakage-sweep.md
+++ b/docs/superpowers/tasks/2026-04-30-c220-contest-layout-breakage-sweep.md
@@ -4,7 +4,7 @@
 - Commit tag: `C220`
 - Branch: `fix/contest-layout-breakage-sweep`
 - Worktree: `.worktrees/contest-layout-breakage-sweep`
-- Status: `not_started`
+- Status: `in_progress`
 
 ## Goal
 

--- a/web/app/(utility)/knowledge/page.tsx
+++ b/web/app/(utility)/knowledge/page.tsx
@@ -773,10 +773,10 @@ export default function KnowledgePage() {
 
   return (
     <div className="h-full overflow-y-auto bg-[var(--background)] [scrollbar-gutter:stable]">
-      <div className="mx-auto max-w-5xl px-6 py-8 pb-10">
+      <div className="mx-auto max-w-5xl px-4 py-8 pb-10 sm:px-6">
         {/* Header */}
-        <div className="mb-6 flex items-start justify-between gap-4">
-          <div>
+        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
             <h1 className="text-2xl font-bold tracking-tight text-[var(--foreground)]">
               {t("Knowledge Packs")}
             </h1>
@@ -785,7 +785,7 @@ export default function KnowledgePage() {
             </p>
           </div>
 
-          <div className="inline-flex shrink-0 rounded-lg border border-[var(--border)] bg-[var(--muted)] p-0.5">
+          <div className="inline-flex shrink-0 self-start rounded-lg border border-[var(--border)] bg-[var(--muted)] p-0.5">
             {[
               { key: "knowledge", label: t("Knowledge Packs"), icon: Database },
               { key: "notebooks", label: t("Notebooks"), icon: NotebookPen },

--- a/web/app/(workspace)/agents/page.tsx
+++ b/web/app/(workspace)/agents/page.tsx
@@ -87,7 +87,7 @@ export default function AgentsPage() {
 
   return (
     <div className="h-full overflow-y-auto [scrollbar-gutter:stable]">
-      <div className="mx-auto max-w-[960px] px-6 py-8">
+      <div className="mx-auto max-w-[1320px] px-4 py-8 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-6">
           <h1 className="text-[24px] font-semibold tracking-tight text-[var(--foreground)]">
@@ -103,7 +103,7 @@ export default function AgentsPage() {
         </div>
 
         {/* Tabs */}
-        <div className="mb-6 flex items-center gap-1 border-b border-[var(--border)]/50 pb-3">
+        <div className="mb-6 flex flex-wrap items-center gap-1 border-b border-[var(--border)]/50 pb-3">
           {([
             { key: "specs" as Tab, label: t("Tutor setup"), icon: FileText },
             { key: "bots" as Tab, label: t("Class tutors"), icon: Bot },

--- a/web/app/(workspace)/dashboard/page.tsx
+++ b/web/app/(workspace)/dashboard/page.tsx
@@ -122,7 +122,7 @@ export default function DashboardPage() {
 
   return (
     <main className="h-full overflow-y-auto bg-[var(--background)]">
-      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-6 px-6 py-8">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-6 px-4 py-8 sm:px-6">
         <header className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>
@@ -269,7 +269,7 @@ export default function DashboardPage() {
           </div>
         )}
 
-        <section className="grid gap-3 md:grid-cols-4">
+        <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           {cards.map((card) => (
             <div
               key={card.label}

--- a/web/components/agents/SpecPackAuthoringTab.tsx
+++ b/web/components/agents/SpecPackAuthoringTab.tsx
@@ -213,10 +213,10 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
   }
 
   return (
-    <div className="grid gap-6 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
-      <aside className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
-        <div className="mb-4 flex items-center justify-between">
-          <div>
+    <div className="grid items-start gap-6 xl:grid-cols-[minmax(240px,280px)_minmax(0,1fr)] 2xl:grid-cols-[minmax(240px,280px)_minmax(0,1fr)_minmax(280px,320px)]">
+      <aside className="min-w-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
             <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
               {t("Teacher setup")}
             </p>
@@ -226,7 +226,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
           </div>
           <button
             onClick={beginNewPack}
-            className="inline-flex items-center gap-1 rounded-lg border border-[var(--border)] px-2.5 py-1.5 text-[12px] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            className="inline-flex shrink-0 items-center gap-1 self-start rounded-lg border border-[var(--border)] px-2.5 py-1.5 text-[12px] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
           >
             <Plus className="h-3.5 w-3.5" />
             {t("New")}
@@ -271,10 +271,10 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
         )}
       </aside>
 
-      <section className="space-y-5">
+      <section className="min-w-0 space-y-5">
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-5">
-          <div className="mb-4 flex items-center justify-between gap-4">
-            <div>
+          <div className="mb-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
               <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
                 {t("Teacher controls")}
               </p>
@@ -285,11 +285,11 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
                 {t("IDENTITY defines who this class tutor supports, SOUL shapes how it coaches when students are wrong or stuck, and RULES keep every response inside your classroom boundaries.")}
               </p>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2 lg:justify-end">
               <button
                 onClick={() => void exportDraft()}
                 disabled={exporting || !draft.agent_id}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-2 text-[12px] text-[var(--muted-foreground)] disabled:opacity-40"
+                className="inline-flex min-w-[104px] items-center justify-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-2 text-[12px] text-[var(--muted-foreground)] disabled:opacity-40"
               >
                 {exporting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
                 {t("Export")}
@@ -297,7 +297,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
               <button
                 onClick={() => void saveDraft()}
                 disabled={saving}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-[12px] font-medium text-[var(--primary-foreground)] disabled:opacity-40"
+                className="inline-flex min-w-[104px] items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-[12px] font-medium text-[var(--primary-foreground)] disabled:opacity-40"
               >
                 {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
                 {draft.version > 0 ? t("Save") : t("Create")}
@@ -403,8 +403,8 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
         </div>
       </section>
 
-      <aside className="space-y-4">
-        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
+      <aside className="min-w-0 space-y-4">
+        <div className="min-w-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
           <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
             {t("Teacher-facing summary")}
           </p>
@@ -420,9 +420,9 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
           </div>
         </div>
 
-        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
-          <div className="flex items-start justify-between gap-3">
-            <div>
+        <div className="min-w-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
               <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
                 {t("Runtime policy audit")}
               </p>
@@ -433,7 +433,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
             <select
               value={auditCapability}
               onChange={(event) => setAuditCapability(event.target.value as "chat" | "deep_question" | "deep_solve")}
-              className="rounded-lg border border-[var(--border)] bg-transparent px-2 py-1 text-[12px] text-[var(--foreground)]"
+              className="w-full rounded-lg border border-[var(--border)] bg-transparent px-2 py-1 text-[12px] text-[var(--foreground)] sm:w-auto"
             >
               <option value="chat">{t("chat")}</option>
               <option value="deep_question">{t("deep_question")}</option>
@@ -475,9 +475,9 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
                 </p>
                 <div className="mt-2 space-y-2">
                   {Object.entries(runtimeAudit.runtime_policy.debug.slice_sources).map(([slice, source]) => (
-                    <div key={slice} className="flex items-start justify-between gap-3">
-                      <span className="font-medium text-[var(--foreground)]">{slice}</span>
-                      <span className="text-right text-[var(--muted-foreground)]">{source}</span>
+                    <div key={slice} className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+                      <span className="font-medium text-[var(--foreground)] break-words">{slice}</span>
+                      <span className="text-left break-words text-[var(--muted-foreground)] sm:text-right">{source}</span>
                     </div>
                   ))}
                 </div>
@@ -490,7 +490,7 @@ export default function SpecPackAuthoringTab({ onToast }: { onToast: (message: s
           )}
         </div>
 
-        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
+        <div className="min-w-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-4">
           <p className="text-[12px] uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
             {t("Markdown preview")}
           </p>
@@ -514,8 +514,8 @@ function StructuredSection({
   children: ReactNode;
 }) {
   return (
-    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-5">
-      <div className="mb-4">
+    <div className="min-w-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/40 p-5">
+      <div className="mb-4 min-w-0">
         <h3 className="text-[16px] font-semibold text-[var(--foreground)]">{title}</h3>
         <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">{description}</p>
       </div>
@@ -574,9 +574,9 @@ function LabeledTextarea({
 
 function SummaryRow({ label, value }: { label: string; value: string }) {
   return (
-    <div>
+    <div className="min-w-0">
       <p className="text-[11px] uppercase tracking-[0.16em] text-[var(--muted-foreground)]">{label}</p>
-      <p className="mt-1 text-[13px] text-[var(--foreground)]">{value || "—"}</p>
+      <p className="mt-1 break-words text-[13px] text-[var(--foreground)]">{value || "—"}</p>
     </div>
   );
 }

--- a/web/components/contest/TeacherCockpit.tsx
+++ b/web/components/contest/TeacherCockpit.tsx
@@ -24,7 +24,7 @@ export function TeacherCockpit() {
 
   return (
     <main className="h-full overflow-y-auto bg-[var(--background)]">
-      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-6 px-6 py-8">
+      <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-4 py-8 sm:px-6">
         <section className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
           <div className="flex flex-col gap-4">
             <div>
@@ -72,9 +72,9 @@ export function TeacherCockpit() {
                     </div>
                     <ArrowRight className="mt-1 h-4 w-4 text-[var(--muted-foreground)] transition group-hover:text-[var(--foreground)]" />
                   </div>
-                  <div className="mt-4">
+                  <div className="mt-4 min-w-0">
                     <div className="text-[15px] font-medium text-[var(--foreground)]">{t(action.title)}</div>
-                    <p className="mt-1 text-[13px] leading-6 text-[var(--muted-foreground)]">
+                    <p className="mt-1 break-words text-[13px] leading-6 text-[var(--muted-foreground)]">
                       {t(action.description)}
                     </p>
                   </div>
@@ -101,9 +101,9 @@ export function TeacherCockpit() {
                     <div className="rounded-xl bg-[var(--secondary)] p-3 text-[var(--foreground)]">
                       <Icon className="h-5 w-5" />
                     </div>
-                    <div>
+                    <div className="min-w-0">
                       <div className="text-[15px] font-medium text-[var(--foreground)]">{t(action.title)}</div>
-                      <p className="mt-1 text-[13px] leading-6 text-[var(--muted-foreground)]">
+                      <p className="mt-1 break-words text-[13px] leading-6 text-[var(--muted-foreground)]">
                         {t(action.description)}
                       </p>
                     </div>


### PR DESCRIPTION
## Summary
- restack the `/agents` spec-pack authoring surface so laptop widths no longer collapse the three-column layout
- widen the `/agents` shell and add wrap/min-width guards around authoring controls, summary rails, and long runtime-audit values
- add smaller responsive protections to the teacher cockpit, Knowledge header, and dashboard metric grid to reduce overflow pressure on the contest path

## Root Cause
The contest-path surfaces were tuned for shorter English copy and desktop-like widths. After the teacher-first cockpit and classroom wording landed, `/agents` in particular still used a fragile `xl` three-column layout with insufficient `min-w-0` and wrapping guards, causing overlap and clipped content.

## Validation
- `cd web && npm install`
- `cd web && npx eslint "components/agents/SpecPackAuthoringTab.tsx" "app/(workspace)/agents/page.tsx" "components/contest/TeacherCockpit.tsx" "components/contest/CoreLoopVisibilityStrip.tsx" "app/(workspace)/dashboard/page.tsx" "app/(utility)/knowledge/page.tsx" "app/(utility)/marketplace/page.tsx"`
- `cd web && npm run build`
- `python3 -m json.tool ai_first/TASK_REGISTRY.json >/dev/null`
- `git diff --check`

## Notes
- ESLint reported `0 errors, 1 warning` from an existing `react-hooks/exhaustive-deps` warning in one `page.tsx`; this lane did not add a new lint error.
- `web/app/(utility)/marketplace/page.tsx` was reviewed and intentionally left unchanged in this sweep.

## Main System Map
- No update required. This lane changes responsive presentation only, not the system architecture or route contracts.
