### PR TITLE
Hide guide and co-writer entry points

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -35,12 +35,12 @@ Rules:
 - Owner: Codex session
 - Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: Polish the `/playground` chat workspace so the right panel is clearer, visible English copy is removed, the chat header is smaller, and the composer is tighter at the bottom
-- Status: implementing
-- Branch: `fix/playground-chat-workspace-polish`
-- Task packet: `docs/superpowers/tasks/2026-04-30-playground-chat-workspace-polish.md`
-- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/components/chat/home/PlaygroundRightPanel.tsx`, `web/components/chat/home/PlaygroundWorkspaceShell.tsx`, `web/components/sidebar/SidebarShell.tsx`, `web/locales/en/app.json`, `web/locales/vi/app.json`, `web/tests/contest-vietnamese-coverage.test.ts`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-chat-workspace-polish.md`, `docs/superpowers/pr-notes/2026-04-30-playground-chat-workspace-polish.md`
+- Task: Hide Guided Learning and Co-Writer from the frontend shell and block direct route access without deleting the underlying code
+- Status: writing spec
+- Branch: `fix/hide-guide-co-writer`
+- Task packet: `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`
+- Owned files: `web/components/sidebar/nav-groups.ts`, `web/app/(workspace)/guide/page.tsx`, `web/app/(workspace)/co-writer/page.tsx`, `web/app/(utility)/knowledge/page.tsx`, `web/locales/en/app.json`, `web/locales/vi/app.json`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`, `docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md`, `docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md`
 - PR: uncreated
 - Last update: 2026-04-30
-- Next action: implement the bounded `/playground` polish pass and rerun focused frontend validation
+- Next action: write the bounded runtime spec for FE hiding plus route redirects, then wait for spec review before implementation
 - Blocker: none

--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -36,11 +36,11 @@ Rules:
 - Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
 - Task: Hide Guided Learning and Co-Writer from the frontend shell and block direct route access without deleting the underlying code
-- Status: writing spec
+- Status: implementing
 - Branch: `fix/hide-guide-co-writer`
 - Task packet: `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`
-- Owned files: `web/components/sidebar/nav-groups.ts`, `web/app/(workspace)/guide/page.tsx`, `web/app/(workspace)/co-writer/page.tsx`, `web/app/(utility)/knowledge/page.tsx`, `web/locales/en/app.json`, `web/locales/vi/app.json`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`, `docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md`, `docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md`
+- Owned files: `web/components/sidebar/nav-groups.ts`, `web/app/(workspace)/guide/layout.tsx`, `web/app/(workspace)/co-writer/layout.tsx`, `web/app/(utility)/knowledge/page.tsx`, `web/tests/sidebar-nav-groups.test.ts`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`, `docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md`, `docs/superpowers/plans/2026-04-30-hide-guide-co-writer.md`, `docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md`
 - PR: uncreated
 - Last update: 2026-04-30
-- Next action: write the bounded runtime spec for FE hiding plus route redirects, then wait for spec review before implementation
+- Next action: finish FE hiding plus route redirects, record PR note, and prepare the lane for review
 - Blocker: none

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -12,6 +12,18 @@
 - Blockers: waiting for owner review of the written spec before implementation starts.
 - Next: after spec approval, implement the bounded FE hiding and route redirects on the same branch.
 
+## Hide Guided Learning and Co-Writer Implementation
+
+- Branch: `fix/hide-guide-co-writer`
+- Task: `UI_HIDE_GUIDE_CO_WRITER`
+- Done: Removed `Guided Learning` and `Co-Writer` from the secondary tool navigation so the visible shell now exposes only `Trò chuyện` and `Bộ nhớ` in that section.
+- Done: Added route-level redirect layouts for `/guide` and `/co-writer` so direct visits are bounced to `/playground` while the underlying feature code remains untouched in-repo.
+- Done: Updated the Knowledge page so only normal chat sessions still expose the open-session action; guided-learning records remain visible as saved content but no longer reopen the hidden flow.
+- Done: Kept guide internals, co-writer internals, backend guide APIs, and persisted data unchanged because this lane only removes public entry points.
+- Tests: `cd web && node --test tests/sidebar-nav-groups.test.ts`; `cd web && npx eslint "components/sidebar/nav-groups.ts" "app/(workspace)/guide/layout.tsx" "app/(workspace)/co-writer/layout.tsx" "app/(utility)/knowledge/page.tsx"`; `cd web && npm run build`
+- Blockers: none
+- Next: add the PR architecture note, stage the bounded diff, and prepare the lane for review.
+
 ## Playground Chat Workspace Polish
 
 - Branch: `fix/playground-chat-workspace-polish`

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -1,5 +1,17 @@
 # Daily Log: 2026-04-30
 
+## Hide Guided Learning and Co-Writer Design
+
+- Branch: `fix/hide-guide-co-writer`
+- Task: `UI_HIDE_GUIDE_CO_WRITER`
+- Done: Opened a new bounded runtime lane to remove Guided Learning and Co-Writer from the visible product shell without deleting their implementation.
+- Done: Recorded the live assignment in `ai_first/ACTIVE_ASSIGNMENTS.md` before code changes.
+- Done: Wrote the execution packet `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md` with owned files, route-gating scope, and validation paths.
+- Done: Wrote the bounded design spec `docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md` covering FE hiding, direct-route redirects to `/playground`, and Knowledge-page deep-link cleanup.
+- Tests: `git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md`
+- Blockers: waiting for owner review of the written spec before implementation starts.
+- Next: after spec approval, implement the bounded FE hiding and route redirects on the same branch.
+
 ## Playground Chat Workspace Polish
 
 - Branch: `fix/playground-chat-workspace-polish`

--- a/docs/superpowers/plans/2026-04-30-hide-guide-co-writer.md
+++ b/docs/superpowers/plans/2026-04-30-hide-guide-co-writer.md
@@ -1,0 +1,51 @@
+# Hide Guided Learning and Co-Writer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide Guided Learning and Co-Writer from the visible shell and redirect direct route access back to `/playground` without deleting underlying implementation.
+
+**Architecture:** Remove FE entry points in the sidebar, add route-level redirects at the route wrapper layer so page internals stay intact, and neutralize Knowledge-page session links that still point into Guided Learning. Keep implementation code dormant but present.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, node test, ESLint
+
+---
+
+### Task 1: Remove visible navigation entries
+
+**Files:**
+- Modify: `web/components/sidebar/nav-groups.ts`
+- Test: `web/tests/sidebar-nav-groups.test.ts`
+
+- [ ] Update the secondary tool list to remove `/guide` and `/co-writer`.
+- [ ] Update the sidebar regression test so the expanded secondary-tools group now contains only `/playground` and `/memory`.
+- [ ] Run: `cd web && node --test tests/sidebar-nav-groups.test.ts`
+
+### Task 2: Block direct route access without deleting page internals
+
+**Files:**
+- Create: `web/app/(workspace)/guide/layout.tsx`
+- Create: `web/app/(workspace)/co-writer/layout.tsx`
+
+- [ ] Add a layout-level redirect for `/guide` that immediately sends users to `/playground`.
+- [ ] Add the same layout-level redirect for `/co-writer`.
+- [ ] Keep the existing `page.tsx` implementations untouched so the underlying code remains in the repo.
+
+### Task 3: Remove routine FE deep links back into Guided Learning
+
+**Files:**
+- Modify: `web/app/(utility)/knowledge/page.tsx`
+
+- [ ] Change Knowledge-page notebook record navigation so only `chat` records expose an open-session action.
+- [ ] Remove the normal-path button that opens guided-learning sessions from saved records.
+- [ ] Keep guided-learning record badges and saved content visible; only the active route entry should disappear.
+
+### Task 4: Validate and record handoff
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md`
+
+- [ ] Run: `cd web && node --test tests/sidebar-nav-groups.test.ts`
+- [ ] Run: `cd web && npx eslint "components/sidebar/nav-groups.ts" "app/(workspace)/guide/layout.tsx" "app/(workspace)/co-writer/layout.tsx" "app/(utility)/knowledge/page.tsx"`
+- [ ] Run: `cd web && npm run build`
+- [ ] Write the PR note with a Mermaid diagram and state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.

--- a/docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md
+++ b/docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md
@@ -1,0 +1,27 @@
+# PR Note: Hide Guided Learning and Co-Writer
+
+## Summary
+
+- Removed `Guided Learning` and `Co-Writer` from the visible sidebar navigation.
+- Redirected direct access to `/guide` and `/co-writer` back to `/playground` through route-level layouts.
+- Kept feature implementation code intact and only removed public frontend entry points.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  A["Sidebar navigation"] --> B["Visible routes"]
+  B --> C["/playground"]
+  B --> D["/memory"]
+  E["Hidden legacy routes"] --> F["/guide"]
+  E --> G["/co-writer"]
+  F --> H["redirect /playground"]
+  G --> H
+  I["Knowledge saved records"] --> J["chat records can reopen session"]
+  I --> K["guided-learning records remain view-only"]
+```
+
+## Main System Map
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated.
+- Reason: this lane only narrows visible frontend entry points and adds reversible route redirects; it does not change the underlying system architecture or backend contracts.

--- a/docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md
+++ b/docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md
@@ -1,0 +1,119 @@
+# Spec: Hide Guided Learning and Co-Writer
+
+Date: 2026-04-30
+Task ID: `UI_HIDE_GUIDE_CO_WRITER`
+Branch: `fix/hide-guide-co-writer`
+
+## Goal
+
+Temporarily remove `Học có hướng dẫn` and `Trợ lý soạn thảo` from the public web shell without deleting their implementation, so the contest-facing product surface stays narrower and easier to control.
+
+## Current behavior
+
+- The workspace sidebar still shows `Guided Learning` and `Co-Writer`.
+- Users can still open `/guide` and `/co-writer` directly.
+- The Knowledge page still contains guided-learning session links that reopen `/guide`.
+
+## Intended behavior
+
+- `Guided Learning` and `Co-Writer` should disappear from frontend navigation.
+- Direct route access to `/guide` and `/co-writer` should redirect to `/playground`.
+- Existing code should remain in the repository for future reactivation.
+- The main user shell should no longer offer a visible or routine path back into those tools.
+
+## Approaches considered
+
+### Approach 1: Hide navigation only
+
+Remove the sidebar entries but leave the routes and existing deep links untouched.
+
+- Pros: smallest code diff
+- Cons: does not actually block users from opening the tools, so it fails the stated requirement
+
+### Approach 2: Hide navigation and redirect route entry points
+
+Remove visible nav entries and make `/guide` and `/co-writer` redirect to `/playground`. Also neutralize the main FE deep link from Knowledge records that assumes guided learning remains public.
+
+- Pros: satisfies the product requirement while keeping internal code intact
+- Pros: low-risk because route-level redirects are easy to reverse later
+- Cons: leaves dormant implementation code in place, which is intentional for now
+
+### Approach 3: Hide FE and disable backend APIs
+
+In addition to navigation and route blocking, also disable or comment backend guide/co-writer entry APIs.
+
+- Pros: strongest lockout
+- Cons: broader impact surface, more regression risk, unnecessary for the current scope
+
+## Chosen approach
+
+Use approach 2.
+
+This preserves the implementation for future development, minimizes behavior changes outside the user shell, and gives a clean contest-facing surface without broad backend churn.
+
+## Planned changes
+
+### 1. Sidebar navigation
+
+Update the secondary tools list so it no longer includes:
+
+- `/guide`
+- `/co-writer`
+
+`/playground` and `/memory` remain visible.
+
+### 2. Route access control
+
+Change the workspace route entry points for:
+
+- `web/app/(workspace)/guide/page.tsx`
+- `web/app/(workspace)/co-writer/page.tsx`
+
+Both routes should immediately redirect to `/playground`.
+
+The redirect should happen at the page-entry layer so the route is blocked even if a user types the URL directly.
+
+### 3. Remaining frontend deep links
+
+Review the Knowledge page behavior that currently maps guided-learning records to `/guide`.
+
+If that action is still visible to end users, replace it with a safer fallback:
+
+- either suppress the open action for guided-learning records
+- or reroute it to `/playground`
+
+The chosen fallback should avoid exposing `/guide` as an active experience.
+
+## Files expected to change
+
+- `web/components/sidebar/nav-groups.ts`
+- `web/app/(workspace)/guide/page.tsx`
+- `web/app/(workspace)/co-writer/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`
+- `docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Files reviewed but expected to remain unchanged
+
+- `web/app/(workspace)/guide/hooks/**`
+- `web/app/(workspace)/guide/components/**`
+- `web/app/(workspace)/co-writer/sampleTemplate.ts`
+- backend guide APIs and persistence modules
+
+## Testing
+
+- `cd web && node --test tests/sidebar-nav-groups.test.ts`
+- `cd web && npx eslint "components/sidebar/nav-groups.ts" "app/(workspace)/guide/page.tsx" "app/(workspace)/co-writer/page.tsx" "app/(utility)/knowledge/page.tsx"`
+- `cd web && npm run build`
+
+## Risks
+
+- Knowledge history surfaces may still reference guided-learning records as a type even after the public route is hidden.
+- Redirecting route entry points without removing all FE deep links can produce a slightly confusing bounce if a hidden link path remains.
+
+## Out of scope
+
+- Deleting Guided Learning or Co-Writer implementation
+- Refactoring backend guide APIs
+- Removing saved historical data associated with those tools

--- a/docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md
+++ b/docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md
@@ -20,15 +20,15 @@ Remove `Học có hướng dẫn` and `Trợ lý soạn thảo` from the visible
 ## Owned files/modules
 
 - `web/components/sidebar/nav-groups.ts`
-- `web/app/(workspace)/guide/page.tsx`
-- `web/app/(workspace)/co-writer/page.tsx`
+- `web/app/(workspace)/guide/layout.tsx`
+- `web/app/(workspace)/co-writer/layout.tsx`
 - `web/app/(utility)/knowledge/page.tsx`
-- `web/locales/en/app.json`
-- `web/locales/vi/app.json`
+- `web/tests/sidebar-nav-groups.test.ts`
 - `ai_first/ACTIVE_ASSIGNMENTS.md`
 - `ai_first/daily/2026-04-30.md`
 - `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`
 - `docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md`
+- `docs/superpowers/plans/2026-04-30-hide-guide-co-writer.md`
 - `docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md`
 
 ## Do-not-touch files/modules
@@ -38,8 +38,10 @@ Remove `Học có hướng dẫn` and `Trợ lý soạn thảo` from the visible
 - `web/app/(workspace)/dashboard/**`
 - `web/app/(utility)/marketplace/**`
 - `web/app/(utility)/settings/**`
+- `web/app/(workspace)/guide/page.tsx`
 - `web/app/(workspace)/guide/hooks/**`
 - `web/app/(workspace)/guide/components/**`
+- `web/app/(workspace)/co-writer/page.tsx`
 - `web/app/(workspace)/co-writer/sampleTemplate.ts`
 - `.github/workflows/**`
 - `requirements/**`
@@ -115,7 +117,7 @@ Use approach 2. Treat the work as a frontend gating pass: remove navigation entr
 ## Required tests
 
 - `cd web && node --test tests/sidebar-nav-groups.test.ts`
-- `cd web && npx eslint "components/sidebar/nav-groups.ts" "app/(workspace)/guide/page.tsx" "app/(workspace)/co-writer/page.tsx" "app/(utility)/knowledge/page.tsx"`
+- `cd web && npx eslint "components/sidebar/nav-groups.ts" "app/(workspace)/guide/layout.tsx" "app/(workspace)/co-writer/layout.tsx" "app/(utility)/knowledge/page.tsx"`
 - `cd web && npm run build`
 
 ## Manual verification

--- a/docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md
+++ b/docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md
@@ -1,0 +1,130 @@
+# Feature Task: Hide Guided Learning and Co-Writer
+
+Task ID: `UI_HIDE_GUIDE_CO_WRITER`
+Commit tag: `UI-HIDE-GUIDE-CO-WRITER`
+Owner: Frontend shell reduction lane
+Branch: `fix/hide-guide-co-writer`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Remove `Học có hướng dẫn` and `Trợ lý soạn thảo` from the visible frontend shell and block direct access to their workspace routes, while keeping the underlying implementation in the repository for future use.
+
+## User-visible outcome
+
+- Sidebar navigation no longer shows Guided Learning or Co-Writer.
+- Direct visits to `/guide` and `/co-writer` no longer open those tools and instead send the user back to `/playground`.
+- Existing code remains in place and is not deleted.
+
+## Owned files/modules
+
+- `web/components/sidebar/nav-groups.ts`
+- `web/app/(workspace)/guide/page.tsx`
+- `web/app/(workspace)/co-writer/page.tsx`
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/locales/en/app.json`
+- `web/locales/vi/app.json`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`
+- `docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md`
+- `docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/**`
+- `web/app/(workspace)/agents/**`
+- `web/app/(workspace)/dashboard/**`
+- `web/app/(utility)/marketplace/**`
+- `web/app/(utility)/settings/**`
+- `web/app/(workspace)/guide/hooks/**`
+- `web/app/(workspace)/guide/components/**`
+- `web/app/(workspace)/co-writer/sampleTemplate.ts`
+- `.github/workflows/**`
+- `requirements/**`
+- `package-lock.json`
+- `web/package-lock.json`
+- `.env*`
+
+## Design before implementation
+
+### Current behavior
+
+- The sidebar still exposes `/guide` and `/co-writer` as secondary tools.
+- Direct navigation to `/guide` and `/co-writer` still opens those experiences.
+- The Knowledge screen still contains a branch that deep-links guided-learning records back into `/guide`.
+
+### Intended behavior change
+
+- Remove Guided Learning and Co-Writer from visible sidebar navigation.
+- Redirect direct hits to `/guide` and `/co-writer` back to `/playground`.
+- Remove or neutralize remaining visible FE deep links that would send normal users back into `/guide`.
+- Keep the feature code in place for future reactivation.
+
+### Candidate approaches
+
+1. Hide only the sidebar entries.
+   - Smallest diff, but users can still open the tools directly or via remaining deep links.
+2. Hide sidebar entries and redirect `/guide` plus `/co-writer` back to `/playground`.
+   - Chosen approach because it meets the requirement without deleting underlying implementation.
+3. Hide FE and disable all related backend APIs.
+   - Too broad for this phase and unnecessary if direct route access is already blocked.
+
+### Chosen approach
+
+Use approach 2. Treat the work as a frontend gating pass: remove navigation entry points, redirect route entry points, and neutralize obvious FE deep links that still assume Guided Learning remains public.
+
+### Codebase survey
+
+- Entry points or handlers:
+  - `web/components/sidebar/nav-groups.ts`
+  - `web/app/(workspace)/guide/page.tsx`
+  - `web/app/(workspace)/co-writer/page.tsx`
+- Adjacent or reused flows:
+  - `web/app/(utility)/knowledge/page.tsx` currently links guided-learning records back into `/guide`
+- Shared contracts, schemas, or types reviewed:
+  - guided-learning record types in Knowledge route display logic
+- Closest existing tests:
+  - `web/tests/sidebar-nav-groups.test.ts`
+  - `web/tests/contest-vietnamese-coverage.test.ts`
+
+### Expected impact surface
+
+- Likely to change:
+  - sidebar grouping data
+  - guide and co-writer route entry behavior
+  - knowledge-page deep-link behavior for guided-learning records
+  - localized strings only if needed for changed visible labels
+  - one focused sidebar test
+- Reviewed but expected to remain unchanged:
+  - guide internal hooks and components
+  - co-writer internals and sample template
+  - backend guide APIs and persistence layer unless a narrow comment is needed
+- Validation paths:
+  - focused sidebar/unit tests
+  - targeted lint on touched files
+  - production frontend build
+
+## Acceptance criteria
+
+- `Guided Learning` and `Co-Writer` are no longer visible in the sidebar.
+- Visiting `/guide` or `/co-writer` redirects to `/playground`.
+- No implementation files for those features are deleted.
+
+## Required tests
+
+- `cd web && node --test tests/sidebar-nav-groups.test.ts`
+- `cd web && npx eslint "components/sidebar/nav-groups.ts" "app/(workspace)/guide/page.tsx" "app/(workspace)/co-writer/page.tsx" "app/(utility)/knowledge/page.tsx"`
+- `cd web && npm run build`
+
+## Manual verification
+
+- Confirm sidebar no longer shows Guided Learning or Co-Writer.
+- Open `/guide` and `/co-writer` directly and confirm redirect to `/playground`.
+- Inspect Knowledge records UI and confirm no normal-path action still opens `/guide`.
+
+## Handoff notes
+
+- Do not delete Guided Learning or Co-Writer internals in this lane.
+- Prefer redirect plus UI hiding over backend shutdown.

--- a/web/app/(utility)/knowledge/page.tsx
+++ b/web/app/(utility)/knowledge/page.tsx
@@ -703,10 +703,6 @@ export default function KnowledgePage() {
     if (!sessionId) return;
     if (record.type === "chat") {
       router.push(`/?session=${encodeURIComponent(sessionId)}`);
-      return;
-    }
-    if (record.type === "guided_learning") {
-      router.push(`/guide?session=${encodeURIComponent(sessionId)}`);
     }
   };
 
@@ -1510,10 +1506,8 @@ export default function KnowledgePage() {
                           const BadgeIcon = badge.icon;
                           const expanded = expandedRecordId === record.id;
                           const canOpenSession =
-                            (record.type === "chat" || record.type === "guided_learning") &&
-                            Boolean(record.metadata?.session_id);
-                          const sessionLabel =
-                            record.type === "chat" ? t("Open chat session") : t("Open guided learning session");
+                            record.type === "chat" && Boolean(record.metadata?.session_id);
+                          const sessionLabel = t("Open chat session");
 
                           return (
                             <div key={record.id} className="group">

--- a/web/app/(workspace)/co-writer/layout.tsx
+++ b/web/app/(workspace)/co-writer/layout.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default function CoWriterLayout() {
+  // Feature remains in-repo for later reactivation; public entry is temporarily disabled.
+  redirect("/playground");
+}

--- a/web/app/(workspace)/guide/layout.tsx
+++ b/web/app/(workspace)/guide/layout.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default function GuideLayout() {
+  // Feature remains in-repo for later reactivation; public entry is temporarily disabled.
+  redirect("/playground");
+}

--- a/web/components/sidebar/nav-groups.ts
+++ b/web/components/sidebar/nav-groups.ts
@@ -19,8 +19,6 @@ const CONTEST_CORE_ITEMS: SidebarNavItem[] = [
 
 const SECONDARY_TOOL_ITEMS: SidebarNavItem[] = [
   { href: "/playground", label: "Chat", icon: "message-square" },
-  { href: "/guide", label: "Guided Learning", icon: "graduation-cap" },
-  { href: "/co-writer", label: "Co-Writer", icon: "pen-line" },
   { href: "/memory", label: "Memory", icon: "brain" },
 ];
 

--- a/web/tests/sidebar-nav-groups.test.ts
+++ b/web/tests/sidebar-nav-groups.test.ts
@@ -18,7 +18,7 @@ test("expanded sidebar groups promote contest-core routes before secondary tools
   assert.equal(groups[1]?.id, "secondary-tools");
   assert.deepEqual(
     groups[1]?.items.map((item) => item.href),
-    ["/playground", "/guide", "/co-writer", "/memory"],
+    ["/playground", "/memory"],
   );
 });
 


### PR DESCRIPTION
## Tóm tắt
- bỏ `Guided Learning` và `Co-Writer` khỏi sidebar ở FE
- chặn truy cập trực tiếp `/guide` và `/co-writer` bằng redirect về `/playground`
- giữ nguyên implementation cũ, chỉ cắt đường vào public và dọn deep link từ Knowledge page

## Kiểm thử
- `cd web && node --test tests/sidebar-nav-groups.test.ts`
- `cd web && npx eslint "components/sidebar/nav-groups.ts" "app/(workspace)/guide/layout.tsx" "app/(workspace)/co-writer/layout.tsx" "app/(utility)/knowledge/page.tsx"`
- `cd web && npm run build`
- `git diff --check`

## Ghi chú kiến trúc
- Có PR note tại `docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md`
- Không cập nhật `ai_first/architecture/MAIN_SYSTEM_MAP.md` vì lane này chỉ thu hẹp entry point FE và redirect route, không đổi kiến trúc nền hoặc contract BE
