### PR TITLE
Refine playground chat visual surfaces

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -35,12 +35,12 @@ Rules:
 - Owner: Codex session
 - Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: Hide Guided Learning and Co-Writer from the frontend shell and block direct route access without deleting the underlying code
-- Status: implementing
-- Branch: `fix/hide-guide-co-writer`
-- Task packet: `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`
-- Owned files: `web/components/sidebar/nav-groups.ts`, `web/app/(workspace)/guide/layout.tsx`, `web/app/(workspace)/co-writer/layout.tsx`, `web/app/(utility)/knowledge/page.tsx`, `web/tests/sidebar-nav-groups.test.ts`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-hide-guide-co-writer.md`, `docs/superpowers/specs/2026-04-30-hide-guide-co-writer-design.md`, `docs/superpowers/plans/2026-04-30-hide-guide-co-writer.md`, `docs/superpowers/pr-notes/2026-04-30-hide-guide-co-writer.md`
+- Task: Refine the `/playground` chat presentation so traces stay visible but feel lighter, calmer, and more product-like
+- Status: writing spec
+- Branch: `fix/playground-chat-visual-refinement`
+- Task packet: `docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md`
+- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/components/common/AssistantResponse.tsx`, `web/components/common/ProcessLogs.tsx`, `web/components/chat/home/PlaygroundRightPanel.tsx`, `web/locales/en/app.json`, `web/locales/vi/app.json`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md`, `docs/superpowers/specs/2026-04-30-playground-chat-visual-refinement-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-chat-visual-refinement.md`
 - PR: uncreated
 - Last update: 2026-04-30
-- Next action: finish FE hiding plus route redirects, record PR note, and prepare the lane for review
+- Next action: write the bounded visual refinement spec for calmer chat bubbles, softer trace cards, and lighter debug surfaces before implementation
 - Blocker: none

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -1,5 +1,17 @@
 # Daily Log: 2026-04-30
 
+## Playground Chat Visual Refinement Design
+
+- Branch: `fix/playground-chat-visual-refinement`
+- Task: `UI_PLAYGROUND_CHAT_VISUAL_REFINEMENT`
+- Done: Opened a new bounded runtime lane for presentation-only refinement of the `/playground` chat surface after the earlier layout and feature-pruning passes had landed on `main`.
+- Done: Recorded the live assignment in `ai_first/ACTIVE_ASSIGNMENTS.md` before any UI edits.
+- Done: Wrote the execution packet `docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md` with a narrow visual-only impact surface focused on bubbles, traces, process logs, metadata, and the command bar.
+- Done: Wrote the bounded design spec `docs/superpowers/specs/2026-04-30-playground-chat-visual-refinement-design.md` covering lighter user bubbles, collapsed-by-default trace surfaces, softer metadata/log treatment, and calmer command-bar chrome.
+- Tests: `git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md docs/superpowers/specs/2026-04-30-playground-chat-visual-refinement-design.md`
+- Blockers: waiting for owner review of the written spec before implementation starts.
+- Next: after spec approval, implement the bounded `/playground` visual refinement on the same branch.
+
 ## Hide Guided Learning and Co-Writer Design
 
 - Branch: `fix/hide-guide-co-writer`

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -12,6 +12,18 @@
 - Blockers: waiting for owner review of the written spec before implementation starts.
 - Next: after spec approval, implement the bounded `/playground` visual refinement on the same branch.
 
+## Playground Chat Visual Refinement Implementation
+
+- Branch: `fix/playground-chat-visual-refinement`
+- Task: `UI_PLAYGROUND_CHAT_VISUAL_REFINEMENT`
+- Done: Softened `/playground` user bubbles from dark, heavy contrast into lighter same-family surfaces while keeping them distinguishable from assistant content.
+- Done: Kept `Thinking`, `Acting`, `Observing`, tool calls/results, process logs, and metadata inside the chat flow but restyled them into quieter accordion and annotation surfaces with lighter borders and calmer backgrounds.
+- Done: Made `Process Logs` default closed and reduced the debug-panel feel of metadata/result blocks without removing any underlying information.
+- Done: Softened the command-bar and right-panel chrome so the overall workspace reads as lighter, calmer, and more minimal.
+- Tests: `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`; `cd web && npm run build`
+- Blockers: none
+- Next: write the PR note, stage the bounded diff, and prepare the lane for review.
+
 ## Hide Guided Learning and Co-Writer Design
 
 - Branch: `fix/hide-guide-co-writer`

--- a/docs/superpowers/plans/2026-04-30-playground-chat-visual-refinement.md
+++ b/docs/superpowers/plans/2026-04-30-playground-chat-visual-refinement.md
@@ -1,0 +1,51 @@
+# Playground Chat Visual Refinement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Soften the `/playground` chat UI so traces remain visible but feel calmer, lighter, and more product-like.
+
+**Architecture:** Keep the existing runtime structure and data surfaces, but restyle message bubbles, trace accordions, process logs, metadata cards, and the command bar into a subtler visual system. Avoid any backend or interaction-logic changes.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Tailwind-style utility classes, ESLint
+
+---
+
+### Task 1: Refine shared supporting surfaces
+
+**Files:**
+- Modify: `web/components/common/AssistantResponse.tsx`
+- Modify: `web/components/common/ProcessLogs.tsx`
+
+- [ ] Soften `AssistantResponse` default presentation so markdown output reads like calm content rather than a hard card body.
+- [ ] Make `ProcessLogs` default closed and restyle its shell, header, and log rows into a subtler collapsed annotation surface.
+- [ ] Keep all data visible when expanded; only presentation and default-open behavior should change.
+
+### Task 2: Refine trace and result surfaces inside `/playground`
+
+**Files:**
+- Modify: `web/app/(workspace)/playground/page.tsx`
+
+- [ ] Soften `TracePanel` accordions so `Thinking`, `Acting`, `Observing`, and related rows default closed and use lighter borders/backgrounds.
+- [ ] Restyle tool-call, tool-result, progress, and error sub-blocks to feel like supporting annotations instead of debug panels.
+- [ ] Restyle `CapabilityResultPanel` response and metadata blocks so metadata defaults closed and reads as lower-priority supporting evidence.
+
+### Task 3: Refine conversation bubbles and command bar
+
+**Files:**
+- Modify: `web/app/(workspace)/playground/page.tsx`
+- Modify: `web/components/chat/home/PlaygroundRightPanel.tsx`
+
+- [ ] Change user bubbles from dark charcoal to a lighter same-family tone with gentle contrast.
+- [ ] Keep assistant cards slightly brighter and calmer, with softer shadow/border treatment.
+- [ ] Lighten the bottom command-bar chrome and send/generate buttons so the composer feels quieter and more refined.
+- [ ] If needed, slightly soften the right panel header chrome so it matches the calmer chat surface.
+
+### Task 4: Verify and record handoff
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-playground-chat-visual-refinement.md`
+
+- [ ] Run: `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`
+- [ ] Run: `cd web && npm run build`
+- [ ] Write the PR note with a Mermaid diagram and state whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` changed.

--- a/docs/superpowers/pr-notes/2026-04-30-playground-chat-visual-refinement.md
+++ b/docs/superpowers/pr-notes/2026-04-30-playground-chat-visual-refinement.md
@@ -1,0 +1,24 @@
+# PR Note: Playground Chat Visual Refinement
+
+## Summary
+
+- softened the `/playground` chat bubbles and command-bar controls so the conversation feels lighter and calmer
+- kept trace, process, and metadata surfaces visible, but made them default-collapsed and visually more subdued
+- reduced the raw debug-panel feel by unifying cards, borders, and backgrounds into a quieter presentation
+
+## Architecture
+
+```mermaid
+flowchart LR
+  A["Conversation canvas"] --> B["User bubble"]
+  A --> C["Assistant response"]
+  C --> D["Trace accordion"]
+  C --> E["Process logs"]
+  C --> F["Metadata and result"]
+  A --> G["Command bar composer"]
+```
+
+## Main System Map
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` not updated.
+- Reason: this lane only refines `/playground` presentation and default-open UI states without changing route behavior, backend contracts, or overall system architecture.

--- a/docs/superpowers/specs/2026-04-30-playground-chat-visual-refinement-design.md
+++ b/docs/superpowers/specs/2026-04-30-playground-chat-visual-refinement-design.md
@@ -1,0 +1,118 @@
+# Spec: Playground Chat Visual Refinement
+
+Date: 2026-04-30
+Task ID: `UI_PLAYGROUND_CHAT_VISUAL_REFINEMENT`
+Branch: `fix/playground-chat-visual-refinement`
+
+## Goal
+
+Make the `/playground` chat interface feel lighter, more minimal, and more refined without removing any of the trace and metadata surfaces that are still useful for product visibility.
+
+## Current behavior
+
+- The chat shell already works functionally, but the visual treatment feels raw.
+- The user bubble is too dark and stands out in a heavy way against the rest of the page.
+- Trace blocks such as `Thinking`, `Acting`, `Observing`, `Responding`, tool results, process logs, and metadata feel like stacked debug components instead of subtle supporting UI.
+- The current presentation exposes too many hard boxes and strong boundaries, making the conversation area feel busy and coarse.
+
+## Intended behavior
+
+- Keep the conversation-first layout intact.
+- Keep trace, process, and metadata surfaces available in the main chat flow.
+- Make those technical surfaces calmer by default:
+  - collapsed where possible
+  - lighter background tones
+  - smaller, subtler headers
+  - softer borders and less card-like heaviness
+- Change the user bubble from near-black to a lighter, same-family tone that still distinguishes it from assistant output.
+- Ensure the overall visual language feels restrained, elegant, and minimal.
+
+## Approaches considered
+
+### Approach 1: Palette-only adjustment
+
+Only change colors and leave all structural wrappers the same.
+
+- Pros: minimal diff
+- Cons: keeps the “raw component stack” feeling
+
+### Approach 2: Visual refinement with same runtime structure
+
+Keep the same data surfaces and same rendering order, but restyle bubbles, accordions, process logs, and metadata into a quieter, more integrated UI.
+
+- Pros: best balance of impact and safety
+- Pros: no backend or data-flow risk
+- Cons: requires coordinated edits across several render surfaces
+
+### Approach 3: Separate debug surfaces from the chat entirely
+
+Move process and metadata out of the chat body into a separate panel or mode.
+
+- Pros: cleanest conversation view
+- Cons: conflicts with the requirement to keep those surfaces visible in the chat
+
+## Chosen approach
+
+Use approach 2.
+
+The user explicitly wants the technical surfaces kept, just not rendered in a crude way. That makes a presentation-only refinement pass the right solution.
+
+## Planned changes
+
+### 1. Chat bubble refinement
+
+- Soften the user bubble from dark charcoal to a much lighter neutral tone.
+- Keep user and assistant bubbles distinguishable, but only with gentle contrast.
+- Slightly reduce the sensation of stacked cards by using lighter fills and quieter shadows.
+
+### 2. Trace surface refinement
+
+- Keep `Thinking`, `Acting`, `Observing`, and `Responding`.
+- Make them collapsed by default.
+- Reduce border contrast and shift toward subtle accordion rows instead of obvious boxed panels.
+- Tone down tool-call and tool-result sub-cards so they feel like annotations, not separate apps inside the chat.
+
+### 3. Process log and metadata refinement
+
+- Keep `Process` and `Metadata` visible and accessible.
+- Make them default closed where possible.
+- Use calmer typography and softer containers.
+- Treat JSON-like metadata as supporting evidence, not a dominant content block.
+
+### 4. Composer refinement
+
+- Preserve the command-bar pattern added earlier.
+- Reduce visual heaviness so it sits naturally in the page rather than appearing as another hard card.
+
+## Files expected to change
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/components/common/AssistantResponse.tsx`
+- `web/components/common/ProcessLogs.tsx`
+- `web/components/chat/home/PlaygroundRightPanel.tsx`
+- `docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md`
+- `docs/superpowers/specs/2026-04-30-playground-chat-visual-refinement-design.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Files reviewed but expected to remain unchanged
+
+- backend stream contracts and execution logic
+- route-selection logic inside the playground shell
+- non-playground routes
+- hidden Guided Learning and Co-Writer lanes
+
+## Testing
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`
+- `cd web && npm run build`
+
+## Risks
+
+- Too much visual softening can make technical surfaces hard to notice; the refinement must preserve discoverability.
+- Default-collapsing traces changes first-glance behavior, so the summary headers need to remain clear enough to invite expansion.
+
+## Out of scope
+
+- Removing traces or metadata entirely
+- Reworking capability execution flow
+- Changing sidebar structure or route behavior

--- a/docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md
+++ b/docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md
@@ -1,0 +1,132 @@
+# Feature Task: Playground Chat Visual Refinement
+
+Task ID: `UI_PLAYGROUND_CHAT_VISUAL_REFINEMENT`
+Commit tag: `UI-CHAT-VISUAL-REFINEMENT`
+Owner: Frontend visual refinement lane
+Branch: `fix/playground-chat-visual-refinement`
+GitHub Issue:
+Active assignment: `ai_first/ACTIVE_ASSIGNMENTS.md`
+
+## Goal
+
+Refine the `/playground` chat presentation so the conversation feels lighter, more minimal, and more product-like while still keeping traces, metadata, and tool-call visibility available inside the main flow.
+
+## User-visible outcome
+
+- User and assistant bubbles use softer, lighter tones instead of harsh dark contrast.
+- `Thinking`, `Acting`, `Observing`, `Responding`, `Process`, and `Metadata` remain visible but default to a more compact, collapsed, and subtle presentation.
+- Technical trace surfaces no longer read like raw debug components; they feel integrated into the same visual language as the chat.
+- The command-bar composer looks calmer and more refined.
+
+## Owned files/modules
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/components/common/AssistantResponse.tsx`
+- `web/components/common/ProcessLogs.tsx`
+- `web/components/chat/home/PlaygroundRightPanel.tsx`
+- `web/locales/en/app.json`
+- `web/locales/vi/app.json`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md`
+- `docs/superpowers/specs/2026-04-30-playground-chat-visual-refinement-design.md`
+- `docs/superpowers/pr-notes/2026-04-30-playground-chat-visual-refinement.md`
+
+## Do-not-touch files/modules
+
+- `deeptutor/**`
+- `web/app/(workspace)/guide/**`
+- `web/app/(workspace)/co-writer/**`
+- `web/app/(workspace)/agents/**`
+- `web/app/(workspace)/dashboard/**`
+- `web/app/(utility)/**`
+- `.github/workflows/**`
+- `requirements/**`
+- `package-lock.json`
+- `web/package-lock.json`
+- `.env*`
+
+## Design before implementation
+
+### Current behavior
+
+- The `/playground` chat shell is functional but visually harsh.
+- User bubbles rely on a dark fill that feels too heavy relative to the rest of the workspace.
+- Trace sections, process logs, and metadata still read like raw technical cards or debug output rather than subtle supporting UI.
+- Several sub-panels remain too boxy and component-like, with stronger borders and contrast than the main conversation needs.
+
+### Intended behavior change
+
+- Keep all current trace and metadata visibility, but move them into a gentler default state.
+- Default trace and metadata sections to collapsed.
+- Use softer background values, lighter contrast, and calmer spacing for user bubbles, assistant content, process logs, and tool-result surfaces.
+- Make the whole chat area feel simplified and refined rather than “debug-first”.
+
+### Candidate approaches
+
+1. Only lighten colors and keep structure unchanged.
+   - low risk, but the trace surfaces still feel too raw
+2. Keep the existing data model and flow, but restyle bubbles, accordions, logs, and result cards into a subtler presentation
+   - chosen approach because it improves tone without reopening runtime logic
+3. Move all traces into a separate side panel
+   - cleaner, but conflicts with the explicit requirement to keep them visible in the chat flow
+
+### Chosen approach
+
+Use approach 2. Preserve the same runtime surfaces and information hierarchy, but re-style them into a lighter visual system with softer tones, less contrast, and collapsed-by-default debug-like sections.
+
+### Codebase survey
+
+- Entry point/handler:
+  - `web/app/(workspace)/playground/page.tsx`
+- Primary presentation modules:
+  - `web/components/common/AssistantResponse.tsx`
+  - `web/components/common/ProcessLogs.tsx`
+  - `web/components/chat/home/PlaygroundRightPanel.tsx`
+- Closest reused surfaces:
+  - trace accordion rendering in `TracePanel`
+  - capability/tool result cards in `CapabilityResultPanel`
+- Shared copy/tests:
+  - `web/locales/en/app.json`
+  - `web/locales/vi/app.json`
+
+### Expected impact surface
+
+- Likely to change:
+  - user and assistant bubble styling
+  - trace accordion defaults and visual chrome
+  - process-log card styling and default openness
+  - metadata/result surface styling
+  - command-bar presentation
+- Reviewed but expected to remain unchanged:
+  - backend stream events and payload structure
+  - capability execution logic
+  - playground route selection/state logic
+  - non-playground routes
+- Validation paths:
+  - targeted lint on touched files
+  - production frontend build
+  - manual browser inspection of calmer tones, collapsed trace defaults, and refined command bar
+
+## Acceptance criteria
+
+- Chat bubbles are visually lighter and more refined.
+- Technical trace sections remain available but default to collapsed and visually subdued.
+- Metadata and process surfaces no longer dominate the conversation.
+- The overall `/playground` conversation area feels calmer, lighter, and more consistent.
+
+## Required tests
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`
+- `cd web && npm run build`
+
+## Manual verification
+
+- Confirm user bubble is no longer solid black.
+- Confirm `Thinking`, `Acting`, `Observing`, `Responding`, `Process`, and `Metadata` are present but default closed where appropriate.
+- Confirm the trace and metadata surfaces read as supporting UI rather than raw debug panels.
+
+## Handoff notes
+
+- Keep trace visibility; do not remove these sections in this lane.
+- Stay inside `/playground` presentation only.

--- a/web/app/(workspace)/playground/page.tsx
+++ b/web/app/(workspace)/playground/page.tsx
@@ -270,30 +270,33 @@ function TracePanel({ events }: { events: StreamEvent[] }) {
         );
         if (!renderable.length) return null;
         return (
-          <details key={stage} className="group overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]">
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 text-[13px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/50">
-              <span>{stage === "session" ? t("Details") : titleCase(stage)}</span>
+          <details key={stage} className="group overflow-hidden rounded-2xl border border-[var(--border)]/60 bg-[var(--background)]/70">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3.5 py-2.5 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/35">
+              <span className="inline-flex items-center gap-2">
+                <span className="h-1.5 w-1.5 rounded-full bg-[var(--muted-foreground)]/45" />
+                {stage === "session" ? t("Details") : titleCase(stage)}
+              </span>
               <ChevronDown size={13} className="text-[var(--muted-foreground)] transition-transform group-open:rotate-180" />
             </summary>
-            <div className="border-t border-[var(--border)] px-3 py-2.5 space-y-1.5">
+            <div className="space-y-2 border-t border-[var(--border)]/55 px-3.5 py-3">
               {renderable.map((ev, i) => {
-                if (ev.type === "thinking") return <p key={`${stage}-t-${i}`} className="text-[12px] italic leading-relaxed text-[var(--muted-foreground)]">{ev.content}</p>;
+                if (ev.type === "thinking") return <p key={`${stage}-t-${i}`} className="text-[12px] italic leading-relaxed text-[var(--muted-foreground)]/90">{ev.content}</p>;
                 if (ev.type === "progress") {
                   const cur = Number(ev.metadata?.current ?? 0), tot = Number(ev.metadata?.total ?? 0);
                   return (
-                    <div key={`${stage}-p-${i}`} className="rounded-md bg-[var(--muted)] px-2.5 py-1.5 text-[12px] text-[var(--muted-foreground)]">
+                    <div key={`${stage}-p-${i}`} className="rounded-xl bg-[var(--muted)]/45 px-3 py-2 text-[12px] text-[var(--muted-foreground)]">
                       <div>{ev.content}</div>
                       {tot > 0 && <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-[var(--border)]"><div className="h-full rounded-full bg-[var(--primary)] transition-all duration-300" style={{ width: `${Math.min(100, (cur / tot) * 100)}%` }} /></div>}
                     </div>
                   );
                 }
                 if (ev.type === "tool_call" || ev.type === "tool_result") return (
-                  <div key={`${stage}-tc-${i}`} className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2.5 py-1.5">
-                    <div className="text-[10px] uppercase tracking-wider text-[var(--muted-foreground)]">{ev.type === "tool_call" ? t("Tool call") : t("Tool result")}</div>
-                    <div className="mt-0.5 text-[12px] text-[var(--foreground)]">{ev.content || String(ev.metadata?.tool ?? "")}</div>
+                  <div key={`${stage}-tc-${i}`} className="rounded-xl border border-[var(--border)]/55 bg-[var(--background)]/82 px-3 py-2">
+                    <div className="text-[10px] uppercase tracking-wider text-[var(--muted-foreground)]/90">{ev.type === "tool_call" ? t("Tool call") : t("Tool result")}</div>
+                    <div className="mt-1 text-[12px] leading-5 text-[var(--foreground)]">{ev.content || String(ev.metadata?.tool ?? "")}</div>
                   </div>
                 );
-                if (ev.type === "error") return <div key={`${stage}-e-${i}`} className="rounded-md border border-red-200 bg-red-50 px-2.5 py-1.5 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">{ev.content}</div>;
+                if (ev.type === "error") return <div key={`${stage}-e-${i}`} className="rounded-xl border border-red-200/70 bg-red-50/85 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">{ev.content}</div>;
                 return null;
               })}
             </div>
@@ -596,27 +599,27 @@ function CapabilityResultPanel({ result }: { result: CapabilityExecResult | null
       </div>
 
       {response && (
-        <div className="max-h-[400px] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--background)] p-4">
+        <div className="max-h-[400px] overflow-y-auto rounded-[24px] border border-[var(--border)]/60 bg-[var(--background)]/78 p-4">
           <MarkdownRenderer content={response} variant="prose" />
         </div>
       )}
 
       {!response && extraKeys.length > 0 && (
-        <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-3">
-          <pre className="overflow-x-auto whitespace-pre-wrap break-all text-[12px] text-[var(--muted-foreground)]">
+        <div className="rounded-[20px] border border-[var(--border)]/55 bg-[var(--background)]/72 p-3">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-all text-[12px] leading-6 text-[var(--muted-foreground)]/90">
             {JSON.stringify(extraData, null, 2)}
           </pre>
         </div>
       )}
 
       {extraKeys.length > 0 && response && (
-        <details className="group rounded-lg border border-[var(--border)] bg-[var(--card)]">
-          <summary className="flex cursor-pointer list-none items-center justify-between px-3 py-2 text-[13px] font-medium text-[var(--foreground)]">
+        <details className="group rounded-2xl border border-[var(--border)]/60 bg-[var(--background)]/68">
+          <summary className="flex cursor-pointer list-none items-center justify-between px-3.5 py-2.5 text-[12px] font-medium text-[var(--foreground)]">
             {t("Metadata")}
             <ChevronDown size={13} className="text-[var(--muted-foreground)] transition-transform group-open:rotate-180" />
           </summary>
-          <div className="border-t border-[var(--border)] px-3 py-2.5">
-            <pre className="overflow-x-auto whitespace-pre-wrap break-all text-[12px] text-[var(--muted-foreground)]">
+          <div className="border-t border-[var(--border)]/55 px-3.5 py-3">
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all text-[12px] leading-6 text-[var(--muted-foreground)]/88">
               {JSON.stringify(extraData, null, 2)}
             </pre>
           </div>
@@ -995,12 +998,12 @@ function DeepQuestionTester({
               <span>{msg.role === "user" ? t("You") : t("Assistant")}</span>
             </div>
             {msg.role === "user" ? (
-              <div className="rounded-[28px] bg-[var(--foreground)] px-5 py-4 text-[15px] leading-7 text-[var(--background)] shadow-sm">
+              <div className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--muted)]/72 px-5 py-4 text-[15px] leading-7 text-[var(--foreground)] shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
                 {msg.content}
               </div>
             ) : (
               <div className="space-y-3">
-                <div className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/65 p-3">
+                <div className="rounded-[24px] border border-[var(--border)]/55 bg-[var(--background)]/58 p-3">
                   <TracePanel events={msg.events || []} />
                 </div>
                 <ProcessLogs
@@ -1009,13 +1012,13 @@ function DeepQuestionTester({
                   title={t("Process")}
                 />
                 {msg.error && (
-                  <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+                  <div className="rounded-[18px] border border-red-200/70 bg-red-50/80 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
                     {msg.error}
                   </div>
                 )}
                 <AssistantResponse
                   content={msg.content}
-                  className="rounded-[28px] border border-[var(--border)] bg-[var(--background)] px-5 py-4 shadow-sm"
+                  className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--background)]/88 px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.03)]"
                 />
                 <CapabilityResultPanel result={msg.result} />
               </div>
@@ -1025,14 +1028,14 @@ function DeepQuestionTester({
       ))}
 
       <div className="sticky bottom-0 z-10 -mx-2 border-t border-[var(--border)] bg-[var(--background)]/94 px-2 pb-2 pt-2 backdrop-blur">
-        <div className="mx-auto flex max-w-4xl items-center justify-between gap-3 rounded-[22px] border border-[var(--border)] bg-[var(--background)]/92 px-3 py-2 shadow-sm">
+        <div className="mx-auto flex max-w-4xl items-center justify-between gap-3 rounded-[22px] border border-[var(--border)]/60 bg-[var(--background)]/86 px-3 py-2 shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
           <div className="text-[11px] text-[var(--muted-foreground)]">
             {t("Review the setup above, then run generation.")}
           </div>
           <button
             onClick={run}
             disabled={!canRun || streaming}
-            className="inline-flex items-center gap-2 rounded-full bg-[var(--foreground)] px-4 py-1.5 text-[12px] font-medium text-[var(--background)] disabled:cursor-not-allowed disabled:opacity-40"
+            className="inline-flex items-center gap-2 rounded-full bg-[var(--muted)] px-4 py-1.5 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/80 disabled:cursor-not-allowed disabled:opacity-40"
           >
             {streaming ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
             {streaming ? t("Running...") : t("Generate")}
@@ -1254,12 +1257,12 @@ function DeepResearchTester({
                   <span>{msg.role === "user" ? t("You") : t("Assistant")}</span>
                 </div>
                 {msg.role === "user" ? (
-                  <div className="rounded-[28px] bg-[var(--foreground)] px-5 py-4 text-[15px] leading-7 text-[var(--background)] shadow-sm">
+                  <div className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--muted)]/72 px-5 py-4 text-[15px] leading-7 text-[var(--foreground)] shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
                     {msg.content}
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    <div className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/65 p-3">
+                    <div className="rounded-[24px] border border-[var(--border)]/55 bg-[var(--background)]/58 p-3">
                       <TracePanel events={msg.events || []} />
                     </div>
                     <ProcessLogs
@@ -1268,13 +1271,13 @@ function DeepResearchTester({
                       title={t("Process")}
                     />
                     {msg.error && (
-                      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+                      <div className="rounded-[18px] border border-red-200/70 bg-red-50/80 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
                         {msg.error}
                       </div>
                     )}
                     <AssistantResponse
                       content={msg.content}
-                      className="rounded-[28px] border border-[var(--border)] bg-[var(--background)] px-5 py-4 shadow-sm"
+                      className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--background)]/88 px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.03)]"
                     />
                     <CapabilityResultPanel result={msg.result} />
                   </div>
@@ -1286,7 +1289,7 @@ function DeepResearchTester({
       </div>
 
       <div className="sticky bottom-0 z-10 shrink-0 border-t border-[var(--border)] bg-[var(--background)]/96 pt-2 backdrop-blur">
-        <div className="rounded-[22px] border border-[var(--border)] bg-[var(--background)] px-3 py-2.5 shadow-sm">
+        <div className="rounded-[22px] border border-[var(--border)]/60 bg-[var(--background)]/84 px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
           <textarea
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -1302,7 +1305,7 @@ function DeepResearchTester({
             <button
               onClick={run}
               disabled={!input.trim() || streaming || !validation.valid}
-              className="inline-flex items-center gap-2 rounded-full bg-[var(--foreground)] px-4 py-1.5 text-[12px] font-medium text-[var(--background)] disabled:cursor-not-allowed disabled:opacity-40"
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--muted)] px-4 py-1.5 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/80 disabled:cursor-not-allowed disabled:opacity-40"
             >
               {streaming ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
               {streaming ? t("Running...") : t("Run Research")}
@@ -1476,12 +1479,12 @@ function CapabilityTester({
                   <span>{msg.role === "user" ? t("You") : t("Assistant")}</span>
                 </div>
                 {msg.role === "user" ? (
-                  <div className="rounded-[28px] bg-[var(--foreground)] px-5 py-4 text-[15px] leading-7 text-[var(--background)] shadow-sm">
+                  <div className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--muted)]/72 px-5 py-4 text-[15px] leading-7 text-[var(--foreground)] shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
                     {msg.content}
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    <div className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/65 p-3">
+                    <div className="rounded-[24px] border border-[var(--border)]/55 bg-[var(--background)]/58 p-3">
                       <TracePanel events={msg.events || []} />
                     </div>
                     <ProcessLogs
@@ -1490,13 +1493,13 @@ function CapabilityTester({
                       title={t("Process")}
                     />
                     {msg.error && (
-                      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+                      <div className="rounded-[18px] border border-red-200/70 bg-red-50/80 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
                         {msg.error}
                       </div>
                     )}
                     <AssistantResponse
                       content={msg.content}
-                      className="rounded-[28px] border border-[var(--border)] bg-[var(--background)] px-5 py-4 shadow-sm"
+                      className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--background)]/88 px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.03)]"
                     />
                     <CapabilityResultPanel result={msg.result} />
                   </div>
@@ -1507,7 +1510,7 @@ function CapabilityTester({
         </div>
       </div>
       <div className="sticky bottom-0 z-10 shrink-0 border-t border-[var(--border)] bg-[var(--background)]/96 pt-2 backdrop-blur">
-        <div className="rounded-[22px] border border-[var(--border)] bg-[var(--background)] px-3 py-2.5 shadow-sm">
+        <div className="rounded-[22px] border border-[var(--border)]/60 bg-[var(--background)]/84 px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
           <textarea
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -1523,7 +1526,7 @@ function CapabilityTester({
             <button
               onClick={send}
               disabled={!input.trim() || streaming}
-              className="inline-flex items-center gap-2 rounded-full bg-[var(--foreground)] px-4 py-1.5 text-[12px] font-medium text-[var(--background)] disabled:cursor-not-allowed disabled:opacity-40"
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--muted)] px-4 py-1.5 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/80 disabled:cursor-not-allowed disabled:opacity-40"
             >
               {streaming ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
               {streaming ? t("Running...") : t("Send")}

--- a/web/components/chat/home/PlaygroundRightPanel.tsx
+++ b/web/components/chat/home/PlaygroundRightPanel.tsx
@@ -19,7 +19,7 @@ export function PlaygroundRightPanel({
 }: PlaygroundRightPanelProps) {
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="border-b border-[var(--border)] px-4 py-4">
+      <div className="border-b border-[var(--border)]/60 bg-[var(--background)]/45 px-4 py-4">
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
@@ -32,7 +32,7 @@ export function PlaygroundRightPanel({
           {headerActions ? <div className="shrink-0">{headerActions}</div> : null}
         </div>
         {description ? (
-          <p className="mt-1.5 text-[12px] leading-5 text-[var(--muted-foreground)]">{description}</p>
+          <p className="mt-1.5 max-w-[28rem] text-[12px] leading-5 text-[var(--muted-foreground)]/95">{description}</p>
         ) : null}
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">{children}</div>

--- a/web/components/common/AssistantResponse.tsx
+++ b/web/components/common/AssistantResponse.tsx
@@ -10,7 +10,7 @@ interface AssistantResponseProps {
 
 export default function AssistantResponse({
   content,
-  className = "text-[14px] leading-[1.75]",
+  className = "text-[14px] leading-[1.8]",
 }: AssistantResponseProps) {
   if (!hasVisibleMarkdownContent(content)) return null;
 
@@ -19,7 +19,7 @@ export default function AssistantResponse({
       <MarkdownRenderer
         content={content}
         variant="prose"
-        className="text-[var(--foreground)]"
+        className="text-[var(--foreground)] [&_p]:my-0 [&_p+*]:mt-3"
       />
     </div>
   );

--- a/web/components/common/ProcessLogs.tsx
+++ b/web/components/common/ProcessLogs.tsx
@@ -19,7 +19,7 @@ export default function ProcessLogs({
 }: ProcessLogsProps) {
   const { t } = useTranslation();
   const resolvedTitle = title ?? t("Process Logs");
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const logContainerRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
 
@@ -42,14 +42,14 @@ export default function ProcessLogs({
     <details
       open={open}
       onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}
-      className="group rounded-lg border border-[var(--border)] bg-[var(--card)]"
+      className="group rounded-2xl border border-[var(--border)]/65 bg-[var(--background)]/72"
     >
-      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 text-[13px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/50">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3.5 py-2.5 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/35">
         <span className="inline-flex items-center gap-1.5">
-          <Terminal size={13} strokeWidth={1.7} />
+          <Terminal size={12} strokeWidth={1.7} className="text-[var(--muted-foreground)]" />
           {resolvedTitle}
           {logs.length > 0 && (
-            <span className="rounded-full bg-[var(--muted)] px-1.5 py-0.5 text-[10px] font-normal text-[var(--muted-foreground)]">
+            <span className="rounded-full bg-[var(--muted)]/75 px-1.5 py-0.5 text-[10px] font-normal text-[var(--muted-foreground)]">
               {logs.length}
             </span>
           )}
@@ -62,7 +62,7 @@ export default function ProcessLogs({
           />
         </div>
       </summary>
-      <div className="border-t border-[var(--border)] bg-[var(--background)]">
+      <div className="border-t border-[var(--border)]/60 bg-[var(--background)]/55">
         <div
           ref={logContainerRef}
           onScroll={(e) => {
@@ -71,10 +71,10 @@ export default function ProcessLogs({
               container.scrollHeight - container.scrollTop - container.clientHeight;
             stickToBottomRef.current = distanceFromBottom <= 24;
           }}
-          className="max-h-[220px] overflow-y-auto px-3 py-2.5 font-mono text-[11px] leading-[1.7] text-[var(--muted-foreground)]"
+          className="max-h-[220px] overflow-y-auto px-3.5 py-3 font-mono text-[11px] leading-[1.7] text-[var(--muted-foreground)]/90"
         >
           {logs.map((line, i) => (
-            <div key={`log-${i}`} className="whitespace-pre-wrap break-all">
+            <div key={`log-${i}`} className="whitespace-pre-wrap break-all rounded-lg px-2 py-1 hover:bg-[var(--muted)]/22">
               <span className="mr-2 select-none text-[var(--border)]">
                 {String(i + 1).padStart(3)}
               </span>


### PR DESCRIPTION
## Tóm tắt
- làm mềm bubble chat, command bar và panel phải của `/playground`
- giữ `Thinking / Acting / Observing / Process / Metadata` nhưng thu gọn, mặc định đóng và bớt cảm giác debug panel
- giảm tương phản gắt để toàn bộ khu chat sáng hơn, nhẹ hơn và tinh giản hơn

## Kiểm thử
- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`
- `cd web && npm run build`
- `git diff --check`

## Ghi chú kiến trúc
- Có PR note tại `docs/superpowers/pr-notes/2026-04-30-playground-chat-visual-refinement.md`
- Không cập nhật `ai_first/architecture/MAIN_SYSTEM_MAP.md` vì lane này chỉ tinh chỉnh presentation của `/playground`, không đổi route, contract hay kiến trúc hệ thống
