### PR TITLE
Refine playground chat back to compact consumer trace style

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -35,12 +35,12 @@ Rules:
 - Owner: Codex session
 - Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: Refine the `/playground` chat presentation so traces stay visible but feel lighter, calmer, and more product-like
+- Task: Realign `/playground` chat turns to the original consumer-chat style while keeping trace stages visible and compact
 - Status: writing spec
-- Branch: `fix/playground-chat-visual-refinement`
-- Task packet: `docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md`
-- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/components/common/AssistantResponse.tsx`, `web/components/common/ProcessLogs.tsx`, `web/components/chat/home/PlaygroundRightPanel.tsx`, `web/locales/en/app.json`, `web/locales/vi/app.json`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-chat-visual-refinement.md`, `docs/superpowers/specs/2026-04-30-playground-chat-visual-refinement-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-chat-visual-refinement.md`
+- Branch: `fix/playground-chat-consumer-trace`
+- Task packet: `docs/superpowers/tasks/2026-04-30-playground-chat-consumer-trace.md`
+- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/components/common/AssistantResponse.tsx`, `web/components/common/ProcessLogs.tsx`, `web/components/chat/home/ChatMessages.tsx`, `web/components/chat/home/TracePanels.tsx`, `web/locales/en/app.json`, `web/locales/vi/app.json`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-chat-consumer-trace.md`, `docs/superpowers/specs/2026-04-30-playground-chat-consumer-trace-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-chat-consumer-trace.md`
 - PR: uncreated
 - Last update: 2026-04-30
-- Next action: write the bounded visual refinement spec for calmer chat bubbles, softer trace cards, and lighter debug surfaces before implementation
+- Next action: write the bounded design spec for restoring the original lightweight trace language and compact chat turn layout before implementation
 - Blocker: none

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -298,3 +298,15 @@
 - Used the teacher-facing replay route `dashboard/sessions/contest-tutor-demo` for the fresh tutor evidence because the current merged product is cockpit-first and that replay surface is the stable seeded transcript path.
 - Updated `docs/contest/EVIDENCE_CHECKLIST.md`, `docs/contest/VALIDATION_REPORT.md`, `docs/contest/README.md`, `docs/contest/SUBMISSION_PACKAGE.md`, `ai_first/evidence/screenshots.md`, `ai_first/AI_OPERATING_PROMPT.md`, `ai_first/EXECUTION_QUEUE.md`, and `ai_first/NEXT_ACTIONS.md` so browser freshness is no longer represented as an open blocker.
 - Next state after this lane: no AI-owned contest freshness blocker remains; only human review, optional video, IP commitment, and final sign-off remain unless a new packet is opened from `main`.
+
+## UI-PLAYGROUND-CONSUMER-TRACE
+
+- Branch: `fix/playground-chat-consumer-trace`
+- Task: `UI-PLAYGROUND-CONSUMER-TRACE`
+- Done: Wrote the bounded design artifact `docs/superpowers/specs/2026-04-30-playground-chat-consumer-trace-design.md` and the implementation plan `docs/superpowers/plans/2026-04-30-playground-chat-consumer-trace.md` before touching runtime code.
+- Done: Reworked `/playground` assistant traces from large boxed accordions into compact trace rows patterned after the original chat surface.
+- Done: Unified the repeated chat-turn rendering across the playground capability testers so the user bubble, trace region, and assistant answer all share one consumer-style layout.
+- Done: Shrank the user bubble, kept it on a light gray surface, and removed the end-user metadata panel plus duplicate assistant response layers.
+- Done: Left runtime payloads unchanged; only the `/playground` presentation changed.
+- Tests: `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx"`; `cd web && npm run build`; `git diff --check`
+- Notes: `cd web && npx tsc --noEmit` still hits pre-existing test import-extension errors in `tests/sidebar-nav-groups.test.ts` and `tests/teacher-cockpit-content.test.ts`, unrelated to this lane.

--- a/docs/superpowers/plans/2026-04-30-playground-chat-consumer-trace.md
+++ b/docs/superpowers/plans/2026-04-30-playground-chat-consumer-trace.md
@@ -1,0 +1,255 @@
+# Playground Chat Consumer Trace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore `/playground` chat turns to a lighter consumer-chat presentation with compact visible trace stages, smaller user bubbles, and no end-user metadata panel.
+
+**Architecture:** Keep the existing `/playground` shell and data flow, but replace the local boxed trace treatment with a compact trace summary patterned after the original chat UI. Collapse duplicate assistant-turn surfaces in the page layer so end users see one compact trace block and one primary answer block per turn.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Tailwind utility classes, i18next locale strings, existing `StreamEvent` chat payloads.
+
+---
+
+### Task 1: Replace heavyweight `/playground` trace blocks with compact consumer-style trace rows
+
+**Files:**
+- Modify: `web/app/(workspace)/playground/page.tsx`
+- Reference only: `web/components/chat/home/TracePanels.tsx`
+- Test: `web` build + ESLint validation
+
+- [ ] **Step 1: Locate the local `/playground` trace renderer and the assistant-turn call sites**
+
+Read the current page sections that define and render the local `TracePanel`, trace wrappers, and metadata/result stacks:
+
+```tsx
+function TracePanel({ events }: { events: StreamEvent[] }) {
+  // current local accordion implementation to replace
+}
+
+{renderTraceEvents.length > 0 ? (
+  <div className="rounded-[30px] border ...">
+    <TracePanel events={renderTraceEvents} />
+  </div>
+) : null}
+```
+
+- [ ] **Step 2: Reshape the trace renderer to a compact row treatment**
+
+Replace the current boxed accordion style with a lighter row-based structure:
+
+```tsx
+function TracePanel({ events }: { events: StreamEvent[] }) {
+  const { t } = useTranslation();
+  if (!events.length) return null;
+
+  const grouped = new Map<string, StreamEvent[]>();
+  for (const ev of events) {
+    const key = ev.stage || "session";
+    const list = grouped.get(key) ?? [];
+    list.push(ev);
+    grouped.set(key, list);
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {Array.from(grouped.entries()).map(([stage, stageEvents]) => {
+        const renderable = stageEvents.filter((e) =>
+          ["thinking", "progress", "tool_call", "tool_result", "error"].includes(e.type),
+        );
+        if (!renderable.length) return null;
+
+        return (
+          <details key={stage} className="group rounded-2xl">
+            <summary className="flex cursor-pointer list-none items-center gap-2 py-1 text-[12px] font-medium text-[var(--muted-foreground)] [&::-webkit-details-marker]:hidden">
+              <ChevronDown size={12} className="transition-transform group-open:rotate-180" />
+              <span>{stage === "session" ? t("Chi tiết") : titleCase(stage)}</span>
+            </summary>
+            <div className="ml-5 space-y-1.5 border-l border-[var(--border)]/35 pl-3">
+              {/* compact trace body rows */}
+            </div>
+          </details>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Remove the large outer trace card wrapper from assistant turns**
+
+Change the assistant-turn call sites so `TracePanel` renders inline without an extra enclosing card:
+
+```tsx
+{renderTraceEvents.length > 0 ? (
+  <div className="mb-3">
+    <TracePanel events={renderTraceEvents} />
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Run lint focused on the modified page**
+
+Run: `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "app/(workspace)/playground/page.tsx"`
+
+Expected: `0 problems`
+
+- [ ] **Step 5: Commit the trace-layout slice**
+
+```bash
+git add web/app/'(workspace)'/playground/page.tsx
+git commit -m "feat(playground): compact chat trace rows [UI-PLAYGROUND-CONSUMER-TRACE]"
+```
+
+### Task 2: Shrink chat-turn visual weight and remove duplicate technical surfaces
+
+**Files:**
+- Modify: `web/app/(workspace)/playground/page.tsx`
+- Modify: `web/components/common/AssistantResponse.tsx`
+- Modify: `web/components/common/ProcessLogs.tsx`
+- Test: `web` build + ESLint validation
+
+- [ ] **Step 1: Tighten the user bubble proportions**
+
+Update the user message container from a broad capsule to a narrower consumer-chat bubble:
+
+```tsx
+className={cn(
+  "max-w-[min(42rem,68%)] rounded-[22px] border border-[var(--border)]/45 bg-[var(--muted)]/78 px-5 py-3 text-[15px] leading-7 text-[var(--foreground)] shadow-[0_10px_28px_rgba(15,23,42,0.04)]",
+  isLatestUserTurn ? "ring-1 ring-[var(--border)]/20" : "",
+)}
+```
+
+- [ ] **Step 2: Remove metadata from end-user assistant turns**
+
+Delete or gate the metadata panel so it does not render in `/playground`:
+
+```tsx
+// remove this block from the end-user assistant surface
+{result.metadata ? (
+  <details>
+    <summary>{t("Metadata")}</summary>
+    ...
+  </details>
+) : null}
+```
+
+- [ ] **Step 3: Collapse duplicated answer/result layers**
+
+Ensure only one primary answer block is shown for a normal assistant turn:
+
+```tsx
+const finalResponse =
+  typeof result?.response === "string" && result.response.trim()
+    ? result.response.trim()
+    : content.trim();
+
+const shouldRenderStandaloneResult = Boolean(result) && !finalResponse;
+```
+
+Then render either the answer or the non-text result surface, not both.
+
+- [ ] **Step 4: De-emphasize or suppress debug-style process logs**
+
+Either stop rendering `ProcessLogs` for normal `/playground` turns or reduce it to a very light inline status strip:
+
+```tsx
+{processLogs.length > 0 && showCompactLogs ? (
+  <ProcessLogs logs={processLogs} compact />
+) : null}
+```
+
+And update `ProcessLogs` styling so it no longer looks like a debug panel:
+
+```tsx
+className="rounded-xl border border-[var(--border)]/35 bg-[var(--background)]/55 px-3 py-2 text-[11px] text-[var(--muted-foreground)]"
+```
+
+- [ ] **Step 5: Keep assistant copy typographic rather than card-heavy**
+
+Lighten the shared assistant response renderer:
+
+```tsx
+<div className="text-[15px] leading-[1.85] text-[var(--foreground)]">
+  <MarkdownRenderer content={content} className="[&_p]:my-0 [&_p+*]:mt-3" />
+</div>
+```
+
+- [ ] **Step 6: Run focused lint for the shared components**
+
+Run: `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx"`
+
+Expected: `0 problems`
+
+- [ ] **Step 7: Commit the turn-surface cleanup**
+
+```bash
+git add web/app/'(workspace)'/playground/page.tsx web/components/common/AssistantResponse.tsx web/components/common/ProcessLogs.tsx
+git commit -m "feat(playground): simplify consumer chat turns [UI-PLAYGROUND-CONSUMER-TRACE]"
+```
+
+### Task 3: Validate the surface and update handoff docs
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-playground-chat-consumer-trace.md`
+- Test: full build and diff checks
+
+- [ ] **Step 1: Run the full validation commands**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npm run build
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check
+```
+
+Expected:
+
+```text
+Next.js build completes successfully
+git diff --check returns no output
+```
+
+- [ ] **Step 2: Record the lane outcome in the daily log**
+
+Append a short entry to `ai_first/daily/2026-04-30.md` covering the UI reset, files changed, and validation run.
+
+```md
+## UI-PLAYGROUND-CONSUMER-TRACE
+
+- Restored `/playground` chat turns toward the original consumer-chat style.
+- Kept visible stage traces but reduced them to compact rows.
+- Hid end-user metadata and removed duplicate answer surfaces.
+```
+
+- [ ] **Step 3: Write the required PR architecture note**
+
+Create `docs/superpowers/pr-notes/2026-04-30-playground-chat-consumer-trace.md` with a concise explanation and one Mermaid diagram:
+
+```md
+# PR Note: Playground Chat Consumer Trace
+
+```mermaid
+flowchart TD
+  U["User bubble"] --> T["Compact trace rows"]
+  T --> A["Primary assistant answer"]
+```
+```
+
+- [ ] **Step 4: Commit the docs and handoff slice**
+
+```bash
+git add ai_first/daily/2026-04-30.md docs/superpowers/pr-notes/2026-04-30-playground-chat-consumer-trace.md
+git commit -m "docs(playground): record consumer trace reset [UI-PLAYGROUND-CONSUMER-TRACE]"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - compact visible stages: Task 1
+  - smaller light-gray user bubble: Task 2
+  - hide metadata: Task 2
+  - remove duplicated oversized surfaces: Task 2
+  - validation and PR-note updates: Task 3
+- Placeholder scan: no `TODO`, `TBD`, or deferred implementation placeholders remain.
+- Type consistency: all referenced files, components, and commands match the current codebase survey.

--- a/docs/superpowers/pr-notes/2026-04-30-playground-chat-consumer-trace.md
+++ b/docs/superpowers/pr-notes/2026-04-30-playground-chat-consumer-trace.md
@@ -1,0 +1,23 @@
+# PR Note: Playground Chat Consumer Trace
+
+## Summary
+
+This lane pulls `/playground` chat turns back toward the original consumer-chat presentation without changing any backend capability contracts. The main work is visual: compact trace rows, smaller user bubbles, lighter assistant surfaces, and removal of end-user metadata noise.
+
+## Architecture impact
+
+- No runtime protocol changes
+- No route changes
+- No capability changes
+- UI composition in `web/app/(workspace)/playground/page.tsx` now uses one shared turn renderer for all playground chat testers, reducing repeated layout drift
+
+```mermaid
+flowchart TD
+  U["Tin nhắn người dùng"] --> T["Trace gọn: Thinking / Acting / Observing / Responding"]
+  T --> A["Câu trả lời chính của trợ lý"]
+  A --> F["Structured fallback only when no text answer exists"]
+```
+
+## MAIN_SYSTEM_MAP
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane only changes presentation inside the existing `/playground` workspace shell.

--- a/docs/superpowers/specs/2026-04-30-playground-chat-consumer-trace-design.md
+++ b/docs/superpowers/specs/2026-04-30-playground-chat-consumer-trace-design.md
@@ -1,0 +1,153 @@
+# Playground Chat Consumer Trace Design
+
+- Date: 2026-04-30
+- Task ID: `UI-PLAYGROUND-CONSUMER-TRACE`
+- Branch: `fix/playground-chat-consumer-trace`
+
+## Goal
+
+Realign `/playground` chat turns with the lighter, more consumer-facing chat presentation already proven in the original chat surfaces, while preserving visible trace stages for end users in a compact and product-like form.
+
+## Current Behavior
+
+- `/playground` renders assistant turns with a custom local `TracePanel` that wraps `Thinking`, `Acting`, `Observing`, and `Responding` inside large bordered accordions.
+- User messages use a softened palette already, but the bubble width and padding still make a short prompt look oversized.
+- Assistant turns can stack multiple heavy blocks in one pass:
+  - a full trace card
+  - the assistant content card
+  - process-log card
+  - metadata card
+- The combination makes a single round occupy too much vertical space and feel closer to a debug console than a consumer AI chat product.
+- The original chat surfaces in `web/components/chat/home/ChatMessages.tsx` and `web/components/chat/home/TracePanels.tsx` already implement the preferred interaction language: compact trace rows, restrained chrome, and response-first hierarchy.
+
+## Intended Behavior Change
+
+- `/playground` should borrow the visual language of the original chat UI for each conversation turn.
+- `Thinking`, `Acting`, `Observing`, and `Responding` must remain visible, but they should look like subtle trace rows instead of standalone debug cards.
+- User messages should render as compact light-gray bubbles with narrower maximum width and smaller vertical padding.
+- `Metadata` must not be shown in the end-user chat flow.
+- Duplicate or low-value technical surfaces inside one assistant turn should be collapsed or removed so that a normal exchange reads as one user bubble, one compact trace region, and one assistant answer.
+
+## Codebase Survey
+
+### Entry points and handlers
+
+- `web/app/(workspace)/playground/page.tsx`
+  - owns the `/playground` chat shell
+  - currently defines the local `TracePanel`
+  - currently renders user/assistant turns, process logs, and result surfaces inline
+
+### Primary service or use-case modules
+
+- `web/components/common/AssistantResponse.tsx`
+  - shared assistant markdown renderer and text presentation
+- `web/components/common/ProcessLogs.tsx`
+  - shared process log surface currently available to `/playground`
+
+### Shared contracts, schemas, or types
+
+- `StreamEvent` usage in `/playground` and `TracePanels.tsx`
+  - determines which stage and tool-call events are available for trace summarization
+
+### Adjacent or reused flows inspected
+
+- `web/components/chat/home/ChatMessages.tsx`
+  - reference consumer-chat composition already used elsewhere
+- `web/components/chat/home/TracePanels.tsx`
+  - reference trace treatment with lightweight rows and restrained expandable details
+
+### Closest existing tests
+
+- No dedicated unit test currently targets `/playground` trace rendering.
+- Existing validation for this surface currently relies on TypeScript, ESLint, app build, and locale coverage where touched.
+
+## Candidate Approaches
+
+### Approach A: Keep local `/playground` structure and restyle it heavily
+
+- Rework the existing `TracePanel`, message wrappers, and metadata blocks in place.
+- Pros:
+  - smallest structural diff
+  - lower risk of runtime wiring regressions
+- Cons:
+  - easier to keep accidental baggage from the current boxed-debug layout
+  - more likely to preserve duplicate surfaces
+
+### Approach B: Reuse the original chat composition patterns as the styling source of truth
+
+- Refactor `/playground` turn rendering to follow the structure and visual language already established in `ChatMessages.tsx` and `TracePanels.tsx`.
+- Pros:
+  - best match for the user’s stated preference
+  - reuses a proven presentation language instead of inventing another variant
+  - naturally pushes trace UI toward compact rows instead of cards
+- Cons:
+  - requires careful adaptation so the original chat components fit the 3-column `/playground` shell without pulling in unrelated logic
+
+### Approach C: Hide nearly all trace UI and show only the final response
+
+- Keep only a single status line or answer card for each assistant turn.
+- Pros:
+  - simplest and smallest visual footprint
+- Cons:
+  - conflicts with the approved requirement that stage traces remain visible
+
+## Chosen Approach
+
+Approach B.
+
+The requirement is not simply “make it smaller”; it is “make it feel like the original chat UI again.” The safest way to hit that target is to use the original consumer-chat and trace components as the design reference and move `/playground` toward that composition, while still keeping the shell, right panel, and workspace routing introduced in previous work.
+
+## Planned Changes
+
+### `/playground` turn layout
+
+- Remove the current heavy trace-card treatment from `web/app/(workspace)/playground/page.tsx`.
+- Replace it with a compact trace presentation patterned after `CallTracePanel`:
+  - small rows
+  - low-contrast chrome
+  - minimal borders
+  - no large outer card around the entire trace stack
+
+### User message treatment
+
+- Reduce user bubble max width so short prompts no longer stretch into oversized capsules.
+- Keep only a light gray background with subtle border separation.
+- Reduce padding and whitespace to align with consumer AI chat norms.
+
+### Assistant turn treatment
+
+- Keep the answer as the primary visual payload.
+- Reduce or remove unnecessary wrapper cards around the assistant text where they add no value.
+- Preserve lightweight success/status hints only if they do not dominate the turn.
+
+### Debug-oriented surfaces
+
+- Hide metadata from the end-user chat surface.
+- Review process-log and tool-result rendering in `/playground`; remove or collapse any layers that duplicate the visible answer or read like debug panels for non-technical users.
+
+## Expected Impact Surface
+
+### Likely to change
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/components/common/AssistantResponse.tsx`
+- `web/components/common/ProcessLogs.tsx`
+
+### Reviewed but expected to remain unchanged unless implementation reveals a hard dependency
+
+- `web/components/chat/home/ChatMessages.tsx`
+- `web/components/chat/home/TracePanels.tsx`
+- `web/locales/en/app.json`
+- `web/locales/vi/app.json`
+
+## Tests To Run
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx"`
+- `cd web && npm run build`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check`
+
+## Non-Goals
+
+- No route or capability changes.
+- No backend or WebSocket protocol changes.
+- No removal of trace data from runtime payloads; only presentation changes for end users.

--- a/docs/superpowers/tasks/2026-04-30-playground-chat-consumer-trace.md
+++ b/docs/superpowers/tasks/2026-04-30-playground-chat-consumer-trace.md
@@ -1,0 +1,64 @@
+# Task Packet: Playground Chat Consumer Trace
+
+- Task ID: `UI-PLAYGROUND-CONSUMER-TRACE`
+- Date: 2026-04-30
+- Branch: `fix/playground-chat-consumer-trace`
+- Status: Spec written
+
+## Objective
+
+Bring `/playground` chat turns back toward the original consumer-chat aesthetic while keeping stage traces visible in a compact, professional, non-debug presentation.
+
+## User-Approved Scope
+
+- Keep `Thinking / Acting / Observing / Responding` visible.
+- Make those stages render compactly and professionally, closer to the original chat UI.
+- Shrink the user bubble and keep it light gray.
+- Hide metadata from end users.
+- Remove duplicate or overly heavy visual blocks that make one chat turn consume too much screen height.
+
+## Owned Files
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/components/common/AssistantResponse.tsx`
+- `web/components/common/ProcessLogs.tsx`
+- `web/components/chat/home/ChatMessages.tsx`
+- `web/components/chat/home/TracePanels.tsx`
+- `web/locales/en/app.json`
+- `web/locales/vi/app.json`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-playground-chat-consumer-trace.md`
+- `docs/superpowers/specs/2026-04-30-playground-chat-consumer-trace-design.md`
+- `docs/superpowers/pr-notes/2026-04-30-playground-chat-consumer-trace.md`
+
+## Do-Not-Touch
+
+- Backend capability implementations
+- Route structure outside `/playground`
+- Hidden `guide` and `co-writer` work
+- Untracked files outside this task scope
+
+## Design Before Implementation
+
+Reference spec:
+
+- `docs/superpowers/specs/2026-04-30-playground-chat-consumer-trace-design.md`
+
+## Codebase Survey Summary
+
+- The current `/playground` page owns a local `TracePanel` that is heavier than the original chat UI.
+- The original consumer-chat feel already exists in `ChatMessages.tsx` and `TracePanels.tsx`.
+- The new implementation should adapt `/playground` toward those reference surfaces instead of inventing another styling system.
+
+## Validation Plan
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx"`
+- `cd web && npm run build`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check`
+
+## Handoff Notes
+
+- This lane is presentation-only.
+- Do not remove trace data from runtime payloads.
+- If implementation reveals duplicated answer rendering between final message content and result metadata, prefer collapsing it in the UI rather than mutating upstream data contracts.

--- a/web/app/(workspace)/playground/page.tsx
+++ b/web/app/(workspace)/playground/page.tsx
@@ -263,46 +263,116 @@ function TracePanel({ events }: { events: StreamEvent[] }) {
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1.5">
       {Array.from(grouped.entries()).map(([stage, stageEvents]) => {
         const renderable = stageEvents.filter((e) =>
           ["thinking", "progress", "tool_call", "tool_result", "error"].includes(e.type),
         );
         if (!renderable.length) return null;
         return (
-          <details key={stage} className="group overflow-hidden rounded-2xl border border-[var(--border)]/60 bg-[var(--background)]/70">
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3.5 py-2.5 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/35">
+          <details key={stage} className="group rounded-2xl">
+            <summary className="flex cursor-pointer list-none items-center gap-2 py-1 text-[12px] font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] [&::-webkit-details-marker]:hidden">
+              <ChevronDown
+                size={12}
+                className="shrink-0 text-[var(--muted-foreground)] transition-transform group-open:rotate-180"
+              />
               <span className="inline-flex items-center gap-2">
-                <span className="h-1.5 w-1.5 rounded-full bg-[var(--muted-foreground)]/45" />
-                {stage === "session" ? t("Details") : titleCase(stage)}
+                <span className="h-1.5 w-1.5 rounded-full bg-[var(--muted-foreground)]/40" />
+                {stage === "session" ? t("Details") : t(titleCase(stage))}
               </span>
-              <ChevronDown size={13} className="text-[var(--muted-foreground)] transition-transform group-open:rotate-180" />
             </summary>
-            <div className="space-y-2 border-t border-[var(--border)]/55 px-3.5 py-3">
+            <div className="ml-3 space-y-1.5 border-l border-[var(--border)]/35 pl-4">
               {renderable.map((ev, i) => {
-                if (ev.type === "thinking") return <p key={`${stage}-t-${i}`} className="text-[12px] italic leading-relaxed text-[var(--muted-foreground)]/90">{ev.content}</p>;
+                if (ev.type === "thinking") return <p key={`${stage}-t-${i}`} className="text-[12px] italic leading-relaxed text-[var(--muted-foreground)]/88">{ev.content}</p>;
                 if (ev.type === "progress") {
                   const cur = Number(ev.metadata?.current ?? 0), tot = Number(ev.metadata?.total ?? 0);
                   return (
-                    <div key={`${stage}-p-${i}`} className="rounded-xl bg-[var(--muted)]/45 px-3 py-2 text-[12px] text-[var(--muted-foreground)]">
+                    <div key={`${stage}-p-${i}`} className="rounded-2xl bg-[var(--muted)]/38 px-3 py-2 text-[12px] text-[var(--muted-foreground)]">
                       <div>{ev.content}</div>
                       {tot > 0 && <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-[var(--border)]"><div className="h-full rounded-full bg-[var(--primary)] transition-all duration-300" style={{ width: `${Math.min(100, (cur / tot) * 100)}%` }} /></div>}
                     </div>
                   );
                 }
                 if (ev.type === "tool_call" || ev.type === "tool_result") return (
-                  <div key={`${stage}-tc-${i}`} className="rounded-xl border border-[var(--border)]/55 bg-[var(--background)]/82 px-3 py-2">
-                    <div className="text-[10px] uppercase tracking-wider text-[var(--muted-foreground)]/90">{ev.type === "tool_call" ? t("Tool call") : t("Tool result")}</div>
-                    <div className="mt-1 text-[12px] leading-5 text-[var(--foreground)]">{ev.content || String(ev.metadata?.tool ?? "")}</div>
+                  <div key={`${stage}-tc-${i}`} className="rounded-2xl border border-[var(--border)]/40 bg-[var(--background)]/66 px-3 py-2">
+                    <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--muted-foreground)]/82">{ev.type === "tool_call" ? t("Tool call") : t("Tool result")}</div>
+                    <div className="mt-1 text-[12px] leading-5 text-[var(--foreground)]/88">{ev.content || String(ev.metadata?.tool ?? "")}</div>
                   </div>
                 );
-                if (ev.type === "error") return <div key={`${stage}-e-${i}`} className="rounded-xl border border-red-200/70 bg-red-50/85 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">{ev.content}</div>;
+                if (ev.type === "error") return <div key={`${stage}-e-${i}`} className="rounded-2xl border border-red-200/60 bg-red-50/72 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">{ev.content}</div>;
                 return null;
               })}
             </div>
           </details>
         );
       })}
+    </div>
+  );
+}
+
+function getResultResponse(result: CapabilityExecResult | null | undefined): string {
+  return typeof result?.data.response === "string" ? result.data.response.trim() : "";
+}
+
+function PlaygroundChatTurn({
+  msg,
+  isStreaming,
+  isLatestAssistant,
+}: {
+  msg: TesterMessage;
+  isStreaming: boolean;
+  isLatestAssistant: boolean;
+}) {
+  const { t } = useTranslation();
+  const resultResponse = getResultResponse(msg.result);
+  const displayedContent = msg.content.trim();
+  const shouldRenderAssistantContent = Boolean(displayedContent);
+  const shouldRenderCapabilityResult =
+    Boolean(msg.result) &&
+    ((!resultResponse && Object.keys(msg.result?.data ?? {}).length > 0) ||
+      (resultResponse && resultResponse !== displayedContent));
+
+  return (
+    <div className={`mx-auto max-w-4xl ${msg.role === "user" ? "flex justify-end" : ""}`}>
+      <div className={msg.role === "user" ? "w-full max-w-[min(42rem,64%)]" : "w-full max-w-[82%]"}>
+        <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-[var(--muted-foreground)]">
+          {msg.role === "user" ? <MessageSquare size={12} /> : <Sparkles size={12} />}
+          <span>{msg.role === "user" ? t("You") : t("Assistant")}</span>
+        </div>
+        {msg.role === "user" ? (
+          <div className="rounded-[22px] border border-[var(--border)]/45 bg-[var(--muted)]/78 px-4 py-3 text-[15px] leading-7 text-[var(--foreground)] shadow-[0_10px_28px_rgba(15,23,42,0.04)]">
+            {msg.content}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {(msg.events || []).length > 0 ? (
+              <div className="mb-1">
+                <TracePanel events={msg.events || []} />
+              </div>
+            ) : null}
+            {msg.error && (
+              <div className="rounded-[18px] border border-red-200/70 bg-red-50/80 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+                {msg.error}
+              </div>
+            )}
+            {shouldRenderAssistantContent ? (
+              <AssistantResponse
+                content={msg.content}
+                className="rounded-[22px] border border-[var(--border)]/38 bg-[var(--background)]/70 px-5 py-4 shadow-[0_8px_24px_rgba(15,23,42,0.03)]"
+              />
+            ) : null}
+            {shouldRenderCapabilityResult ? (
+              <CapabilityResultPanel result={msg.result} streamedContent={msg.content} />
+            ) : null}
+            {!msg.error && isStreaming && isLatestAssistant && !shouldRenderAssistantContent ? (
+              <div className="inline-flex items-center gap-2 rounded-full bg-[var(--muted)]/55 px-3 py-1.5 text-[12px] text-[var(--muted-foreground)]">
+                <Loader2 size={12} className="animate-spin" />
+                {t("Running...")}
+              </div>
+            ) : null}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -569,62 +639,67 @@ function ToolExecutor({ tool, knowledgeBases }: { tool: ToolInfo; knowledgeBases
 /*  CapabilityResultPanel                                              */
 /* ------------------------------------------------------------------ */
 
-function CapabilityResultPanel({ result }: { result: CapabilityExecResult | null | undefined }) {
+function CapabilityResultPanel({
+  result,
+  streamedContent = "",
+}: {
+  result: CapabilityExecResult | null | undefined;
+  streamedContent?: string;
+}) {
   const { t } = useTranslation();
   if (!result) return null;
 
-  const response = typeof result.data.response === "string" ? result.data.response : "";
+  const response = getResultResponse(result);
+  const normalizedStreamedContent = streamedContent.trim();
+  const shouldRenderResponse = Boolean(response) && response !== normalizedStreamedContent;
   const extraData = Object.fromEntries(
     Object.entries(result.data).filter(([key]) => key !== "response"),
   );
   const extraKeys = Object.keys(extraData);
+  const shouldRenderStructuredFallback = !response && extraKeys.length > 0;
+  const shouldRenderStatus =
+    !result.success ||
+    (!shouldRenderResponse && !shouldRenderStructuredFallback && !normalizedStreamedContent);
+
+  if (!shouldRenderResponse && !shouldRenderStructuredFallback && !shouldRenderStatus) {
+    return null;
+  }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        {result.success ? (
-          <span className="inline-flex items-center gap-1 rounded-md bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700 dark:bg-green-950/30 dark:text-green-400">
-            <Check size={10} /> {t("Success")}
-          </span>
-        ) : (
-          <span className="inline-flex items-center gap-1 rounded-md bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-700 dark:bg-red-950/30 dark:text-red-400">
-            <X size={10} /> {t("Failed")}
-          </span>
-        )}
-        {typeof result.elapsedMs === "number" && (
-          <span className="text-[11px] text-[var(--muted-foreground)]">
-            {result.elapsedMs} {t("ms")}
-          </span>
-        )}
-      </div>
-
-      {response && (
-        <div className="max-h-[400px] overflow-y-auto rounded-[24px] border border-[var(--border)]/60 bg-[var(--background)]/78 p-4">
-          <MarkdownRenderer content={response} variant="prose" />
+    <div className="space-y-2">
+      {shouldRenderStatus ? (
+        <div className="flex items-center gap-2 text-[11px] text-[var(--muted-foreground)]">
+          {!result.success ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-0.5 text-red-700 dark:bg-red-950/30 dark:text-red-300">
+              <X size={10} /> {t("Failed")}
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-green-700 dark:bg-green-950/30 dark:text-green-400">
+              <Check size={10} /> {t("Success")}
+            </span>
+          )}
+          {typeof result.elapsedMs === "number" ? (
+            <span>
+              {result.elapsedMs} {t("ms")}
+            </span>
+          ) : null}
         </div>
-      )}
+      ) : null}
 
-      {!response && extraKeys.length > 0 && (
-        <div className="rounded-[20px] border border-[var(--border)]/55 bg-[var(--background)]/72 p-3">
+      {shouldRenderResponse ? (
+        <AssistantResponse
+          content={response}
+          className="rounded-[22px] border border-[var(--border)]/38 bg-[var(--background)]/66 px-5 py-4 shadow-[0_8px_24px_rgba(15,23,42,0.03)]"
+        />
+      ) : null}
+
+      {shouldRenderStructuredFallback ? (
+        <div className="rounded-[20px] border border-[var(--border)]/45 bg-[var(--background)]/64 p-3">
           <pre className="overflow-x-auto whitespace-pre-wrap break-all text-[12px] leading-6 text-[var(--muted-foreground)]/90">
             {JSON.stringify(extraData, null, 2)}
           </pre>
         </div>
-      )}
-
-      {extraKeys.length > 0 && response && (
-        <details className="group rounded-2xl border border-[var(--border)]/60 bg-[var(--background)]/68">
-          <summary className="flex cursor-pointer list-none items-center justify-between px-3.5 py-2.5 text-[12px] font-medium text-[var(--foreground)]">
-            {t("Metadata")}
-            <ChevronDown size={13} className="text-[var(--muted-foreground)] transition-transform group-open:rotate-180" />
-          </summary>
-          <div className="border-t border-[var(--border)]/55 px-3.5 py-3">
-            <pre className="overflow-x-auto whitespace-pre-wrap break-all text-[12px] leading-6 text-[var(--muted-foreground)]/88">
-              {JSON.stringify(extraData, null, 2)}
-            </pre>
-          </div>
-        </details>
-      )}
+      ) : null}
     </div>
   );
 }
@@ -988,43 +1063,12 @@ function DeepQuestionTester({
       </div>
 
       {messages.map((msg, i) => (
-        <div
+        <PlaygroundChatTurn
           key={`${msg.role}-${i}`}
-          className={`mx-auto max-w-4xl ${msg.role === "user" ? "flex justify-end" : ""}`}
-        >
-          <div className={msg.role === "user" ? "w-full max-w-[78%]" : "w-full max-w-[88%]"}>
-            <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-[var(--muted-foreground)]">
-              {msg.role === "user" ? <MessageSquare size={12} /> : <Sparkles size={12} />}
-              <span>{msg.role === "user" ? t("You") : t("Assistant")}</span>
-            </div>
-            {msg.role === "user" ? (
-              <div className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--muted)]/72 px-5 py-4 text-[15px] leading-7 text-[var(--foreground)] shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
-                {msg.content}
-              </div>
-            ) : (
-              <div className="space-y-3">
-                <div className="rounded-[24px] border border-[var(--border)]/55 bg-[var(--background)]/58 p-3">
-                  <TracePanel events={msg.events || []} />
-                </div>
-                <ProcessLogs
-                  logs={msg.processLogs || []}
-                  executing={streaming && i === messages.length - 1}
-                  title={t("Process")}
-                />
-                {msg.error && (
-                  <div className="rounded-[18px] border border-red-200/70 bg-red-50/80 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-                    {msg.error}
-                  </div>
-                )}
-                <AssistantResponse
-                  content={msg.content}
-                  className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--background)]/88 px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.03)]"
-                />
-                <CapabilityResultPanel result={msg.result} />
-              </div>
-            )}
-          </div>
-        </div>
+          msg={msg}
+          isStreaming={streaming}
+          isLatestAssistant={i === messages.length - 1}
+        />
       ))}
 
       <div className="sticky bottom-0 z-10 -mx-2 border-t border-[var(--border)] bg-[var(--background)]/94 px-2 pb-2 pt-2 backdrop-blur">
@@ -1247,43 +1291,12 @@ function DeepResearchTester({
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="space-y-5 pb-4">
           {messages.map((msg, i) => (
-            <div
+            <PlaygroundChatTurn
               key={`${msg.role}-${i}`}
-              className={`mx-auto max-w-4xl ${msg.role === "user" ? "flex justify-end" : ""}`}
-            >
-              <div className={msg.role === "user" ? "w-full max-w-[78%]" : "w-full max-w-[88%]"}>
-                <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-[var(--muted-foreground)]">
-                  {msg.role === "user" ? <MessageSquare size={12} /> : <Sparkles size={12} />}
-                  <span>{msg.role === "user" ? t("You") : t("Assistant")}</span>
-                </div>
-                {msg.role === "user" ? (
-                  <div className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--muted)]/72 px-5 py-4 text-[15px] leading-7 text-[var(--foreground)] shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
-                    {msg.content}
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    <div className="rounded-[24px] border border-[var(--border)]/55 bg-[var(--background)]/58 p-3">
-                      <TracePanel events={msg.events || []} />
-                    </div>
-                    <ProcessLogs
-                      logs={msg.processLogs || []}
-                      executing={streaming && i === messages.length - 1}
-                      title={t("Process")}
-                    />
-                    {msg.error && (
-                      <div className="rounded-[18px] border border-red-200/70 bg-red-50/80 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-                        {msg.error}
-                      </div>
-                    )}
-                    <AssistantResponse
-                      content={msg.content}
-                      className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--background)]/88 px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.03)]"
-                    />
-                    <CapabilityResultPanel result={msg.result} />
-                  </div>
-                )}
-              </div>
-            </div>
+              msg={msg}
+              isStreaming={streaming}
+              isLatestAssistant={i === messages.length - 1}
+            />
           ))}
         </div>
       </div>
@@ -1469,43 +1482,12 @@ function CapabilityTester({
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="space-y-5 pb-4">
           {messages.map((msg, i) => (
-            <div
+            <PlaygroundChatTurn
               key={`${msg.role}-${i}`}
-              className={`mx-auto max-w-4xl ${msg.role === "user" ? "flex justify-end" : ""}`}
-            >
-              <div className={msg.role === "user" ? "w-full max-w-[78%]" : "w-full max-w-[88%]"}>
-                <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-[var(--muted-foreground)]">
-                  {msg.role === "user" ? <MessageSquare size={12} /> : <Sparkles size={12} />}
-                  <span>{msg.role === "user" ? t("You") : t("Assistant")}</span>
-                </div>
-                {msg.role === "user" ? (
-                  <div className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--muted)]/72 px-5 py-4 text-[15px] leading-7 text-[var(--foreground)] shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
-                    {msg.content}
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    <div className="rounded-[24px] border border-[var(--border)]/55 bg-[var(--background)]/58 p-3">
-                      <TracePanel events={msg.events || []} />
-                    </div>
-                    <ProcessLogs
-                      logs={msg.processLogs || []}
-                      executing={streaming && i === messages.length - 1}
-                      title={t("Process")}
-                    />
-                    {msg.error && (
-                      <div className="rounded-[18px] border border-red-200/70 bg-red-50/80 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-                        {msg.error}
-                      </div>
-                    )}
-                    <AssistantResponse
-                      content={msg.content}
-                      className="rounded-[28px] border border-[var(--border)]/55 bg-[var(--background)]/88 px-5 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.03)]"
-                    />
-                    <CapabilityResultPanel result={msg.result} />
-                  </div>
-                )}
-              </div>
-            </div>
+              msg={msg}
+              isStreaming={streaming}
+              isLatestAssistant={i === messages.length - 1}
+            />
           ))}
         </div>
       </div>

--- a/web/components/common/AssistantResponse.tsx
+++ b/web/components/common/AssistantResponse.tsx
@@ -10,7 +10,7 @@ interface AssistantResponseProps {
 
 export default function AssistantResponse({
   content,
-  className = "text-[14px] leading-[1.8]",
+  className = "text-[15px] leading-[1.85]",
 }: AssistantResponseProps) {
   if (!hasVisibleMarkdownContent(content)) return null;
 


### PR DESCRIPTION
## Tóm tắt
- đưa các turn chat trên `/playground` về layout tiêu dùng gọn hơn với bubble người dùng nhỏ hơn và một renderer chung cho các capability tester
- thay trace card dày bằng các trace row nhẹ theo tinh thần chat gốc, vẫn giữ `Thinking / Acting / Observing / Responding` nhưng không còn cảm giác debug panel
- ẩn metadata khỏi end user và gộp các lớp answer/result trùng để một lượt chat không còn chiếm gần hết màn hình

## Kiểm tra
- [x] `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx"`
- [x] `cd web && npm run build`
- [x] `git diff --check`
- [ ] `cd web && npx tsc --noEmit` vẫn lỗi do import `.ts` trong test có sẵn ngoài phạm vi lane này
