### PR TITLE
Fix playground chat history hydration

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -35,12 +35,12 @@ Rules:
 - Owner: Codex session
 - Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: Realign `/playground` chat turns to the original consumer-chat style while keeping trace stages visible and compact
+- Task: Restore chat history loading on `/playground` for the `chat` capability by reconnecting the page to `UnifiedChatContext`
 - Status: writing spec
-- Branch: `fix/playground-chat-consumer-trace`
-- Task packet: `docs/superpowers/tasks/2026-04-30-playground-chat-consumer-trace.md`
-- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/components/common/AssistantResponse.tsx`, `web/components/common/ProcessLogs.tsx`, `web/components/chat/home/ChatMessages.tsx`, `web/components/chat/home/TracePanels.tsx`, `web/locales/en/app.json`, `web/locales/vi/app.json`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-chat-consumer-trace.md`, `docs/superpowers/specs/2026-04-30-playground-chat-consumer-trace-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-chat-consumer-trace.md`
+- Branch: `fix/playground-chat-history-restore`
+- Task packet: `docs/superpowers/tasks/2026-04-30-playground-chat-history-restore.md`
+- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/context/UnifiedChatContext.tsx`, `web/components/chat/home/ChatMessages.tsx`, `web/components/chat/home/ChatComposer.tsx`, `web/components/sidebar/WorkspaceSidebar.tsx`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-chat-history-restore.md`, `docs/superpowers/specs/2026-04-30-playground-chat-history-restore-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-chat-history-restore.md`
 - PR: uncreated
 - Last update: 2026-04-30
-- Next action: write the bounded design spec for restoring the original lightweight trace language and compact chat turn layout before implementation
+- Next action: write the bounded bugfix spec for reconnecting `/playground` chat mode to session history hydration before implementation
 - Blocker: none

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -310,3 +310,13 @@
 - Done: Left runtime payloads unchanged; only the `/playground` presentation changed.
 - Tests: `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/common/AssistantResponse.tsx" "components/common/ProcessLogs.tsx"`; `cd web && npm run build`; `git diff --check`
 - Notes: `cd web && npx tsc --noEmit` still hits pre-existing test import-extension errors in `tests/sidebar-nav-groups.test.ts` and `tests/teacher-cockpit-content.test.ts`, unrelated to this lane.
+
+## BUG-PLAYGROUND-CHAT-HISTORY-RESTORE
+
+- Branch: `fix/playground-chat-history-restore`
+- Task: `BUG-PLAYGROUND-CHAT-HISTORY-RESTORE`
+- Done: Wrote the bounded design artifact `docs/superpowers/specs/2026-04-30-playground-chat-history-restore-design.md` and the implementation plan `docs/superpowers/plans/2026-04-30-playground-chat-history-restore.md`.
+- Done: Reconnected `/playground` chat mode to `UnifiedChatContext` so sidebar session selection again hydrates the center chat panel from the real session source of truth.
+- Done: Forced `/playground` back to `chat` mode when an existing sidebar session is selected, so a previously opened deep capability tester no longer hides the restored history.
+- Done: Left non-chat capability testers unchanged for the next lane that will hide them from UI.
+- Tests: `cd web && npx eslint "app/(workspace)/playground/page.tsx"`; `cd web && npm run build`; `git diff --check`

--- a/docs/superpowers/plans/2026-04-30-playground-chat-history-restore.md
+++ b/docs/superpowers/plans/2026-04-30-playground-chat-history-restore.md
@@ -1,0 +1,211 @@
+# Playground Chat History Restore Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore history replay on `/playground` for the standard `chat` capability by reconnecting the page to `UnifiedChatContext`.
+
+**Architecture:** Keep the current `/playground` shell and the local tester state for non-chat capabilities, but route only the `chat` capability back through the shared `UnifiedChatContext` state and actions. This restores sidebar-driven session hydration without broadening the scope to capability cleanup or backend changes.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, existing `UnifiedChatContext`, Tailwind CSS, i18next.
+
+---
+
+### Task 1: Reconnect `/playground` chat mode to shared session state
+
+**Files:**
+- Modify: `web/app/(workspace)/playground/page.tsx`
+- Reference only: `web/context/UnifiedChatContext.tsx`
+- Reference only: `web/components/chat/home/ChatMessages.tsx`
+- Reference only: `web/components/chat/home/ChatComposer.tsx`
+- Test: `web` build and ESLint
+
+- [ ] **Step 1: Locate the chat-mode render branch and current local state**
+
+Read the current `chat` capability branch inside `/playground` and identify the local `messages` state that currently blocks session hydration:
+
+```tsx
+const [messages, setMessages] = useState<TesterMessage[]>([]);
+
+return activeCapability ? (
+  activeCapability.name === "deep_question" ? (
+    <DeepQuestionTester ... />
+  ) : activeCapability.name === "deep_research" ? (
+    <DeepResearchTester ... />
+  ) : (
+    <CapabilityTester capability={activeCapability} ... />
+  )
+) : null;
+```
+
+- [ ] **Step 2: Pull shared chat state and actions from `useUnifiedChat()`**
+
+Add the context hook to `/playground` and read the shared chat state only once near the top-level page component:
+
+```tsx
+import { useUnifiedChat } from "@/context/UnifiedChatContext";
+
+const {
+  state: unifiedChatState,
+  sendMessage,
+  cancelStreamingTurn,
+  setTools,
+  setCapability,
+  setKBs,
+  setLanguage,
+} = useUnifiedChat();
+```
+
+- [ ] **Step 3: Keep playground configuration synced into the shared chat context when `chat` is active**
+
+Inside the `/playground` page, add a focused effect that mirrors the active chat playground config into context:
+
+```tsx
+useEffect(() => {
+  if (!activeCapability || activeCapability.name !== "chat" || !activeCapabilityConfig) return;
+  setCapability("chat");
+  setTools(activeCapabilityConfig.enabledTools);
+  setKBs(activeCapabilityConfig.knowledgeBase ? [activeCapabilityConfig.knowledgeBase] : []);
+}, [activeCapability, activeCapabilityConfig, setCapability, setKBs, setTools]);
+```
+
+And keep language aligned:
+
+```tsx
+useEffect(() => {
+  setLanguage(i18n.language);
+}, [i18n.language, setLanguage]);
+```
+
+- [ ] **Step 4: Add a dedicated `/playground` chat panel that renders from context messages**
+
+Create a small local component in `web/app/(workspace)/playground/page.tsx` that maps `UnifiedChatContext` messages into the existing visual surface:
+
+```tsx
+function PlaygroundChatCapability({
+  messages,
+  isStreaming,
+  onSend,
+  onCancel,
+}: {
+  messages: MessageItem[];
+  isStreaming: boolean;
+  onSend: (content: string) => void;
+  onCancel: () => void;
+}) {
+  // render context-backed chat turns here
+}
+```
+
+This component should render `messages` from context instead of maintaining a local `useState(messages)` copy.
+
+- [ ] **Step 5: Route only the `chat` capability through the new context-backed panel**
+
+Replace the generic fallback branch so `chat` uses the shared context-backed component and the other capabilities stay local:
+
+```tsx
+{activeCapability.name === "chat" ? (
+  <PlaygroundChatCapability
+    messages={unifiedChatState.messages}
+    isStreaming={unifiedChatState.isStreaming}
+    onSend={(content) => sendMessage(content)}
+    onCancel={cancelStreamingTurn}
+  />
+) : (
+  <CapabilityTester capability={activeCapability} ... />
+)}
+```
+
+- [ ] **Step 6: Preserve the current consumer-style visual treatment for restored history**
+
+Use the existing compact turn renderer for the chat capability so restored sessions match the latest `/playground` style rather than falling back to the older generic chat page.
+
+```tsx
+<PlaygroundChatTurn
+  key={`${msg.role}-${i}`}
+  msg={msg}
+  isStreaming={isStreaming}
+  isLatestAssistant={i === messages.length - 1}
+/>
+```
+
+But feed it data transformed from `UnifiedChatContext` message items.
+
+- [ ] **Step 7: Run focused lint for the page**
+
+Run: `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "app/(workspace)/playground/page.tsx"`
+
+Expected: `0 problems`
+
+- [ ] **Step 8: Commit the runtime fix**
+
+```bash
+git add web/app/'(workspace)'/playground/page.tsx
+git commit -m "fix(playground): restore chat history hydration [BUG-PLAYGROUND-CHAT-HISTORY-RESTORE]"
+```
+
+### Task 2: Validate and document the bugfix lane
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-playground-chat-history-restore.md`
+- Test: build and diff checks
+
+- [ ] **Step 1: Run the verification commands**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npm run build
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check
+```
+
+Expected:
+
+```text
+Next.js build completes successfully
+git diff --check returns no output
+```
+
+- [ ] **Step 2: Record the bugfix in the daily log**
+
+Append a compact entry to `ai_first/daily/2026-04-30.md`:
+
+```md
+## BUG-PLAYGROUND-CHAT-HISTORY-RESTORE
+
+- Reconnected `/playground` chat mode to `UnifiedChatContext`.
+- Restored sidebar-selected session replay for standard chat.
+- Left non-chat playground capability testers unchanged.
+```
+
+- [ ] **Step 3: Write the PR note with a Mermaid diagram**
+
+Create `docs/superpowers/pr-notes/2026-04-30-playground-chat-history-restore.md`:
+
+```md
+# PR Note: Playground Chat History Restore
+
+```mermaid
+flowchart TD
+  S["Sidebar session click"] --> L["loadSession(sessionId)"]
+  L --> C["UnifiedChatContext messages"]
+  C --> P["/playground chat panel"]
+```
+```
+
+- [ ] **Step 4: Commit the docs slice**
+
+```bash
+git add ai_first/daily/2026-04-30.md docs/superpowers/pr-notes/2026-04-30-playground-chat-history-restore.md
+git commit -m "docs(playground): record chat history restore fix [BUG-PLAYGROUND-CHAT-HISTORY-RESTORE]"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - reconnect `chat` mode to context: Task 1
+  - restore sidebar-selected history: Task 1
+  - keep non-chat capabilities unchanged: Task 1
+  - validation and PR note: Task 2
+- Placeholder scan: no `TODO`, `TBD`, or deferred placeholders remain.
+- Type consistency: all named hooks, files, and commands exist in the surveyed codebase.

--- a/docs/superpowers/pr-notes/2026-04-30-playground-chat-history-restore.md
+++ b/docs/superpowers/pr-notes/2026-04-30-playground-chat-history-restore.md
@@ -1,0 +1,23 @@
+# PR Note: Playground Chat History Restore
+
+## Summary
+
+This lane fixes a regression where clicking a previous chat session in the sidebar no longer restored that conversation inside `/playground`. The fix reconnects only the standard `chat` mode to `UnifiedChatContext`, while leaving the other capability testers untouched for the next UI-scope lane.
+
+## Architecture impact
+
+- No backend changes
+- No session schema changes
+- No capability removals in this lane
+- `/playground` now uses the shared chat session state again when the active capability is `chat`
+
+```mermaid
+flowchart TD
+  S["Sidebar session click"] --> L["loadSession(sessionId)"]
+  L --> C["UnifiedChatContext messages"]
+  C --> P["/playground chat panel"]
+```
+
+## MAIN_SYSTEM_MAP
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane restores an existing session-history integration and does not change the system architecture.

--- a/docs/superpowers/specs/2026-04-30-playground-chat-history-restore-design.md
+++ b/docs/superpowers/specs/2026-04-30-playground-chat-history-restore-design.md
@@ -1,0 +1,126 @@
+# Playground Chat History Restore Design
+
+- Date: 2026-04-30
+- Task ID: `BUG-PLAYGROUND-CHAT-HISTORY-RESTORE`
+- Branch: `fix/playground-chat-history-restore`
+
+## Goal
+
+Restore the ability to click an existing chat session in the sidebar and have `/playground` show that historical conversation again for the standard `chat` capability.
+
+## Current Behavior
+
+- `WorkspaceSidebar` still calls `loadSession(sessionId)` from `UnifiedChatContext`.
+- `UnifiedChatContext` still fetches the session and hydrates the real message history into context state.
+- `/playground` no longer reads that context for its `chat` mode.
+- Instead, `CapabilityTester` and the other playground testers keep their own local `messages` arrays with `useState`.
+- Result: selecting a prior session updates context, but the center chat panel stays on its local state and appears broken.
+
+## Intended Behavior Change
+
+- When the active playground mode is `chat`, the center chat panel must render from `UnifiedChatContext`.
+- Clicking a previous session in the sidebar must immediately show that session’s messages in `/playground`.
+- Sending a new chat message from `/playground` chat mode must continue through `UnifiedChatContext` so history and live chat stay on the same source of truth.
+- Non-chat capability testers (`deep_solve`, `deep_question`, `deep_research`) remain unchanged in this lane.
+
+## Codebase Survey
+
+### Entry points and handlers
+
+- `web/app/(workspace)/playground/page.tsx`
+  - owns the `/playground` shell and currently chooses which tester surface to render
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+  - dispatches `loadSession(sessionId)` on history click
+
+### Primary service or use-case modules
+
+- `web/context/UnifiedChatContext.tsx`
+  - authoritative session hydration, message streaming, selected session state
+
+### Shared contracts, schemas, or types
+
+- `MessageItem`, `ChatState`, `SendMessageOptions` in `UnifiedChatContext`
+- `StreamEvent` in the existing chat rendering pipeline
+
+### Adjacent or reused flows inspected
+
+- `web/components/chat/home/ChatMessages.tsx`
+  - existing history-aware message list already wired for hydrated sessions
+- `web/components/chat/home/ChatComposer.tsx`
+  - existing composer behavior for context-backed chat flows
+
+### Closest existing tests
+
+- No focused `/playground` history test currently exists.
+- Existing validation will rely on ESLint, build, and targeted manual code-path inspection unless a narrow test seam is practical.
+
+## Candidate Approaches
+
+### Approach A: Keep `/playground` local state and add a second session-fetch path
+
+- On session click, call the session API again directly inside `/playground` and sync local tester state.
+- Pros:
+  - minimal reshaping of current page structure
+- Cons:
+  - duplicates session hydration logic
+  - creates two competing sources of truth for the same chat route
+  - likely to regress again
+
+### Approach B: Reconnect `/playground` chat mode to `UnifiedChatContext`
+
+- Use context state for the `chat` capability only, while keeping the other capability testers local.
+- Pros:
+  - matches the original architecture
+  - fixes sidebar selection and history replay at the source
+  - avoids duplicate loading logic
+- Cons:
+  - requires careful split between `chat` mode and non-chat testers inside `/playground`
+
+### Approach C: Move all playground capabilities into shared context immediately
+
+- Broaden `UnifiedChatContext` to own every playground tester mode.
+- Pros:
+  - one long-term model
+- Cons:
+  - too broad for this bugfix
+  - conflicts with the user’s request to defer capability cleanup to the next task
+
+## Chosen Approach
+
+Approach B.
+
+The bug is caused by `/playground` chat mode drifting away from the existing session source of truth. Reconnecting only `chat` mode to `UnifiedChatContext` fixes the regression directly without broadening scope to the other capability testers.
+
+## Planned Changes
+
+- In `web/app/(workspace)/playground/page.tsx`:
+  - detect when the active capability is `chat`
+  - render the main chat surface from `useUnifiedChat().state.messages`
+  - route send/cancel behavior through `sendMessage` and `cancelStreamingTurn`
+- Reuse the existing message/composer components where practical instead of maintaining a second local chat implementation.
+- Keep `deep_solve`, `deep_question`, and `deep_research` on their current local tester state in this lane.
+
+## Expected Impact Surface
+
+### Likely to change
+
+- `web/app/(workspace)/playground/page.tsx`
+
+### Reviewed but expected to remain unchanged unless implementation reveals a hard dependency
+
+- `web/context/UnifiedChatContext.tsx`
+- `web/components/chat/home/ChatMessages.tsx`
+- `web/components/chat/home/ChatComposer.tsx`
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+
+## Tests To Run
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx"`
+- `cd web && npm run build`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check`
+
+## Non-Goals
+
+- No hiding or removing capabilities in this lane.
+- No backend changes.
+- No session schema changes.

--- a/docs/superpowers/tasks/2026-04-30-playground-chat-history-restore.md
+++ b/docs/superpowers/tasks/2026-04-30-playground-chat-history-restore.md
@@ -1,0 +1,45 @@
+# Task Packet: Playground Chat History Restore
+
+- Task ID: `BUG-PLAYGROUND-CHAT-HISTORY-RESTORE`
+- Date: 2026-04-30
+- Branch: `fix/playground-chat-history-restore`
+- Status: Spec written
+
+## Objective
+
+Fix the regression where selecting a previous chat session in the sidebar no longer restores that conversation inside `/playground`.
+
+## User-Approved Scope
+
+- restore history loading for the standard `chat` mode on `/playground`
+- do not hide or remove `Giải sâu`, `Nghiên cứu sâu`, or other capabilities in this lane
+- capability hiding is deferred to the next task
+
+## Owned Files
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/context/UnifiedChatContext.tsx`
+- `web/components/chat/home/ChatMessages.tsx`
+- `web/components/chat/home/ChatComposer.tsx`
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-playground-chat-history-restore.md`
+- `docs/superpowers/specs/2026-04-30-playground-chat-history-restore-design.md`
+- `docs/superpowers/pr-notes/2026-04-30-playground-chat-history-restore.md`
+
+## Do-Not-Touch
+
+- backend session APIs
+- capability-hiding work for the next lane
+- unrelated untracked files
+
+## Design Before Implementation
+
+- `docs/superpowers/specs/2026-04-30-playground-chat-history-restore-design.md`
+
+## Validation Plan
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx"`
+- `cd web && npm run build`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check`

--- a/web/app/(workspace)/playground/page.tsx
+++ b/web/app/(workspace)/playground/page.tsx
@@ -34,6 +34,7 @@ import { PlaygroundWorkspaceShell } from "@/components/chat/home/PlaygroundWorks
 import AssistantResponse from "@/components/common/AssistantResponse";
 import MarkdownRenderer from "@/components/common/MarkdownRenderer";
 import ProcessLogs from "@/components/common/ProcessLogs";
+import { useUnifiedChat, type MessageItem } from "@/context/UnifiedChatContext";
 import ResearchConfigPanel from "@/components/research/ResearchConfigPanel";
 import { extractBase64FromDataUrl, readFileAsDataUrl } from "@/lib/file-attachments";
 import { listKnowledgeBases } from "@/lib/knowledge-api";
@@ -184,6 +185,10 @@ interface TesterMessage {
   error?: string | null;
 }
 
+interface PlaygroundChatMessage extends TesterMessage {
+  role: "user" | "assistant";
+}
+
 type DeepQuestionMode = "custom" | "mimic";
 
 interface DeepQuestionFormConfig {
@@ -314,6 +319,23 @@ function getResultResponse(result: CapabilityExecResult | null | undefined): str
   return typeof result?.data.response === "string" ? result.data.response.trim() : "";
 }
 
+function toPlaygroundChatMessages(messages: MessageItem[]): PlaygroundChatMessage[] {
+  return messages.flatMap((message) => {
+    if (message.role === "system") return [];
+    const errorEvent = message.events?.find((event) => event.type === "error");
+    return [
+      {
+        role: message.role,
+        content: message.content,
+        events: message.events ?? [],
+        result: null,
+        processLogs: [],
+        error: errorEvent?.content || null,
+      },
+    ];
+  });
+}
+
 function PlaygroundChatTurn({
   msg,
   isStreaming,
@@ -372,6 +394,81 @@ function PlaygroundChatTurn({
             ) : null}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+function PlaygroundSharedChat({
+  messages,
+  isStreaming,
+  title,
+  onSend,
+  onCancel,
+}: {
+  messages: MessageItem[];
+  isStreaming: boolean;
+  title: string;
+  onSend: (content: string) => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+  const [input, setInput] = useState("");
+  const chatMessages = useMemo(() => toPlaygroundChatMessages(messages), [messages]);
+
+  const send = () => {
+    const content = input.trim();
+    if (!content || isStreaming) return;
+    onSend(content);
+    setInput("");
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="space-y-5 pb-4">
+          {chatMessages.map((msg, i) => (
+            <PlaygroundChatTurn
+              key={`${msg.role}-${i}`}
+              msg={msg}
+              isStreaming={isStreaming}
+              isLatestAssistant={i === chatMessages.length - 1}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="sticky bottom-0 z-10 shrink-0 border-t border-[var(--border)] bg-[var(--background)]/96 pt-2 backdrop-blur">
+        <div className="rounded-[22px] border border-[var(--border)]/60 bg-[var(--background)]/84 px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                if (isStreaming) onCancel();
+                else send();
+              }
+            }}
+            rows={2}
+            placeholder={`${t("Try")} ${title}...`}
+            className="w-full resize-none bg-transparent text-[13px] leading-5 text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
+          />
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <div className="text-[11px] text-[var(--muted-foreground)]">
+              {isStreaming
+                ? t("Press Enter to stop the current answer.")
+                : t("Enter to send, Shift+Enter for a new line.")}
+            </div>
+            <button
+              onClick={isStreaming ? onCancel : send}
+              disabled={!isStreaming && !input.trim()}
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--muted)] px-4 py-1.5 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/80 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {isStreaming ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
+              {isStreaming ? t("Stop") : t("Send")}
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -1525,7 +1622,17 @@ function CapabilityTester({
 /* ------------------------------------------------------------------ */
 
 export default function PlaygroundPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const {
+    state: unifiedChatState,
+    sendMessage,
+    cancelStreamingTurn,
+    setTools,
+    setCapability,
+    setKBs,
+    setLanguage,
+    selectedSessionId,
+  } = useUnifiedChat();
   const [tools, setToolsList] = useState<ToolInfo[]>([]);
   const [capabilities, setCapabilities] = useState<CapabilityInfo[]>([]);
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
@@ -1727,6 +1834,23 @@ export default function PlaygroundPage() {
     });
   };
 
+  useEffect(() => {
+    if (!activeCapability || activeCapability.name !== "chat" || !activeCapabilityConfig) return;
+    setCapability("chat");
+    setTools(activeCapabilityConfig.enabledTools);
+    setKBs(activeCapabilityConfig.knowledgeBase ? [activeCapabilityConfig.knowledgeBase] : []);
+  }, [activeCapability, activeCapabilityConfig, setCapability, setKBs, setTools]);
+
+  useEffect(() => {
+    setLanguage(i18n.language);
+  }, [i18n.language, setLanguage]);
+
+  useEffect(() => {
+    if (!selectedSessionId) return;
+    setActiveKind("capability");
+    setActiveName("chat");
+  }, [selectedSessionId]);
+
   const selectionPanel = (
     <section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
       <div className="flex items-center justify-between gap-3">
@@ -1858,7 +1982,15 @@ export default function PlaygroundPage() {
         ) : activeKind === "tool" && activeTool ? (
           <ToolExecutor tool={activeTool} knowledgeBases={knowledgeBases} />
         ) : activeCapability ? (
-          activeCapability.name === "deep_question" ? (
+          activeCapability.name === "chat" ? (
+            <PlaygroundSharedChat
+              title={t(getCapabilityLabel(activeCapability.name))}
+              messages={unifiedChatState.messages}
+              isStreaming={unifiedChatState.isStreaming}
+              onSend={(content) => sendMessage(content)}
+              onCancel={cancelStreamingTurn}
+            />
+          ) : activeCapability.name === "deep_question" ? (
             <DeepQuestionTester
               key={activeCapability.name}
               capability={activeCapability}


### PR DESCRIPTION
## Tóm tắt
- nối lại mode `Trò chuyện` trên `/playground` vào `UnifiedChatContext` để session đã chọn từ sidebar hydrate lại đúng vào khung chat giữa
- ép `/playground` quay về mode `chat` khi người dùng chọn một session lịch sử, tránh trường hợp đang đứng ở tester capability khác rồi nhìn như history bị mất
- giữ nguyên các capability như `Giải sâu`, `Nghiên cứu sâu`, `Tạo bài kiểm tra` cho lane sau, không ẩn hoặc sửa hành vi của chúng trong PR này

## Kiểm tra
- [x] `cd web && npx eslint "app/(workspace)/playground/page.tsx"`
- [x] `cd web && npm run build`
- [x] `git diff --check`

## Main System Map
- Không cập nhật; đây là bugfix khôi phục tích hợp session history đã tồn tại, không đổi kiến trúc hệ thống.
