### PR TITLE
Hide playground mode switcher panel

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -35,12 +35,12 @@ Rules:
 - Owner: Codex session
 - Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: Restore chat history loading on `/playground` for the `chat` capability by reconnecting the page to `UnifiedChatContext`
+- Task: Hide the right-panel mode and tool switcher on `/playground` while keeping the underlying capability logic intact
 - Status: writing spec
-- Branch: `fix/playground-chat-history-restore`
-- Task packet: `docs/superpowers/tasks/2026-04-30-playground-chat-history-restore.md`
-- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/context/UnifiedChatContext.tsx`, `web/components/chat/home/ChatMessages.tsx`, `web/components/chat/home/ChatComposer.tsx`, `web/components/sidebar/WorkspaceSidebar.tsx`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-chat-history-restore.md`, `docs/superpowers/specs/2026-04-30-playground-chat-history-restore-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-chat-history-restore.md`
+- Branch: `fix/playground-hide-mode-switcher`
+- Task packet: `docs/superpowers/tasks/2026-04-30-playground-hide-mode-switcher.md`
+- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/components/chat/home/PlaygroundRightPanel.tsx`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-hide-mode-switcher.md`, `docs/superpowers/specs/2026-04-30-playground-hide-mode-switcher-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-hide-mode-switcher.md`
 - PR: uncreated
 - Last update: 2026-04-30
-- Next action: write the bounded bugfix spec for reconnecting `/playground` chat mode to session history hydration before implementation
+- Next action: write the bounded spec for removing the visible mode/tool chooser from the right panel before implementation
 - Blocker: none

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -320,3 +320,12 @@
 - Done: Forced `/playground` back to `chat` mode when an existing sidebar session is selected, so a previously opened deep capability tester no longer hides the restored history.
 - Done: Left non-chat capability testers unchanged for the next lane that will hide them from UI.
 - Tests: `cd web && npx eslint "app/(workspace)/playground/page.tsx"`; `cd web && npm run build`; `git diff --check`
+
+## UI-PLAYGROUND-HIDE-MODE-SWITCHER
+
+- Branch: `fix/playground-hide-mode-switcher`
+- Task: `UI-PLAYGROUND-HIDE-MODE-SWITCHER`
+- Done: Wrote the bounded design artifact `docs/superpowers/specs/2026-04-30-playground-hide-mode-switcher-design.md` and the implementation plan `docs/superpowers/plans/2026-04-30-playground-hide-mode-switcher.md`.
+- Done: Removed the visible `Chuyển chế độ` chooser from the `/playground` right panel for both capability and tool contexts.
+- Done: Kept the underlying capability and tool state logic intact so the chooser can be restored later without rebuilding runtime behavior.
+- Tests: `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`; `cd web && npm run build`; `git diff --check`

--- a/docs/superpowers/plans/2026-04-30-playground-hide-mode-switcher.md
+++ b/docs/superpowers/plans/2026-04-30-playground-hide-mode-switcher.md
@@ -1,0 +1,129 @@
+# Playground Hide Mode Switcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the visible `Năng lực / Công cụ` chooser from the `/playground` right panel while keeping the underlying state and runtime logic intact.
+
+**Architecture:** Leave the capability and tool selection logic in `/playground` untouched, but stop mounting the chooser block into the right panel. This keeps future reactivation cheap while delivering a cleaner, locked-down FE surface now.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Tailwind CSS.
+
+---
+
+### Task 1: Stop rendering the right-panel chooser
+
+**Files:**
+- Modify: `web/app/(workspace)/playground/page.tsx`
+- Reference only: `web/components/chat/home/PlaygroundRightPanel.tsx`
+- Test: `web` lint and build
+
+- [ ] **Step 1: Identify the chooser block and its right-panel insertion point**
+
+Read the `selectionPanel` definition and the place where it is rendered in the right panel:
+
+```tsx
+const selectionPanel = (
+  <section>
+    {/* Switch mode chooser */}
+  </section>
+);
+
+<PlaygroundRightPanel ...>
+  {selectionPanel}
+  ...
+</PlaygroundRightPanel>
+```
+
+- [ ] **Step 2: Remove the chooser block from the visible right-panel composition**
+
+Update the right-panel children so the chooser no longer renders:
+
+```tsx
+<PlaygroundRightPanel ...>
+  {/* chooser intentionally hidden for current product version */}
+  {otherContextPanels}
+</PlaygroundRightPanel>
+```
+
+If `selectionPanel` becomes fully unused, delete the local constant and any imports or helper text used only by that block.
+
+- [ ] **Step 3: Keep capability logic intact**
+
+Do not remove state like `activeKind`, `activeName`, or capability config persistence unless lint proves a symbol is truly unused and safe to drop. The runtime selection logic must remain available for future reactivation.
+
+- [ ] **Step 4: Run focused lint**
+
+Run: `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "app/(workspace)/playground/page.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`
+
+Expected: `0 problems`
+
+- [ ] **Step 5: Commit the runtime UI hide**
+
+```bash
+git add web/app/'(workspace)'/playground/page.tsx
+git commit -m "feat(playground): hide mode switcher panel [UI-PLAYGROUND-HIDE-MODE-SWITCHER]"
+```
+
+### Task 2: Validate and document the lane
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-playground-hide-mode-switcher.md`
+- Test: build and diff checks
+
+- [ ] **Step 1: Run verification**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npm run build
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check
+```
+
+Expected:
+
+```text
+Next.js build completes successfully
+git diff --check returns no output
+```
+
+- [ ] **Step 2: Record the lane in the daily log**
+
+Append:
+
+```md
+## UI-PLAYGROUND-HIDE-MODE-SWITCHER
+
+- Hid the right-panel `Năng lực / Công cụ` chooser on `/playground`.
+- Kept underlying capability and tool logic intact for later reactivation.
+```
+
+- [ ] **Step 3: Write the PR note**
+
+Create `docs/superpowers/pr-notes/2026-04-30-playground-hide-mode-switcher.md`:
+
+```md
+# PR Note: Playground Hide Mode Switcher
+
+```mermaid
+flowchart TD
+  C["Conversation workspace"] --> R["Right panel context"]
+  R -. hidden .-> S["Mode/tool chooser"]
+```
+```
+
+- [ ] **Step 4: Commit the docs slice**
+
+```bash
+git add ai_first/daily/2026-04-30.md docs/superpowers/pr-notes/2026-04-30-playground-hide-mode-switcher.md
+git commit -m "docs(playground): record hidden mode switcher lane [UI-PLAYGROUND-HIDE-MODE-SWITCHER]"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - hide right-panel chooser: Task 1
+  - keep underlying logic intact: Task 1
+  - validation and PR note: Task 2
+- Placeholder scan: no `TODO`, `TBD`, or deferred placeholders remain.
+- Type consistency: all referenced files and commands exist in the current codebase.

--- a/docs/superpowers/pr-notes/2026-04-30-playground-hide-mode-switcher.md
+++ b/docs/superpowers/pr-notes/2026-04-30-playground-hide-mode-switcher.md
@@ -1,0 +1,22 @@
+# PR Note: Playground Hide Mode Switcher
+
+## Summary
+
+This lane removes the visible `Năng lực / Công cụ` chooser from the `/playground` right panel for the current product version. The underlying capability and tool logic stays in place, so the chooser can be restored later without reworking runtime behavior.
+
+## Architecture impact
+
+- No backend changes
+- No route changes
+- No capability removal in this lane
+- Right-panel presentation is simplified by no longer mounting the chooser surface
+
+```mermaid
+flowchart TD
+  C["Conversation workspace"] --> R["Right panel context"]
+  R -. hidden .-> S["Mode / tool chooser"]
+```
+
+## MAIN_SYSTEM_MAP
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane only hides a right-panel UI surface and does not change system architecture.

--- a/docs/superpowers/specs/2026-04-30-playground-hide-mode-switcher-design.md
+++ b/docs/superpowers/specs/2026-04-30-playground-hide-mode-switcher-design.md
@@ -1,0 +1,117 @@
+# Playground Hide Mode Switcher Design
+
+- Date: 2026-04-30
+- Task ID: `UI-PLAYGROUND-HIDE-MODE-SWITCHER`
+- Branch: `fix/playground-hide-mode-switcher`
+
+## Goal
+
+Hide the right-panel mode and tool chooser on `/playground` for the current product version while preserving the underlying capability and tool logic for future reactivation.
+
+## Current Behavior
+
+- The right panel on `/playground` shows a large `Chuyển chế độ` block.
+- That block includes:
+  - the `Năng lực / Công cụ` toggle
+  - the capability list (`Trò chuyện`, `Giải sâu`, `Tạo bài kiểm tra`, `Nghiên cứu sâu`, etc.)
+  - the tool list (`Động não`, `RAG`, `Tìm kiếm web`, etc.)
+- Even though the page already has a main chat workspace, this chooser keeps exposing internal product structure that the user wants hidden for the current release.
+
+## Intended Behavior Change
+
+- The right panel must no longer show the mode-switching chooser or the tool-switching chooser.
+- No capability or tool implementation is removed.
+- The active capability and tool state can continue to exist in code and storage.
+- This is a presentation-only hide for the current version.
+
+## Codebase Survey
+
+### Entry points and handlers
+
+- `web/app/(workspace)/playground/page.tsx`
+  - constructs the `selectionPanel`
+  - passes that panel into the right-side layout
+
+### Primary service or use-case modules
+
+- `web/components/chat/home/PlaygroundRightPanel.tsx`
+  - generic right-panel shell for `/playground`
+
+### Shared contracts, schemas, or types
+
+- no backend or schema contract involved
+
+### Adjacent or reused flows inspected
+
+- current `/playground` shell already separates center conversation workspace from right-side contextual UI, so removing the chooser is bounded to the right panel content only
+
+### Closest existing tests
+
+- no focused test exists for right-panel chooser visibility
+- validation will rely on ESLint, app build, and diff checks
+
+## Candidate Approaches
+
+### Approach A: Hide the chooser with CSS only
+
+- Keep rendering the block but visually hide it.
+- Pros:
+  - smallest diff
+- Cons:
+  - leaves dead UI markup in the DOM
+  - easier for the block to reappear accidentally
+
+### Approach B: Stop rendering the chooser block in the right panel
+
+- Remove the visible `selectionPanel` from the `/playground` right panel while keeping all state logic intact.
+- Pros:
+  - cleanest presentation result
+  - no user-facing trace of internal mode switching
+  - preserves logic for future reactivation
+- Cons:
+  - requires checking the right panel still reads well after the block is removed
+
+### Approach C: Remove capability and tool switching logic entirely
+
+- Delete the visible chooser and underlying state wiring.
+- Pros:
+  - strongest lock-down
+- Cons:
+  - broader than requested
+  - conflicts with the requirement to keep the feature for later
+
+## Chosen Approach
+
+Approach B.
+
+The user wants the chooser hidden from FE now, not deleted from the product. Removing the visible block while keeping state and runtime logic intact is the smallest correct change.
+
+## Planned Changes
+
+- In `web/app/(workspace)/playground/page.tsx`:
+  - stop rendering the `selectionPanel` into the right panel
+  - keep capability/tool state logic untouched unless dead imports or dead variables need cleanup
+- In `web/components/chat/home/PlaygroundRightPanel.tsx`:
+  - keep the shell unchanged unless spacing needs a small cleanup after the chooser is removed
+
+## Expected Impact Surface
+
+### Likely to change
+
+- `web/app/(workspace)/playground/page.tsx`
+
+### Reviewed but expected to remain unchanged unless implementation reveals a small layout cleanup need
+
+- `web/components/chat/home/PlaygroundRightPanel.tsx`
+
+## Tests To Run
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`
+- `cd web && npm run build`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check`
+
+## Non-Goals
+
+- No capability hiding in the runtime layer
+- No backend changes
+- No route changes

--- a/docs/superpowers/tasks/2026-04-30-playground-hide-mode-switcher.md
+++ b/docs/superpowers/tasks/2026-04-30-playground-hide-mode-switcher.md
@@ -1,0 +1,42 @@
+# Task Packet: Playground Hide Mode Switcher
+
+- Task ID: `UI-PLAYGROUND-HIDE-MODE-SWITCHER`
+- Date: 2026-04-30
+- Branch: `fix/playground-hide-mode-switcher`
+- Status: Spec written
+
+## Objective
+
+Hide the right-panel chooser for `Năng lực / Công cụ` on `/playground` without deleting the underlying capability or tool logic.
+
+## User-Approved Scope
+
+- hide the visible mode/tool chooser in the right panel
+- keep the underlying logic for later upgrades
+- do not remove capabilities or tools from backend/runtime in this lane
+
+## Owned Files
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/components/chat/home/PlaygroundRightPanel.tsx`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-playground-hide-mode-switcher.md`
+- `docs/superpowers/specs/2026-04-30-playground-hide-mode-switcher-design.md`
+- `docs/superpowers/pr-notes/2026-04-30-playground-hide-mode-switcher.md`
+
+## Do-Not-Touch
+
+- backend capability implementations
+- session history bugfix lane
+- unrelated untracked files
+
+## Design Before Implementation
+
+- `docs/superpowers/specs/2026-04-30-playground-hide-mode-switcher-design.md`
+
+## Validation Plan
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`
+- `cd web && npm run build`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check`

--- a/web/app/(workspace)/playground/page.tsx
+++ b/web/app/(workspace)/playground/page.tsx
@@ -103,10 +103,6 @@ function getToolIcon(name: string): LucideIcon {
   return TOOL_ICONS[name] ?? Terminal;
 }
 
-function getCapIcon(name: string): LucideIcon {
-  return CAPABILITY_ICONS[name] ?? Sparkles;
-}
-
 function getToolLabel(name: string): string {
   return TOOL_LABELS[name] ?? titleCase(name);
 }
@@ -121,15 +117,6 @@ function getToolDescription(description: string, t: (key: string) => string): st
 
 function getCapabilityDescription(description: string, t: (key: string) => string): string {
   return t(description);
-}
-
-function getListSectionDescription(
-  activeKind: "tool" | "capability",
-  t: (key: string) => string,
-): string {
-  return activeKind === "tool"
-    ? t("Choose the tool that best matches your task.")
-    : t("Choose the capability flow that best matches your goal.");
 }
 
 /* ------------------------------------------------------------------ */
@@ -1709,14 +1696,6 @@ export default function PlaygroundPage() {
       ),
     [activeCapabilityConfig?.config],
   );
-  const listItems = useMemo(
-    () =>
-      activeKind === "tool"
-        ? tools.map((t) => ({ name: t.name, description: t.description }))
-        : capabilityCatalog.map((c) => ({ name: c.name, description: c.description })),
-    [activeKind, capabilityCatalog, tools],
-  );
-
   const activeLabel =
     activeKind === "tool"
       ? activeTool
@@ -1851,105 +1830,6 @@ export default function PlaygroundPage() {
     setActiveName("chat");
   }, [selectedSessionId]);
 
-  const selectionPanel = (
-    <section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
-            {t("Switch mode")}
-          </p>
-          <h3 className="mt-1 text-sm font-semibold tracking-tight text-[var(--foreground)]">
-            {t("Choose what you want to do")}
-          </h3>
-          <p className="mt-1 text-[12px] leading-5 text-[var(--muted-foreground)]">
-            {getListSectionDescription(activeKind, t)}
-          </p>
-        </div>
-        <div className="inline-flex rounded-xl border border-[var(--border)] bg-[var(--background)]/70 p-1">
-          <button
-            type="button"
-            onClick={() => {
-              setActiveKind("capability");
-              if (capabilityCatalog.length) setActiveName(capabilityCatalog[0]?.name ?? "");
-            }}
-            className={`rounded-lg px-3 py-1.5 text-[12px] font-medium transition ${
-              activeKind === "capability"
-                ? "bg-[var(--foreground)] text-[var(--background)]"
-                : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-            }`}
-          >
-            {t("Capabilities")}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setActiveKind("tool");
-              if (tools.length) setActiveName(tools[0]?.name ?? "");
-            }}
-            className={`rounded-lg px-3 py-1.5 text-[12px] font-medium transition ${
-              activeKind === "tool"
-                ? "bg-[var(--foreground)] text-[var(--background)]"
-                : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-            }`}
-          >
-            {t("Tools")}
-          </button>
-        </div>
-      </div>
-
-      <div className="mt-4 space-y-2">
-        {listItems.map((item) => {
-          const Icon = activeKind === "tool" ? getToolIcon(item.name) : getCapIcon(item.name);
-          const selected = activeName === item.name;
-          return (
-            <button
-              key={item.name}
-              type="button"
-              onClick={() => setActiveName(item.name)}
-              title={activeKind === "tool" ? t(getToolLabel(item.name)) : t(getCapabilityLabel(item.name))}
-              aria-label={activeKind === "tool" ? t(getToolLabel(item.name)) : t(getCapabilityLabel(item.name))}
-              className={`w-full rounded-2xl border px-3 py-3 text-left transition ${
-                selected
-                  ? "border-[var(--foreground)]/10 bg-[var(--background)] text-[var(--foreground)] shadow-sm ring-1 ring-[var(--foreground)]/6"
-                  : "border-transparent bg-transparent text-[var(--muted-foreground)] hover:border-[var(--border)] hover:bg-[var(--background)]/75 hover:text-[var(--foreground)]"
-              }`}
-            >
-              <div className="flex items-start gap-2.5">
-                <div
-                  className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl ${
-                    selected
-                      ? "bg-[var(--foreground)] text-[var(--background)]"
-                      : "bg-[var(--muted)]/70 text-[var(--muted-foreground)]"
-                  }`}
-                >
-                  <Icon size={15} strokeWidth={1.9} />
-                </div>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <div className="text-[13px] font-medium">
-                      {activeKind === "tool" ? t(getToolLabel(item.name)) : t(getCapabilityLabel(item.name))}
-                    </div>
-                    {selected ? (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-[var(--foreground)] px-2 py-0.5 text-[10px] font-semibold text-[var(--background)]">
-                        <Check size={10} strokeWidth={2.2} />
-                        {t("Selected")}
-                      </span>
-                    ) : null}
-                  </div>
-                  <div className="mt-1 line-clamp-2 text-[11px] leading-5 text-[var(--muted-foreground)]">
-                    {activeKind === "tool"
-                      ? getToolDescription(item.description, t)
-                      : getCapabilityDescription(item.description, t)}
-                  </div>
-                </div>
-              </div>
-            </button>
-          );
-        })}
-      </div>
-    </section>
-  );
-
   const centerPanel = (
     <main aria-label={t("Conversation workspace")} className="flex h-full min-h-0 flex-col">
       <div className="border-b border-[var(--border)] px-6 py-1.5">
@@ -2040,7 +1920,6 @@ export default function PlaygroundPage() {
             {getToolDescription(activeTool.description, t)}
           </p>
         </section>
-        {selectionPanel}
         <section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
           <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
             {t("Knowledge source")}
@@ -2080,7 +1959,6 @@ export default function PlaygroundPage() {
             {getCapabilityDescription(activeCapability.description, t)}
           </p>
         </section>
-        {selectionPanel}
         <section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
           <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
             {t("Enabled tools")}


### PR DESCRIPTION
## Tóm tắt
- ẩn toàn bộ khối `Chuyển chế độ` cùng danh sách `Năng lực / Công cụ` khỏi panel phải của `/playground`
- giữ nguyên logic capability/tool bên dưới để có thể bật lại sau mà không phải làm lại runtime
- không đụng backend, route, hay session flow trong PR này

## Kiểm tra
- [x] `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`
- [x] `cd web && npm run build`
- [x] `git diff --check`

## Main System Map
- Không cập nhật; đây là thay đổi presentation-only trong panel phải của `/playground`.
