### PR TITLE
[codex] Fix playground reasoning trace wrap

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,6 +34,21 @@ Rules:
 
 - Owner: Codex session
 - Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-chat-reasoning-wrap`
+- Task: Fix `/playground` trace rendering so streamed `Reasoning` text no longer breaks into one-word-per-line blocks
+- Status: ready for handoff
+- Branch: `fix/chat-reasoning-wrap`
+- Task packet: `docs/superpowers/tasks/2026-04-30-playground-reasoning-wrap-fix.md`
+- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/lib/playground-trace.ts`, `web/tests/playground-trace.test.ts`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-reasoning-wrap-fix.md`, `docs/superpowers/specs/2026-04-30-playground-reasoning-wrap-fix-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-reasoning-wrap-fix.md`
+- PR: uncreated
+- Last update: 2026-04-30
+- Next action: stage the bounded diff and open a draft PR from the isolated worktree
+- Blocker: none
+
+### Assignment
+
+- Owner: Codex session
+- Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
 - Task: Hide the right-panel mode and tool switcher on `/playground` while keeping the underlying capability logic intact
 - Status: writing spec

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -1,5 +1,19 @@
 # Daily Log: 2026-04-30
 
+## Playground Reasoning Wrap Fix
+
+- Branch: `fix/chat-reasoning-wrap`
+- Task: `UI-PLAYGROUND-REASONING-WRAP`
+- Done: Created isolated worktree `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-chat-reasoning-wrap` from `origin/main` to keep this lane separate from the active repo-root checkout.
+- Done: Recorded the live assignment, wrote the task packet `docs/superpowers/tasks/2026-04-30-playground-reasoning-wrap-fix.md`, and wrote the bounded design spec `docs/superpowers/specs/2026-04-30-playground-reasoning-wrap-fix-design.md` before editing runtime code.
+- Done: Traced the bug to the local `TracePanel` in `web/app/(workspace)/playground/page.tsx`, which rendered each streamed `thinking` chunk as its own paragraph even though the backend was sending tokenized reasoning deltas.
+- Done: Added `web/lib/playground-trace.ts` to coalesce consecutive `thinking` chunks into one readable reasoning row while preserving `progress`, `tool_call`, `tool_result`, and `error` rows unchanged.
+- Done: Updated the local `/playground` trace renderer to use the normalized rows instead of rendering raw `thinking` events one-by-one.
+- Done: Added focused regression coverage in `web/tests/playground-trace.test.ts` for merged reasoning rows and preserved tool rows.
+- Tests: `cd web && node --test tests/playground-trace.test.ts`; `cd web && ./node_modules/.bin/eslint "app/(workspace)/playground/page.tsx" "lib/playground-trace.ts" "tests/playground-trace.test.ts"`; `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-chat-reasoning-wrap && git diff --check`
+- Blockers: none
+- Next: create the draft PR from the isolated worktree after staging the bounded diff.
+
 ## Playground Chat Visual Refinement Design
 
 - Branch: `fix/playground-chat-visual-refinement`

--- a/docs/superpowers/pr-notes/2026-04-30-playground-reasoning-wrap-fix.md
+++ b/docs/superpowers/pr-notes/2026-04-30-playground-reasoning-wrap-fix.md
@@ -1,0 +1,34 @@
+# PR Note: Playground Reasoning Wrap Fix
+
+- Date: 2026-04-30
+- Task ID: `UI-PLAYGROUND-REASONING-WRAP`
+- Branch: `fix/chat-reasoning-wrap`
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` updated: no
+
+## Summary
+
+- Fixes `/playground` trace rendering so streamed `Reasoning` text is shown as normal readable prose instead of one token block per line.
+- Keeps the existing stage grouping and tool/result cards unchanged.
+- Adds a focused frontend regression test for chunk coalescing.
+
+## Architecture Note
+
+```mermaid
+flowchart LR
+    A["StreamEvent[] for one stage"] --> B["buildPlaygroundTraceRows"]
+    B --> C["merge consecutive thinking chunks"]
+    B --> D["preserve progress/tool/error rows"]
+    C --> E["local TracePanel renders one reasoning block"]
+    D --> F["existing tool/progress cards stay intact"]
+```
+
+## Validation
+
+- `cd web && node --test tests/playground-trace.test.ts`
+- `cd web && ./node_modules/.bin/eslint "app/(workspace)/playground/page.tsx" "lib/playground-trace.ts" "tests/playground-trace.test.ts"`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-chat-reasoning-wrap && git diff --check`
+
+## Risks
+
+- The fix is intentionally local to `/playground`; other trace consumers are unchanged.
+- If a future UI wants per-chunk animation for `thinking`, it should opt in explicitly instead of reusing the normalized rows.

--- a/docs/superpowers/specs/2026-04-30-playground-reasoning-wrap-fix-design.md
+++ b/docs/superpowers/specs/2026-04-30-playground-reasoning-wrap-fix-design.md
@@ -1,0 +1,120 @@
+# Playground Reasoning Wrap Fix Design
+
+- Date: 2026-04-30
+- Task ID: `UI-PLAYGROUND-REASONING-WRAP`
+- Branch: `fix/chat-reasoning-wrap`
+
+## Goal
+
+Make `/playground` trace `Reasoning` content render as continuous readable text during and after streaming, without changing the underlying stream payloads or removing the existing trace sections.
+
+## Current Behavior
+
+- The local `TracePanel` in `web/app/(workspace)/playground/page.tsx` groups events by stage.
+- Inside each stage, it renders every `thinking` event as a separate paragraph.
+- The chat pipeline streams reasoning in many small `thinking` chunks, often one token or short phrase at a time.
+- As a result, the UI shows one short fragment per line, which looks like a width or wrapping bug even though the real problem is per-chunk block rendering.
+
+## Intended Behavior Change
+
+- Consecutive streamed `thinking` chunks in the same stage should be coalesced into one readable reasoning block before rendering.
+- `progress`, `tool_call`, `tool_result`, and `error` rendering should keep their existing visual treatment unless a small compatibility adjustment is needed.
+- No backend stream contract, event shape, or stage labeling changes.
+
+## Codebase Survey
+
+### Entry points and handlers
+
+- `web/app/(workspace)/playground/page.tsx`
+  - owns the local `TracePanel`
+  - appends stream events into assistant messages in real time
+
+### Primary service or use-case modules
+
+- `web/lib/unified-ws.ts`
+  - defines the frontend `StreamEvent` contract
+
+### Shared contracts, schemas, or types
+
+- `StreamEvent` carries tokenized `thinking` chunks and full tool/progress metadata
+
+### Adjacent or reused flows inspected
+
+- `web/components/chat/home/TracePanels.tsx`
+  - reconstructs trace text by joining event chunks before rendering
+- `web/context/UnifiedChatContext.tsx`
+  - accumulates assistant content progressively but leaves event arrays untouched
+
+### Closest existing tests
+
+- `web/tests/markdown-display.test.ts`
+  - shows the lightweight `node:test` pattern used by frontend utility tests
+
+## Candidate Approaches
+
+### Approach A: Widen the `Reasoning` container with CSS
+
+- Pros:
+  - very small diff
+- Cons:
+  - does not fix the actual problem because every streamed chunk is still a separate block
+  - tool and progress rows are already rendering acceptably
+
+### Approach B: Coalesce streamed `thinking` chunks in the local playground trace renderer
+
+- Pros:
+  - fixes the real root cause in the affected UI surface
+  - preserves existing backend payloads and trace structure
+  - easy to test with a small pure helper
+- Cons:
+  - requires a small utility extraction so the grouping logic is testable
+
+### Approach C: Change backend streaming so reasoning arrives as larger chunks
+
+- Pros:
+  - could improve multiple consumers at once
+- Cons:
+  - broader runtime risk
+  - touches server behavior outside the requested scope
+  - unnecessary because the shared trace UI already handles chunked reasoning correctly
+
+## Chosen Approach
+
+Approach B.
+
+The bug is local to `/playground` and comes from rendering tokenized `thinking` events one-by-one. Coalescing those chunks in the local trace renderer is the smallest correct fix with the lowest runtime risk.
+
+## Planned Changes
+
+- Add a small helper in `web/lib/playground-trace.ts` that converts a stage event list into render rows, merging consecutive `thinking` chunks into one combined text block.
+- Update `web/app/(workspace)/playground/page.tsx` to render the local `TracePanel` from those normalized rows instead of raw event-by-event paragraphs.
+- Add a focused test in `web/tests/playground-trace.test.ts` covering:
+  - multiple streamed `thinking` chunks becoming one readable block
+  - `tool_call` and `tool_result` rows staying distinct
+  - non-thinking rows preserving order around the merged reasoning block
+
+## Expected Impact Surface
+
+### Likely to change
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/lib/playground-trace.ts`
+- `web/tests/playground-trace.test.ts`
+
+### Reviewed but expected to remain unchanged
+
+- `web/components/chat/home/TracePanels.tsx`
+- `web/context/UnifiedChatContext.tsx`
+- `web/lib/unified-ws.ts`
+
+## Tests To Run
+
+- `cd web && node --test tests/playground-trace.test.ts`
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "lib/playground-trace.ts" "tests/playground-trace.test.ts"`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-chat-reasoning-wrap && git diff --check`
+
+## Non-Goals
+
+- No backend streaming changes
+- No redesign of the shared chat trace components
+- No changes to capability logic, tool execution, or message persistence

--- a/docs/superpowers/tasks/2026-04-30-playground-reasoning-wrap-fix.md
+++ b/docs/superpowers/tasks/2026-04-30-playground-reasoning-wrap-fix.md
@@ -1,0 +1,57 @@
+# Task Packet: Playground Reasoning Wrap Fix
+
+- Task ID: `UI-PLAYGROUND-REASONING-WRAP`
+- Date: 2026-04-30
+- Branch: `fix/chat-reasoning-wrap`
+- Status: Spec written
+
+## Objective
+
+Fix `/playground` trace rendering so streamed `Reasoning` text displays as normal sentences instead of one word or token per line, while keeping `Acting`, `Tool call`, and the rest of the trace surface intact.
+
+## User-Approved Scope
+
+- Use a separate worktree for this lane.
+- Fix the chat UI issue where `Reasoning` content wraps into many short lines because each streamed chunk is rendered separately.
+- Keep the existing trace sections and overall playground UI behavior.
+
+## Owned Files
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/lib/playground-trace.ts`
+- `web/tests/playground-trace.test.ts`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-playground-reasoning-wrap-fix.md`
+- `docs/superpowers/specs/2026-04-30-playground-reasoning-wrap-fix-design.md`
+- `docs/superpowers/pr-notes/2026-04-30-playground-reasoning-wrap-fix.md`
+
+## Do-Not-Touch
+
+- Backend streaming protocol and capability implementations
+- Shared trace panel UX outside `/playground`
+- Existing active lanes in other worktrees
+- Untracked files from the repo-root checkout
+
+## Design Before Implementation
+
+Reference spec:
+
+- `docs/superpowers/specs/2026-04-30-playground-reasoning-wrap-fix-design.md`
+
+## Codebase Survey Summary
+
+- `/playground` still owns a local `TracePanel` implementation inside `web/app/(workspace)/playground/page.tsx`.
+- That local panel renders each `thinking` event as its own paragraph, which is incompatible with token-streamed reasoning chunks.
+- The shared chat trace renderer in `web/components/chat/home/TracePanels.tsx` already reconstructs trace text by joining chunks before markdown rendering, so the bug is bounded to the local playground trace surface.
+
+## Validation Plan
+
+- `cd web && node --test tests/playground-trace.test.ts`
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "lib/playground-trace.ts" "tests/playground-trace.test.ts"`
+- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-chat-reasoning-wrap && git diff --check`
+
+## Handoff Notes
+
+- Prefer a local UI-layer fix over backend stream changes unless new evidence disproves the root cause.
+- Preserve the existing stage grouping and tool/result cards in the playground trace.

--- a/web/app/(workspace)/playground/page.tsx
+++ b/web/app/(workspace)/playground/page.tsx
@@ -39,6 +39,7 @@ import ResearchConfigPanel from "@/components/research/ResearchConfigPanel";
 import { extractBase64FromDataUrl, readFileAsDataUrl } from "@/lib/file-attachments";
 import { listKnowledgeBases } from "@/lib/knowledge-api";
 import type { StreamEvent } from "@/lib/unified-ws";
+import { buildPlaygroundTraceRows } from "@/lib/playground-trace";
 import {
   filterFrontendTools,
   FRONTEND_HIDDEN_TOOLS,
@@ -260,7 +261,8 @@ function TracePanel({ events }: { events: StreamEvent[] }) {
         const renderable = stageEvents.filter((e) =>
           ["thinking", "progress", "tool_call", "tool_result", "error"].includes(e.type),
         );
-        if (!renderable.length) return null;
+        const rows = buildPlaygroundTraceRows(renderable);
+        if (!rows.length) return null;
         return (
           <details key={stage} className="group rounded-2xl">
             <summary className="flex cursor-pointer list-none items-center gap-2 py-1 text-[12px] font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] [&::-webkit-details-marker]:hidden">
@@ -274,24 +276,24 @@ function TracePanel({ events }: { events: StreamEvent[] }) {
               </span>
             </summary>
             <div className="ml-3 space-y-1.5 border-l border-[var(--border)]/35 pl-4">
-              {renderable.map((ev, i) => {
-                if (ev.type === "thinking") return <p key={`${stage}-t-${i}`} className="text-[12px] italic leading-relaxed text-[var(--muted-foreground)]/88">{ev.content}</p>;
-                if (ev.type === "progress") {
-                  const cur = Number(ev.metadata?.current ?? 0), tot = Number(ev.metadata?.total ?? 0);
+              {rows.map((row, i) => {
+                if (row.type === "thinking") return <p key={`${stage}-t-${i}`} className="text-[12px] italic leading-relaxed text-[var(--muted-foreground)]/88">{row.content}</p>;
+                if (row.type === "progress") {
+                  const cur = Number(row.event.metadata?.current ?? 0), tot = Number(row.event.metadata?.total ?? 0);
                   return (
                     <div key={`${stage}-p-${i}`} className="rounded-2xl bg-[var(--muted)]/38 px-3 py-2 text-[12px] text-[var(--muted-foreground)]">
-                      <div>{ev.content}</div>
+                      <div>{row.content}</div>
                       {tot > 0 && <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-[var(--border)]"><div className="h-full rounded-full bg-[var(--primary)] transition-all duration-300" style={{ width: `${Math.min(100, (cur / tot) * 100)}%` }} /></div>}
                     </div>
                   );
                 }
-                if (ev.type === "tool_call" || ev.type === "tool_result") return (
+                if (row.type === "tool_call" || row.type === "tool_result") return (
                   <div key={`${stage}-tc-${i}`} className="rounded-2xl border border-[var(--border)]/40 bg-[var(--background)]/66 px-3 py-2">
-                    <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--muted-foreground)]/82">{ev.type === "tool_call" ? t("Tool call") : t("Tool result")}</div>
-                    <div className="mt-1 text-[12px] leading-5 text-[var(--foreground)]/88">{ev.content || String(ev.metadata?.tool ?? "")}</div>
+                    <div className="text-[10px] uppercase tracking-[0.14em] text-[var(--muted-foreground)]/82">{row.type === "tool_call" ? t("Tool call") : t("Tool result")}</div>
+                    <div className="mt-1 text-[12px] leading-5 text-[var(--foreground)]/88">{row.content || String(row.event.metadata?.tool ?? "")}</div>
                   </div>
                 );
-                if (ev.type === "error") return <div key={`${stage}-e-${i}`} className="rounded-2xl border border-red-200/60 bg-red-50/72 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">{ev.content}</div>;
+                if (row.type === "error") return <div key={`${stage}-e-${i}`} className="rounded-2xl border border-red-200/60 bg-red-50/72 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">{row.content}</div>;
                 return null;
               })}
             </div>

--- a/web/lib/playground-trace.ts
+++ b/web/lib/playground-trace.ts
@@ -1,0 +1,48 @@
+import type { StreamEvent } from "./unified-ws";
+
+export type PlaygroundTraceRow =
+  | {
+      type: "thinking";
+      content: string;
+    }
+  | {
+      type: "progress" | "tool_call" | "tool_result" | "error";
+      content: string;
+      event: StreamEvent;
+    };
+
+export function buildPlaygroundTraceRows(events: StreamEvent[]): PlaygroundTraceRow[] {
+  const rows: PlaygroundTraceRow[] = [];
+  let thinkingBuffer = "";
+
+  function flushThinking() {
+    if (!thinkingBuffer) return;
+    rows.push({ type: "thinking", content: thinkingBuffer });
+    thinkingBuffer = "";
+  }
+
+  for (const event of events) {
+    if (event.type === "thinking") {
+      thinkingBuffer += event.content;
+      continue;
+    }
+
+    flushThinking();
+
+    if (
+      event.type === "progress" ||
+      event.type === "tool_call" ||
+      event.type === "tool_result" ||
+      event.type === "error"
+    ) {
+      rows.push({
+        type: event.type,
+        content: event.content,
+        event,
+      });
+    }
+  }
+
+  flushThinking();
+  return rows;
+}

--- a/web/tests/playground-trace.test.ts
+++ b/web/tests/playground-trace.test.ts
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildPlaygroundTraceRows } from "../lib/playground-trace.ts";
+import type { StreamEvent } from "../lib/unified-ws.ts";
+
+function event(type: StreamEvent["type"], content: string): StreamEvent {
+  return {
+    type,
+    source: "chat",
+    stage: "thinking",
+    content,
+    metadata: {},
+    timestamp: 0,
+  };
+}
+
+test("buildPlaygroundTraceRows merges consecutive thinking chunks into one readable row", () => {
+  const rows = buildPlaygroundTraceRows([
+    event("thinking", "Hello"),
+    event("thinking", " "),
+    event("thinking", "world"),
+    event("thinking", "!"),
+  ]);
+
+  assert.deepEqual(rows, [
+    {
+      type: "thinking",
+      content: "Hello world!",
+    },
+  ]);
+});
+
+test("buildPlaygroundTraceRows preserves tool rows around merged thinking text", () => {
+  const rows = buildPlaygroundTraceRows([
+    event("thinking", "Need"),
+    event("thinking", " tools"),
+    event("tool_call", "web_search"),
+    event("tool_result", "Found result"),
+    event("thinking", "Done"),
+  ]);
+
+  assert.deepEqual(rows, [
+    { type: "thinking", content: "Need tools" },
+    { type: "tool_call", content: "web_search", event: event("tool_call", "web_search") },
+    { type: "tool_result", content: "Found result", event: event("tool_result", "Found result") },
+    { type: "thinking", content: "Done" },
+  ]);
+});


### PR DESCRIPTION
## Summary
- fix `/playground` trace rendering so streamed `Reasoning` text is shown as one readable block instead of one token or short phrase per line
- add a small local trace-normalization helper for the playground-only trace surface
- add regression coverage for merged thinking chunks while preserving tool/progress rows

## Root Cause
The local `TracePanel` in `/playground` rendered each streamed `thinking` event as its own paragraph. Because the backend emits reasoning as many small chunks, the UI appeared to wrap every word onto a new line even though the real problem was per-chunk block rendering.

## Validation
- `cd web && node --test tests/playground-trace.test.ts`
- `cd web && ./node_modules/.bin/eslint "app/(workspace)/playground/page.tsx" "lib/playground-trace.ts" "tests/playground-trace.test.ts"`
- `cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-chat-reasoning-wrap && git diff --check`

## Notes
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this change is a bounded presentation fix with no architecture or workflow change.
- PR note: `docs/superpowers/pr-notes/2026-04-30-playground-reasoning-wrap-fix.md`
