### PR TITLE
Add tutor pack binding to playground chat

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -35,12 +35,12 @@ Rules:
 - Owner: Codex session
 - Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
-- Task: Hide the right-panel mode and tool switcher on `/playground` while keeping the underlying capability logic intact
+- Task: Add `Gói gia sư` selection and session binding for `/playground` chat using imported marketplace packs
 - Status: writing spec
-- Branch: `fix/playground-hide-mode-switcher`
-- Task packet: `docs/superpowers/tasks/2026-04-30-playground-hide-mode-switcher.md`
-- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/components/chat/home/PlaygroundRightPanel.tsx`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-hide-mode-switcher.md`, `docs/superpowers/specs/2026-04-30-playground-hide-mode-switcher-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-hide-mode-switcher.md`
+- Branch: `fix/playground-tutor-pack-chat`
+- Task packet: `docs/superpowers/tasks/2026-04-30-playground-tutor-pack-chat.md`
+- Owned files: `web/app/(workspace)/playground/page.tsx`, `web/context/UnifiedChatContext.tsx`, `web/components/sidebar/WorkspaceSidebar.tsx`, `web/lib/session-api.ts`, `web/lib/marketplace-api.ts`, `deeptutor/api/routers/sessions.py`, `deeptutor/services/session/turn_runtime.py`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-playground-tutor-pack-chat.md`, `docs/superpowers/specs/2026-04-30-playground-tutor-pack-chat-design.md`, `docs/superpowers/pr-notes/2026-04-30-playground-tutor-pack-chat.md`
 - PR: uncreated
 - Last update: 2026-04-30
-- Next action: write the bounded spec for removing the visible mode/tool chooser from the right panel before implementation
+- Next action: write the bounded spec for binding each chat session to one imported `Gói gia sư`
 - Blocker: none

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -1,6 +1,6 @@
 # Main System Map
 
-Last updated: 2026-04-28
+Last updated: 2026-04-30
 
 This is the required top-level Mermaid map for the project. Any PR that adds, removes, or materially changes product features, capabilities, tools, routers, routes, data models, or AI-first workflow must update this map.
 
@@ -95,6 +95,10 @@ flowchart TD
   StudentTutor --> TutorKBContext["Knowledge Pack Tutoring Context"]
   StudentTutor --> TutorKBBadges["KB Context Badges in Chat Messages"]
   StudentTutor --> TutorFollowups["Optional follow-up questions in tutor replies"]
+  StudentTutor --> TutorPackBinding["Tutor Pack binding for /playground chat sessions"]
+  TutorPackBinding --> TutorPackUI["UI term: Gói gia sư"]
+  TutorPackBinding --> TutorPackSessionPrefs["Session preferences: tutor_pack + knowledge_bases[0]"]
+  TutorPackBinding --> TutorPackHistory["Session history restore + sidebar badge + unavailable-send gate"]
   TutorKBBadges --> SnapshotKBs["Message requestSnapshot.knowledgeBases"]
   TutorFollowups --> ChatResponse["Agentic chat final response section: Follow-up questions"]
   

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -329,3 +329,13 @@
 - Done: Removed the visible `Chuyển chế độ` chooser from the `/playground` right panel for both capability and tool contexts.
 - Done: Kept the underlying capability and tool state logic intact so the chooser can be restored later without rebuilding runtime behavior.
 - Tests: `cd web && npx eslint "app/(workspace)/playground/page.tsx" "components/chat/home/PlaygroundRightPanel.tsx"`; `cd web && npm run build`; `git diff --check`
+
+## UI-PLAYGROUND-TUTOR-PACK-CHAT
+
+- Branch: `fix/playground-tutor-pack-chat`
+- Task: `UI-PLAYGROUND-TUTOR-PACK-CHAT`
+- Done: Added a first-class `Gói gia sư` session binding on `/playground` chat by persisting `tutor_pack` alongside `knowledge_bases` in session preferences.
+- Done: Auto-binds the only imported tutor pack for new draft chats, requires explicit choice when multiple packs are available, and restores the binding from history.
+- Done: Blocks new sends when the bound tutor pack is no longer available while still allowing the user to read old messages.
+- Done: Shows the bound tutor pack in chat context and as a compact badge in session history.
+- Tests: `cd web && ./node_modules/.bin/eslint "app/(workspace)/playground/page.tsx" context/UnifiedChatContext.tsx components/SessionList.tsx lib/session-api.ts`; `cd web && npm run build`; `python3 -m py_compile deeptutor/api/routers/sessions.py deeptutor/services/session/turn_runtime.py`; `git diff --check`

--- a/deeptutor/api/routers/sessions.py
+++ b/deeptutor/api/routers/sessions.py
@@ -74,6 +74,25 @@ def _session_knowledge_bases(session: dict[str, Any]) -> list[str]:
     return [str(item).strip() for item in raw if str(item).strip()]
 
 
+def _session_tutor_pack(session: dict[str, Any]) -> dict[str, Any] | None:
+    preferences = session.get("preferences")
+    if not isinstance(preferences, dict):
+        return None
+    raw = preferences.get("tutor_pack")
+    if not isinstance(raw, dict):
+        return None
+    name = str(raw.get("name") or "").strip()
+    knowledge_base = str(raw.get("knowledge_base") or "").strip()
+    if not name or not knowledge_base:
+        return None
+    status = str(raw.get("status") or "available").strip() or "available"
+    return {
+        "name": name,
+        "knowledge_base": knowledge_base,
+        "status": "missing" if status == "missing" else "available",
+    }
+
+
 def _latest_message_content(session: dict[str, Any], role: str) -> str | None:
     for message in reversed(session.get("messages", [])):
         if str(message.get("role") or "") != role:
@@ -183,8 +202,13 @@ async def get_session(session_id: str):
     session = await store.get_session_with_messages(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
+    preferences = dict(session.get("preferences") or {})
+    tutor_pack = _session_tutor_pack(session)
+    if tutor_pack is not None:
+        preferences["tutor_pack"] = tutor_pack
     return {
         **session,
+        "preferences": preferences,
         "context_support": _build_context_support(session),
     }
 

--- a/deeptutor/services/session/turn_runtime.py
+++ b/deeptutor/services/session/turn_runtime.py
@@ -261,6 +261,7 @@ class TurnRuntimeManager:
 
     async def start_turn(self, payload: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
         capability = str(payload.get("capability") or "chat")
+        tutor_pack = payload.get("tutor_pack")
         raw_config = dict(payload.get("config", {}) or {})
         runtime_only_keys = ("_persist_user_message", "followup_question_context")
         runtime_only_config = {
@@ -280,6 +281,18 @@ class TurnRuntimeManager:
             "config": {**validated_public_config, **runtime_only_config},
         }
         session = await self.store.ensure_session(payload.get("session_id"))
+        normalized_tutor_pack = None
+        if isinstance(tutor_pack, dict):
+            name = str(tutor_pack.get("name") or "").strip()
+            knowledge_base = str(tutor_pack.get("knowledge_base") or "").strip()
+            if name and knowledge_base:
+                normalized_tutor_pack = {
+                    "name": name,
+                    "knowledge_base": knowledge_base,
+                    "status": "missing"
+                    if str(tutor_pack.get("status") or "").strip() == "missing"
+                    else "available",
+                }
         await self.store.update_session_preferences(
             session["id"],
             {
@@ -287,6 +300,7 @@ class TurnRuntimeManager:
                 "tools": list(payload.get("tools") or []),
                 "knowledge_bases": list(payload.get("knowledge_bases") or []),
                 "language": str(payload.get("language") or "en"),
+                **({"tutor_pack": normalized_tutor_pack} if normalized_tutor_pack else {}),
             },
         )
         await _ensure_agent_spec_pin(

--- a/docs/superpowers/plans/2026-04-30-playground-tutor-pack-chat.md
+++ b/docs/superpowers/plans/2026-04-30-playground-tutor-pack-chat.md
@@ -1,0 +1,638 @@
+# Playground Tutor Pack Chat Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind each `/playground` chat session to exactly one imported `Gói gia sư`, restore that binding from history, and block new sends when the bound pack becomes unavailable.
+
+**Architecture:** Extend session preferences with a thin `tutor_pack` object while keeping runtime requests mapped to `knowledge_bases: [knowledge_base]`. The frontend will treat `Gói gia sư` as the product-level concept for session creation, restoration, composer gating, and sidebar badging, while the backend persists additive preference metadata through the existing session store.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, FastAPI, Python session runtime, SQLite-backed session preferences.
+
+---
+
+### Task 1: Extend session contracts to carry `tutor_pack`
+
+**Files:**
+- Modify: `web/lib/session-api.ts`
+- Modify: `deeptutor/api/routers/sessions.py`
+- Modify: `deeptutor/services/session/turn_runtime.py`
+- Reference only: `deeptutor/services/session/sqlite_store.py`
+- Test: session contract smoke via frontend build and backend import sanity
+
+- [ ] **Step 1: Add FE types for tutor-pack preferences**
+
+Update `web/lib/session-api.ts` so `SessionSummary.preferences` and `SessionDetail.preferences` can carry a tutor-pack object:
+
+```ts
+export interface SessionTutorPackPreference {
+  name: string;
+  knowledge_base: string;
+  status?: "available" | "missing";
+}
+
+export interface SessionPreferences {
+  capability?: string;
+  tools?: string[];
+  knowledge_bases?: string[];
+  language?: string;
+  tutor_pack?: SessionTutorPackPreference;
+}
+```
+
+Then reuse `SessionPreferences` in both `SessionSummary` and `SessionDetail`.
+
+- [ ] **Step 2: Add backend serializer helper for tutor-pack preferences**
+
+In `deeptutor/api/routers/sessions.py`, add a small helper that normalizes a tutor-pack object out of `session["preferences"]`:
+
+```python
+def _session_tutor_pack(session: dict[str, Any]) -> dict[str, Any] | None:
+    preferences = session.get("preferences")
+    if not isinstance(preferences, dict):
+        return None
+    raw = preferences.get("tutor_pack")
+    if not isinstance(raw, dict):
+        return None
+    name = str(raw.get("name") or "").strip()
+    knowledge_base = str(raw.get("knowledge_base") or "").strip()
+    if not name or not knowledge_base:
+        return None
+    status = str(raw.get("status") or "available").strip() or "available"
+    return {
+        "name": name,
+        "knowledge_base": knowledge_base,
+        "status": "missing" if status == "missing" else "available",
+    }
+```
+
+- [ ] **Step 3: Surface tutor-pack preferences in session responses**
+
+Still in `deeptutor/api/routers/sessions.py`, ensure both session detail and context-support helpers can return the normalized `tutor_pack` inside `preferences` without altering the rest of the session payload:
+
+```python
+@router.get("/{session_id}")
+async def get_session(session_id: str):
+    store = get_sqlite_session_store()
+    session = await store.get_session_with_messages(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    tutor_pack = _session_tutor_pack(session)
+    preferences = dict(session.get("preferences") or {})
+    if tutor_pack is not None:
+        preferences["tutor_pack"] = tutor_pack
+    return {
+        **session,
+        "preferences": preferences,
+        "context_support": _build_context_support(session),
+    }
+```
+
+Keep `list_sessions()` passthrough behavior intact because the store already returns `preferences`.
+
+- [ ] **Step 4: Persist tutor-pack metadata when a turn starts**
+
+In `deeptutor/services/session/turn_runtime.py`, extend the `update_session_preferences()` call in `start_turn()` to persist tutor-pack metadata coming from the client config:
+
+```python
+tutor_pack = payload.get("tutor_pack")
+normalized_tutor_pack = None
+if isinstance(tutor_pack, dict):
+    name = str(tutor_pack.get("name") or "").strip()
+    knowledge_base = str(tutor_pack.get("knowledge_base") or "").strip()
+    if name and knowledge_base:
+        normalized_tutor_pack = {
+            "name": name,
+            "knowledge_base": knowledge_base,
+            "status": "missing" if str(tutor_pack.get("status") or "") == "missing" else "available",
+        }
+
+await self.store.update_session_preferences(
+    session["id"],
+    {
+        "capability": capability,
+        "tools": list(payload.get("tools") or []),
+        "knowledge_bases": list(payload.get("knowledge_bases") or []),
+        "language": str(payload.get("language") or "en"),
+        **({"tutor_pack": normalized_tutor_pack} if normalized_tutor_pack else {}),
+    },
+)
+```
+
+- [ ] **Step 5: Run contract sanity checks**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "lib/session-api.ts"
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npm run build
+```
+
+Expected:
+
+```text
+ESLint reports 0 problems for lib/session-api.ts
+Next.js build completes successfully
+```
+
+- [ ] **Step 6: Commit contract updates**
+
+```bash
+git add web/lib/session-api.ts deeptutor/api/routers/sessions.py deeptutor/services/session/turn_runtime.py
+git commit -m "feat(chat): persist tutor pack session binding [UI-PLAYGROUND-TUTOR-PACK-CHAT]"
+```
+
+### Task 2: Teach `UnifiedChatContext` to store and restore tutor-pack state
+
+**Files:**
+- Modify: `web/context/UnifiedChatContext.tsx`
+- Modify: `web/lib/session-api.ts`
+- Test: focused lint and build
+
+- [ ] **Step 1: Extend chat-state types with tutor-pack session state**
+
+In `web/context/UnifiedChatContext.tsx`, add explicit tutor-pack types and state:
+
+```ts
+export interface TutorPackBinding {
+  name: string;
+  knowledgeBase: string;
+  status: "available" | "missing";
+}
+
+export interface ChatState {
+  sessionId: string | null;
+  enabledTools: string[];
+  activeCapability: string | null;
+  knowledgeBases: string[];
+  tutorPack: TutorPackBinding | null;
+  messages: MessageItem[];
+  isStreaming: boolean;
+  currentStage: string;
+  language: string;
+}
+```
+
+Also add `tutorPack` to `createSessionEntry()`.
+
+- [ ] **Step 2: Add reducer actions for tutor-pack state**
+
+Add actions for setting and loading tutor-pack data:
+
+```ts
+type Action =
+  | { type: "SET_TUTOR_PACK"; tutorPack: TutorPackBinding | null }
+  | {
+      type: "LOAD_SESSION";
+      key: string;
+      sessionId: string;
+      messages: MessageItem[];
+      tutorPack?: TutorPackBinding | null;
+      ...
+    };
+```
+
+Reducer handling should mirror the existing `SET_KB` and `LOAD_SESSION` behavior:
+
+```ts
+case "SET_TUTOR_PACK":
+  return updateSelectedSession(state, (session) => ({
+    ...session,
+    tutorPack: action.tutorPack,
+    knowledgeBases: action.tutorPack ? [action.tutorPack.knowledgeBase] : session.knowledgeBases,
+  }));
+```
+
+- [ ] **Step 3: Expose `setTutorPack` on the context API**
+
+Extend `ChatContextValue` and the provider return value:
+
+```ts
+interface ChatContextValue {
+  state: ChatState;
+  setTutorPack: (tutorPack: TutorPackBinding | null) => void;
+  ...
+}
+```
+
+Implementation:
+
+```ts
+const setTutorPack = useCallback((tutorPack: TutorPackBinding | null) => {
+  dispatch({ type: "SET_TUTOR_PACK", tutorPack });
+}, []);
+```
+
+- [ ] **Step 4: Hydrate tutor-pack state from session detail**
+
+In `loadSession()`, normalize `session.preferences?.tutor_pack` into the frontend type:
+
+```ts
+const tutorPack = session.preferences?.tutor_pack
+  ? {
+      name: session.preferences.tutor_pack.name,
+      knowledgeBase: session.preferences.tutor_pack.knowledge_base,
+      status: session.preferences.tutor_pack.status === "missing" ? "missing" : "available",
+    }
+  : null;
+
+dispatch({
+  type: "LOAD_SESSION",
+  key: sessionId,
+  sessionId,
+  messages: hydrateMessages(session.messages),
+  capability: session.preferences?.capability ?? null,
+  tools: session.preferences?.tools ?? [],
+  knowledgeBases: Array.isArray(session.preferences?.knowledge_bases)
+    ? session.preferences!.knowledge_bases!
+    : tutorPack
+      ? [tutorPack.knowledgeBase]
+      : [],
+  tutorPack,
+  language: session.preferences?.language ?? readStoredLanguage(),
+  status: session.status ?? "idle",
+  activeTurnId: session.active_turn_id ?? null,
+});
+```
+
+- [ ] **Step 5: Include tutor-pack metadata in outgoing turn payloads**
+
+In `sendMessage()`, include the bound tutor pack when building the request payload for `UnifiedWSClient`:
+
+```ts
+const tutorPackPayload = session.tutorPack
+  ? {
+      name: session.tutorPack.name,
+      knowledge_base: session.tutorPack.knowledgeBase,
+      status: session.tutorPack.status,
+    }
+  : undefined;
+
+client.send({
+  type: "message",
+  ...
+  knowledge_bases: shouldSendKnowledgeBases ? [...effectiveKnowledgeBases] : [],
+  ...(tutorPackPayload ? { tutor_pack: tutorPackPayload } : {}),
+});
+```
+
+Keep `knowledge_bases` as the runtime seam for actual retrieval.
+
+- [ ] **Step 6: Run focused validation**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "context/UnifiedChatContext.tsx"
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npm run build
+```
+
+Expected:
+
+```text
+ESLint reports 0 problems for UnifiedChatContext.tsx
+Next.js build completes successfully
+```
+
+- [ ] **Step 7: Commit context hydration changes**
+
+```bash
+git add web/context/UnifiedChatContext.tsx
+git commit -m "feat(chat): hydrate tutor pack state in unified context [UI-PLAYGROUND-TUTOR-PACK-CHAT]"
+```
+
+### Task 3: Add tutor-pack selection and unavailable-state gating to `/playground`
+
+**Files:**
+- Modify: `web/app/(workspace)/playground/page.tsx`
+- Modify: `web/lib/marketplace-api.ts`
+- Reference only: `web/app/(utility)/knowledge/page.tsx`
+- Test: focused lint and build
+
+- [ ] **Step 1: Add a tutor-pack listing adapter on the frontend**
+
+In `web/lib/marketplace-api.ts`, add a lightweight imported-pack shape and loader that reuses current APIs:
+
+```ts
+export interface ImportedTutorPack {
+  name: string;
+  knowledgeBase: string;
+  subject?: string | null;
+  grade?: string | null;
+  owner?: string | null;
+  language?: string | null;
+}
+```
+
+If there is no dedicated imported-pack endpoint yet, plan to derive these from `listKnowledgeBases()` inside `/playground` instead of over-designing a new API helper. Keep this file unchanged if that path proves cleaner during implementation.
+
+- [ ] **Step 2: Add tutor-pack selection state to the chat-mode shell**
+
+In `web/app/(workspace)/playground/page.tsx`, read tutor-pack state from the chat context:
+
+```ts
+const {
+  state: { messages, isStreaming, currentStage, enabledTools, knowledgeBases: selectedKbs, tutorPack },
+  sendMessage,
+  cancelStreamingTurn,
+  setTools,
+  setKBs,
+  setCapability,
+  setTutorPack,
+  selectedSessionId,
+} = useUnifiedChat();
+```
+
+Also derive:
+
+```ts
+const [availableTutorPacks, setAvailableTutorPacks] = useState<ImportedTutorPack[]>([]);
+const [pendingTutorPackName, setPendingTutorPackName] = useState("");
+const selectedTutorPack = tutorPack;
+const missingTutorPack = tutorPack?.status === "missing";
+const requiresTutorPackSelection = !selectedSessionId && availableTutorPacks.length > 1 && !selectedTutorPack;
+```
+
+- [ ] **Step 3: Populate tutor-pack candidates from imported knowledge bases**
+
+Use `listKnowledgeBases()` to compute imported tutor-pack candidates from ready/imported knowledge bases:
+
+```ts
+useEffect(() => {
+  let cancelled = false;
+  void (async () => {
+    const items = await listKnowledgeBases();
+    if (cancelled) return;
+    const packs = items
+      .filter((kb) => kb.status === "ready")
+      .map((kb) => ({
+        name: kb.metadata?.display_name || kb.name,
+        knowledgeBase: kb.name,
+        subject: kb.metadata?.subject ?? null,
+        grade: kb.metadata?.grade ?? null,
+        owner: kb.metadata?.owner ?? null,
+        language: kb.metadata?.language ?? null,
+      }));
+    setAvailableTutorPacks(packs);
+  })();
+  return () => {
+    cancelled = true;
+  };
+}, []);
+```
+
+If `availableTutorPacks.length === 1` and there is no active tutor-pack binding yet for a draft session, auto-call:
+
+```ts
+setTutorPack({
+  name: packs[0].name,
+  knowledgeBase: packs[0].knowledgeBase,
+  status: "available",
+});
+setKBs([packs[0].knowledgeBase]);
+```
+
+- [ ] **Step 4: Gate composer sends on tutor-pack selection and availability**
+
+Wrap the chat send handler so it refuses to send when there is no selected pack or the pack is missing:
+
+```ts
+const canSendInChat =
+  !!selectedTutorPack &&
+  selectedTutorPack.status === "available" &&
+  (!availableTutorPacks.length || availableTutorPacks.some((pack) => pack.knowledgeBase === selectedTutorPack.knowledgeBase));
+
+const handleChatSubmit = (content: string) => {
+  if (!selectedTutorPack || selectedTutorPack.status !== "available") {
+    return;
+  }
+  sendMessage(content, undefined, undefined, undefined, undefined);
+};
+```
+
+Update the composer props so the disabled state and helper text reflect:
+- “Chọn Gói gia sư trước khi bắt đầu”
+- “Gói gia sư này không còn khả dụng”
+
+- [ ] **Step 5: Render the tutor-pack picker for new chat sessions**
+
+In the chat-specific right panel or top-of-chat context, add a small selection card only for draft/new chat:
+
+```tsx
+{!selectedSessionId && availableTutorPacks.length > 1 ? (
+  <section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
+    <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+      {t("Gói gia sư")}
+    </h3>
+    <select
+      value={pendingTutorPackName}
+      onChange={(event) => {
+        const pack = availableTutorPacks.find((item) => item.knowledgeBase === event.target.value);
+        setPendingTutorPackName(event.target.value);
+        if (pack) {
+          setTutorPack({ name: pack.name, knowledgeBase: pack.knowledgeBase, status: "available" });
+          setKBs([pack.knowledgeBase]);
+        }
+      }}
+      className="mt-3 w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm"
+    >
+      <option value="">{t("Chọn gói gia sư")}</option>
+      {availableTutorPacks.map((pack) => (
+        <option key={pack.knowledgeBase} value={pack.knowledgeBase}>
+          {pack.name}
+        </option>
+      ))}
+    </select>
+  </section>
+) : null}
+```
+
+- [ ] **Step 6: Render the bound pack and missing-state warning in chat UI**
+
+Add a compact tutor-pack card in the chat context surface:
+
+```tsx
+<section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
+  <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+    {t("Gói gia sư")}
+  </h3>
+  {selectedTutorPack ? (
+    <>
+      <p className="mt-2 text-sm font-medium text-[var(--foreground)]">{selectedTutorPack.name}</p>
+      {selectedTutorPack.status === "missing" ? (
+        <p className="mt-2 text-[12px] leading-5 text-amber-700">
+          {t("Gói gia sư này không còn khả dụng. Bạn vẫn có thể xem lịch sử nhưng chưa thể gửi thêm tin nhắn.")}
+        </p>
+      ) : null}
+    </>
+  ) : (
+    <p className="mt-2 text-[12px] leading-5 text-[var(--muted-foreground)]">
+      {t("Chọn một gói gia sư để bắt đầu cuộc trò chuyện này.")}
+    </p>
+  )}
+</section>
+```
+
+- [ ] **Step 7: Validate the `/playground` UI slice**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "app/(workspace)/playground/page.tsx" "lib/marketplace-api.ts"
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npm run build
+```
+
+Expected:
+
+```text
+ESLint reports 0 problems for the touched files
+Next.js build completes successfully
+```
+
+- [ ] **Step 8: Commit chat-surface changes**
+
+```bash
+git add web/app/'(workspace)'/playground/page.tsx web/lib/marketplace-api.ts
+git commit -m "feat(playground): lock chat sessions to tutor packs [UI-PLAYGROUND-TUTOR-PACK-CHAT]"
+```
+
+### Task 4: Show tutor-pack badges in session history
+
+**Files:**
+- Modify: `web/components/sidebar/WorkspaceSidebar.tsx`
+- Modify: `web/lib/session-api.ts`
+- Test: focused lint and build
+
+- [ ] **Step 1: Extend sidebar session row rendering with a tutor-pack badge**
+
+Locate the session-item render path in `web/components/sidebar/WorkspaceSidebar.tsx` and add a compact second-line badge when `session.preferences?.tutor_pack` exists:
+
+```tsx
+{session.preferences?.tutor_pack ? (
+  <div className="mt-1 flex items-center gap-2">
+    <span className="inline-flex max-w-full items-center truncate rounded-full bg-[var(--muted)] px-2 py-0.5 text-[10px] font-medium text-[var(--muted-foreground)]">
+      {session.preferences.tutor_pack.name}
+    </span>
+    {session.preferences.tutor_pack.status === "missing" ? (
+      <span className="text-[10px] text-amber-700">{t("Không khả dụng")}</span>
+    ) : null}
+  </div>
+) : null}
+```
+
+- [ ] **Step 2: Keep the session row compact**
+
+Adjust any existing `line-clamp`, gap, or title spacing so the session list still reads cleanly with the added badge:
+
+```tsx
+<div className="min-w-0">
+  <p className="truncate text-sm font-medium text-[var(--foreground)]">{session.title}</p>
+  {/* tutor pack badge */}
+</div>
+```
+
+Do not redesign the whole sidebar in this lane.
+
+- [ ] **Step 3: Verify sidebar rendering stays clean**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "components/sidebar/WorkspaceSidebar.tsx"
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npm run build
+```
+
+Expected:
+
+```text
+ESLint reports 0 problems for WorkspaceSidebar.tsx
+Next.js build completes successfully
+```
+
+- [ ] **Step 4: Commit sidebar badge changes**
+
+```bash
+git add web/components/sidebar/WorkspaceSidebar.tsx
+git commit -m "feat(sidebar): show tutor pack badges on chat history [UI-PLAYGROUND-TUTOR-PACK-CHAT]"
+```
+
+### Task 5: Document, verify, and prepare PR handoff
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-playground-tutor-pack-chat.md`
+- Test: final lint/build/diff checks
+
+- [ ] **Step 1: Run final validation**
+
+Run:
+
+```bash
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npx eslint "app/(workspace)/playground/page.tsx" "context/UnifiedChatContext.tsx" "components/sidebar/WorkspaceSidebar.tsx" "lib/session-api.ts"
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform/web && npm run build
+cd /Users/nguyenhuuloc/Documents/Multiagent-learning-platform && git diff --check
+```
+
+Expected:
+
+```text
+ESLint reports 0 problems
+Next.js build completes successfully
+git diff --check returns no output
+```
+
+- [ ] **Step 2: Record the lane in the daily log**
+
+Append to `ai_first/daily/2026-04-30.md`:
+
+```md
+## UI-PLAYGROUND-TUTOR-PACK-CHAT
+
+- Added `Gói gia sư` binding for `/playground` chat sessions.
+- Locked each session to one imported tutor pack from creation through history restore.
+- Blocked new sends when the bound tutor pack is no longer available while preserving readable history.
+```
+
+- [ ] **Step 3: Write the PR architecture note**
+
+Create `docs/superpowers/pr-notes/2026-04-30-playground-tutor-pack-chat.md`:
+
+```md
+# PR Note: Playground Tutor Pack Chat
+
+## Summary
+
+This lane adds a product-level `Gói gia sư` concept to `/playground` chat sessions by storing a thin tutor-pack binding in session preferences while preserving the existing `knowledge_bases` runtime contract.
+
+```mermaid
+flowchart TD
+  P["Imported tutor pack"] --> K["knowledge_bases[0] runtime seam"]
+  P --> S["session.preferences.tutor_pack"]
+  S --> H["history restore + sidebar badge"]
+  K --> C["chat turn execution"]
+```
+
+## MAIN_SYSTEM_MAP
+
+Update `ai_first/architecture/MAIN_SYSTEM_MAP.md` only if the final implementation introduces a new durable product concept that should be reflected in the architecture map. If the implementation stays as a thin session-preference extension on top of existing chat/runtime edges, note explicitly in the PR that the architecture map was not changed.
+```
+
+- [ ] **Step 4: Commit docs and handoff artifacts**
+
+```bash
+git add ai_first/daily/2026-04-30.md docs/superpowers/pr-notes/2026-04-30-playground-tutor-pack-chat.md
+git commit -m "docs(playground): record tutor pack chat lane [UI-PLAYGROUND-TUTOR-PACK-CHAT]"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - tutor-pack product framing and one-pack-per-session model: Tasks 1-3
+  - history restore and unavailable-state blocking: Tasks 2-3
+  - sidebar badge: Task 4
+  - docs and PR note: Task 5
+- Placeholder scan:
+  - no `TODO`, `TBD`, or deferred implementation placeholders remain in tasks
+- Type consistency:
+  - use `tutor_pack` in backend/session contracts
+  - use `TutorPackBinding` and `knowledgeBase` in frontend state
+  - keep runtime request payload mapped to `knowledge_bases`

--- a/docs/superpowers/pr-notes/2026-04-30-playground-tutor-pack-chat.md
+++ b/docs/superpowers/pr-notes/2026-04-30-playground-tutor-pack-chat.md
@@ -1,0 +1,24 @@
+# PR Note: Playground Tutor Pack Chat
+
+## Summary
+
+This lane adds a product-level `Gói gia sư` concept to `/playground` chat sessions. Each session now binds to exactly one imported tutor pack, stores that binding in session preferences, restores it from history, and blocks new sends if the bound pack later becomes unavailable.
+
+## Architecture impact
+
+- session preferences now carry a thin `tutor_pack` binding alongside `knowledge_bases`
+- `/playground` chat continues to execute against `knowledge_bases[0]` for retrieval/runtime compatibility
+- session history and sidebar can now render the product-level tutor-pack identity without inferring it only from raw KB names
+
+```mermaid
+flowchart TD
+  P["Imported tutor pack"] --> K["knowledge_bases[0] runtime seam"]
+  P --> S["session.preferences.tutor_pack"]
+  S --> H["history restore + sidebar badge"]
+  S --> G["missing-pack send gate"]
+  K --> C["chat turn execution"]
+```
+
+## MAIN_SYSTEM_MAP
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated because this lane introduces a durable `Gói gia sư` session-binding feature in the student tutor workspace.

--- a/docs/superpowers/specs/2026-04-30-playground-tutor-pack-chat-design.md
+++ b/docs/superpowers/specs/2026-04-30-playground-tutor-pack-chat-design.md
@@ -1,0 +1,219 @@
+# Playground Tutor Pack Chat Design
+
+- Date: 2026-04-30
+- Task ID: `UI-PLAYGROUND-TUTOR-PACK-CHAT`
+- Branch: `fix/playground-tutor-pack-chat`
+
+## Goal
+
+Add `Gói gia sư` selection to `/playground` chat so each chat session is bound to exactly one imported marketplace tutor pack from the moment the session is created. The chat must restore that binding from history, show it in the UI, and block further sending if the bound pack is no longer available.
+
+## Product framing
+
+- User-facing term: `Gói gia sư`
+- A `Gói gia sư` is broader than a plain knowledge base:
+  - source knowledge
+  - teacher-defined teaching method
+  - tone, rules, and instructional behavior encoded in imported Markdown and pack metadata
+- The current chat should speak in this product language even if the runtime still uses `knowledge_bases` under the hood.
+
+## Current Behavior
+
+- `/playground` chat currently relies on `UnifiedChatContext` session state and sends `knowledgeBases` as a list in each request snapshot.
+- The right panel shows current `Knowledge source`, but that is still a technical knowledge-base selection surface, not a tutor-pack workflow.
+- New chat sessions do not require selecting an imported marketplace pack.
+- Session history currently restores:
+  - capability
+  - enabled tools
+  - knowledge bases
+  - language
+- Session history does not currently expose a first-class `Gói gia sư` binding or its availability status.
+- If a knowledge base disappears, the UI has no dedicated session-level behavior for “history remains readable but sending is blocked”.
+
+## Intended Behavior Change
+
+- Every `/playground` chat session in `Trò chuyện` mode must be bound to exactly one imported `Gói gia sư`.
+- When the user starts a new chat:
+  - if only one imported tutor pack is available, auto-bind it
+  - if multiple imported tutor packs are available, the user must pick one before sending
+- Once a session is created, the bound tutor pack cannot be changed inside that session.
+- Session history must restore the exact bound tutor pack.
+- The sidebar must show a compact tutor-pack badge under the session title.
+- If the bound tutor pack is deleted or becomes unavailable:
+  - history still opens
+  - sending new messages is blocked
+  - the UI explains that the bound tutor pack is no longer available
+
+## Codebase Survey
+
+### Entry points and handlers
+
+- `web/app/(workspace)/playground/page.tsx`
+  - current chat workspace shell and right-panel context for `/playground`
+  - currently wires `UnifiedChatContext` state into the visible chat UI
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+  - loads sessions from history and opens them
+- `web/context/UnifiedChatContext.tsx`
+  - source of truth for chat session state, request snapshots, hydration, and message sending
+- `web/lib/session-api.ts`
+  - FE session contracts for list/detail hydration
+- `deeptutor/api/routers/sessions.py`
+  - returns session summary/detail payloads
+- `deeptutor/services/session/turn_runtime.py`
+  - persists session preferences when a turn starts
+
+### Primary service or use-case modules
+
+- `web/lib/marketplace-api.ts`
+  - marketplace pack listing/import API helpers
+- `web/app/(utility)/knowledge/page.tsx`
+  - current imported knowledge-base management surface
+- `deeptutor/api/routers/marketplace.py`
+  - import pipeline and marketplace metadata exposure
+
+### Shared contracts, schemas, or types
+
+- `web/context/UnifiedChatContext.tsx`
+  - `ChatState`, `MessageRequestSnapshot`, `LOAD_SESSION` payload
+- `web/lib/session-api.ts`
+  - `SessionSummary.preferences`
+  - `SessionDetail.preferences`
+- `deeptutor/services/session/sqlite_store.py`
+  - session `preferences_json` already supports additive metadata keys
+
+### Adjacent or reused flows inspected
+
+- history restore on `/playground` already rehydrates from `UnifiedChatContext`
+- session preferences already carry `agent_spec_pin`, so the repo already uses additive preference metadata for runtime-adjacent binding
+- dashboard and review flows read `preferences.knowledge_bases`, so the new field must not break existing readers
+
+### Closest existing tests
+
+- no focused test currently covers tutor-pack binding in `/playground`
+- current validation path relies on targeted lint/build plus existing session and chat behavior smoke coverage
+
+## Candidate Approaches
+
+### Approach A: Infer `Gói gia sư` only from `knowledge_bases[0]`
+
+- Do not add new session metadata.
+- Treat the single selected knowledge base as the tutor pack.
+- Pros:
+  - smallest backend diff
+  - reuse current request contract almost entirely
+- Cons:
+  - product language becomes leaky because the UI can only see a KB name
+  - weak support for `unavailable` status and future pack-specific behavior
+  - ambiguous if later the runtime allows pack metadata or teaching-method rules beyond raw KB identity
+
+### Approach B: Add a thin `tutor_pack` binding to session preferences while still sending one `knowledge_base`
+
+- Persist a first-class tutor-pack object in session preferences, for example:
+  - `tutor_pack.name`
+  - `tutor_pack.knowledge_base`
+  - `tutor_pack.status`
+- Keep runtime message execution mapped to `knowledge_bases: [knowledge_base]`.
+- Pros:
+  - correct user-facing language
+  - stable history badge and unavailable-state handling
+  - preserves the current chat runtime seam
+  - easy to extend later with pack version, owner, or teaching-style metadata
+- Cons:
+  - requires additive session contract updates across FE and backend
+
+### Approach C: Build a separate chat-profile runtime for tutor packs
+
+- Introduce a new top-level runtime object distinct from session preferences and knowledge bases.
+- Pros:
+  - strongest long-term domain separation
+- Cons:
+  - too wide for this lane
+  - touches runtime orchestration, import flow, and session model more deeply than needed
+
+## Chosen Approach
+
+Approach B.
+
+The product needs a real `Gói gia sư` concept in session history and UI, but the current runtime already accepts `knowledge_bases` cleanly. A thin `tutor_pack` binding in session preferences gives the UI the right semantics while keeping orchestration changes bounded.
+
+## Planned Changes
+
+### Session preference contract
+
+- Extend stored session preferences with a new additive field:
+  - `tutor_pack`
+    - `name: string`
+    - `knowledge_base: string`
+    - `status: "available" | "missing"`
+- Keep existing `knowledge_bases` list for runtime compatibility.
+- For a tutor-pack-bound chat session, `knowledge_bases` should still be exactly `[knowledge_base]`.
+
+### New chat creation flow
+
+- `/playground` chat mode must compute the list of imported tutor packs available to the user.
+- If there is one available pack, auto-bind it on new-session creation.
+- If there are multiple, show a pack-selection step before allowing the first send.
+- The first real send persists both:
+  - `preferences.knowledge_bases`
+  - `preferences.tutor_pack`
+
+### Session restore flow
+
+- `UnifiedChatContext.loadSession()` must hydrate:
+  - current pack binding
+  - availability state
+- `/playground` must render the restored pack in the main chat UI and right-panel context.
+
+### Unavailable-pack behavior
+
+- If a restored session points at a tutor pack whose underlying knowledge base no longer exists:
+  - show historical messages normally
+  - set the session pack state to `missing`
+  - disable composer submission for that session
+  - render a clear warning explaining that the bound `Gói gia sư` is no longer available
+
+### Sidebar history
+
+- Each session row in the workspace sidebar should show a compact tutor-pack badge below the title when available.
+- If the pack is missing, the badge or helper text should reflect that degraded state in a compact way.
+
+## Expected Impact Surface
+
+### Likely to change
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/context/UnifiedChatContext.tsx`
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+- `web/lib/session-api.ts`
+- `deeptutor/api/routers/sessions.py`
+- `deeptutor/services/session/turn_runtime.py`
+
+### Reviewed but expected to remain unchanged unless implementation reveals a small adapter need
+
+- `web/lib/marketplace-api.ts`
+- `web/app/(utility)/knowledge/page.tsx`
+- `deeptutor/api/routers/marketplace.py`
+- `deeptutor/services/session/sqlite_store.py`
+
+## Tests To Add or Run
+
+- FE:
+  - `cd web && npx eslint "app/(workspace)/playground/page.tsx" "context/UnifiedChatContext.tsx" "components/sidebar/WorkspaceSidebar.tsx" "lib/session-api.ts"`
+  - `cd web && npm run build`
+- Backend:
+  - targeted session router/runtime validation if a suitable test seam exists
+- Behavior checks:
+  - single imported pack auto-binds on new chat
+  - multiple imported packs force explicit selection before first send
+  - history restore reopens the correct bound pack
+  - deleted pack still shows history but blocks send
+  - sidebar badge shows the bound tutor pack
+- Final hygiene:
+  - `git diff --check`
+
+## Non-Goals
+
+- No multi-pack selection in one session
+- No in-session pack switching
+- No marketplace prompt/preset sharing in this lane
+- No broad marketplace authoring redesign

--- a/docs/superpowers/tasks/2026-04-30-playground-tutor-pack-chat.md
+++ b/docs/superpowers/tasks/2026-04-30-playground-tutor-pack-chat.md
@@ -1,0 +1,52 @@
+# Task Packet: Playground Tutor Pack Chat
+
+- Task ID: `UI-PLAYGROUND-TUTOR-PACK-CHAT`
+- Date: 2026-04-30
+- Branch: `fix/playground-tutor-pack-chat`
+- Status: Spec written
+
+## Objective
+
+Add `Gói gia sư` selection and session binding to `/playground` chat so each chat session is locked to one imported marketplace tutor pack from creation through history restore.
+
+## User-Approved Scope
+
+- user-facing entity is `Gói gia sư`
+- each chat session is locked to one tutor pack from the start
+- if only one imported tutor pack exists, auto-select it
+- if multiple exist, require explicit selection before first send
+- session history must restore the same tutor pack
+- if the pack later becomes unavailable, history stays visible but sending is blocked
+- sidebar should show a small tutor-pack badge for each session
+
+## Owned Files
+
+- `web/app/(workspace)/playground/page.tsx`
+- `web/context/UnifiedChatContext.tsx`
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+- `web/lib/session-api.ts`
+- `web/lib/marketplace-api.ts`
+- `deeptutor/api/routers/sessions.py`
+- `deeptutor/services/session/turn_runtime.py`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-playground-tutor-pack-chat.md`
+- `docs/superpowers/specs/2026-04-30-playground-tutor-pack-chat-design.md`
+- `docs/superpowers/pr-notes/2026-04-30-playground-tutor-pack-chat.md`
+
+## Do-Not-Touch
+
+- capability removal/hiding lane beyond what already exists
+- marketplace authoring model
+- unrelated untracked files in repo root
+
+## Design Before Implementation
+
+- `docs/superpowers/specs/2026-04-30-playground-tutor-pack-chat-design.md`
+
+## Validation Plan
+
+- `cd web && npx eslint "app/(workspace)/playground/page.tsx" "context/UnifiedChatContext.tsx" "components/sidebar/WorkspaceSidebar.tsx" "lib/session-api.ts"`
+- `cd web && npm run build`
+- backend-targeted verification if implementation touches session preference persistence
+- `git diff --check`

--- a/web/app/(workspace)/playground/page.tsx
+++ b/web/app/(workspace)/playground/page.tsx
@@ -34,10 +34,10 @@ import { PlaygroundWorkspaceShell } from "@/components/chat/home/PlaygroundWorks
 import AssistantResponse from "@/components/common/AssistantResponse";
 import MarkdownRenderer from "@/components/common/MarkdownRenderer";
 import ProcessLogs from "@/components/common/ProcessLogs";
-import { useUnifiedChat, type MessageItem } from "@/context/UnifiedChatContext";
+import { useUnifiedChat, type MessageItem, type TutorPackBinding } from "@/context/UnifiedChatContext";
 import ResearchConfigPanel from "@/components/research/ResearchConfigPanel";
 import { extractBase64FromDataUrl, readFileAsDataUrl } from "@/lib/file-attachments";
-import { listKnowledgeBases } from "@/lib/knowledge-api";
+import { listKnowledgeBases, type KnowledgeBaseSummary } from "@/lib/knowledge-api";
 import type { StreamEvent } from "@/lib/unified-ws";
 import {
   filterFrontendTools,
@@ -161,6 +161,17 @@ interface CapabilityExecResult {
 interface KnowledgeBase {
   name: string;
   is_default?: boolean;
+  status?: string;
+  metadata?: KnowledgeBaseSummary["metadata"];
+}
+
+interface TutorPackOption {
+  name: string;
+  knowledgeBase: string;
+  subject?: string | null;
+  grade?: string | null;
+  owner?: string | null;
+  language?: string | null;
 }
 
 interface TesterMessage {
@@ -392,12 +403,16 @@ function PlaygroundSharedChat({
   title,
   onSend,
   onCancel,
+  disabled,
+  disabledReason,
 }: {
   messages: MessageItem[];
   isStreaming: boolean;
   title: string;
   onSend: (content: string) => void;
   onCancel: () => void;
+  disabled?: boolean;
+  disabledReason?: string | null;
 }) {
   const { t } = useTranslation();
   const [input, setInput] = useState("");
@@ -405,7 +420,7 @@ function PlaygroundSharedChat({
 
   const send = () => {
     const content = input.trim();
-    if (!content || isStreaming) return;
+    if (!content || isStreaming || disabled) return;
     onSend(content);
     setInput("");
   };
@@ -433,22 +448,25 @@ function PlaygroundSharedChat({
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
                 if (isStreaming) onCancel();
-                else send();
+                else if (!disabled) send();
               }
             }}
             rows={2}
             placeholder={`${t("Try")} ${title}...`}
-            className="w-full resize-none bg-transparent text-[13px] leading-5 text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
+            disabled={disabled}
+            className="w-full resize-none bg-transparent text-[13px] leading-5 text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
           />
           <div className="mt-2 flex items-center justify-between gap-3">
             <div className="text-[11px] text-[var(--muted-foreground)]">
-              {isStreaming
+              {disabled && disabledReason
+                ? disabledReason
+                : isStreaming
                 ? t("Press Enter to stop the current answer.")
                 : t("Enter to send, Shift+Enter for a new line.")}
             </div>
             <button
               onClick={isStreaming ? onCancel : send}
-              disabled={!isStreaming && !input.trim()}
+              disabled={disabled || (!isStreaming && !input.trim())}
               className="inline-flex items-center gap-2 rounded-full bg-[var(--muted)] px-4 py-1.5 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]/80 disabled:cursor-not-allowed disabled:opacity-40"
             >
               {isStreaming ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
@@ -1617,6 +1635,7 @@ export default function PlaygroundPage() {
     setTools,
     setCapability,
     setKBs,
+    setTutorPack,
     setLanguage,
     selectedSessionId,
   } = useUnifiedChat();
@@ -1631,6 +1650,8 @@ export default function PlaygroundPage() {
     "comfortable",
   );
   const [loading, setLoading] = useState(true);
+  const [availableTutorPacks, setAvailableTutorPacks] = useState<TutorPackOption[]>([]);
+  const [pendingTutorPackKnowledgeBase, setPendingTutorPackKnowledgeBase] = useState("");
 
   useEffect(() => {
     (async () => {
@@ -1653,6 +1674,17 @@ export default function PlaygroundPage() {
         setCapabilities(visibleCapabilities);
         setCapabilityConfigs(loadCapabilityPlaygroundConfigs());
         setKnowledgeBases(knowledgeBaseList);
+        const tutorPacks = knowledgeBaseList
+          .filter((kb) => kb.status === "ready" || kb.status === "offline-cached" || !kb.status)
+          .map((kb) => ({
+            name: kb.name,
+            knowledgeBase: kb.name,
+            subject: kb.metadata?.subject ?? null,
+            grade: kb.metadata?.grade ?? null,
+            owner: kb.metadata?.owner ?? null,
+            language: kb.metadata?.language ?? null,
+          }));
+        setAvailableTutorPacks(tutorPacks);
 
         const defaultCapability =
           visibleCapabilities.find((cap: CapabilityInfo) => cap.name === "chat") ??
@@ -1674,6 +1706,21 @@ export default function PlaygroundPage() {
 
   const activeTool = tools.find((t) => t.name === activeName);
   const activeCapability = capabilityCatalog.find((c) => c.name === activeName);
+  const selectedTutorPack = unifiedChatState.tutorPack;
+  const requiresTutorPackSelection =
+    !selectedSessionId &&
+    activeCapability?.name === "chat" &&
+    availableTutorPacks.length > 1 &&
+    !selectedTutorPack;
+  const chatDisabledReason =
+    selectedTutorPack?.status === "missing"
+      ? t("Gói gia sư này không còn khả dụng. Bạn vẫn có thể xem lịch sử nhưng chưa thể gửi thêm tin nhắn.")
+      : activeCapability?.name === "chat" && availableTutorPacks.length === 0
+        ? t("Chưa có Gói gia sư khả dụng. Hãy import một gói từ Marketplace trước.")
+        : requiresTutorPackSelection
+          ? t("Chọn Gói gia sư trước khi bắt đầu cuộc trò chuyện này.")
+          : null;
+  const isChatSendDisabled = Boolean(chatDisabledReason);
   const activeCapabilityConfig = useMemo(
     () =>
       activeCapability
@@ -1817,8 +1864,14 @@ export default function PlaygroundPage() {
     if (!activeCapability || activeCapability.name !== "chat" || !activeCapabilityConfig) return;
     setCapability("chat");
     setTools(activeCapabilityConfig.enabledTools);
-    setKBs(activeCapabilityConfig.knowledgeBase ? [activeCapabilityConfig.knowledgeBase] : []);
-  }, [activeCapability, activeCapabilityConfig, setCapability, setKBs, setTools]);
+    setKBs(
+      selectedTutorPack?.knowledgeBase
+        ? [selectedTutorPack.knowledgeBase]
+        : activeCapabilityConfig.knowledgeBase
+          ? [activeCapabilityConfig.knowledgeBase]
+          : [],
+    );
+  }, [activeCapability, activeCapabilityConfig, selectedTutorPack, setCapability, setKBs, setTools]);
 
   useEffect(() => {
     setLanguage(i18n.language);
@@ -1829,6 +1882,60 @@ export default function PlaygroundPage() {
     setActiveKind("capability");
     setActiveName("chat");
   }, [selectedSessionId]);
+
+  useEffect(() => {
+    if (activeCapability?.name !== "chat" || loading) return;
+    if (selectedSessionId) return;
+    if (selectedTutorPack) return;
+    if (availableTutorPacks.length !== 1) return;
+    const onlyPack = availableTutorPacks[0];
+    setPendingTutorPackKnowledgeBase(onlyPack.knowledgeBase);
+    setTutorPack({
+      name: onlyPack.name,
+      knowledgeBase: onlyPack.knowledgeBase,
+      status: "available",
+    });
+    setKBs([onlyPack.knowledgeBase]);
+  }, [
+    activeCapability,
+    availableTutorPacks,
+    loading,
+    selectedSessionId,
+    selectedTutorPack,
+    setKBs,
+    setTutorPack,
+  ]);
+
+  useEffect(() => {
+    if (!selectedTutorPack) return;
+    const stillAvailable = availableTutorPacks.some(
+      (pack) => pack.knowledgeBase === selectedTutorPack.knowledgeBase,
+    );
+    if (!stillAvailable && selectedTutorPack.status !== "missing") {
+      setTutorPack({ ...selectedTutorPack, status: "missing" });
+      return;
+    }
+    if (stillAvailable && selectedTutorPack.status === "missing") {
+      setTutorPack({ ...selectedTutorPack, status: "available" });
+    }
+  }, [availableTutorPacks, selectedTutorPack, setTutorPack]);
+
+  const handleTutorPackSelection = (knowledgeBase: string) => {
+    setPendingTutorPackKnowledgeBase(knowledgeBase);
+    const selectedPack = availableTutorPacks.find((pack) => pack.knowledgeBase === knowledgeBase);
+    if (!selectedPack) {
+      setTutorPack(null);
+      setKBs([]);
+      return;
+    }
+    const nextTutorPack: TutorPackBinding = {
+      name: selectedPack.name,
+      knowledgeBase: selectedPack.knowledgeBase,
+      status: "available",
+    };
+    setTutorPack(nextTutorPack);
+    setKBs([selectedPack.knowledgeBase]);
+  };
 
   const centerPanel = (
     <main aria-label={t("Conversation workspace")} className="flex h-full min-h-0 flex-col">
@@ -1869,6 +1976,8 @@ export default function PlaygroundPage() {
               isStreaming={unifiedChatState.isStreaming}
               onSend={(content) => sendMessage(content)}
               onCancel={cancelStreamingTurn}
+              disabled={isChatSendDisabled}
+              disabledReason={chatDisabledReason}
             />
           ) : activeCapability.name === "deep_question" ? (
             <DeepQuestionTester
@@ -1959,6 +2068,53 @@ export default function PlaygroundPage() {
             {getCapabilityDescription(activeCapability.description, t)}
           </p>
         </section>
+        {activeCapability.name === "chat" ? (
+          <section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
+            <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+              {t("Gói gia sư")}
+            </h3>
+            {!selectedSessionId && availableTutorPacks.length > 1 ? (
+              <div className="mt-3 space-y-3">
+                <select
+                  value={pendingTutorPackKnowledgeBase}
+                  onChange={(e) => handleTutorPackSelection(e.target.value)}
+                  className="w-full rounded-2xl border border-[var(--border)] bg-[var(--background)] px-3 py-3 text-[13px] text-[var(--foreground)] outline-none focus:border-[var(--primary)]/40"
+                >
+                  <option value="">{t("Chọn gói gia sư")}</option>
+                  {availableTutorPacks.map((pack) => (
+                    <option key={pack.knowledgeBase} value={pack.knowledgeBase}>
+                      {pack.name}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-[12px] leading-5 text-[var(--muted-foreground)]">
+                  {t("Mỗi cuộc trò chuyện sẽ khóa vào một Gói gia sư từ lúc bắt đầu và không đổi giữa chừng.")}
+                </p>
+              </div>
+            ) : selectedTutorPack ? (
+              <div className="mt-3 rounded-2xl border border-[var(--border)] bg-[var(--background)]/70 px-3 py-3">
+                <div className="text-[13px] font-medium text-[var(--foreground)]">
+                  {selectedTutorPack.name}
+                </div>
+                {selectedTutorPack.status === "missing" ? (
+                  <p className="mt-2 text-[12px] leading-5 text-amber-700">
+                    {t("Gói gia sư này không còn khả dụng. Bạn vẫn có thể xem lịch sử nhưng chưa thể gửi thêm tin nhắn.")}
+                  </p>
+                ) : (
+                  <p className="mt-1 text-[12px] leading-5 text-[var(--muted-foreground)]">
+                    {t("Cuộc trò chuyện này đang bám theo gói gia sư đã khóa cho session hiện tại.")}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <p className="mt-3 text-[13px] text-[var(--muted-foreground)]">
+                {availableTutorPacks.length === 1
+                  ? t("Gói gia sư sẽ được gán tự động cho cuộc trò chuyện mới.")
+                  : t("Chưa có Gói gia sư khả dụng. Hãy import từ Marketplace trước khi bắt đầu chat.")}
+              </p>
+            )}
+          </section>
+        ) : null}
         <section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
           <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
             {t("Enabled tools")}
@@ -1992,7 +2148,7 @@ export default function PlaygroundPage() {
           )}
         </section>
 
-        {activeCapabilityConfig?.enabledTools.includes("rag") ? (
+        {activeCapability.name !== "chat" && activeCapabilityConfig?.enabledTools.includes("rag") ? (
           <section className="rounded-2xl border border-[var(--border)] bg-[var(--background)]/78 px-4 py-4">
             <h3 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
               {t("Knowledge source")}

--- a/web/components/SessionList.tsx
+++ b/web/components/SessionList.tsx
@@ -23,6 +23,19 @@ interface SessionListProps {
   onDelete: (sessionId: string) => void | Promise<void>;
 }
 
+function getTutorPackLabel(session: SessionSummary): string | null {
+  const value = session.preferences?.tutor_pack?.name;
+  const text = typeof value === "string" ? value.trim() : "";
+  return text || null;
+}
+
+function getTutorPackStatus(session: SessionSummary): "available" | "missing" | null {
+  const raw = session.preferences?.tutor_pack?.status;
+  if (raw === "missing") return "missing";
+  if (raw === "available") return "available";
+  return session.preferences?.tutor_pack ? "available" : null;
+}
+
 function statusColor(status?: SessionRuntimeStatus): string {
   switch (status) {
     case "running":
@@ -186,6 +199,8 @@ export default function SessionList({
             {items.map((session) => {
               const active = activeSessionId === session.session_id;
               const isEditing = editingId === session.session_id;
+              const tutorPackLabel = getTutorPackLabel(session);
+              const tutorPackStatus = getTutorPackStatus(session);
               return (
                 <div
                   key={session.session_id}
@@ -224,9 +239,21 @@ export default function SessionList({
                       className="min-w-0 flex-1 rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-px text-[12px] text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--primary)]/40"
                     />
                   ) : (
-                    <span className={`min-w-0 flex-1 truncate text-[13px] ${active ? "font-medium" : ""}`}>
-                      {session.title || t("Untitled chat")}
-                    </span>
+                    <div className="min-w-0 flex-1">
+                      <span className={`block truncate text-[13px] ${active ? "font-medium" : ""}`}>
+                        {session.title || t("Untitled chat")}
+                      </span>
+                      {tutorPackLabel ? (
+                        <div className="mt-1 flex items-center gap-1.5">
+                          <span className="inline-flex max-w-full items-center truncate rounded-full bg-[var(--muted)] px-2 py-0.5 text-[10px] font-medium text-[var(--muted-foreground)]">
+                            {tutorPackLabel}
+                          </span>
+                          {tutorPackStatus === "missing" ? (
+                            <span className="text-[10px] text-amber-700">{t("Unavailable")}</span>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
                   )}
                   <div className="flex shrink-0 items-center gap-px opacity-0 transition-opacity group-hover:opacity-100">
                     {isEditing ? (
@@ -275,6 +302,8 @@ export default function SessionList({
             {items.map((session) => {
               const active = activeSessionId === session.session_id;
               const isEditing = editingId === session.session_id;
+              const tutorPackLabel = getTutorPackLabel(session);
+              const tutorPackStatus = getTutorPackStatus(session);
               return (
                 <div
                   key={session.session_id}
@@ -327,9 +356,21 @@ export default function SessionList({
                         </div>
                       )}
                       {!isEditing && (
-                        <div className="mt-0.5 line-clamp-1 text-[11px] leading-tight text-[var(--muted-foreground)]">
-                          {session.last_message || relativeTime(session.updated_at, i18n.language)}
-                        </div>
+                        <>
+                          {tutorPackLabel ? (
+                            <div className="mt-1 flex items-center gap-1.5">
+                              <span className="inline-flex max-w-full items-center truncate rounded-full bg-[var(--muted)] px-2 py-0.5 text-[10px] font-medium text-[var(--muted-foreground)]">
+                                {tutorPackLabel}
+                              </span>
+                              {tutorPackStatus === "missing" ? (
+                                <span className="text-[10px] text-amber-700">{t("Unavailable")}</span>
+                              ) : null}
+                            </div>
+                          ) : null}
+                          <div className="mt-0.5 line-clamp-1 text-[11px] leading-tight text-[var(--muted-foreground)]">
+                            {session.last_message || relativeTime(session.updated_at, i18n.language)}
+                          </div>
+                        </>
                       )}
                     </div>
                     <div className="flex shrink-0 items-center gap-0.5 pt-px opacity-0 transition-opacity group-hover:opacity-100">

--- a/web/context/UnifiedChatContext.tsx
+++ b/web/context/UnifiedChatContext.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/context/AppShellContext";
 import type { StreamEvent, ChatMessage } from "@/lib/unified-ws";
 import { UnifiedWSClient } from "@/lib/unified-ws";
-import { getSession, type SessionMessage } from "@/lib/session-api";
+import { getSession, type SessionMessage, type SessionTutorPackPreference } from "@/lib/session-api";
 import { normalizeMarkdownForDisplay } from "@/lib/markdown-display";
 import { shouldAppendEventContent } from "@/lib/stream";
 
@@ -54,6 +54,7 @@ export interface ChatState {
   enabledTools: string[];
   activeCapability: string | null;
   knowledgeBases: string[];
+  tutorPack: TutorPackBinding | null;
   messages: MessageItem[];
   isStreaming: boolean;
   currentStage: string;
@@ -80,6 +81,7 @@ export interface MessageRequestSnapshot {
   capability?: string | null;
   enabledTools: string[];
   knowledgeBases: string[];
+  tutorPack?: TutorPackBinding | null;
   language: string;
   attachments?: MessageAttachment[];
   config?: Record<string, unknown>;
@@ -104,6 +106,12 @@ interface SessionEntry extends ChatState {
   updatedAt: number;
 }
 
+export interface TutorPackBinding {
+  name: string;
+  knowledgeBase: string;
+  status: "available" | "missing";
+}
+
 interface ProviderState {
   selectedKey: string | null;
   sessions: Record<string, SessionEntry>;
@@ -114,6 +122,7 @@ type Action =
   | { type: "SET_TOOLS"; tools: string[] }
   | { type: "SET_CAPABILITY"; cap: string | null }
   | { type: "SET_KB"; kbs: string[] }
+  | { type: "SET_TUTOR_PACK"; tutorPack: TutorPackBinding | null }
   | { type: "SET_LANGUAGE"; lang: string }
   | {
       type: "ADD_USER_MSG";
@@ -137,6 +146,7 @@ type Action =
       tools?: string[];
       capability?: string | null;
       knowledgeBases?: string[];
+      tutorPack?: TutorPackBinding | null;
       language?: string;
     }
   | { type: "NEW_SESSION"; key: string };
@@ -148,6 +158,7 @@ function createSessionEntry(key: string, sessionId: string | null = null): Sessi
     enabledTools: [],
     activeCapability: null,
     knowledgeBases: [],
+    tutorPack: null,
     messages: [],
     isStreaming: false,
     currentStage: "",
@@ -199,6 +210,12 @@ function reducer(state: ProviderState, action: Action): ProviderState {
       return updateSelectedSession(state, (session) => ({
         ...session,
         knowledgeBases: action.kbs,
+      }));
+    case "SET_TUTOR_PACK":
+      return updateSelectedSession(state, (session) => ({
+        ...session,
+        tutorPack: action.tutorPack,
+        knowledgeBases: action.tutorPack ? [action.tutorPack.knowledgeBase] : session.knowledgeBases,
       }));
     case "SET_LANGUAGE":
       return updateSelectedSession(state, (session) => ({
@@ -340,6 +357,7 @@ function reducer(state: ProviderState, action: Action): ProviderState {
             activeCapability:
               action.capability !== undefined ? action.capability : existing.activeCapability,
             knowledgeBases: action.knowledgeBases ?? existing.knowledgeBases,
+            tutorPack: action.tutorPack !== undefined ? action.tutorPack : existing.tutorPack,
             messages: action.messages,
             isStreaming: (action.status || "idle") === "running",
             currentStage: "",
@@ -380,6 +398,7 @@ interface ChatContextValue {
   setTools: (tools: string[]) => void;
   setCapability: (cap: string | null) => void;
   setKBs: (kbs: string[]) => void;
+  setTutorPack: (tutorPack: TutorPackBinding | null) => void;
   setLanguage: (lang: string) => void;
   sendMessage: (
     content: string,
@@ -398,6 +417,20 @@ interface ChatContextValue {
 }
 
 const ChatCtx = createContext<ChatContextValue | null>(null);
+
+function normalizeTutorPackPreference(
+  tutorPack: SessionTutorPackPreference | null | undefined,
+): TutorPackBinding | null {
+  if (!tutorPack) return null;
+  const name = String(tutorPack.name || "").trim();
+  const knowledgeBase = String(tutorPack.knowledge_base || "").trim();
+  if (!name || !knowledgeBase) return null;
+  return {
+    name,
+    knowledgeBase,
+    status: tutorPack.status === "missing" ? "missing" : "available",
+  };
+}
 
 export function UnifiedChatProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -567,6 +600,7 @@ export function UnifiedChatProvider({ children }: { children: React.ReactNode })
     async (sessionId: string) => {
       const session = await getSession(sessionId);
       const activeTurn = Array.isArray(session.active_turns) ? session.active_turns[0] : undefined;
+      const tutorPack = normalizeTutorPackPreference(session.preferences?.tutor_pack);
       dispatch({
         type: "LOAD_SESSION",
         key: session.session_id || session.id,
@@ -578,7 +612,10 @@ export function UnifiedChatProvider({ children }: { children: React.ReactNode })
         capability: session.preferences?.capability || null,
         knowledgeBases: Array.isArray(session.preferences?.knowledge_bases)
           ? session.preferences.knowledge_bases
+          : tutorPack
+            ? [tutorPack.knowledgeBase]
           : [],
+        tutorPack,
         language: session.preferences?.language || "en",
       });
       if (activeTurn?.turn_id || activeTurn?.id) {
@@ -640,6 +677,7 @@ export function UnifiedChatProvider({ children }: { children: React.ReactNode })
       const effectiveCapability = replaySnapshot?.capability ?? session.activeCapability;
       const effectiveTools = replaySnapshot?.enabledTools ?? session.enabledTools;
       const effectiveKnowledgeBases = replaySnapshot?.knowledgeBases ?? session.knowledgeBases;
+      const effectiveTutorPack = replaySnapshot?.tutorPack ?? session.tutorPack;
       const effectiveLanguage = replaySnapshot?.language ?? session.language;
       const researchSources = Array.isArray(config?.sources)
         ? config.sources.filter((value): value is string => typeof value === "string")
@@ -652,6 +690,7 @@ export function UnifiedChatProvider({ children }: { children: React.ReactNode })
         capability: effectiveCapability,
         enabledTools: [...effectiveTools],
         knowledgeBases: shouldSendKnowledgeBases ? [...effectiveKnowledgeBases] : [],
+        tutorPack: effectiveTutorPack,
         language: effectiveLanguage,
         ...(msgAttachments?.length ? { attachments: msgAttachments } : {}),
         ...(config && Object.keys(config).length > 0 ? { config } : {}),
@@ -682,6 +721,15 @@ export function UnifiedChatProvider({ children }: { children: React.ReactNode })
         session_id: session.sessionId,
         attachments,
         language: effectiveLanguage,
+        ...(effectiveTutorPack
+          ? {
+              tutor_pack: {
+                name: effectiveTutorPack.name,
+                knowledge_base: effectiveTutorPack.knowledgeBase,
+                status: effectiveTutorPack.status,
+              },
+            }
+          : {}),
         ...(notebookReferences?.length
           ? { notebook_references: notebookReferences }
           : {}),
@@ -719,6 +767,7 @@ export function UnifiedChatProvider({ children }: { children: React.ReactNode })
       enabledTools: current.enabledTools,
       activeCapability: current.activeCapability,
       knowledgeBases: current.knowledgeBases,
+      tutorPack: current.tutorPack,
       messages: current.messages,
       isStreaming: current.isStreaming,
       currentStage: current.currentStage,
@@ -756,6 +805,10 @@ export function UnifiedChatProvider({ children }: { children: React.ReactNode })
     dispatch({ type: "SET_LANGUAGE", lang });
   }, []);
 
+  const setTutorPack = useCallback((tutorPack: TutorPackBinding | null) => {
+    dispatch({ type: "SET_TUTOR_PACK", tutorPack });
+  }, []);
+
   const newSession = useCallback(() => {
     dispatch({ type: "NEW_SESSION", key: makeDraftKey() });
   }, [makeDraftKey]);
@@ -765,6 +818,7 @@ export function UnifiedChatProvider({ children }: { children: React.ReactNode })
     setTools,
     setCapability,
     setKBs,
+    setTutorPack,
     setLanguage,
     sendMessage,
     cancelStreamingTurn,

--- a/web/lib/session-api.ts
+++ b/web/lib/session-api.ts
@@ -37,6 +37,20 @@ export interface SessionContextSupport {
   }>;
 }
 
+export interface SessionTutorPackPreference {
+  name: string;
+  knowledge_base: string;
+  status?: "available" | "missing";
+}
+
+export interface SessionPreferences {
+  capability?: string;
+  tools?: string[];
+  knowledge_bases?: string[];
+  language?: string;
+  tutor_pack?: SessionTutorPackPreference;
+}
+
 export interface SessionSummary {
   id: string;
   session_id: string;
@@ -47,12 +61,7 @@ export interface SessionSummary {
   last_message: string;
   status?: "idle" | "running" | "completed" | "failed" | "cancelled" | "rejected";
   active_turn_id?: string;
-  preferences?: {
-    capability?: string;
-    tools?: string[];
-    knowledge_bases?: string[];
-    language?: string;
-  };
+  preferences?: SessionPreferences;
 }
 
 export interface ActiveTurnSummary {
@@ -78,12 +87,7 @@ export interface SessionDetail {
   active_turn_id?: string;
   compressed_summary?: string;
   summary_up_to_msg_id?: number;
-  preferences?: {
-    capability?: string;
-    tools?: string[];
-    knowledge_bases?: string[];
-    language?: string;
-  };
+  preferences?: SessionPreferences;
   messages: SessionMessage[];
   active_turns?: ActiveTurnSummary[];
   context_support?: SessionContextSupport;


### PR DESCRIPTION
## Tóm tắt
- thêm khái niệm `Gói gia sư` cho chat `/playground`, khóa mỗi session vào đúng 1 gói đã import
- khôi phục đúng `Gói gia sư` khi mở lại lịch sử, hiện badge ở sidebar, và chặn gửi tiếp nếu gói đã không còn khả dụng
- giữ seam runtime hiện tại bằng cách persist `tutor_pack` trong session preferences nhưng vẫn chạy retrieval qua `knowledge_bases[0]`

## Kiểm tra
- [x] `cd web && ./node_modules/.bin/eslint "app/(workspace)/playground/page.tsx" context/UnifiedChatContext.tsx components/SessionList.tsx lib/session-api.ts`
- [x] `cd web && node --test tests/playground-trace.test.ts`
- [x] `cd web && npm run build`
- [x] `python3 -m py_compile deeptutor/api/routers/sessions.py deeptutor/services/session/turn_runtime.py`
- [x] `git diff --check`

## MAIN_SYSTEM_MAP
- Đã cập nhật `ai_first/architecture/MAIN_SYSTEM_MAP.md` vì lane này thêm feature bền vững `Gói gia sư` gắn vào session chat của student tutor workspace.
