### PR TITLE
[codex] Redesign knowledge pack flow as wizard

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -59,3 +59,18 @@ Rules:
 - Last update: 2026-04-30
 - Next action: stage the bounded integration files, commit the lane, and prepare review handoff
 - Blocker: none
+
+### Assignment
+
+- Owner: Codex session
+- Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-knowledge-pack-wizard-redesign`
+- Task: Redesign the `Gói kiến thức` screen into a wizard-first Vietnamese flow with FE notebook removal, hidden provider/model selection, and OpenAI-default indexing status
+- Status: implemented, pending PR
+- Branch: `fix/knowledge-pack-wizard-redesign`
+- Task packet: `docs/superpowers/tasks/2026-04-30-knowledge-pack-wizard-redesign.md`
+- Owned files: `web/app/(utility)/knowledge/page.tsx`, `web/locales/vi/app.json`, `web/locales/en/app.json`, `web/lib/notebook-api.ts`, `web/tests/contest-vietnamese-coverage.test.ts`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-knowledge-pack-wizard-redesign.md`, `docs/superpowers/specs/2026-04-30-knowledge-pack-wizard-redesign-design.md`, `docs/superpowers/plans/2026-04-30-knowledge-pack-wizard-redesign.md`, `docs/superpowers/pr-notes/2026-04-30-knowledge-pack-wizard-redesign.md`
+- PR: uncreated
+- Last update: 2026-04-30
+- Next action: stage the bounded runtime/docs diff and open the draft PR after optional FE dependency install for lint/build verification
+- Blocker: none

--- a/ai_first/architecture/MAIN_SYSTEM_MAP.md
+++ b/ai_first/architecture/MAIN_SYSTEM_MAP.md
@@ -56,6 +56,8 @@ flowchart TD
   Product --> KnowledgePack["Knowledge Pack"]
   KnowledgePack --> KPMetaFlow["Metadata Create/Edit/Update Flow"]
   KnowledgePack --> KPVersions["Versioned teacher-pack metadata: current_version + version_history"]
+  KnowledgePack --> KPWizard["Wizard-first teacher flow: Thông tin -> Tài liệu -> Hoàn tất"]
+  KnowledgePack --> KPIngestStatus["Pack-level + per-file indexing status surface"]
   
   Product --> Marketplace["Knowledge Pack Marketplace"]
   Marketplace --> MarketplaceAPI["/api/v1/marketplace"]

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -1,5 +1,31 @@
 # Daily Log: 2026-04-30
 
+## Knowledge Pack Wizard Redesign Runtime Lane Open
+
+- Branch: `fix/knowledge-pack-wizard-redesign`
+- Task: `UI_KNOWLEDGE_PACK_WIZARD_REDESIGN`
+- Done: Created isolated runtime worktree `.worktrees/fix-knowledge-pack-wizard-redesign` from `origin/main` because the approved spec and plan were authored on a docs-only branch and runtime implementation cannot proceed on a `docs/*` lane.
+- Done: Copied the approved spec `docs/superpowers/specs/2026-04-30-knowledge-pack-wizard-redesign-design.md` and implementation plan `docs/superpowers/plans/2026-04-30-knowledge-pack-wizard-redesign.md` into the runtime lane.
+- Done: Added the live assignment and task packet for the runtime implementation lane before starting Task 1 of the approved plan.
+- Tests: `git diff --check -- ai_first/ACTIVE_ASSIGNMENTS.md ai_first/daily/2026-04-30.md docs/superpowers/tasks/2026-04-30-knowledge-pack-wizard-redesign.md docs/superpowers/specs/2026-04-30-knowledge-pack-wizard-redesign-design.md docs/superpowers/plans/2026-04-30-knowledge-pack-wizard-redesign.md`
+- Blockers: none
+- Next: execute the plan from Task 1 by tracing the current FE create/upload contract to the exact backend indexing path and status payloads.
+
+## Knowledge Pack Wizard Redesign Implementation
+
+- Branch: `fix/knowledge-pack-wizard-redesign`
+- Task: `UI_KNOWLEDGE_PACK_WIZARD_REDESIGN`
+- Done: Replaced the old mixed create/upload/notebook shell on `/knowledge` with a wizard-first Vietnamese flow: `Thông tin -> Tài liệu -> Hoàn tất`.
+- Done: Removed notebook and provider-selection UI from the knowledge screen, and changed the old `Grade/Cấp độ` meaning on this route into `Mức độ khó` with segmented options `Cơ bản`, `Trung bình`, `Nâng cao`.
+- Done: Kept backend indexing on the single system-default pipeline and stopped the FE from sending `rag_provider` during normal pack creation.
+- Done: Extended knowledge-base progress persistence so `.progress.json` and KB config progress now carry `file_statuses`, enabling a real per-file completion panel instead of fake client-only placeholders.
+- Done: Updated the backend initialization/upload flows to publish pack-level and per-file ingest states for uploaded, processing, indexed, skipped, and error outcomes.
+- Done: Added focused regression coverage for provider omission, persisted file-status progress, and the new FE wizard shell expectations.
+- Tests: `pytest tests/api/test_knowledge_router.py tests/knowledge/test_progress_tracker.py -q`; `cd web && node --test tests/knowledge-page-wizard-shell.test.ts tests/contest-vietnamese-coverage.test.ts`
+- Tests: `cd web && npm run lint -- --file 'app/(utility)/knowledge/page.tsx'` could not run because `eslint` is not available in this worktree environment (`sh: eslint: command not found`).
+- Blockers: FE lint/build verification remains blocked by missing `web/node_modules` or unavailable local eslint binary in this worktree.
+- Next: stage the bounded diff, write the PR note, and open the draft PR once the owner is ready.
+
 ## Code Review Graph Integration Design
 
 - Branch: `fix/code-review-graph-integration`

--- a/deeptutor/api/routers/knowledge.py
+++ b/deeptutor/api/routers/knowledge.py
@@ -189,6 +189,26 @@ def _task_log(task_id: str, message: str, level: str = "info") -> None:
         logger.info(f"[{task_id}] {message}")
 
 
+def _build_file_statuses(
+    file_names: list[str],
+    status: str,
+    *,
+    error_by_name: dict[str, str] | None = None,
+) -> list[dict[str, str]]:
+    timestamp = datetime.now().isoformat()
+    statuses: list[dict[str, str]] = []
+    for name in file_names:
+        item = {
+            "name": name,
+            "status": status,
+            "updated_at": timestamp,
+        }
+        if error_by_name and error_by_name.get(name):
+            item["error"] = error_by_name[name]
+        statuses.append(item)
+    return statuses
+
+
 def _validate_registered_provider(raw_provider: str | None) -> str:
     candidate = (raw_provider or DEFAULT_PROVIDER).strip().lower()
     if not candidate:
@@ -367,7 +387,14 @@ async def run_initialization_task(initializer: KnowledgeBaseInitializer, task_id
             _task_log(task_id, "Finalizing initialization")
 
             initializer.progress_tracker.update(
-                ProgressStage.COMPLETED, "Knowledge base initialization complete!", current=1, total=1
+                ProgressStage.COMPLETED,
+                "Knowledge base initialization complete!",
+                current=1,
+                total=1,
+                file_statuses=_build_file_statuses(
+                    [path.name for path in initializer.raw_dir.glob("*") if path.is_file()],
+                    "indexed",
+                ),
             )
 
             manager = get_kb_manager()
@@ -380,6 +407,10 @@ async def run_initialization_task(initializer: KnowledgeBaseInitializer, task_id
                     "percent": 100,
                     "current": 1,
                     "total": 1,
+                    "file_statuses": _build_file_statuses(
+                        [path.name for path in initializer.raw_dir.glob("*") if path.is_file()],
+                        "indexed",
+                    ),
                     "task_id": task_id,
                     "timestamp": datetime.now().isoformat(),
                 },
@@ -406,6 +437,15 @@ async def run_initialization_task(initializer: KnowledgeBaseInitializer, task_id
                     "message": f"Initialization failed: {error_msg}",
                     "percent": 0,
                     "error": error_msg,
+                    "file_statuses": _build_file_statuses(
+                        [path.name for path in initializer.raw_dir.glob("*") if path.is_file()],
+                        "error",
+                        error_by_name={
+                            path.name: error_msg
+                            for path in initializer.raw_dir.glob("*")
+                            if path.is_file()
+                        },
+                    ),
                     "task_id": task_id,
                     "timestamp": datetime.now().isoformat(),
                 },
@@ -450,6 +490,10 @@ async def run_upload_processing_task(
                 f"Processing {len(uploaded_file_paths)} files...",
                 current=0,
                 total=len(uploaded_file_paths),
+                file_statuses=_build_file_statuses(
+                    [Path(path).name for path in uploaded_file_paths],
+                    "uploaded",
+                ),
             )
 
             adder = DocumentAdder(
@@ -469,6 +513,10 @@ async def run_upload_processing_task(
                     "No new files to process (all duplicates or invalid)",
                     current=0,
                     total=0,
+                    file_statuses=_build_file_statuses(
+                        [Path(path).name for path in uploaded_file_paths],
+                        "skipped",
+                    ),
                 )
                 task_manager.update_task_status(task_id, "completed")
                 task_stream_manager.emit_complete(
@@ -506,6 +554,10 @@ async def run_upload_processing_task(
                 f"Successfully processed {num_processed} files!",
                 current=num_processed,
                 total=num_processed,
+                file_statuses=_build_file_statuses(
+                    [path.name for path in processed_files] if processed_files else [],
+                    "indexed",
+                ),
             )
 
             _task_log(task_id, f"Processed {num_processed} file(s) for '{kb_name}'", level="success")
@@ -520,7 +572,16 @@ async def run_upload_processing_task(
             task_manager.update_task_status(task_id, "error", error=error_msg)
 
             progress_tracker.update(
-                ProgressStage.ERROR, f"Processing failed: {error_msg}", error=error_msg
+                ProgressStage.ERROR,
+                f"Processing failed: {error_msg}",
+                file_statuses=_build_file_statuses(
+                    [Path(path).name for path in uploaded_file_paths],
+                    "error",
+                    error_by_name={
+                        Path(path).name: error_msg for path in uploaded_file_paths
+                    },
+                ),
+                error=error_msg,
             )
             task_stream_manager.emit_failed(task_id, error_msg)
 
@@ -899,6 +960,7 @@ async def create_knowledge_base(
             f"Saved {len(uploaded_files)} files, preparing to process...",
             current=0,
             total=len(uploaded_files),
+            file_statuses=_build_file_statuses(uploaded_files, "uploaded"),
         )
 
         background_tasks.add_task(run_initialization_task, initializer, task_id)

--- a/deeptutor/knowledge/add_documents.py
+++ b/deeptutor/knowledge/add_documents.py
@@ -24,6 +24,10 @@ logger = get_logger("KnowledgeInit")
 DEFAULT_BASE_DIR = "./data/knowledge_bases"
 
 
+def _status_payload(statuses: dict[str, dict[str, str]]) -> list[dict[str, str]]:
+    return list(statuses.values())
+
+
 class DocumentAdder:
     """Add documents to an existing llamaindex knowledge base."""
 
@@ -127,9 +131,22 @@ class DocumentAdder:
         pipeline = LlamaIndexPipeline(kb_base_dir=str(self.base_dir))
         processed_files: list[Path] = []
         total_files = len(new_files)
+        file_statuses = {
+            doc_file.name: {
+                "name": doc_file.name,
+                "status": "uploaded",
+                "updated_at": datetime.now().isoformat(),
+            }
+            for doc_file in new_files
+        }
 
         for idx, doc_file in enumerate(new_files, 1):
             try:
+                file_statuses[doc_file.name] = {
+                    "name": doc_file.name,
+                    "status": "processing",
+                    "updated_at": datetime.now().isoformat(),
+                }
                 if self.progress_tracker is not None:
                     from deeptutor.knowledge.progress_tracker import ProgressStage
 
@@ -138,16 +155,70 @@ class DocumentAdder:
                         f"Indexing (LlamaIndex) {doc_file.name}",
                         current=idx,
                         total=total_files,
+                        file_name=doc_file.name,
+                        file_statuses=_status_payload(file_statuses),
                     )
 
                 success = await pipeline.add_documents(self.kb_name, [str(doc_file)])
                 if success:
                     processed_files.append(doc_file)
                     self._record_successful_hash(doc_file)
+                    file_statuses[doc_file.name] = {
+                        "name": doc_file.name,
+                        "status": "indexed",
+                        "updated_at": datetime.now().isoformat(),
+                    }
+                    if self.progress_tracker is not None:
+                        from deeptutor.knowledge.progress_tracker import ProgressStage
+
+                        self.progress_tracker.update(
+                            ProgressStage.PROCESSING_FILE,
+                            f"Indexed {doc_file.name}",
+                            current=idx,
+                            total=total_files,
+                            file_name=doc_file.name,
+                            file_statuses=_status_payload(file_statuses),
+                        )
                     logger.info(f"Processed (LlamaIndex): {doc_file.name}")
                 else:
+                    file_statuses[doc_file.name] = {
+                        "name": doc_file.name,
+                        "status": "error",
+                        "updated_at": datetime.now().isoformat(),
+                        "error": "RAG pipeline returned failure",
+                    }
+                    if self.progress_tracker is not None:
+                        from deeptutor.knowledge.progress_tracker import ProgressStage
+
+                        self.progress_tracker.update(
+                            ProgressStage.PROCESSING_FILE,
+                            f"Failed to index {doc_file.name}",
+                            current=idx,
+                            total=total_files,
+                            file_name=doc_file.name,
+                            file_statuses=_status_payload(file_statuses),
+                            error="RAG pipeline returned failure",
+                        )
                     logger.error(f"Failed to index: {doc_file.name}")
             except Exception as e:
+                file_statuses[doc_file.name] = {
+                    "name": doc_file.name,
+                    "status": "error",
+                    "updated_at": datetime.now().isoformat(),
+                    "error": str(e),
+                }
+                if self.progress_tracker is not None:
+                    from deeptutor.knowledge.progress_tracker import ProgressStage
+
+                    self.progress_tracker.update(
+                        ProgressStage.PROCESSING_FILE,
+                        f"Failed to index {doc_file.name}",
+                        current=idx,
+                        total=total_files,
+                        file_name=doc_file.name,
+                        file_statuses=_status_payload(file_statuses),
+                        error=str(e),
+                    )
                 logger.exception(f"Failed {doc_file.name}: {e}")
 
         return processed_files

--- a/deeptutor/knowledge/initializer.py
+++ b/deeptutor/knowledge/initializer.py
@@ -22,6 +22,21 @@ from deeptutor.knowledge.progress_tracker import ProgressStage, ProgressTracker
 logger = get_logger("KnowledgeInit")
 
 
+def _file_statuses_for_paths(paths: list[Path], status: str, error: str | None = None) -> list[dict]:
+    timestamp = datetime.now().isoformat()
+    statuses: list[dict] = []
+    for path in paths:
+        item = {
+            "name": path.name,
+            "status": status,
+            "updated_at": timestamp,
+        }
+        if error:
+            item["error"] = error
+        statuses.append(item)
+    return statuses
+
+
 class KnowledgeBaseInitializer:
     """Knowledge base initializer."""
 
@@ -168,6 +183,7 @@ class KnowledgeBaseInitializer:
             f"Found {len(doc_files)} documents, starting to process...",
             current=0,
             total=len(doc_files),
+            file_statuses=_file_statuses_for_paths(doc_files, "processing"),
         )
 
         rag_service = RAGService(
@@ -204,6 +220,7 @@ class KnowledgeBaseInitializer:
                 "Documents processed successfully",
                 current=len(doc_files),
                 total=len(doc_files),
+                file_statuses=_file_statuses_for_paths(doc_files, "indexed"),
             )
         except Exception as e:
             error_msg = str(e)
@@ -211,6 +228,7 @@ class KnowledgeBaseInitializer:
             self.progress_tracker.update(
                 ProgressStage.ERROR,
                 "Failed to process documents",
+                file_statuses=_file_statuses_for_paths(doc_files, "error", error_msg),
                 error=error_msg,
             )
             raise

--- a/deeptutor/knowledge/progress_tracker.py
+++ b/deeptutor/knowledge/progress_tracker.py
@@ -9,6 +9,7 @@ from enum import Enum
 import json
 from pathlib import Path
 import logging
+from typing import Any
 
 # Use unified logging system
 from deeptutor.logging import get_logger
@@ -116,6 +117,7 @@ class ProgressTracker:
                     "current": progress.get("current", 0),
                     "total": progress.get("total", 0),
                     "file_name": progress.get("file_name"),
+                    "file_statuses": progress.get("file_statuses"),
                     "error": progress.get("error"),
                     "timestamp": progress.get("timestamp"),
                     "task_id": progress.get("task_id"),
@@ -124,6 +126,13 @@ class ProgressTracker:
         except Exception as e:
             _get_logger().warning("Failed to save progress to kb_config.json: %s", e)
 
+        try:
+            self.kb_dir.mkdir(parents=True, exist_ok=True)
+            with open(self.progress_file, "w", encoding="utf-8") as handle:
+                json.dump(progress, handle, indent=2, ensure_ascii=False)
+        except Exception as e:
+            _get_logger().warning("Failed to save progress to local file: %s", e)
+
     def update(
         self,
         stage: ProgressStage,
@@ -131,6 +140,7 @@ class ProgressTracker:
         current: int = 0,
         total: int = 0,
         file_name: str = "",
+        file_statuses: list[dict[str, Any]] | None = None,
         error: str | None = None,
     ):
         """Update progress"""
@@ -145,6 +155,9 @@ class ProgressTracker:
             "progress_percent": int(current / total * 100) if total > 0 else 0,
             "timestamp": datetime.now().isoformat(),
         }
+
+        if file_statuses is not None:
+            progress["file_statuses"] = file_statuses
 
         if error:
             progress["error"] = error

--- a/docs/superpowers/plans/2026-04-30-knowledge-pack-wizard-redesign.md
+++ b/docs/superpowers/plans/2026-04-30-knowledge-pack-wizard-redesign.md
@@ -1,0 +1,287 @@
+# Knowledge Pack Wizard Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the `Gói kiến thức` page into a Vietnamese-first three-step wizard with a right-side ingestion status panel, no FE notebook branch, and no user-facing model/provider selector.
+
+**Architecture:** Keep the route the same but split the current monolithic screen into a small set of focused FE sections: wizard state, ingestion/status panel, and simplified pack cards. Route all creation/indexing through a default backend OpenAI indexing path, and extend the data contract only where needed to render overall and per-file status in step `Hoàn tất`.
+
+**Tech Stack:** Next.js App Router, React state/hooks, existing web locale JSON files, existing knowledge-pack API flow, Python backend knowledge-pack/indexing services
+
+---
+
+### Task 1: Audit The Existing Knowledge-Pack Data Contract
+
+**Files:**
+- Review: `web/app/(utility)/knowledge/page.tsx`
+- Review: backend knowledge-pack and indexing handlers reachable from the current create/upload flow
+- Review: any FE API wrappers used by the knowledge page
+
+- [ ] **Step 1: Trace the FE create/upload calls to the exact backend endpoints**
+
+```bash
+rg -n "createKnowledgeBase|uploadToKnowledgeBase|setSelectedProvider|providers|progress" web/app/'(utility)'/knowledge/page.tsx web/lib deeptutor/api deeptutor/services -S
+```
+
+- [ ] **Step 2: Record the contract gaps that block the target wizard**
+
+Run: inspect the matched FE and backend files from Step 1
+Expected: a written list of whether the backend already returns:
+- overall knowledge-pack indexing status
+- per-file upload/index status
+- the current field name and persistence behavior for `Grade`
+- where provider/model defaults are currently chosen
+
+- [ ] **Step 3: Commit the contract/audit checkpoint**
+
+```bash
+git add docs/superpowers/plans/2026-04-30-knowledge-pack-wizard-redesign.md
+git commit -m "docs(knowledge): record wizard redesign plan checkpoint [UI_KNOWLEDGE_PACK_WIZARD_REDESIGN]"
+```
+
+### Task 2: Add Or Adjust Data Tests For The New Metadata And Status Contract
+
+**Files:**
+- Modify or create: backend tests that cover knowledge-pack create/upload/status behavior
+- Modify or create: FE/unit tests for field mapping and completion-state rendering
+
+- [ ] **Step 1: Write the failing backend-focused test for default indexing path**
+
+```text
+Test that a normal knowledge-pack create/upload flow does not require a user-provided provider/model choice and resolves to the default OpenAI indexing path.
+```
+
+- [ ] **Step 2: Run the focused backend test to verify the current behavior fails or is missing**
+
+Run: the narrowest backend test command for the touched module, for example `pytest <exact-test-file> -k knowledge_pack -v`
+Expected: FAIL or missing-coverage confirmation that proves the contract still needs implementation.
+
+- [ ] **Step 3: Write the failing FE test for the new wizard labels and hidden notebook/provider controls**
+
+```text
+Add a focused test that asserts:
+- no `Notebooks` tab on the knowledge page
+- no provider/model selector
+- `Mức độ khó` segmented control renders instead of the old `Grade` input
+```
+
+- [ ] **Step 4: Run the focused FE test to verify it fails**
+
+Run: the narrowest FE test command for the new test file
+Expected: FAIL because the current page still shows the old layout and controls.
+
+- [ ] **Step 5: Commit the failing-test checkpoint**
+
+```bash
+git add <backend-test-files> <frontend-test-files>
+git commit -m "test(knowledge): lock wizard redesign expectations [UI_KNOWLEDGE_PACK_WIZARD_REDESIGN]"
+```
+
+### Task 3: Refactor The Knowledge Page Shell Into Wizard-Friendly FE Units
+
+**Files:**
+- Modify: `web/app/(utility)/knowledge/page.tsx`
+- Create: extracted FE sections/components for:
+  - wizard steps
+  - status panel
+  - simplified pack cards
+- Modify: any FE helper/state files created to keep page logic bounded
+
+- [ ] **Step 1: Extract the current notebook branch out of the visible page flow**
+
+```text
+Remove the page-level `Knowledge Packs / Notebooks` tab switcher from the visible screen and keep only the knowledge-pack branch active on this route.
+```
+
+- [ ] **Step 2: Replace the top create/upload cards with wizard state**
+
+```text
+Introduce explicit wizard steps:
+- `Thông tin`
+- `Tài liệu`
+- `Hoàn tất`
+with step navigation state stored in the page or a dedicated hook.
+```
+
+- [ ] **Step 3: Replace the old `Grade` field with a segmented `Mức độ khó` control**
+
+```text
+Implement three options:
+- `Cơ bản`
+- `Trung bình`
+- `Nâng cao`
+and map them through the FE state that currently backs the `Grade` metadata.
+```
+
+- [ ] **Step 4: Remove the provider/model selector from the create flow**
+
+```text
+Delete the visible selector from the wizard UI and remove any FE dependency on the user choosing a provider.
+```
+
+- [ ] **Step 5: Build the right-side status panel**
+
+```text
+Show active pack metadata and ingestion progress:
+- tên gói
+- chủ đề
+- mức độ khó
+- chương trình học
+- số tài liệu
+- trạng thái index
+```
+
+- [ ] **Step 6: Run the FE test and lint commands for the refactored page**
+
+Run: focused FE tests plus targeted eslint on the touched files
+Expected: PASS for the new wizard/notebook/provider visibility rules.
+
+- [ ] **Step 7: Commit the FE shell refactor**
+
+```bash
+git add web/app/'(utility)'/knowledge/page.tsx web/components web/lib <new-test-files>
+git commit -m "feat(knowledge): add wizard-first knowledge page shell [UI_KNOWLEDGE_PACK_WIZARD_REDESIGN]"
+```
+
+### Task 4: Implement The File-Only Upload Step And Completion-State Rendering
+
+**Files:**
+- Modify: wizard step components and upload state handling
+- Modify: FE API wrappers if needed
+- Modify: backend progress/status endpoints if current data is insufficient
+
+- [ ] **Step 1: Limit the document step to file upload only**
+
+```text
+Keep one dropzone-style file upload surface, remove notebook/link/provider branches, and render selected-file chips or rows before upload starts.
+```
+
+- [ ] **Step 2: Render step `Hoàn tất` with two levels of status**
+
+```text
+Top summary:
+- uploaded count
+- indexed count
+- overall state
+
+Bottom list:
+- per-file name
+- per-file status
+- per-file error if present
+```
+
+- [ ] **Step 3: Extend backend or FE normalization if per-file state is missing**
+
+```text
+If the current API only returns aggregate KB progress, add the minimal contract needed so FE can render file-level status instead of inventing fake client-side states.
+```
+
+- [ ] **Step 4: Run focused backend and FE tests for upload/completion behavior**
+
+Run:
+- focused backend test command for create/upload/progress
+- focused FE test command for completion-step rendering
+Expected: PASS for overall and file-level status behavior.
+
+- [ ] **Step 5: Commit the ingestion/status implementation**
+
+```bash
+git add web deeptutor <tests>
+git commit -m "feat(knowledge): show file-level ingestion status [UI_KNOWLEDGE_PACK_WIZARD_REDESIGN]"
+```
+
+### Task 5: Simplify Existing Pack Cards And Finish Vietnamese Copy Coverage
+
+**Files:**
+- Modify: existing pack list rendering in `web/app/(utility)/knowledge/page.tsx` or extracted card component
+- Modify: `web/locales/vi/app.json`
+- Modify: `web/locales/en/app.json`
+- Modify: any FE tests that validate visible copy
+
+- [ ] **Step 1: Reduce each pack card to the approved information set**
+
+```text
+Keep only:
+- tên gói
+- chủ đề
+- mức độ khó
+- chương trình học
+- số tài liệu
+- trạng thái index
+```
+
+- [ ] **Step 2: Reduce the default inline actions to the approved action set**
+
+```text
+Main actions:
+- `Xem chi tiết`
+- `Chỉnh sửa`
+
+Secondary action:
+- `Xóa`
+```
+
+- [ ] **Step 3: Complete the Vietnamese-first locale pass**
+
+```text
+Replace remaining visible English copy on this route, keeping technical English only where the system status genuinely needs it.
+```
+
+- [ ] **Step 4: Run locale and screen-level regression checks**
+
+Run:
+- the focused FE test for Vietnamese labels
+- any existing locale JSON validity checks
+- targeted eslint/build command for the touched screen
+Expected: PASS with no newly introduced untranslated labels on the route.
+
+- [ ] **Step 5: Commit the card and locale polish**
+
+```bash
+git add web/locales web/app/'(utility)'/knowledge/page.tsx web/components <tests>
+git commit -m "feat(knowledge): simplify cards and localize wizard UI [UI_KNOWLEDGE_PACK_WIZARD_REDESIGN]"
+```
+
+### Task 6: Final Verification, Docs, And Handoff
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-knowledge-pack-wizard-redesign.md`
+- Update if required: `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+- [ ] **Step 1: Write the PR note with a Mermaid diagram**
+
+```text
+Document:
+- wizard layout
+- default OpenAI indexing path
+- FE notebook/provider removal
+- status panel and completion-state behavior
+```
+
+- [ ] **Step 2: Update the daily log with implementation and verification outcomes**
+
+```text
+Record what changed, what stayed out of scope, and the exact commands used for FE/backend verification.
+```
+
+- [ ] **Step 3: Decide whether `ai_first/architecture/MAIN_SYSTEM_MAP.md` needs an update**
+
+Run: inspect whether the final implementation changes product workflow or architecture enough to update the map
+Expected: update the map only if the runtime/user-flow change materially changes the documented system structure.
+
+- [ ] **Step 4: Run final verification**
+
+Run:
+- focused backend tests
+- focused FE tests
+- targeted eslint/build
+- `git diff --check`
+Expected: all relevant checks pass and the patch is formatting-clean.
+
+- [ ] **Step 5: Commit the final docs/handoff checkpoint**
+
+```bash
+git add ai_first/daily/2026-04-30.md docs/superpowers/pr-notes/2026-04-30-knowledge-pack-wizard-redesign.md ai_first/architecture/MAIN_SYSTEM_MAP.md
+git commit -m "docs(knowledge): capture wizard redesign handoff [UI_KNOWLEDGE_PACK_WIZARD_REDESIGN]"
+```

--- a/docs/superpowers/pr-notes/2026-04-30-knowledge-pack-wizard-redesign.md
+++ b/docs/superpowers/pr-notes/2026-04-30-knowledge-pack-wizard-redesign.md
@@ -1,0 +1,36 @@
+# PR Note: Knowledge Pack Wizard Redesign
+
+This PR redesigns `/knowledge` into a wizard-first teacher flow and removes the leftover notebook/provider branching from the visible FE path. It also extends KB progress persistence so the completion step can show both overall and per-file indexing status.
+
+## What changed
+
+- replaced the old dual-card create/upload shell with a 3-step wizard: `Thông tin -> Tài liệu -> Hoàn tất`
+- removed visible `Notebooks` and provider/model selection from the knowledge screen
+- changed the route’s authoring semantics from ambiguous `Grade/Cấp độ` input to `Mức độ khó`
+- kept backend indexing on the system-default pipeline instead of inventing a new `openai` provider id
+- added persisted `file_statuses` progress so the FE can render real completion-state rows per uploaded document
+
+```mermaid
+flowchart LR
+  A["Wizard: Thông tin"] --> B["Wizard: Tài liệu"]
+  B --> C["POST /api/v1/knowledge/create"]
+  C --> D["Default KB pipeline (system-configured)"]
+  D --> E["ProgressTracker"]
+  E --> F["KB progress + file_statuses"]
+  F --> G["Wizard: Hoàn tất"]
+  F --> H["Danh sách gói kiến thức"]
+```
+
+## Architecture impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was updated.
+- The subsystem boundary did not change, but the teacher-facing Knowledge Pack flow now has two explicit product surfaces:
+  - wizard-first authoring flow
+  - persisted pack-level and per-file ingest status surface
+
+## Verification
+
+- `pytest tests/api/test_knowledge_router.py tests/knowledge/test_progress_tracker.py -q`
+- `cd web && node --test tests/knowledge-page-wizard-shell.test.ts tests/contest-vietnamese-coverage.test.ts`
+- `cd web && npm run lint -- --file 'app/(utility)/knowledge/page.tsx'`
+  - blocked in this worktree because `eslint` is not installed or not available in PATH

--- a/docs/superpowers/specs/2026-04-30-knowledge-pack-wizard-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-30-knowledge-pack-wizard-redesign-design.md
@@ -1,0 +1,284 @@
+# Knowledge Pack Wizard Redesign
+
+- Date: 2026-04-30
+- Task ID: `UI_KNOWLEDGE_PACK_WIZARD_REDESIGN`
+- Branch: `docs/knowledge-pack-wizard-redesign`
+
+## Goal
+
+Redesign the `Gói kiến thức` screen into a simpler Vietnamese-first wizard that removes notebook and model/provider noise, clarifies the metadata model for teachers, and surfaces OpenAI-backed indexing progress in a way that feels closer to modern RAG document-ingestion products.
+
+## Current Behavior
+
+- The page currently mixes multiple jobs in one surface:
+  - create a knowledge pack
+  - upload documents into an existing pack
+  - edit pack metadata inline
+  - browse knowledge packs
+  - switch to a separate `Notebooks` tab
+- The visible UI still mixes Vietnamese and English strings.
+- The create form exposes technical implementation choices such as the RAG provider (`LlamaIndex`) even though the end user should not make that decision.
+- The current `Grade` field is ambiguous and reads like a metadata label rather than a teaching-facing concept.
+- Upload and indexing are functional but the page does not present the ingestion flow as a clear teacher-friendly sequence.
+
+## User-Approved Product Decisions
+
+- Replace the current create/upload layout with a wizard:
+  - `Thông tin`
+  - `Tài liệu`
+  - `Hoàn tất`
+- Remove `Notebooks` from the FE for this screen.
+- Hide model/provider selection from end users completely.
+- The backend should always use a default `OpenAI index` path.
+- `Cấp độ` is redefined as `Mức độ khó`.
+- `Mức độ khó` options are:
+  - `Cơ bản`
+  - `Trung bình`
+  - `Nâng cao`
+- Step `Thông tin` keeps only these required fields:
+  - `Tên gói kiến thức`
+  - `Chủ đề`
+  - `Mức độ khó`
+  - `Chương trình học`
+  - `Mục tiêu học tập`
+- Step `Tài liệu` supports only direct file upload for now.
+- The screen should show uploaded documents and indexing progress in a style inspired by common RAG/document-ingestion products.
+- Language should be almost fully Vietnamese, with technical terms preserved only where genuinely necessary for system status.
+
+## Codebase Survey
+
+### Entry points and handlers
+
+- `web/app/(utility)/knowledge/page.tsx`
+  - owns the current screen composition
+  - currently contains both knowledge-pack and notebook branches
+  - currently mixes create, upload, list, edit, and notebook detail flows in one file
+
+### Primary service or use-case modules
+
+- `web/lib/notebook-api.ts`
+  - supports the notebook branch that is now a candidate for FE hiding on this screen
+- `web/lib/session-api.ts`, `web/lib/marketplace-api.ts`
+  - adjacent APIs, not directly responsible for this page today but related to broader pack usage flows
+
+### Shared contracts, schemas, or types
+
+- current FE state uses `Grade` metadata and provider selection patterns
+- provider display strings are currently translation-backed and still expose `LlamaIndex`
+- indexing progress is already surfaced at the knowledge-base level, but per-file status may need a stronger backend contract if not already available
+
+### Adjacent or reused flows inspected
+
+- locale coverage in:
+  - `web/locales/vi/app.json`
+  - `web/locales/en/app.json`
+- the current header copy and tab switcher in the knowledge page
+- the current card list structure for existing knowledge packs
+
+### Closest existing tests
+
+- `web/tests/contest-vietnamese-coverage.test.ts`
+  - shows existing locale-oriented FE coverage patterns
+- no focused test currently appears to cover this screen's wizard flow, notebook hiding, or provider hiding
+
+## Candidate Approaches
+
+### Approach A: Light cleanup on the existing page
+
+- Keep the current page structure and only rename labels, hide the provider selector, and remove the notebook tab.
+- Pros:
+  - smallest diff
+  - least disruption to the current code
+- Cons:
+  - preserves the current cognitive overload
+  - still leaves create, upload, list, and edit stacked together without a clean task flow
+  - does not deliver the “modern RAG upload” feel the user asked for
+
+### Approach B: Wizard redesign inside the existing route
+
+- Replace the top create/upload surface with a three-step wizard, keep the list of existing packs underneath, and keep the active-pack status panel visible on the right.
+- Pros:
+  - matches the approved UX direction
+  - simplifies the teacher task without requiring route-level IA changes
+  - supports OpenAI indexing status clearly
+  - lets the list of existing packs remain visible and reachable
+- Cons:
+  - requires refactoring the current page structure
+  - likely benefits from splitting the current large page component into smaller UI units
+
+### Approach C: Split create flow into a separate dedicated route
+
+- Move pack creation into its own full-screen flow and leave the current page mostly as a list/detail screen.
+- Pros:
+  - cleanest information architecture long-term
+- Cons:
+  - broader route and navigation scope
+  - more expensive than needed for the current product goal
+  - unnecessary before validating the simpler wizard concept
+
+## Chosen Approach
+
+Approach B.
+
+It is the smallest redesign that still changes the user experience in a meaningful way. It keeps the current route intact, delivers a more modern wizard-based ingestion flow, removes notebook/provider confusion from the visible screen, and avoids a broader IA rewrite.
+
+## Proposed UX
+
+### Layout
+
+- Top-level screen remains on the current `Gói kiến thức` route.
+- The top section becomes a two-column layout:
+  - left: the active wizard
+  - right: a persistent status panel for the pack currently being created or indexed
+- The list of existing packs remains below the wizard/status area.
+
+### Header
+
+- Keep a simpler page title and helper text.
+- Remove the `Knowledge Packs / Notebooks` tab switcher from FE.
+- Keep the teacher-first framing but shorten the visual noise around the core loop strip.
+
+### Step 1: `Thông tin`
+
+- Required fields only:
+  - `Tên gói kiến thức`
+  - `Chủ đề`
+  - `Mức độ khó`
+  - `Chương trình học`
+  - `Mục tiêu học tập`
+- `Mức độ khó` uses a segmented horizontal control with:
+  - `Cơ bản`
+  - `Trung bình`
+  - `Nâng cao`
+- Remove from this flow:
+  - owner
+  - sharing mode
+  - team members
+  - invite emails
+  - provider/model selection
+
+### Step 2: `Tài liệu`
+
+- One upload mode only: file upload.
+- UI should feel like a modern ingestion tool:
+  - large drag-and-drop zone
+  - clear accepted file types
+  - selected files listed immediately
+  - ability to remove selected files before upload/index starts
+- No links in this version.
+- No notebooks in this version.
+
+### Step 3: `Hoàn tất`
+
+- Overall status summary at the top:
+  - number of uploaded files
+  - number indexed
+  - overall state such as:
+    - `Đang tải lên`
+    - `Đang xử lý`
+    - `Hoàn tất`
+    - `Có lỗi`
+- File-level list underneath:
+  - file name
+  - per-file status
+  - error message if present
+  - optional last-updated time if the API already provides it
+- Final CTAs:
+  - primary: `Xem gói kiến thức`
+  - secondary: `Tạo gói mới`
+
+### Right-side status panel
+
+- Always summarizes the active pack being created:
+  - name
+  - subject
+  - difficulty
+  - curriculum
+  - file count
+  - indexing progress
+- During steps 2 and 3, this panel acts like a “live ingestion status” companion.
+
+### Existing pack cards
+
+- Each card should keep only high-value information:
+  - `Tên gói`
+  - `Chủ đề`
+  - `Mức độ khó`
+  - `Chương trình học`
+  - `Số tài liệu`
+  - `Trạng thái index`
+- Hide `Mục tiêu học tập` from the default collapsed card surface.
+- Main actions:
+  - `Xem chi tiết`
+  - `Chỉnh sửa`
+- Secondary action:
+  - `Xóa`
+- `Đặt mặc định` should not remain a primary inline action on the default card if the simplified wizard/list direction is adopted.
+
+## Language Direction
+
+- The screen should be Vietnamese-first.
+- Visible UI labels should be translated into natural Vietnamese wherever possible.
+- English or technical terms should be preserved only in system-status or debugging contexts where a Vietnamese rendering would reduce clarity.
+- Specific wording updates include:
+  - `Grade` -> `Mức độ khó`
+  - `Knowledge bases` -> `Danh sách gói kiến thức` or a similarly teacher-friendly label
+  - `Upload documents` -> `Tải tài liệu`
+  - `Learning objectives` -> `Mục tiêu học tập`
+
+## Data and Backend Expectations
+
+### FE expectations
+
+- FE no longer exposes model/provider choice.
+- FE no longer exposes notebooks on this screen.
+- FE treats the ingestion process as one wizard, not two independent top cards.
+
+### Backend expectations
+
+- The create/update path should default to `OpenAI index` without asking the user.
+- The system should expose enough indexing state for:
+  - overall pack progress
+  - per-file progress or per-file status where possible
+- If the current API only exposes aggregate KB progress, a contract extension may be needed before the `Hoàn tất` step can fully match the target UX.
+
+### OpenAI credential handling
+
+- The user plans to provide an OpenAI key later if the current project credentials are not usable.
+- The redesign should assume a default OpenAI indexing path but should not hardcode secret values into FE.
+
+## Impact Surface For Implementation
+
+### Likely to change
+
+- `web/app/(utility)/knowledge/page.tsx`
+- locale files under `web/locales/`
+- supporting FE units extracted from the current page if the implementation splits the page into smaller components
+- possibly backend/session or knowledge-pack progress contracts if file-level indexing status is not already exposed
+
+### Reviewed but expected to remain unchanged unless implementation reveals a hard dependency
+
+- unrelated tutor, dashboard, or marketplace routes
+- notebook internals outside the FE hiding decision for this screen
+- broad system architecture docs unless the runtime integration path changes materially
+
+## Testing Expectations
+
+- Add or update FE tests for:
+  - notebook tab hidden on this screen
+  - provider/model selector hidden
+  - difficulty segmented control behavior
+  - Vietnamese text coverage for the new wizard labels
+  - file list and status rendering in the completion step
+- Validate runtime flow for:
+  - wizard progression
+  - create pack
+  - upload files
+  - index status rendering
+
+## Non-Goals
+
+- no notebook redesign in this pass
+- no link-ingestion flow in this pass
+- no full IA split into a separate create route in this pass
+- no user-facing model/provider choice in this pass

--- a/docs/superpowers/tasks/2026-04-30-knowledge-pack-wizard-redesign.md
+++ b/docs/superpowers/tasks/2026-04-30-knowledge-pack-wizard-redesign.md
@@ -1,0 +1,150 @@
+# Task Packet: Knowledge Pack Wizard Redesign
+
+- Task ID: `UI_KNOWLEDGE_PACK_WIZARD_REDESIGN`
+- Date: 2026-04-30
+- Branch: `fix/knowledge-pack-wizard-redesign`
+- Status: Implemented, pending PR
+
+## Objective
+
+Redesign the `Gói kiến thức` screen into a Vietnamese-first wizard with `Thông tin -> Tài liệu -> Hoàn tất`, hide notebooks and model/provider selection from FE, and route indexing through a default OpenAI-backed path.
+
+## User-Approved Scope
+
+- replace the current top create/upload layout with a wizard
+- remove `Notebooks` from FE on this screen
+- hide provider/model selection from end users
+- redefine `Grade/Cấp độ` as `Mức độ khó`
+- support file upload only in this version
+- show overall and per-file indexing status in the completion step
+
+## Owned Files
+
+- `web/app/(utility)/knowledge/page.tsx`
+- `web/locales/vi/app.json`
+- `web/locales/en/app.json`
+- `web/lib/notebook-api.ts`
+- `web/tests/contest-vietnamese-coverage.test.ts`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-knowledge-pack-wizard-redesign.md`
+- `docs/superpowers/specs/2026-04-30-knowledge-pack-wizard-redesign-design.md`
+- `docs/superpowers/plans/2026-04-30-knowledge-pack-wizard-redesign.md`
+- `docs/superpowers/pr-notes/2026-04-30-knowledge-pack-wizard-redesign.md`
+
+## Do-Not-Touch
+
+- unrelated `/playground` runtime lanes
+- unrelated contest-control-plane lanes
+- global OpenAI/Codex machine configuration files
+
+## API/data contract
+
+- The FE should stop asking the user for provider/model.
+- The backend should resolve the indexing path to a default OpenAI-backed provider.
+- The screen needs enough status data to render:
+  - overall indexing state
+  - per-file status in step `Hoàn tất`
+
+## Design before implementation
+
+- Runtime behavior change: yes
+- If yes: confirm `.github/skills/brainstorming/SKILL.md` was read before implementation.
+- Current behavior:
+  - the page mixes create, upload, list, edit, and notebook flows in one surface
+  - the page exposes provider choice and ambiguous `Grade` metadata
+- Intended behavior change:
+  - wizard-first pack creation flow with Vietnamese-first wording and FE notebook/provider removal
+- Candidate approach A:
+  - shallow label cleanup on the existing page shell
+- Candidate approach B:
+  - wizard redesign inside the existing route with a status panel and simplified pack cards
+- Chosen approach and reason:
+  - approach B; it is the smallest redesign that meaningfully simplifies the teacher flow without a broader route split
+- Concrete files/modules expected to change:
+  - `web/app/(utility)/knowledge/page.tsx`
+  - locale files under `web/locales/`
+  - adjacent FE helpers/tests as needed
+- Tests to add or update:
+  - FE coverage for hidden notebook/provider UI, difficulty control, Vietnamese labels, and completion-state rendering
+  - backend or contract coverage for default provider/index path if missing
+
+## Required code reading
+
+- Entry points/handlers to inspect:
+  - `web/app/(utility)/knowledge/page.tsx`
+- Primary logic/service/use-case modules to inspect:
+  - current FE create/upload handlers and the backend handlers they call
+- Shared contracts/schemas/types to inspect:
+  - metadata fields for `Grade`
+  - pack progress/status payloads
+  - provider selection flow
+- Adjacent or reused flows to inspect:
+  - locale coverage in `web/locales/vi/app.json` and `web/locales/en/app.json`
+  - notebook FE entry points that are visible on this screen
+- Existing tests to inspect:
+  - `web/tests/contest-vietnamese-coverage.test.ts`
+- Notes from codebase survey:
+  - the current screen is monolithic and likely needs smaller FE units during implementation
+
+## Impact surface and stop conditions
+
+- Expected affected areas:
+  - knowledge page shell
+  - localized copy
+  - FE upload/index status rendering
+- Files/modules likely to change:
+  - `web/app/(utility)/knowledge/page.tsx`
+  - extracted FE components/helpers if created during refactor
+- Files/modules that must be reviewed even if they may remain unchanged:
+  - `web/lib/notebook-api.ts`
+  - backend handlers that currently set pack provider/status
+- Minimum validation paths before the task can stop:
+  - create a pack through the wizard
+  - upload files
+  - view overall and per-file status
+  - confirm notebook/provider controls are gone from visible FE
+- What would count as a shallow fix for this task:
+  - only renaming labels while leaving the old dual-card layout and notebook tab in place
+- Conditions that must be checked before marking done:
+  - runtime path really defaults provider/model
+  - Vietnamese-first copy is visible on the route
+  - completion step shows status with real data rather than placeholder text
+
+## Acceptance criteria
+
+- `Gói kiến thức` uses a wizard-first top section
+- `Notebooks` is no longer visible on this screen
+- provider/model selection is not visible to the end user
+- `Mức độ khó` replaces `Grade/Cấp độ`
+- `Hoàn tất` shows overall and per-file status
+
+## Required tests
+
+- focused FE tests for wizard labels and hidden controls
+- focused backend/contract tests if the default provider path or status contract changes
+- targeted lint/build on touched FE files
+
+## Manual verification
+
+- open the knowledge page and step through all wizard states
+- confirm the right panel tracks the active pack
+- confirm the existing pack cards are simplified and mostly Vietnamese
+
+## Parallel-work notes
+
+- Confirm `ai_first/ACTIVE_ASSIGNMENTS.md` is updated before code starts.
+- This lane is in a dedicated worktree under `.worktrees/fix-knowledge-pack-wizard-redesign`.
+- Sync `origin/main` inside this lane before any further substantial edit if `main` advances again.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- Must update `ai_first/architecture/MAIN_SYSTEM_MAP.md` if the runtime workflow change materially changes the documented product structure.
+
+## Handoff notes
+
+- The user will provide an OpenAI key later if the current project credential path is not usable.
+- Runtime nuance confirmed during implementation: the repo does not expose a separate KB provider named `openai`; the knowledge-base pipeline remains the single default `llamaindex` path, while the FE now hides provider/model selection entirely.
+- The completion step now relies on backend `progress.file_statuses` published from initialization and incremental-upload flows.
+- Focused verification passed for backend router/progress tests and FE shell/source tests, but eslint could not run in this worktree because the local binary is unavailable.

--- a/tests/api/test_knowledge_router.py
+++ b/tests/api/test_knowledge_router.py
@@ -141,6 +141,33 @@ def test_create_kb_does_not_require_llm_precheck(monkeypatch, tmp_path: Path) ->
     assert manager.config["knowledge_bases"]["kb-new"]["needs_reindex"] is False
 
 
+def test_create_kb_defaults_to_system_provider_when_request_omits_provider(
+    monkeypatch, tmp_path: Path
+) -> None:
+    knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
+    manager = _FakeKBManager(tmp_path / "knowledge_bases")
+    monkeypatch.setattr(knowledge_module, "get_kb_manager", lambda: manager)
+    monkeypatch.setattr(knowledge_module, "KnowledgeBaseInitializer", _FakeInitializer)
+
+    async def _noop_init_task(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(knowledge_module, "run_initialization_task", _noop_init_task)
+    monkeypatch.setattr(knowledge_module, "_kb_base_dir", tmp_path / "knowledge_bases")
+
+    with TestClient(_build_app(knowledge_module)) as client:
+        response = client.post(
+            "/api/v1/knowledge/create",
+            data={"name": "kb-default-provider"},
+            files=_upload_payload(),
+        )
+
+    assert response.status_code == 200
+    assert (
+        manager.config["knowledge_bases"]["kb-default-provider"]["rag_provider"] == "llamaindex"
+    )
+
+
 def test_create_rejects_unregistered_provider(monkeypatch, tmp_path: Path) -> None:
     knowledge_module = _import_knowledge_router(monkeypatch, tmp_path)
     manager = _FakeKBManager(tmp_path / "knowledge_bases")

--- a/tests/knowledge/test_progress_tracker.py
+++ b/tests/knowledge/test_progress_tracker.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from deeptutor.knowledge.progress_tracker import ProgressStage, ProgressTracker
+
+
+def test_progress_tracker_persists_file_statuses_in_kb_progress(tmp_path) -> None:
+    tracker = ProgressTracker("demo-kb", tmp_path)
+
+    tracker.update(
+        ProgressStage.PROCESSING_FILE,
+        "Indexing documents",
+        current=1,
+        total=2,
+        file_name="chapter-1.pdf",
+        file_statuses=[
+            {
+                "name": "chapter-1.pdf",
+                "status": "indexed",
+                "updated_at": "2026-04-30T09:00:00",
+            },
+            {
+                "name": "chapter-2.pdf",
+                "status": "processing",
+                "updated_at": "2026-04-30T09:00:03",
+            },
+        ],
+    )
+
+    progress = tracker.get_progress()
+
+    assert progress is not None
+    assert progress["file_statuses"] == [
+        {
+            "name": "chapter-1.pdf",
+            "status": "indexed",
+            "updated_at": "2026-04-30T09:00:00",
+        },
+        {
+            "name": "chapter-2.pdf",
+            "status": "processing",
+            "updated_at": "2026-04-30T09:00:03",
+        },
+    ]

--- a/web/app/(utility)/knowledge/page.tsx
+++ b/web/app/(utility)/knowledge/page.tsx
@@ -2,24 +2,17 @@
 
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
-import { useTranslation } from "react-i18next";
 import {
+  AlertCircle,
+  ArrowLeft,
   ArrowRight,
   BookOpen,
-  ChevronDown,
-  ChevronRight,
-  Database,
-  ExternalLink,
-  FileUp,
-  GraduationCap,
+  CheckCircle2,
+  FileText,
   Loader2,
-  MessageSquare,
-  NotebookPen,
-  PenLine,
+  PencilLine,
   Plus,
-  Search,
-  Star,
+  Sparkles,
   Trash2,
   Upload,
 } from "lucide-react";
@@ -27,23 +20,24 @@ import { apiUrl, wsUrl } from "@/lib/api";
 import {
   invalidateKnowledgeCaches,
   listKnowledgeBases,
-  listRagProviders,
   type TeacherPackMetadata,
   updateKnowledgeBaseConfig,
 } from "@/lib/knowledge-api";
-import {
-  getNotebookDetail,
-  invalidateNotebookCaches,
-  listNotebooks,
-} from "@/lib/notebook-api";
 import { CoreLoopVisibilityStrip } from "@/components/contest/CoreLoopVisibilityStrip";
 
-const MarkdownRenderer = dynamic(() => import("@/components/common/MarkdownRenderer"), {
-  ssr: false,
-});
 const ProcessLogs = dynamic(() => import("@/components/common/ProcessLogs"), {
   ssr: false,
 });
+
+type WizardStep = "info" | "files" | "done";
+type DifficultyValue = "beginner" | "intermediate" | "advanced";
+
+interface FileStatusInfo {
+  name: string;
+  status: string;
+  error?: string;
+  updated_at?: string;
+}
 
 interface ProgressInfo {
   task_id?: string;
@@ -53,6 +47,9 @@ interface ProgressInfo {
   total?: number;
   percent?: number;
   progress_percent?: number;
+  file_name?: string;
+  file_statuses?: FileStatusInfo[];
+  error?: string;
 }
 
 interface KnowledgeBase {
@@ -70,41 +67,6 @@ interface KnowledgeBase {
   };
 }
 
-interface NotebookInfo {
-  id: string;
-  name: string;
-  description?: string;
-  record_count?: number;
-  color?: string;
-  icon?: string;
-  updated_at?: number;
-}
-
-interface NotebookRecord {
-  id: string;
-  type: string;
-  title: string;
-  summary?: string;
-  user_query?: string;
-  output: string;
-  metadata?: Record<string, unknown>;
-  created_at?: number;
-}
-
-interface NotebookDetail extends NotebookInfo {
-  records: NotebookRecord[];
-}
-
-interface RAGProvider {
-  id: string;
-  name: string;
-  description: string;
-}
-
-interface KnowledgeTaskResponse {
-  task_id?: string;
-}
-
 interface ProcessState {
   taskId: string | null;
   label: string;
@@ -112,8 +74,6 @@ interface ProcessState {
   executing: boolean;
   error: string | null;
 }
-
-type ProcessKind = "create" | "upload";
 
 const EMPTY_PROCESS_STATE: ProcessState = {
   taskId: null,
@@ -123,13 +83,94 @@ const EMPTY_PROCESS_STATE: ProcessState = {
   error: null,
 };
 
+const WIZARD_STEPS: Array<{ key: WizardStep; label: string }> = [
+  { key: "info", label: "Thông tin" },
+  { key: "files", label: "Tài liệu" },
+  { key: "done", label: "Hoàn tất" },
+];
+
+const DIFFICULTY_OPTIONS: Array<{ value: DifficultyValue; label: string; hint: string }> = [
+  { value: "beginner", label: "Cơ bản", hint: "Nội dung nền tảng, dễ bắt đầu." },
+  { value: "intermediate", label: "Trung bình", hint: "Cân bằng giữa luyện tập và suy luận." },
+  { value: "advanced", label: "Nâng cao", hint: "Phù hợp bài học nhiều thử thách hơn." },
+];
+
 const resolveKbStatus = (kb: KnowledgeBase): string => kb.status ?? kb.statistics?.status ?? "unknown";
 
-const kbNeedsReindex = (kb: KnowledgeBase): boolean =>
-  Boolean(kb.statistics?.needs_reindex) || resolveKbStatus(kb) === "needs_reindex";
+const resolveProgress = (kb: KnowledgeBase, progressMap: Record<string, ProgressInfo>): ProgressInfo | null =>
+  progressMap[kb.name] ?? kb.progress ?? kb.statistics?.progress ?? null;
 
-const kbIsUploadable = (kb: KnowledgeBase): boolean =>
-  resolveKbStatus(kb) === "ready" && !kbNeedsReindex(kb);
+const difficultyLabel = (value?: string | null): string => {
+  switch (value) {
+    case "beginner":
+      return "Cơ bản";
+    case "intermediate":
+      return "Trung bình";
+    case "advanced":
+      return "Nâng cao";
+    default:
+      return value?.trim() || "Chưa chọn";
+  }
+};
+
+const statusLabel = (status?: string | null): string => {
+  switch (status) {
+    case "initializing":
+      return "Đang khởi tạo";
+    case "processing":
+    case "processing_documents":
+    case "processing_file":
+      return "Đang xử lý";
+    case "extracting_items":
+      return "Đang hoàn thiện";
+    case "completed":
+    case "ready":
+      return "Hoàn tất";
+    case "error":
+      return "Có lỗi";
+    case "uploaded":
+      return "Đã tải lên";
+    case "indexed":
+      return "Đã lập chỉ mục";
+    case "skipped":
+      return "Đã bỏ qua";
+    case "needs_reindex":
+      return "Cần lập chỉ mục lại";
+    default:
+      return "Chưa rõ";
+  }
+};
+
+const progressPercent = (progress?: ProgressInfo | null): number => {
+  if (!progress) return 0;
+  if (typeof progress.progress_percent === "number") return progress.progress_percent;
+  if (typeof progress.percent === "number") return progress.percent;
+  if (progress.total && progress.current) {
+    return Math.round((progress.current / progress.total) * 100);
+  }
+  return 0;
+};
+
+const progressSummaryLabel = (progress?: ProgressInfo | null): string => {
+  if (!progress) return "Sẵn sàng tiếp nhận tài liệu";
+  if (progress.error) return "Tiến trình gặp lỗi";
+  switch (progress.stage) {
+    case "initializing":
+      return "Đang khởi tạo gói kiến thức";
+    case "processing_documents":
+      return "Đang xử lý tài liệu";
+    case "processing_file":
+      return progress.file_name ? `Đang xử lý ${progress.file_name}` : "Đang xử lý từng tài liệu";
+    case "extracting_items":
+      return "Đang hoàn thiện dữ liệu lập chỉ mục";
+    case "completed":
+      return "Gói kiến thức đã sẵn sàng";
+    case "error":
+      return "Không thể hoàn tất lập chỉ mục";
+    default:
+      return progress.message || "Đang cập nhật trạng thái";
+  }
+};
 
 const parseLearningObjectives = (value: string): string[] =>
   value
@@ -137,114 +178,73 @@ const parseLearningObjectives = (value: string): string[] =>
     .map((item) => item.trim())
     .filter(Boolean);
 
-const parseMultilineList = (value: string): string[] =>
-  value
-    .split("\n")
-    .map((item) => item.trim())
-    .filter(Boolean);
-
-const formatLearningObjectives = (value?: string[] | null): string =>
-  Array.isArray(value) ? value.join("\n") : "";
-
-const formatMultilineList = (value?: string[] | null): string =>
-  Array.isArray(value) ? value.join("\n") : "";
-
-const normalizeSharingStatus = (value: string): "private" | "team" | "public" | null => {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "private" || normalized === "team" || normalized === "public") {
-    return normalized;
-  }
-  return null;
-};
-
 const buildTeacherPackMetadata = (input: {
   subject: string;
-  grade: string;
+  difficulty: DifficultyValue;
   curriculum: string;
   learningObjectives: string;
-  owner: string;
-  sharingStatus: string;
-  teamMembers: string;
-  pendingInvites: string;
-}): TeacherPackMetadata | null => {
-  const metadata: TeacherPackMetadata = {};
-  const learningObjectives = parseLearningObjectives(input.learningObjectives);
-  const teamMembers = parseMultilineList(input.teamMembers);
-  const pendingInvites = parseMultilineList(input.pendingInvites);
+}): TeacherPackMetadata => ({
+  subject: input.subject.trim(),
+  curriculum: input.curriculum.trim(),
+  difficulty: input.difficulty,
+  learning_objectives: parseLearningObjectives(input.learningObjectives),
+  grade: null,
+});
 
-  if (input.subject.trim()) metadata.subject = input.subject.trim();
-  if (input.grade.trim()) metadata.grade = input.grade.trim();
-  if (input.curriculum.trim()) metadata.curriculum = input.curriculum.trim();
-  if (learningObjectives.length) metadata.learning_objectives = learningObjectives;
-  if (input.owner.trim()) metadata.owner = input.owner.trim();
-  const sharingStatus = normalizeSharingStatus(input.sharingStatus);
-  if (sharingStatus) metadata.sharing_status = sharingStatus;
-  if (sharingStatus === "team") {
-    if (teamMembers.length) metadata.team_members = teamMembers;
-    if (pendingInvites.length) metadata.pending_invites = pendingInvites;
+const formatBytes = (bytes: number): string => {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
-
-  return Object.keys(metadata).length ? metadata : null;
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
 };
 
+const makeInitialFileStatuses = (files: File[]): FileStatusInfo[] =>
+  files.map((file) => ({
+    name: file.name,
+    status: "uploaded",
+  }));
+
 export default function KnowledgePage() {
-  const router = useRouter();
-  const { t } = useTranslation();
-  const [tab, setTab] = useState<"knowledge" | "notebooks">("knowledge");
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
-  const [notebooks, setNotebooks] = useState<NotebookInfo[]>([]);
-  const [providers, setProviders] = useState<RAGProvider[]>([]);
+  const [progressMap, setProgressMap] = useState<Record<string, ProgressInfo>>({});
   const [loading, setLoading] = useState(true);
   const [pageError, setPageError] = useState<string | null>(null);
+  const [wizardStep, setWizardStep] = useState<WizardStep>("info");
   const [creating, setCreating] = useState(false);
-  const [uploadingKb, setUploadingKb] = useState<string | null>(null);
-  const [progressMap, setProgressMap] = useState<Record<string, ProgressInfo>>({});
-  const [newKbName, setNewKbName] = useState("");
-  const [newKbFiles, setNewKbFiles] = useState<File[]>([]);
-  const [selectedProvider, setSelectedProvider] = useState("llamaindex");
-  const [newKbSubject, setNewKbSubject] = useState("");
-  const [newKbGrade, setNewKbGrade] = useState("");
-  const [newKbCurriculum, setNewKbCurriculum] = useState("");
-  const [newKbLearningObjectives, setNewKbLearningObjectives] = useState("");
-  const [newKbOwner, setNewKbOwner] = useState("");
-  const [newKbSharingStatus, setNewKbSharingStatus] = useState<"private" | "team" | "public">("private");
-  const [newKbTeamMembers, setNewKbTeamMembers] = useState("");
-  const [newKbPendingInvites, setNewKbPendingInvites] = useState("");
-  const [editingKbName, setEditingKbName] = useState<string | null>(null);
-  const [editKbSubject, setEditKbSubject] = useState("");
-  const [editKbGrade, setEditKbGrade] = useState("");
-  const [editKbCurriculum, setEditKbCurriculum] = useState("");
-  const [editKbLearningObjectives, setEditKbLearningObjectives] = useState("");
-  const [editKbOwner, setEditKbOwner] = useState("");
-  const [editKbSharingStatus, setEditKbSharingStatus] = useState<"private" | "team" | "public">("private");
-  const [editKbTeamMembers, setEditKbTeamMembers] = useState("");
-  const [editKbPendingInvites, setEditKbPendingInvites] = useState("");
-  const [savingKbMetadata, setSavingKbMetadata] = useState(false);
-  const [editKbError, setEditKbError] = useState<string | null>(null);
-  const [uploadTarget, setUploadTarget] = useState("");
-  const [uploadFiles, setUploadFiles] = useState<File[]>([]);
-  const [newNotebookName, setNewNotebookName] = useState("");
-  const [newNotebookDescription, setNewNotebookDescription] = useState("");
-  const [selectedNotebookId, setSelectedNotebookId] = useState<string | null>(null);
-  const [selectedNotebook, setSelectedNotebook] = useState<NotebookDetail | null>(null);
-  const [loadingNotebookDetail, setLoadingNotebookDetail] = useState(false);
-  const [expandedRecordId, setExpandedRecordId] = useState<string | null>(null);
   const [createProcess, setCreateProcess] = useState<ProcessState>(EMPTY_PROCESS_STATE);
-  const [uploadProcess, setUploadProcess] = useState<ProcessState>(EMPTY_PROCESS_STATE);
+  const [packName, setPackName] = useState("");
+  const [subject, setSubject] = useState("");
+  const [difficulty, setDifficulty] = useState<DifficultyValue>("beginner");
+  const [curriculum, setCurriculum] = useState("");
+  const [learningObjectives, setLearningObjectives] = useState("");
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [activePackName, setActivePackName] = useState<string | null>(null);
+  const [detailPackName, setDetailPackName] = useState<string | null>(null);
+  const [draftSummary, setDraftSummary] = useState<{
+    name: string;
+    subject: string;
+    difficulty: DifficultyValue;
+    curriculum: string;
+    learningObjectives: string[];
+    fileNames: string[];
+  } | null>(null);
+  const [editingKbName, setEditingKbName] = useState<string | null>(null);
+  const [editSubject, setEditSubject] = useState("");
+  const [editDifficulty, setEditDifficulty] = useState<DifficultyValue>("beginner");
+  const [editCurriculum, setEditCurriculum] = useState("");
+  const [editLearningObjectives, setEditLearningObjectives] = useState("");
+  const [savingMetadata, setSavingMetadata] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const socketsRef = useRef<Record<string, WebSocket>>({});
-  const logSourcesRef = useRef<Record<ProcessKind, EventSource | null>>({
-    create: null,
-    upload: null,
-  });
-  const createFileRef = useRef<HTMLInputElement>(null);
-  const uploadFileRef = useRef<HTMLInputElement>(null);
+  const logSourceRef = useRef<EventSource | null>(null);
 
-  const getProcessSetter = (kind: ProcessKind) =>
-    kind === "create" ? setCreateProcess : setUploadProcess;
-
-  const closeTaskLogStream = (kind: ProcessKind) => {
-    logSourcesRef.current[kind]?.close();
-    logSourcesRef.current[kind] = null;
+  const closeLogStream = () => {
+    logSourceRef.current?.close();
+    logSourceRef.current = null;
   };
 
   const closeProgressSocket = (kbName: string) => {
@@ -257,137 +257,26 @@ export default function KnowledgePage() {
     socketsRef.current = {};
   };
 
-  const openTaskLogStream = (kind: ProcessKind, taskId: string, label: string) => {
-    closeTaskLogStream(kind);
-    const setProcess = getProcessSetter(kind);
-    setProcess({
-      taskId,
-      label,
-      logs: [],
-      executing: true,
-      error: null,
-    });
-
-    const source = new EventSource(apiUrl(`/api/v1/knowledge/tasks/${taskId}/stream`));
-    logSourcesRef.current[kind] = source;
-
-    let settled = false;
-
-    source.addEventListener("log", (event) => {
-      try {
-        const payload = JSON.parse((event as MessageEvent).data) as { line?: string };
-        if (!payload.line) return;
-        setProcess((prev) => ({
-          ...prev,
-          taskId,
-          label,
-          logs: [...prev.logs, payload.line!],
-        }));
-      } catch {
-        // Ignore malformed log events.
-      }
-    });
-
-    source.addEventListener("complete", () => {
-      settled = true;
-      setProcess((prev) => ({ ...prev, taskId, label, executing: false }));
-      closeTaskLogStream(kind);
-    });
-
-    source.addEventListener("failed", (event) => {
-      settled = true;
-      let detail = "Task failed";
-      try {
-        const payload = JSON.parse((event as MessageEvent).data) as { detail?: string };
-        detail = payload.detail || detail;
-      } catch {
-        // Ignore malformed failure events.
-      }
-      setProcess((prev) => ({
-        ...prev,
-        taskId,
-        label,
-        executing: false,
-        error: detail,
-      }));
-      closeTaskLogStream(kind);
-    });
-
-    source.onerror = () => {
-      if (settled) return;
-      setProcess((prev) => {
-        if (!prev.executing) return prev;
-        return {
-          ...prev,
-          taskId,
-          label,
-          executing: false,
-          error: prev.error || "Process log stream disconnected.",
-        };
-      });
-      closeTaskLogStream(kind);
-    };
-  };
-
   const loadAll = async () => {
     setLoading(true);
     setPageError(null);
     try {
-      const [kbs, providerData, nextNotebooks] = await Promise.all([
-        listKnowledgeBases(),
-        listRagProviders(),
-        listNotebooks(),
-      ]);
-      setKnowledgeBases(kbs);
-      setProviders(
-        providerData.length
-          ? providerData
-          : [
-              {
-                id: "llamaindex",
-                name: "LlamaIndex",
-                description: "Pure vector retrieval, fastest processing speed.",
-              },
-            ],
-      );
-      setNotebooks(nextNotebooks);
-      if (!selectedNotebookId && nextNotebooks.length > 0) {
-        void loadNotebookDetail(nextNotebooks[0].id);
-      } else if (selectedNotebookId) {
-        const stillExists = nextNotebooks.some((item: NotebookInfo) => item.id === selectedNotebookId);
-        if (stillExists) {
-          void loadNotebookDetail(selectedNotebookId);
-        } else {
-          setSelectedNotebookId(null);
-          setSelectedNotebook(null);
-        }
-      }
+      const nextKbs = await listKnowledgeBases({ force: true });
+      setKnowledgeBases(nextKbs);
 
-      const preferredUploadTarget =
-        kbs.find((kb: KnowledgeBase) => kb.is_default && kbIsUploadable(kb))?.name ??
-        kbs.find((kb: KnowledgeBase) => kbIsUploadable(kb))?.name ??
-        "";
-      setUploadTarget((prev) => {
-        if (prev && kbs.some((kb: KnowledgeBase) => kb.name === prev && kbIsUploadable(kb))) {
-          return prev;
-        }
-        return preferredUploadTarget;
-      });
-
-      for (const kb of kbs) {
-        const status = kb.status ?? kb.statistics?.status;
+      for (const kb of nextKbs) {
+        const status = resolveKbStatus(kb);
         const progress = kb.progress ?? kb.statistics?.progress;
-        const progressStage = (progress as ProgressInfo | undefined)?.stage;
+        const stage = progress?.stage;
         if (
           status &&
           status !== "ready" &&
           status !== "error" &&
-          progressStage !== "completed" &&
-          progressStage !== "error"
+          stage !== "completed" &&
+          stage !== "error"
         ) {
           setProgressMap((prev) => ({ ...prev, [kb.name]: progress || prev[kb.name] || {} }));
-          const taskId = (progress as ProgressInfo | undefined)?.task_id;
-          subscribeProgress(kb.name, taskId || undefined);
+          subscribeProgress(kb.name, progress?.task_id);
         }
       }
     } catch (error) {
@@ -398,13 +287,11 @@ export default function KnowledgePage() {
   };
 
   useEffect(() => {
-    loadAll();
+    void loadAll();
     return () => {
       closeAllProgressSockets();
-      closeTaskLogStream("create");
-      closeTaskLogStream("upload");
+      closeLogStream();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const subscribeProgress = (kbName: string, expectedTaskId?: string) => {
@@ -419,7 +306,6 @@ export default function KnowledgePage() {
         const rawData = JSON.parse(event.data) as {
           type?: string;
           data?: ProgressInfo;
-          message?: string;
         };
         const progress =
           rawData?.type === "progress" && rawData.data ? rawData.data : (rawData as ProgressInfo);
@@ -427,15 +313,12 @@ export default function KnowledgePage() {
         if (expectedTaskId && progress.task_id && progress.task_id !== expectedTaskId) return;
 
         setProgressMap((prev) => ({ ...prev, [kbName]: progress }));
-        const stage = progress.stage;
-        if (stage === "completed" || stage === "error") {
+        if (progress.stage === "completed" || progress.stage === "error") {
           closeProgressSocket(kbName);
-          if (expectedTaskId) {
-            void loadAll();
-          }
+          void loadAll();
         }
       } catch {
-        // Ignore malformed progress events.
+        // Ignore malformed progress payloads.
       }
     };
 
@@ -448,282 +331,178 @@ export default function KnowledgePage() {
     };
   };
 
-  const createKnowledgeBase = async () => {
-    if (!newKbName.trim() || !newKbFiles.length) return;
-    const kbName = newKbName.trim();
-    const fileCount = newKbFiles.length;
-    const teacherPackMetadata = buildTeacherPackMetadata({
-      subject: newKbSubject,
-      grade: newKbGrade,
-      curriculum: newKbCurriculum,
-      learningObjectives: newKbLearningObjectives,
-      owner: newKbOwner,
-      sharingStatus: newKbSharingStatus,
-      teamMembers: newKbTeamMembers,
-      pendingInvites: newKbPendingInvites,
+  const openTaskLogStream = (taskId: string, label: string) => {
+    closeLogStream();
+    setCreateProcess({
+      taskId,
+      label,
+      logs: [],
+      executing: true,
+      error: null,
     });
+
+    const source = new EventSource(apiUrl(`/api/v1/knowledge/tasks/${taskId}/stream`));
+    logSourceRef.current = source;
+
+    let settled = false;
+
+    source.addEventListener("log", (event) => {
+      try {
+        const payload = JSON.parse((event as MessageEvent).data) as { line?: string };
+        if (!payload.line) return;
+        setCreateProcess((prev) => ({ ...prev, logs: [...prev.logs, payload.line!] }));
+      } catch {
+        // Ignore malformed log events.
+      }
+    });
+
+    source.addEventListener("complete", () => {
+      settled = true;
+      setCreateProcess((prev) => ({ ...prev, executing: false }));
+      closeLogStream();
+    });
+
+    source.addEventListener("failed", (event) => {
+      settled = true;
+      let detail = "Tiến trình xử lý thất bại.";
+      try {
+        const payload = JSON.parse((event as MessageEvent).data) as { detail?: string };
+        detail = payload.detail || detail;
+      } catch {
+        // Ignore malformed failure events.
+      }
+      setCreateProcess((prev) => ({
+        ...prev,
+        executing: false,
+        error: detail,
+      }));
+      closeLogStream();
+    });
+
+    source.onerror = () => {
+      if (settled) return;
+      setCreateProcess((prev) =>
+        prev.executing
+          ? { ...prev, executing: false, error: prev.error || "Mất kết nối nhật ký xử lý." }
+          : prev,
+      );
+      closeLogStream();
+    };
+  };
+
+  const clearWizardInputs = () => {
+    setPackName("");
+    setSubject("");
+    setDifficulty("beginner");
+    setCurriculum("");
+    setLearningObjectives("");
+    setSelectedFiles([]);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const resetWizard = () => {
+    setWizardStep("info");
+    setDraftSummary(null);
+    setCreateProcess(EMPTY_PROCESS_STATE);
+    setActivePackName(null);
+    clearWizardInputs();
+  };
+
+  const createKnowledgeBase = async () => {
+    if (!packName.trim() || !subject.trim() || !curriculum.trim() || !learningObjectives.trim() || !selectedFiles.length) {
+      return;
+    }
+
+    const kbName = packName.trim();
+    const metadata = buildTeacherPackMetadata({
+      subject,
+      difficulty,
+      curriculum,
+      learningObjectives,
+    });
+
     setCreating(true);
+    setWizardStep("done");
+    setActivePackName(kbName);
+    setDetailPackName(kbName);
+    setDraftSummary({
+      name: kbName,
+      subject: metadata.subject || "",
+      difficulty,
+      curriculum: metadata.curriculum || "",
+      learningObjectives: metadata.learning_objectives || [],
+      fileNames: selectedFiles.map((file) => file.name),
+    });
+
     try {
       const form = new FormData();
       form.append("name", kbName);
-      form.append("rag_provider", selectedProvider);
-      newKbFiles.forEach((file) => form.append("files", file));
+      selectedFiles.forEach((file) => form.append("files", file));
 
       const res = await fetch(apiUrl("/api/v1/knowledge/create"), {
         method: "POST",
         body: form,
       });
+
       if (!res.ok) {
-        const error = await res.json();
-        throw new Error(error.detail || t("Failed to create knowledge base"));
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error?.detail || "Không thể tạo gói kiến thức.");
       }
 
-      const data = (await res.json()) as KnowledgeTaskResponse;
-      let metadataSyncError: string | null = null;
-
-      if (teacherPackMetadata) {
-        try {
-          await updateKnowledgeBaseConfig(kbName, teacherPackMetadata);
-        } catch (error) {
-          metadataSyncError =
-            error instanceof Error
-              ? error.message
-              : t('Knowledge base "{{name}}" was created but teacher pack metadata could not be saved.', {
-                  name: kbName,
-                });
-        }
-      }
-
+      const data = (await res.json()) as { task_id?: string };
+      await updateKnowledgeBaseConfig(kbName, metadata);
       invalidateKnowledgeCaches();
+
       if (data.task_id) {
-        openTaskLogStream("create", data.task_id, t('Create "{{name}}"', { name: kbName }));
-        subscribeProgress(kbName, data.task_id);
         setProgressMap((prev) => ({
           ...prev,
           [kbName]: {
             task_id: data.task_id,
-            stage: "initializing",
-            message: t("Initializing knowledge base..."),
+            stage: "processing_documents",
+            message: "Đang chuẩn bị tài liệu để lập chỉ mục...",
             current: 0,
-            total: fileCount,
+            total: selectedFiles.length,
             progress_percent: 0,
+            file_statuses: makeInitialFileStatuses(selectedFiles),
           },
         }));
-      } else {
-        subscribeProgress(kbName);
+        openTaskLogStream(data.task_id, `Đang xử lý ${kbName}`);
+        subscribeProgress(kbName, data.task_id);
       }
 
-      setNewKbName("");
-      setNewKbFiles([]);
-      setNewKbSubject("");
-      setNewKbGrade("");
-      setNewKbCurriculum("");
-      setNewKbLearningObjectives("");
-      setNewKbOwner("");
-      setNewKbSharingStatus("private");
-      setNewKbTeamMembers("");
-      setNewKbPendingInvites("");
-      if (createFileRef.current) createFileRef.current.value = "";
+      clearWizardInputs();
       await loadAll();
-
-      if (metadataSyncError) {
-        setCreateProcess((prev) => ({
-          ...prev,
-          error: metadataSyncError,
-          label: prev.label || t('Create "{{name}}"', { name: kbName }),
-        }));
-      }
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       setCreateProcess((prev) => ({
         ...prev,
         executing: false,
-        error: error instanceof Error ? error.message : String(error),
-        label: prev.label || `Create ${kbName}`,
+        error: message,
+        label: prev.label || `Tạo ${kbName}`,
+      }));
+      setProgressMap((prev) => ({
+        ...prev,
+        [kbName]: {
+          stage: "error",
+          message,
+          total: selectedFiles.length,
+          current: 0,
+          file_statuses: selectedFiles.map((file) => ({
+            name: file.name,
+            status: "error",
+            error: message,
+          })),
+        },
       }));
     } finally {
       setCreating(false);
     }
   };
 
-  const uploadToKnowledgeBase = async () => {
-    if (!uploadTarget || !uploadFiles.length) return;
-    const targetKb = uploadTarget;
-    const fileCount = uploadFiles.length;
-    setUploadingKb(uploadTarget);
-    try {
-      const form = new FormData();
-      uploadFiles.forEach((file) => form.append("files", file));
-      if (selectedProvider) form.append("rag_provider", selectedProvider);
-
-      const res = await fetch(apiUrl(`/api/v1/knowledge/${targetKb}/upload`), {
-        method: "POST",
-        body: form,
-      });
-      if (!res.ok) {
-        const error = await res.json();
-        throw new Error(error.detail || t("Failed to upload files"));
-      }
-
-      const data = (await res.json()) as KnowledgeTaskResponse;
-      invalidateKnowledgeCaches();
-      if (data.task_id) {
-        openTaskLogStream("upload", data.task_id, t('Upload to "{{name}}"', { name: targetKb }));
-        subscribeProgress(targetKb, data.task_id);
-        setProgressMap((prev) => ({
-          ...prev,
-          [targetKb]: {
-            task_id: data.task_id,
-            stage: "processing_documents",
-            message: t("Processing {{count}} files...", { count: fileCount }),
-            current: 0,
-            total: fileCount,
-            progress_percent: 0,
-          },
-        }));
-      } else {
-        subscribeProgress(targetKb);
-      }
-
-      setUploadFiles([]);
-      if (uploadFileRef.current) uploadFileRef.current.value = "";
-      await loadAll();
-    } catch (error) {
-      setUploadProcess((prev) => ({
-        ...prev,
-        executing: false,
-        error: error instanceof Error ? error.message : String(error),
-          label: prev.label || t('Upload to "{{name}}"', { name: targetKb }),
-      }));
-    } finally {
-      setUploadingKb(null);
-    }
-  };
-
-  const setDefaultKnowledgeBase = async (kbName: string) => {
-    await fetch(apiUrl(`/api/v1/knowledge/default/${kbName}`), { method: "PUT" });
-    invalidateKnowledgeCaches();
-    await loadAll();
-  };
-
-  const deleteKnowledgeBase = async (kbName: string) => {
-    if (!window.confirm(t('Delete knowledge base "{{name}}"?', { name: kbName }))) return;
-    await fetch(apiUrl(`/api/v1/knowledge/${kbName}`), { method: "DELETE" });
-    invalidateKnowledgeCaches();
-    await loadAll();
-  };
-
-  const startEditKnowledgePack = (kb: KnowledgeBase) => {
-    setEditingKbName(kb.name);
-    setEditKbError(null);
-    setEditKbSubject(kb.metadata?.subject ?? "");
-    setEditKbGrade(kb.metadata?.grade ?? "");
-    setEditKbCurriculum(kb.metadata?.curriculum ?? "");
-    setEditKbLearningObjectives(formatLearningObjectives(kb.metadata?.learning_objectives));
-    setEditKbOwner(kb.metadata?.owner ?? "");
-    setEditKbTeamMembers(formatMultilineList(kb.metadata?.team_members));
-    setEditKbPendingInvites(formatMultilineList(kb.metadata?.pending_invites));
-    const sharingStatus = kb.metadata?.sharing_status;
-    if (sharingStatus === "private" || sharingStatus === "team" || sharingStatus === "public") {
-      setEditKbSharingStatus(sharingStatus);
-    } else {
-      setEditKbSharingStatus("private");
-    }
-  };
-
-  const cancelEditKnowledgePack = () => {
-    setEditingKbName(null);
-    setEditKbError(null);
-    setSavingKbMetadata(false);
-  };
-
-  const saveKnowledgePackMetadata = async () => {
-    if (!editingKbName) return;
-
-    const learningObjectives = parseLearningObjectives(editKbLearningObjectives);
-    const teamMembers = parseMultilineList(editKbTeamMembers);
-    const pendingInvites = parseMultilineList(editKbPendingInvites);
-    const payload: TeacherPackMetadata = {
-      subject: editKbSubject.trim() || null,
-      grade: editKbGrade.trim() || null,
-      curriculum: editKbCurriculum.trim() || null,
-      learning_objectives: learningObjectives.length ? learningObjectives : null,
-      owner: editKbOwner.trim() || null,
-      sharing_status: editKbSharingStatus,
-      team_members: editKbSharingStatus === "team" && teamMembers.length ? teamMembers : null,
-      pending_invites:
-        editKbSharingStatus === "team" && pendingInvites.length ? pendingInvites : null,
-    };
-
-    setSavingKbMetadata(true);
-    setEditKbError(null);
-    try {
-      await updateKnowledgeBaseConfig(editingKbName, payload);
-      invalidateKnowledgeCaches();
-      await loadAll();
-      setEditingKbName(null);
-    } catch (error) {
-      setEditKbError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setSavingKbMetadata(false);
-    }
-  };
-
-  const createNotebook = async () => {
-    if (!newNotebookName.trim()) return;
-    await fetch(apiUrl("/api/v1/notebook/create"), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: newNotebookName.trim(),
-        description: newNotebookDescription.trim(),
-      }),
-    });
-    invalidateNotebookCaches();
-    setNewNotebookName("");
-    setNewNotebookDescription("");
-    await loadAll();
-  };
-
-  const loadNotebookDetail = async (notebookId: string) => {
-    setSelectedNotebookId(notebookId);
-    setExpandedRecordId(null);
-    setLoadingNotebookDetail(true);
-    try {
-      const notebook = (await getNotebookDetail(notebookId)) as NotebookDetail;
-      setSelectedNotebook(notebook);
-    } catch {
-      setSelectedNotebook(null);
-    } finally {
-      setLoadingNotebookDetail(false);
-    }
-  };
-
-  const openNotebookRecord = (record: NotebookRecord) => {
-    const sessionId = String(record.metadata?.session_id || "");
-    if (!sessionId) return;
-    if (record.type === "chat") {
-      router.push(`/?session=${encodeURIComponent(sessionId)}`);
-    }
-  };
-
-  const formatTimestamp = (value?: number) => {
-    if (!value) return t("Unknown time");
-    return new Date(value * 1000).toLocaleString();
-  };
-
-  const getRecordBadge = (type: string) => {
-    switch (type) {
-      case "chat":
-        return { label: t("Chat"), color: "bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300", icon: MessageSquare };
-      case "guided_learning":
-        return { label: t("Guided Learning"), color: "bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300", icon: GraduationCap };
-      case "co_writer":
-        return { label: t("Co-Writer"), color: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300", icon: PenLine };
-      case "research":
-        return { label: t("Research"), color: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300", icon: Search };
-      default:
-        return { label: type, color: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400", icon: NotebookPen };
-    }
+  const removeSelectedFile = (fileName: string) => {
+    setSelectedFiles((prev) => prev.filter((file) => file.name !== fileName));
   };
 
   const combinedKbs = useMemo(
@@ -731,86 +510,128 @@ export default function KnowledgePage() {
       knowledgeBases.map((kb) => ({
         ...kb,
         status: kb.status ?? kb.statistics?.status,
-        progress: progressMap[kb.name] || kb.progress || kb.statistics?.progress,
+        progress: resolveProgress(kb, progressMap) || undefined,
       })),
     [knowledgeBases, progressMap],
   );
 
-  const hasUploadableKb = useMemo(
-    () => combinedKbs.some((kb) => kbIsUploadable(kb)),
-    [combinedKbs],
-  );
+  const selectedPack =
+    combinedKbs.find((kb) => kb.name === (activePackName || detailPackName)) ??
+    combinedKbs.find((kb) => kb.name === detailPackName) ??
+    null;
 
-  const uploadTargetKb = useMemo(
-    () => combinedKbs.find((kb) => kb.name === uploadTarget) ?? null,
-    [combinedKbs, uploadTarget],
-  );
+  const summaryFileStatuses =
+    selectedPack?.progress?.file_statuses?.length
+      ? selectedPack.progress.file_statuses
+      : draftSummary?.fileNames.map((name) => ({ name, status: "uploaded" })) ?? [];
 
-  const uploadBlockedReason = useMemo(() => {
-    if (!uploadTargetKb) return null;
-    if (kbNeedsReindex(uploadTargetKb)) {
-      return t("This knowledge base is in legacy index format and needs reindex before upload.");
+  const indexedCount = summaryFileStatuses.filter((item) => item.status === "indexed").length;
+  const processingCount = summaryFileStatuses.filter((item) =>
+    ["uploaded", "processing"].includes(item.status),
+  ).length;
+  const errorCount = summaryFileStatuses.filter((item) => item.status === "error").length;
+
+  const activeSummary = selectedPack
+    ? {
+        name: selectedPack.name,
+        subject: selectedPack.metadata?.subject ?? draftSummary?.subject ?? "Chưa chọn",
+        difficulty:
+          selectedPack.metadata?.difficulty ??
+          selectedPack.metadata?.grade ??
+          draftSummary?.difficulty ??
+          null,
+        curriculum: selectedPack.metadata?.curriculum ?? draftSummary?.curriculum ?? "Chưa chọn",
+        documentCount:
+          selectedPack.statistics?.raw_documents ??
+          summaryFileStatuses.length ??
+          draftSummary?.fileNames.length ??
+          0,
+        status: selectedPack.progress?.stage ?? selectedPack.status ?? "unknown",
+        progress: selectedPack.progress ?? null,
+      }
+    : draftSummary
+      ? {
+          name: draftSummary.name,
+          subject: draftSummary.subject,
+          difficulty: draftSummary.difficulty,
+          curriculum: draftSummary.curriculum,
+          documentCount: draftSummary.fileNames.length,
+          status: "draft",
+          progress: null,
+        }
+      : null;
+
+  const startEditKnowledgePack = (kb: KnowledgeBase) => {
+    setEditingKbName(kb.name);
+    setDetailPackName(kb.name);
+    setEditError(null);
+    setEditSubject(kb.metadata?.subject ?? "");
+    setEditDifficulty((kb.metadata?.difficulty as DifficultyValue) ?? "beginner");
+    setEditCurriculum(kb.metadata?.curriculum ?? "");
+    setEditLearningObjectives((kb.metadata?.learning_objectives ?? []).join("\n"));
+  };
+
+  const saveKnowledgePackMetadata = async () => {
+    if (!editingKbName) return;
+
+    setSavingMetadata(true);
+    setEditError(null);
+    try {
+      await updateKnowledgeBaseConfig(editingKbName, {
+        subject: editSubject.trim(),
+        curriculum: editCurriculum.trim(),
+        difficulty: editDifficulty,
+        grade: null,
+        learning_objectives: parseLearningObjectives(editLearningObjectives),
+      });
+      invalidateKnowledgeCaches();
+      await loadAll();
+      setEditingKbName(null);
+    } catch (error) {
+      setEditError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSavingMetadata(false);
     }
-    const status = resolveKbStatus(uploadTargetKb);
-    if (status !== "ready") {
-      return t("This knowledge base is currently {{status}} and cannot accept uploads yet.", { status: status.replaceAll("_", " ") });
-    }
-    return null;
-  }, [t, uploadTargetKb]);
+  };
 
-  const uploadDisabled =
-    !uploadTarget || !uploadFiles.length || !!uploadingKb || Boolean(uploadBlockedReason);
-  const metadataProgressCount = [
-    editKbSubject,
-    editKbGrade,
-    editKbCurriculum,
-    editKbOwner,
-  ].filter((value) => value.trim().length > 0).length;
+  const deleteKnowledgeBase = async (kbName: string) => {
+    if (!window.confirm(`Bạn muốn xóa gói kiến thức "${kbName}"?`)) return;
+    await fetch(apiUrl(`/api/v1/knowledge/${kbName}`), { method: "DELETE" });
+    invalidateKnowledgeCaches();
+    if (detailPackName === kbName) setDetailPackName(null);
+    if (activePackName === kbName) setActivePackName(null);
+    await loadAll();
+  };
+
+  const canContinueInfoStep =
+    packName.trim() && subject.trim() && curriculum.trim() && learningObjectives.trim();
+
+  const canSubmitWizard = canContinueInfoStep && selectedFiles.length > 0 && !creating;
 
   return (
     <div className="h-full overflow-y-auto bg-[var(--background)] [scrollbar-gutter:stable]">
-      <div className="mx-auto max-w-5xl px-4 py-8 pb-10 sm:px-6">
-        {/* Header */}
-        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="min-w-0">
-            <h1 className="text-2xl font-bold tracking-tight text-[var(--foreground)]">
-              {t("Knowledge Packs")}
+      <div className="mx-auto max-w-6xl px-4 py-8 pb-12 sm:px-6">
+        <div className="mb-6 flex flex-col gap-3">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight text-[var(--foreground)]">
+              Gói kiến thức
             </h1>
-            <p className="mt-1 text-[13px] text-[var(--muted-foreground)]">
-              {t("Manage classroom knowledge packs and notebooks in one place.")}
+            <p className="mt-2 max-w-2xl text-sm text-[var(--muted-foreground)]">
+              Tạo kho tài liệu lớp học theo một luồng rõ ràng: khai báo thông tin, tải tài liệu,
+              theo dõi tiến trình lập chỉ mục, rồi đưa vào sử dụng.
             </p>
-          </div>
-
-          <div className="inline-flex shrink-0 self-start rounded-lg border border-[var(--border)] bg-[var(--muted)] p-0.5">
-            {[
-              { key: "knowledge", label: t("Knowledge Packs"), icon: Database },
-              { key: "notebooks", label: t("Notebooks"), icon: NotebookPen },
-            ].map((item) => (
-              <button
-                key={item.key}
-                onClick={() => setTab(item.key as "knowledge" | "notebooks")}
-                className={`inline-flex items-center gap-1.5 rounded-md px-3.5 py-1.5 text-[13px] font-medium transition-all ${
-                  tab === item.key
-                    ? "bg-[var(--card)] text-[var(--foreground)] shadow-sm"
-                    : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-                }`}
-              >
-                <item.icon size={14} />
-                {item.label}
-              </button>
-            ))}
           </div>
         </div>
 
         <CoreLoopVisibilityStrip
           currentStep="Knowledge Pack"
           nextStep="Assessment"
-          helperText={t("Start with teacher-owned source material so class tutoring, assessment, and teacher review all stay grounded in the same classroom knowledge pack.")}
+          helperText="Gói kiến thức là lớp nền để phần luyện tập, gia sư và đánh giá dùng chung một nguồn tư liệu đáng tin cậy."
         />
 
         {pageError && (
-          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-            {t("Knowledge Pack page failed to load")}: {pageError}
+          <div className="mb-5 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+            Không thể tải màn hình gói kiến thức: {pageError}
           </div>
         )}
 
@@ -818,772 +639,601 @@ export default function KnowledgePage() {
           <div className="flex items-center justify-center py-20">
             <Loader2 className="h-5 w-5 animate-spin text-[var(--muted-foreground)]" />
           </div>
-        ) : tab === "knowledge" ? (
-          <div className="space-y-5">
-            <div className="grid gap-5 lg:grid-cols-2">
-              {/* Create KB */}
-              <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
-                <div className="mb-4 flex items-center gap-2">
-                  <Plus size={15} className="text-[var(--muted-foreground)]" />
-                  <h2 className="text-[14px] font-semibold text-[var(--foreground)]">
-                    {t("Create Knowledge Pack")}
-                  </h2>
-                </div>
-
-                <div className="space-y-3">
-                  <input
-                    value={newKbName}
-                    onChange={(event) => setNewKbName(event.target.value)}
-                    placeholder={t("Knowledge Pack name")}
-                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                  />
-
-                  <div className="grid gap-3 md:grid-cols-2">
-                    <input
-                      value={newKbSubject}
-                      onChange={(event) => setNewKbSubject(event.target.value)}
-                      placeholder={t("Subject")}
-                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                    />
-                    <input
-                      value={newKbGrade}
-                      onChange={(event) => setNewKbGrade(event.target.value)}
-                      placeholder={t("Grade")}
-                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                    />
+        ) : (
+          <div className="space-y-6">
+            <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+              <section className="overflow-hidden rounded-[28px] border border-[var(--border)] bg-[var(--card)] shadow-sm">
+                <div className="border-b border-[var(--border)] bg-[linear-gradient(135deg,rgba(248,244,238,0.95),rgba(255,255,255,0.92))] px-6 py-5">
+                  <div className="flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                    <Sparkles className="h-4 w-4 text-amber-500" />
+                    Luồng tạo gói kiến thức
                   </div>
-
-                  <input
-                    value={newKbCurriculum}
-                    onChange={(event) => setNewKbCurriculum(event.target.value)}
-                    placeholder={t("Curriculum")}
-                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                  />
-
-                  <textarea
-                    value={newKbLearningObjectives}
-                    onChange={(event) => setNewKbLearningObjectives(event.target.value)}
-                    placeholder={t("Learning objectives (one per line)")}
-                    rows={4}
-                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                  />
-
-                  <div className="grid gap-3 md:grid-cols-[1fr_180px]">
-                    <input
-                      value={newKbOwner}
-                      onChange={(event) => setNewKbOwner(event.target.value)}
-                      placeholder={t("Owner")}
-                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                    />
-                    <select
-                      value={newKbSharingStatus}
-                      onChange={(event) =>
-                        setNewKbSharingStatus(event.target.value as "private" | "team" | "public")
-                      }
-                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none"
-                    >
-                      <option value="private">{t("Private")}</option>
-                      <option value="team">{t("Team")}</option>
-                      <option value="public">{t("Public")}</option>
-                    </select>
-                  </div>
-
-                  {newKbSharingStatus === "team" && (
-                    <div className="grid gap-3 md:grid-cols-2">
-                      <textarea
-                        value={newKbTeamMembers}
-                        onChange={(event) => setNewKbTeamMembers(event.target.value)}
-                        placeholder={t("Team members (one per line)")}
-                        rows={4}
-                        className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                      />
-                      <textarea
-                        value={newKbPendingInvites}
-                        onChange={(event) => setNewKbPendingInvites(event.target.value)}
-                        placeholder={t("Invite emails (one per line)")}
-                        rows={4}
-                        className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                      />
-                    </div>
-                  )}
-
-                  <select
-                    value={selectedProvider}
-                    onChange={(event) => setSelectedProvider(event.target.value)}
-                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none"
-                  >
-                    {providers.map((provider) => (
-                      <option key={provider.id} value={provider.id}>
-                        {provider.name}
-                      </option>
-                    ))}
-                  </select>
-
-                  {/* Styled file upload area */}
-                  <button
-                    type="button"
-                    onClick={() => createFileRef.current?.click()}
-                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-[var(--border)] bg-[var(--background)] px-4 py-3 text-[13px] text-[var(--muted-foreground)] transition-colors hover:border-[var(--foreground)]/25 hover:text-[var(--foreground)]"
-                  >
-                    <FileUp size={15} />
-                    {newKbFiles.length
-                      ? newKbFiles.length > 1
-                        ? t("{n} files selected", { n: newKbFiles.length })
-                        : t("{n} file selected", { n: newKbFiles.length })
-                      : t("Choose files...")}
-                  </button>
-                  <input
-                    ref={createFileRef}
-                    type="file"
-                    multiple
-                    className="hidden"
-                    onChange={(event) =>
-                      setNewKbFiles(Array.from(event.target.files || []))
-                    }
-                  />
-
-                  {!!newKbFiles.length && (
-                    <div className="flex flex-wrap gap-1.5">
-                      {newKbFiles.map((file) => (
-                        <span
-                          key={file.name}
-                          className="rounded-md bg-[var(--muted)] px-2 py-0.5 text-[11px] text-[var(--muted-foreground)]"
-                        >
-                          {file.name}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-
-                  <button
-                    onClick={createKnowledgeBase}
-                    disabled={creating || !newKbName.trim() || !newKbFiles.length}
-                    className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3.5 py-1.5 text-[13px] font-medium text-[var(--primary-foreground)] transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
-                  >
-                    {creating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus size={14} />}
-                    {t("Create")}
-                  </button>
-
-                  {(createProcess.taskId || createProcess.logs.length > 0 || createProcess.executing) && (
-                    <div className="space-y-2">
-                      {createProcess.label && (
-                        <div className="text-[11px] text-[var(--muted-foreground)]">
-                          {createProcess.label}
-                          {createProcess.taskId ? ` · ${createProcess.taskId}` : ""}
-                        </div>
-                      )}
-                      <ProcessLogs
-                        logs={createProcess.logs}
-                        executing={createProcess.executing}
-                        title={t("Create Process")}
-                      />
-                    </div>
-                  )}
-
-                  {createProcess.error && (
-                    <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-                      {createProcess.error}
-                    </div>
-                  )}
-                </div>
-              </section>
-
-              {/* Upload to existing KB */}
-              <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
-                <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="flex items-center gap-2">
-                    <Upload size={15} className="text-[var(--muted-foreground)]" />
-                    <h2 className="text-[14px] font-semibold text-[var(--foreground)]">
-                      {t("Upload documents")}
-                    </h2>
-                  </div>
-                  <div className="rounded-full bg-[var(--background)] px-3 py-1 text-[11px] text-[var(--muted-foreground)]">
-                    {uploadFiles.length}
-                  </div>
-                </div>
-
-                <div className="space-y-3">
-                  <select
-                    value={uploadTarget}
-                    onChange={(event) => setUploadTarget(event.target.value)}
-                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none"
-                  >
-                    <option value="">{t("Select a knowledge base")}</option>
-                    {combinedKbs.map((kb) => {
-                      const status = resolveKbStatus(kb);
-                      const needsReindex = kbNeedsReindex(kb);
-                      const uploadable = kbIsUploadable(kb);
-                      let suffix = "";
-                      if (needsReindex) {
-                        suffix = ` (${t("needs reindex")})`;
-                      } else if (status !== "ready") {
-                        suffix = ` (${status.replaceAll("_", " ")})`;
-                      }
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {WIZARD_STEPS.map((step, index) => {
+                      const isActive = wizardStep === step.key;
+                      const isDone =
+                        WIZARD_STEPS.findIndex((item) => item.key === wizardStep) > index;
                       return (
-                        <option key={kb.name} value={kb.name} disabled={!uploadable}>
-                          {kb.name}
-                          {suffix}
-                        </option>
+                        <button
+                          key={step.key}
+                          type="button"
+                          disabled={step.key === "done" && wizardStep !== "done"}
+                          onClick={() => {
+                            if (step.key === "info") setWizardStep("info");
+                            if (step.key === "files" && canContinueInfoStep) setWizardStep("files");
+                          }}
+                          className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition ${
+                            isActive
+                              ? "border-[var(--foreground)] bg-[var(--foreground)] text-[var(--background)]"
+                              : isDone
+                                ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                                : "border-[var(--border)] bg-[var(--background)] text-[var(--muted-foreground)]"
+                          }`}
+                        >
+                          <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-black/5 text-[11px]">
+                            {index + 1}
+                          </span>
+                          {step.label}
+                        </button>
                       );
                     })}
-                  </select>
+                  </div>
+                </div>
 
-                  {!hasUploadableKb && (
-                    <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-700 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
-                      {t("No ready knowledge base is available for upload. Create a new KB or reindex legacy KBs first.")}
-                    </div>
-                  )}
+                <div className="px-6 py-6">
+                  {wizardStep === "info" && (
+                    <div className="space-y-5">
+                      <div>
+                        <h2 className="text-xl font-semibold text-[var(--foreground)]">
+                          Thông tin gói kiến thức
+                        </h2>
+                        <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                          Điền nhanh 5 trường cốt lõi để hệ thống hiểu đúng phạm vi bộ tài liệu.
+                        </p>
+                      </div>
 
-                  {uploadBlockedReason && (
-                    <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-700 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
-                      {uploadBlockedReason}
-                    </div>
-                  )}
+                      <div className="space-y-3">
+                        <input
+                          value={packName}
+                          onChange={(event) => setPackName(event.target.value)}
+                          placeholder="Tên gói kiến thức"
+                          className="w-full rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--foreground)]/20"
+                        />
+                        <div className="grid gap-3 md:grid-cols-2">
+                          <input
+                            value={subject}
+                            onChange={(event) => setSubject(event.target.value)}
+                            placeholder="Chủ đề"
+                            className="w-full rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--foreground)]/20"
+                          />
+                          <input
+                            value={curriculum}
+                            onChange={(event) => setCurriculum(event.target.value)}
+                            placeholder="Chương trình học"
+                            className="w-full rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--foreground)]/20"
+                          />
+                        </div>
+                      </div>
 
-                  <button
-                    type="button"
-                    onClick={() => uploadFileRef.current?.click()}
-                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-[var(--border)] bg-[var(--background)] px-4 py-3 text-[13px] text-[var(--muted-foreground)] transition-colors hover:border-[var(--foreground)]/25 hover:text-[var(--foreground)]"
-                  >
-                    <FileUp size={15} />
-                    {uploadFiles.length
-                      ? uploadFiles.length > 1
-                        ? t("{n} files selected", { n: uploadFiles.length })
-                        : t("{n} file selected", { n: uploadFiles.length })
-                      : t("Choose files...")}
-                  </button>
-                  <input
-                    ref={uploadFileRef}
-                    type="file"
-                    multiple
-                    className="hidden"
-                    onChange={(event) =>
-                      setUploadFiles(Array.from(event.target.files || []))
-                    }
-                  />
+                      <div className="rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4">
+                        <div className="mb-3 text-sm font-medium text-[var(--foreground)]">
+                          Mức độ khó
+                        </div>
+                        <div className="grid gap-2 md:grid-cols-3">
+                          {DIFFICULTY_OPTIONS.map((option) => (
+                            <button
+                              key={option.value}
+                              type="button"
+                              onClick={() => setDifficulty(option.value)}
+                              className={`rounded-2xl border px-4 py-3 text-left transition ${
+                                difficulty === option.value
+                                  ? "border-amber-300 bg-amber-50 text-amber-900"
+                                  : "border-[var(--border)] bg-[var(--card)] text-[var(--foreground)]"
+                              }`}
+                            >
+                              <div className="text-sm font-medium">{option.label}</div>
+                              <div className="mt-1 text-xs text-[var(--muted-foreground)]">
+                                {option.hint}
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
 
-                  {!!uploadFiles.length && (
-                    <div className="flex flex-wrap gap-1.5">
-                      {uploadFiles.map((file) => (
-                        <span
-                          key={file.name}
-                          className="rounded-md bg-[var(--muted)] px-2 py-0.5 text-[11px] text-[var(--muted-foreground)]"
+                      <textarea
+                        value={learningObjectives}
+                        onChange={(event) => setLearningObjectives(event.target.value)}
+                        placeholder="Mục tiêu học tập, mỗi dòng một ý"
+                        rows={5}
+                        className="w-full rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--foreground)]/20"
+                      />
+
+                      <div className="flex items-center justify-between gap-3 rounded-2xl bg-[var(--muted)]/60 px-4 py-3">
+                        <div className="text-sm text-[var(--muted-foreground)]">
+                          Bước tiếp theo là tải tài liệu nguồn. Người dùng không cần chọn model hay provider.
+                        </div>
+                        <button
+                          type="button"
+                          disabled={!canContinueInfoStep}
+                          onClick={() => setWizardStep("files")}
+                          className="inline-flex items-center gap-2 rounded-full bg-[var(--foreground)] px-4 py-2 text-sm font-medium text-[var(--background)] disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                          {file.name}
-                        </span>
-                      ))}
+                          Tiếp tục
+                          <ArrowRight className="h-4 w-4" />
+                        </button>
+                      </div>
                     </div>
                   )}
 
-                  <button
-                    onClick={uploadToKnowledgeBase}
-                    disabled={uploadDisabled}
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3.5 py-1.5 text-[13px] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] disabled:cursor-not-allowed disabled:opacity-40"
-                  >
-                    {uploadingKb ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Upload size={14} />
-                    )}
-                    {t("Upload")}
-                  </button>
+                  {wizardStep === "files" && (
+                    <div className="space-y-5">
+                      <div>
+                        <h2 className="text-xl font-semibold text-[var(--foreground)]">Tài liệu</h2>
+                        <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                          Tải lên các tệp nguồn như `pdf`, `docx`, `pptx`, `txt`. Hệ thống sẽ dùng cấu hình lập chỉ mục mặc định ở backend.
+                        </p>
+                      </div>
 
-                  {(uploadProcess.taskId || uploadProcess.logs.length > 0 || uploadProcess.executing) && (
-                    <div className="space-y-2">
-                      {uploadProcess.label && (
-                        <div className="text-[11px] text-[var(--muted-foreground)]">
-                          {uploadProcess.label}
-                          {uploadProcess.taskId ? ` · ${uploadProcess.taskId}` : ""}
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="group flex min-h-56 w-full flex-col items-center justify-center rounded-[28px] border border-dashed border-[var(--border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(248,244,238,0.96))] px-6 py-8 text-center transition hover:border-amber-300 hover:bg-amber-50/40"
+                      >
+                        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+                          <Upload className="h-6 w-6" />
+                        </div>
+                        <div className="mt-4 text-base font-medium text-[var(--foreground)]">
+                          Kéo thả tài liệu vào đây hoặc bấm để chọn tệp
+                        </div>
+                        <div className="mt-2 text-sm text-[var(--muted-foreground)]">
+                          Giao diện upload được giữ theo kiểu các sản phẩm RAG hiện đại: gọn, rõ và ưu tiên trạng thái ingest.
+                        </div>
+                      </button>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        className="hidden"
+                        onChange={(event) => setSelectedFiles(Array.from(event.target.files || []))}
+                      />
+
+                      <div className="space-y-2">
+                        {selectedFiles.length ? (
+                          selectedFiles.map((file) => (
+                            <div
+                              key={file.name}
+                              className="flex items-center justify-between rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3"
+                            >
+                              <div className="min-w-0">
+                                <div className="truncate text-sm font-medium text-[var(--foreground)]">
+                                  {file.name}
+                                </div>
+                                <div className="mt-1 text-xs text-[var(--muted-foreground)]">
+                                  {formatBytes(file.size)} • Sẵn sàng tải lên
+                                </div>
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => removeSelectedFile(file.name)}
+                                className="rounded-full border border-[var(--border)] p-2 text-[var(--muted-foreground)] transition hover:border-red-200 hover:bg-red-50 hover:text-red-600"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </div>
+                          ))
+                        ) : (
+                          <div className="rounded-2xl border border-dashed border-[var(--border)] px-4 py-6 text-sm text-[var(--muted-foreground)]">
+                            Chưa có tài liệu nào được chọn.
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <button
+                          type="button"
+                          onClick={() => setWizardStep("info")}
+                          className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] px-4 py-2 text-sm text-[var(--foreground)]"
+                        >
+                          <ArrowLeft className="h-4 w-4" />
+                          Quay lại
+                        </button>
+                        <button
+                          type="button"
+                          disabled={!canSubmitWizard}
+                          onClick={() => void createKnowledgeBase()}
+                          className="inline-flex items-center gap-2 rounded-full bg-[var(--foreground)] px-4 py-2 text-sm font-medium text-[var(--background)] disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                          {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                          Tạo và lập chỉ mục
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {wizardStep === "done" && (
+                    <div className="space-y-5">
+                      <div>
+                        <h2 className="text-xl font-semibold text-[var(--foreground)]">Hoàn tất</h2>
+                        <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                          Theo dõi tiến trình tổng quan ở trên và trạng thái từng tài liệu ở ngay bên dưới.
+                        </p>
+                      </div>
+
+                      <div className="grid gap-3 md:grid-cols-3">
+                        <div className="rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-4">
+                          <div className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                            Tổng tài liệu
+                          </div>
+                          <div className="mt-2 text-2xl font-semibold text-[var(--foreground)]">
+                            {summaryFileStatuses.length}
+                          </div>
+                        </div>
+                        <div className="rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-4">
+                          <div className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                            Đã lập chỉ mục
+                          </div>
+                          <div className="mt-2 text-2xl font-semibold text-[var(--foreground)]">
+                            {indexedCount}
+                          </div>
+                        </div>
+                        <div className="rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-4">
+                          <div className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                            Trạng thái
+                          </div>
+                          <div className="mt-2 text-2xl font-semibold text-[var(--foreground)]">
+                            {errorCount > 0
+                              ? "Có lỗi"
+                              : processingCount > 0
+                                ? "Đang xử lý"
+                                : "Hoàn tất"}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="space-y-2 rounded-3xl border border-[var(--border)] bg-[var(--background)] p-4">
+                        {summaryFileStatuses.length ? (
+                          summaryFileStatuses.map((file) => (
+                            <div
+                              key={`${file.name}-${file.status}`}
+                              className="flex items-center justify-between gap-3 rounded-2xl border border-[var(--border)] bg-[var(--card)] px-4 py-3"
+                            >
+                              <div className="min-w-0">
+                                <div className="truncate text-sm font-medium text-[var(--foreground)]">
+                                  {file.name}
+                                </div>
+                                {file.error ? (
+                                  <div className="mt-1 text-xs text-red-600">{file.error}</div>
+                                ) : (
+                                  <div className="mt-1 text-xs text-[var(--muted-foreground)]">
+                                    {file.updated_at || "Đang cập nhật trạng thái"}
+                                  </div>
+                                )}
+                              </div>
+                              <div
+                                className={`rounded-full px-3 py-1 text-xs font-medium ${
+                                  file.status === "indexed"
+                                    ? "bg-emerald-50 text-emerald-700"
+                                    : file.status === "error"
+                                      ? "bg-red-50 text-red-700"
+                                      : "bg-amber-50 text-amber-700"
+                                }`}
+                              >
+                                {statusLabel(file.status)}
+                              </div>
+                            </div>
+                          ))
+                        ) : (
+                          <div className="rounded-2xl border border-dashed border-[var(--border)] px-4 py-6 text-sm text-[var(--muted-foreground)]">
+                            Chưa có tài liệu nào để hiển thị.
+                          </div>
+                        )}
+                      </div>
+
+                      {(createProcess.taskId || createProcess.logs.length > 0 || createProcess.executing) && (
+                        <div className="space-y-2">
+                          <div className="text-xs text-[var(--muted-foreground)]">
+                            {createProcess.label}
+                            {createProcess.taskId ? ` · ${createProcess.taskId}` : ""}
+                          </div>
+                          <ProcessLogs
+                            logs={createProcess.logs}
+                            executing={createProcess.executing}
+                            title="Nhật ký xử lý"
+                          />
                         </div>
                       )}
-                      <ProcessLogs
-                        logs={uploadProcess.logs}
-                        executing={uploadProcess.executing}
-                        title={t("Upload Process")}
-                      />
-                    </div>
-                  )}
 
-                  {uploadProcess.error && (
-                    <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-                      {t("Document upload failed")}: {uploadProcess.error}
+                      {createProcess.error && (
+                        <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+                          {createProcess.error}
+                        </div>
+                      )}
+
+                      <div className="flex flex-wrap gap-3">
+                        <button
+                          type="button"
+                          onClick={() => setDetailPackName(activePackName)}
+                          className="inline-flex items-center gap-2 rounded-full bg-[var(--foreground)] px-4 py-2 text-sm font-medium text-[var(--background)]"
+                        >
+                          Xem gói kiến thức
+                        </button>
+                        <button
+                          type="button"
+                          onClick={resetWizard}
+                          className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] px-4 py-2 text-sm text-[var(--foreground)]"
+                        >
+                          Tạo gói mới
+                        </button>
+                      </div>
                     </div>
                   )}
                 </div>
               </section>
-            </div>
 
-            {/* KB list */}
-              <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
-                <div className="mb-4 flex items-center gap-2">
-                  <BookOpen size={15} className="text-[var(--muted-foreground)]" />
-                  <h2 className="text-[14px] font-semibold text-[var(--foreground)]">
-                  {t("Knowledge bases")}
-                </h2>
-              </div>
+              <aside className="rounded-[28px] border border-[var(--border)] bg-[linear-gradient(180deg,rgba(248,244,238,0.94),rgba(255,255,255,0.98))] p-6 shadow-sm">
+                <div className="flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                  <FileText className="h-4 w-4 text-amber-600" />
+                  Bảng trạng thái ingest
+                </div>
+                <div className="mt-3 text-sm text-[var(--muted-foreground)]">
+                  Bảng này luôn phản ánh gói đang tạo hoặc gói bạn vừa chọn từ danh sách phía dưới.
+                </div>
 
-              <div className="space-y-3">
-                {combinedKbs.map((kb) => {
-                  const progress = kb.progress;
-                  const status = resolveKbStatus(kb);
-                  const needsReindex = kbNeedsReindex(kb);
-                  const displayStatus =
-                    needsReindex
-                      ? t("needs reindex")
-                      : status !== "ready"
-                        ? status.replaceAll("_", " ")
-                        : null;
-                  const percent =
-                    progress?.progress_percent ??
-                    progress?.percent ??
-                    ((progress?.current ?? 0) && (progress?.total ?? 0)
-                      ? Math.round(((progress?.current ?? 0) / (progress?.total ?? 1)) * 100)
-                      : 0);
-
-                  return (
-                    <div
-                      key={kb.name}
-                      className="group rounded-2xl border border-[var(--border)] bg-[var(--background)] p-4 shadow-sm transition-colors hover:border-[var(--foreground)]/10"
-                    >
-                      <div className="flex flex-wrap items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <div className="flex items-center gap-2">
-                            <h3 className="text-[14px] font-medium text-[var(--foreground)]">
-                              {kb.name}
-                            </h3>
-                            {kb.is_default && (
-                              <span className="inline-flex items-center gap-1 rounded-md bg-[var(--muted)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--muted-foreground)]">
-                                <Star size={10} /> {t("Default")}
-                              </span>
-                            )}
+                {activeSummary ? (
+                  <div className="mt-6 space-y-4">
+                    <div className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-4">
+                      <div className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                        Gói đang theo dõi
+                      </div>
+                      <div className="mt-2 text-xl font-semibold text-[var(--foreground)]">
+                        {activeSummary.name}
+                      </div>
+                      <div className="mt-4 grid gap-3">
+                        <div className="rounded-2xl bg-[var(--background)] px-4 py-3">
+                          <div className="text-xs text-[var(--muted-foreground)]">Chủ đề</div>
+                          <div className="mt-1 text-sm font-medium text-[var(--foreground)]">
+                            {activeSummary.subject || "Chưa chọn"}
                           </div>
-                          <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-[var(--muted-foreground)]">
-                            <span>{t("Provider")}: {kb.statistics?.rag_provider || "llamaindex"}</span>
-                            <span>{t("Documents")}: {kb.statistics?.raw_documents ?? 0}</span>
-                            {displayStatus && (
-                              <span
-                                className={
-                                  needsReindex
-                                    ? "font-medium text-amber-600 dark:text-amber-400"
-                                    : "capitalize"
-                                }
-                              >
-                                {t("Status")}: {displayStatus}
-                              </span>
-                            )}
-                          </div>
-                          {kb.metadata && (
-                            <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] text-[var(--muted-foreground)]">
-                              {kb.metadata.subject && (
-                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
-                                  {t("Subject")}: {kb.metadata.subject}
-                                </span>
-                              )}
-                              {kb.metadata.grade && (
-                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
-                                  {t("Grade")}: {kb.metadata.grade}
-                                </span>
-                              )}
-                              {kb.metadata.curriculum && (
-                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
-                                  {t("Curriculum")}: {kb.metadata.curriculum}
-                                </span>
-                              )}
-                              {kb.metadata.owner && (
-                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
-                                  {t("Owner")}: {kb.metadata.owner}
-                                </span>
-                              )}
-                              {kb.metadata.sharing_status && (
-                                <span className="rounded-md bg-[var(--muted)] px-2 py-0.5">
-                                  {t("Sharing")}: {kb.metadata.sharing_status}
-                                </span>
-                              )}
-                            </div>
-                          )}
-                          {kb.metadata?.learning_objectives?.length ? (
-                            <div className="mt-2 text-[11px] text-[var(--muted-foreground)]">
-                              {t("Learning objectives")}: {kb.metadata.learning_objectives.join(", ")}
-                            </div>
-                          ) : null}
-                          {kb.metadata?.team_members?.length ? (
-                            <div className="mt-2 text-[11px] text-[var(--muted-foreground)]">
-                              {t("Team members")}: {kb.metadata.team_members.join(", ")}
-                            </div>
-                          ) : null}
-                          {kb.metadata?.pending_invites?.length ? (
-                            <div className="mt-1 text-[11px] text-[var(--muted-foreground)]">
-                              {t("Pending invites")}: {kb.metadata.pending_invites.join(", ")}
-                            </div>
-                          ) : null}
                         </div>
-
-                        <div className="flex items-center gap-1.5">
-                          <button
-                            onClick={() => startEditKnowledgePack(kb)}
-                            className="rounded-md border border-[var(--border)] px-2.5 py-1 text-[12px] text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]"
-                          >
-                            {t("Edit pack")}
-                          </button>
-                          {!kb.is_default && (
-                            <button
-                              onClick={() => setDefaultKnowledgeBase(kb.name)}
-                              className="rounded-md border border-[var(--border)] px-2.5 py-1 text-[12px] text-[var(--foreground)] transition-colors hover:bg-[var(--muted)]"
-                            >
-                              {t("Set default")}
-                            </button>
-                          )}
-                          <button
-                            onClick={() => deleteKnowledgeBase(kb.name)}
-                            className="rounded-md border border-[var(--border)] p-1.5 text-[var(--muted-foreground)] transition-colors hover:border-red-200 hover:bg-red-50 hover:text-red-600 dark:hover:border-red-900 dark:hover:bg-red-950/30 dark:hover:text-red-400"
-                          >
-                            <Trash2 size={13} />
-                          </button>
+                        <div className="rounded-2xl bg-[var(--background)] px-4 py-3">
+                          <div className="text-xs text-[var(--muted-foreground)]">Mức độ khó</div>
+                          <div className="mt-1 text-sm font-medium text-[var(--foreground)]">
+                            {difficultyLabel(activeSummary.difficulty)}
+                          </div>
+                        </div>
+                        <div className="rounded-2xl bg-[var(--background)] px-4 py-3">
+                          <div className="text-xs text-[var(--muted-foreground)]">Chương trình học</div>
+                          <div className="mt-1 text-sm font-medium text-[var(--foreground)]">
+                            {activeSummary.curriculum}
+                          </div>
                         </div>
                       </div>
-
-                      {progress?.message && (
-                        <div className="mt-3 rounded-lg bg-[var(--muted)] p-3">
-                          <div className="text-[12px] text-[var(--foreground)]">
-                            {progress.message}
-                          </div>
-                          {percent > 0 && (
-                            <div className="mt-2 h-1 overflow-hidden rounded-full bg-[var(--border)]">
-                              <div
-                                className="h-full rounded-full bg-[var(--primary)] transition-all duration-300"
-                                style={{ width: `${percent}%` }}
-                              />
-                            </div>
-                          )}
-                        </div>
-                      )}
-
-                      {editingKbName === kb.name && (
-                        <div className="mt-3 space-y-4 rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
-                          <div className="flex flex-wrap items-center justify-between gap-2">
-                            <div className="text-[12px] font-medium text-[var(--foreground)]">
-                              {t("Edit Knowledge Pack Metadata")}
-                            </div>
-                            <div className="rounded-full bg-[var(--background)] px-3 py-1 text-[11px] text-[var(--muted-foreground)]">
-                              {metadataProgressCount}
-                            </div>
-                          </div>
-
-                          <div className="grid gap-2 rounded-xl bg-[var(--background)] p-3 md:grid-cols-2">
-                            <input
-                              value={editKbSubject}
-                              onChange={(event) => setEditKbSubject(event.target.value)}
-                              placeholder={t("Subject")}
-                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                            />
-                            <input
-                              value={editKbGrade}
-                              onChange={(event) => setEditKbGrade(event.target.value)}
-                              placeholder={t("Grade")}
-                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                            />
-                          </div>
-
-                          <div className="rounded-xl bg-[var(--background)] p-3">
-                            <input
-                              value={editKbCurriculum}
-                              onChange={(event) => setEditKbCurriculum(event.target.value)}
-                              placeholder={t("Curriculum")}
-                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                            />
-                          </div>
-
-                          <div className="rounded-xl bg-[var(--background)] p-3">
-                            <textarea
-                              value={editKbLearningObjectives}
-                              onChange={(event) => setEditKbLearningObjectives(event.target.value)}
-                              placeholder={t("Learning objectives (one per line)")}
-                              rows={4}
-                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                            />
-                          </div>
-
-                          <div className="grid gap-2 rounded-xl bg-[var(--background)] p-3 md:grid-cols-[1fr_180px]">
-                            <input
-                              value={editKbOwner}
-                              onChange={(event) => setEditKbOwner(event.target.value)}
-                              placeholder={t("Owner")}
-                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                            />
-                            <select
-                              value={editKbSharingStatus}
-                              onChange={(event) =>
-                                setEditKbSharingStatus(event.target.value as "private" | "team" | "public")
-                              }
-                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none"
-                            >
-                              <option value="private">{t("Private")}</option>
-                              <option value="team">{t("Team")}</option>
-                              <option value="public">{t("Public")}</option>
-                            </select>
-                          </div>
-
-                          {editKbSharingStatus === "team" && (
-                            <div className="grid gap-2 rounded-xl bg-[var(--background)] p-3 md:grid-cols-2">
-                              <textarea
-                                value={editKbTeamMembers}
-                                onChange={(event) => setEditKbTeamMembers(event.target.value)}
-                                placeholder={t("Team members (one per line)")}
-                                rows={4}
-                                className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                              />
-                              <textarea
-                                value={editKbPendingInvites}
-                                onChange={(event) => setEditKbPendingInvites(event.target.value)}
-                                placeholder={t("Invite emails (one per line)")}
-                                rows={4}
-                                className="w-full rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                              />
-                            </div>
-                          )}
-
-                          {editKbError && (
-                            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-                              {t("Knowledge Pack metadata could not be saved")}: {editKbError}
-                            </div>
-                          )}
-
-                          <div className="flex items-center gap-2">
-                            <button
-                              onClick={saveKnowledgePackMetadata}
-                              disabled={savingKbMetadata}
-                              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3.5 py-1.5 text-[13px] font-medium text-[var(--primary-foreground)] transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
-                            >
-                              {savingKbMetadata ? (
-                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                              ) : (
-                                <PenLine size={14} />
-                              )}
-                              {t("Save metadata")}
-                            </button>
-
-                            <button
-                              onClick={cancelEditKnowledgePack}
-                              disabled={savingKbMetadata}
-                              className="rounded-lg border border-[var(--border)] px-3.5 py-1.5 text-[13px] text-[var(--foreground)] transition-colors hover:bg-[var(--muted)] disabled:cursor-not-allowed disabled:opacity-40"
-                            >
-                              {t("Cancel")}
-                            </button>
-                          </div>
-                        </div>
-                      )}
                     </div>
-                  );
-                })}
 
-                {!combinedKbs.length && (
-                  <div className="rounded-lg border border-dashed border-[var(--border)] px-6 py-10 text-center text-[13px] text-[var(--muted-foreground)]">
-                    {t("No knowledge bases yet. Create one to get started.")}
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-4 py-4">
+                        <div className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                          Số tài liệu
+                        </div>
+                        <div className="mt-2 text-2xl font-semibold text-[var(--foreground)]">
+                          {activeSummary.documentCount}
+                        </div>
+                      </div>
+                      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-4 py-4">
+                        <div className="text-xs uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                          Trạng thái index
+                        </div>
+                        <div className="mt-2 text-2xl font-semibold text-[var(--foreground)]">
+                          {statusLabel(activeSummary.status)}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <div>
+                          <div className="text-sm font-medium text-[var(--foreground)]">
+                            Tiến trình tổng quan
+                          </div>
+                          <div className="mt-1 text-xs text-[var(--muted-foreground)]">
+                            {progressSummaryLabel(activeSummary.progress)}
+                          </div>
+                        </div>
+                        <div className="text-sm font-semibold text-[var(--foreground)]">
+                          {progressPercent(activeSummary.progress)}%
+                        </div>
+                      </div>
+                      <div className="mt-3 h-2 overflow-hidden rounded-full bg-[var(--border)]">
+                        <div
+                          className="h-full rounded-full bg-[linear-gradient(90deg,#e7a658,#d97706)] transition-all"
+                          style={{ width: `${progressPercent(activeSummary.progress)}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-6 rounded-3xl border border-dashed border-[var(--border)] px-5 py-10 text-center text-sm text-[var(--muted-foreground)]">
+                    Điền thông tin ở wizard hoặc bấm `Xem chi tiết` trên một gói hiện có để xem trạng thái ở đây.
                   </div>
                 )}
-              </div>
-            </section>
-          </div>
-        ) : (
-          <div className="space-y-5">
-            {/* Create notebook */}
-            <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
-              <div className="mb-4 flex items-center gap-2">
-                <Plus size={15} className="text-[var(--muted-foreground)]" />
-                <h2 className="text-[14px] font-semibold text-[var(--foreground)]">
-                  {t("Create notebook")}
-                </h2>
-              </div>
+              </aside>
+            </div>
 
-              <div className="grid gap-3 md:grid-cols-[1fr_1fr_auto]">
-                <input
-                  value={newNotebookName}
-                  onChange={(event) => setNewNotebookName(event.target.value)}
-                  placeholder={t("Notebook name")}
-                  className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                />
-                <input
-                  value={newNotebookDescription}
-                  onChange={(event) => setNewNotebookDescription(event.target.value)}
-                  placeholder={t("Description")}
-                  className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-[13px] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/25"
-                />
-                <button
-                  onClick={createNotebook}
-                  disabled={!newNotebookName.trim()}
-                  className="rounded-lg bg-[var(--primary)] px-3.5 py-2 text-[13px] font-medium text-[var(--primary-foreground)] disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  {t("Create")}
-                </button>
+            <section className="rounded-[28px] border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+              <div className="flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                <BookOpen className="h-4 w-4 text-amber-600" />
+                Danh sách gói kiến thức
               </div>
-            </section>
-
-            {/* Notebook list */}
-            <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
-              <div className="mb-4 flex items-center gap-2">
-                <NotebookPen size={15} className="text-[var(--muted-foreground)]" />
-                <h2 className="text-[14px] font-semibold text-[var(--foreground)]">
-                  {t("Notebooks")}
-                </h2>
-              </div>
-
-              <div className="grid gap-5 xl:grid-cols-[280px_minmax(0,1fr)]">
-                <div className="xl:sticky xl:top-8 xl:max-h-[calc(100vh-12rem)] space-y-3 overflow-y-auto pr-1">
-                  {notebooks.map((notebook) => {
-                    const active = selectedNotebookId === notebook.id;
+              <div className="mt-5 space-y-4">
+                {combinedKbs.length ? (
+                  combinedKbs.map((kb) => {
+                    const progress = kb.progress;
+                    const currentDifficulty = kb.metadata?.difficulty ?? kb.metadata?.grade ?? null;
                     return (
-                      <button
-                        key={notebook.id}
-                        onClick={() => void loadNotebookDetail(notebook.id)}
-                        className={`w-full rounded-xl border p-4 text-left transition-all ${
-                          active
-                            ? "border-indigo-200 bg-indigo-50/70 shadow-[0_8px_24px_rgba(99,102,241,0.08)] dark:border-indigo-800 dark:bg-indigo-950/25"
-                            : "border-[var(--border)] bg-[var(--background)] hover:border-[var(--foreground)]/12 hover:bg-[var(--muted)]/18"
-                        }`}
+                      <div
+                        key={kb.name}
+                        className="rounded-[24px] border border-[var(--border)] bg-[var(--background)] p-4"
                       >
-                        <div className="flex items-start gap-3">
-                          <div
-                            className="mt-1 h-3 w-3 rounded-full"
-                            style={{ backgroundColor: notebook.color || "#6366f1" }}
-                          />
-                          <div className="min-w-0 flex-1">
-                            <div className="text-[14px] font-semibold text-[var(--foreground)]">
-                              {notebook.name}
-                            </div>
-                            {notebook.description && (
-                              <p className="mt-1 line-clamp-2 text-[12px] leading-relaxed text-[var(--muted-foreground)]">
-                                {notebook.description}
-                              </p>
-                            )}
-                            <div className="mt-3 flex items-center justify-between text-[11px] text-[var(--muted-foreground)]">
-                              <span>{notebook.record_count ?? 0} {t("records")}</span>
-                              <span>{notebook.updated_at ? formatTimestamp(notebook.updated_at) : ""}</span>
-                            </div>
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-
-                  {!notebooks.length && (
-                    <div className="rounded-xl border border-dashed border-[var(--border)] px-6 py-10 text-center text-[13px] text-[var(--muted-foreground)]">
-                      {t("No notebooks yet. Create one to organize outputs.")}
-                    </div>
-                  )}
-                </div>
-
-                <div className="flex min-h-[560px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] p-4 xl:h-[calc(100vh-12rem)]">
-                  {loadingNotebookDetail ? (
-                    <div className="flex min-h-[320px] items-center justify-center">
-                      <Loader2 className="h-5 w-5 animate-spin text-[var(--muted-foreground)]" />
-                    </div>
-                  ) : selectedNotebook ? (
-                    <div className="flex min-h-0 flex-1 flex-col">
-                      <div className="mb-3 flex shrink-0 items-center justify-between gap-4 pb-3">
-                        <div className="flex items-center gap-2.5">
-                          <div
-                            className="h-2.5 w-2.5 rounded-full"
-                            style={{ backgroundColor: selectedNotebook.color || "#6366f1" }}
-                          />
-                          <h3 className="text-[15px] font-semibold text-[var(--foreground)]">
-                            {selectedNotebook.name}
-                          </h3>
-                          {selectedNotebook.description && (
-                            <span className="text-[12px] text-[var(--muted-foreground)]">
-                              — {selectedNotebook.description}
-                            </span>
-                          )}
-                        </div>
-                        <span className="text-[11px] tabular-nums text-[var(--muted-foreground)]">
-                          {selectedNotebook.records?.length || 0} {t("records")}
-                        </span>
-                      </div>
-
-                      <div className="min-h-0 flex-1 overflow-y-auto pr-1">
-                        <div className="divide-y divide-[var(--border)]">
-                        {selectedNotebook.records?.map((record) => {
-                          const badge = getRecordBadge(record.type);
-                          const BadgeIcon = badge.icon;
-                          const expanded = expandedRecordId === record.id;
-                          const canOpenSession =
-                            record.type === "chat" && Boolean(record.metadata?.session_id);
-                          const sessionLabel = t("Open chat session");
-
-                          return (
-                            <div key={record.id} className="group">
-                              {/* Collapsed row — always visible */}
-                              <button
-                                onClick={() => setExpandedRecordId(expanded ? null : record.id)}
-                                className="flex w-full items-center gap-3 px-1 py-3.5 text-left transition-colors hover:bg-[var(--muted)]/30"
-                              >
-                                <span className="shrink-0 text-[var(--muted-foreground)]">
-                                  {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <h3 className="text-lg font-semibold text-[var(--foreground)]">
+                                {kb.name}
+                              </h3>
+                              {kb.is_default && (
+                                <span className="rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700">
+                                  Mặc định
                                 </span>
-                                <span className={`inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium ${badge.color}`}>
-                                  <BadgeIcon size={11} />
-                                  {badge.label}
-                                </span>
-                                <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[var(--foreground)]">
-                                  {record.title}
-                                </span>
-                                <span className="shrink-0 text-[11px] tabular-nums text-[var(--muted-foreground)]">
-                                  {formatTimestamp(record.created_at)}
-                                </span>
-                              </button>
-
-                              {/* Expanded detail */}
-                              {expanded && (
-                                <div className="pb-4 pl-8 pr-1">
-                                  {record.summary && (
-                                    <p className="mb-3 text-[13px] leading-6 text-[var(--foreground)]/85">
-                                      {record.summary}
-                                    </p>
-                                  )}
-                                  {record.type !== "chat" && record.user_query && (
-                                    <div className="mb-3 flex items-baseline gap-2 text-[12px]">
-                                      <span className="shrink-0 font-medium text-[var(--muted-foreground)]">{t("Query:")}</span>
-                                      <span className="text-[var(--foreground)]/70">{record.user_query}</span>
-                                    </div>
-                                  )}
-
-                                  {canOpenSession && (
-                                    <button
-                                      onClick={() => openNotebookRecord(record)}
-                                      className="mb-3 inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)] px-3.5 py-2 text-[12px] font-medium text-[var(--foreground)] transition-colors hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700 dark:hover:border-indigo-700 dark:hover:bg-indigo-950/30 dark:hover:text-indigo-300"
-                                    >
-                                      <ExternalLink size={13} />
-                                      {sessionLabel}
-                                      <ArrowRight size={13} />
-                                    </button>
-                                  )}
-
-                                  <div className="max-h-[320px] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 p-3">
-                                    <MarkdownRenderer
-                                      content={record.output || ""}
-                                      variant="prose"
-                                      className="text-[12px] leading-5 text-[var(--foreground)]"
-                                    />
-                                  </div>
-                                </div>
                               )}
                             </div>
-                          );
-                        })}
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              <span className="rounded-full bg-[var(--card)] px-3 py-1 text-xs text-[var(--muted-foreground)]">
+                                Chủ đề: {kb.metadata?.subject || "Chưa có"}
+                              </span>
+                              <span className="rounded-full bg-[var(--card)] px-3 py-1 text-xs text-[var(--muted-foreground)]">
+                                Mức độ khó: {difficultyLabel(currentDifficulty)}
+                              </span>
+                              <span className="rounded-full bg-[var(--card)] px-3 py-1 text-xs text-[var(--muted-foreground)]">
+                                Chương trình học: {kb.metadata?.curriculum || "Chưa có"}
+                              </span>
+                              <span className="rounded-full bg-[var(--card)] px-3 py-1 text-xs text-[var(--muted-foreground)]">
+                                Số tài liệu: {kb.statistics?.raw_documents ?? 0}
+                              </span>
+                              <span className="rounded-full bg-[var(--card)] px-3 py-1 text-xs text-[var(--muted-foreground)]">
+                                Trạng thái index: {statusLabel(progress?.stage ?? kb.status)}
+                              </span>
+                            </div>
+                          </div>
 
-                        {!selectedNotebook.records?.length && (
-                          <div className="px-6 py-12 text-center text-[13px] text-[var(--muted-foreground)]">
-                            {t("This notebook is empty for now.")}
+                          <div className="flex flex-wrap gap-2">
+                            <button
+                              type="button"
+                              onClick={() => setDetailPackName(kb.name)}
+                              className="rounded-full border border-[var(--border)] px-4 py-2 text-sm text-[var(--foreground)]"
+                            >
+                              Xem chi tiết
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => startEditKnowledgePack(kb)}
+                              className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] px-4 py-2 text-sm text-[var(--foreground)]"
+                            >
+                              <PencilLine className="h-4 w-4" />
+                              Chỉnh sửa
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => void deleteKnowledgeBase(kb.name)}
+                              className="inline-flex items-center gap-2 rounded-full border border-red-200 px-4 py-2 text-sm text-red-700"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              Xóa
+                            </button>
+                          </div>
+                        </div>
+
+                        {progress && (
+                          <div className="mt-4 rounded-2xl border border-[var(--border)] bg-[var(--card)] px-4 py-3">
+                            <div className="flex items-center justify-between gap-3">
+                              <div className="text-sm text-[var(--foreground)]">
+                                {progressSummaryLabel(progress)}
+                              </div>
+                              <div className="text-sm font-medium text-[var(--foreground)]">
+                                {progressPercent(progress)}%
+                              </div>
+                            </div>
+                            <div className="mt-3 h-2 overflow-hidden rounded-full bg-[var(--border)]">
+                              <div
+                                className="h-full rounded-full bg-[linear-gradient(90deg,#e7a658,#d97706)] transition-all"
+                                style={{ width: `${progressPercent(progress)}%` }}
+                              />
+                            </div>
                           </div>
                         )}
-                        </div>
+
+                        {editingKbName === kb.name && (
+                          <div className="mt-4 rounded-[24px] border border-[var(--border)] bg-[var(--card)] p-4">
+                            <div className="mb-4 text-sm font-medium text-[var(--foreground)]">
+                              Chỉnh sửa gói kiến thức
+                            </div>
+                            <div className="grid gap-3 md:grid-cols-2">
+                              <input
+                                value={editSubject}
+                                onChange={(event) => setEditSubject(event.target.value)}
+                                placeholder="Chủ đề"
+                                className="rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] outline-none"
+                              />
+                              <input
+                                value={editCurriculum}
+                                onChange={(event) => setEditCurriculum(event.target.value)}
+                                placeholder="Chương trình học"
+                                className="rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] outline-none"
+                              />
+                            </div>
+                            <div className="mt-3 grid gap-2 md:grid-cols-3">
+                              {DIFFICULTY_OPTIONS.map((option) => (
+                                <button
+                                  key={option.value}
+                                  type="button"
+                                  onClick={() => setEditDifficulty(option.value)}
+                                  className={`rounded-2xl border px-4 py-3 text-left text-sm ${
+                                    editDifficulty === option.value
+                                      ? "border-amber-300 bg-amber-50 text-amber-900"
+                                      : "border-[var(--border)] bg-[var(--background)] text-[var(--foreground)]"
+                                  }`}
+                                >
+                                  {option.label}
+                                </button>
+                              ))}
+                            </div>
+                            <textarea
+                              value={editLearningObjectives}
+                              onChange={(event) => setEditLearningObjectives(event.target.value)}
+                              placeholder="Mục tiêu học tập, mỗi dòng một ý"
+                              rows={4}
+                              className="mt-3 w-full rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] outline-none"
+                            />
+                            {editError && (
+                              <div className="mt-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                                {editError}
+                              </div>
+                            )}
+                            <div className="mt-4 flex flex-wrap gap-3">
+                              <button
+                                type="button"
+                                disabled={savingMetadata}
+                                onClick={() => void saveKnowledgePackMetadata()}
+                                className="inline-flex items-center gap-2 rounded-full bg-[var(--foreground)] px-4 py-2 text-sm font-medium text-[var(--background)] disabled:cursor-not-allowed disabled:opacity-40"
+                              >
+                                {savingMetadata ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+                                Lưu thay đổi
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setEditingKbName(null)}
+                                className="rounded-full border border-[var(--border)] px-4 py-2 text-sm text-[var(--foreground)]"
+                              >
+                                Hủy
+                              </button>
+                            </div>
+                          </div>
+                        )}
                       </div>
+                    );
+                  })
+                ) : (
+                  <div className="rounded-[24px] border border-dashed border-[var(--border)] px-6 py-12 text-center">
+                    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[var(--muted)]">
+                      <AlertCircle className="h-5 w-5 text-[var(--muted-foreground)]" />
                     </div>
-                  ) : (
-                    <div className="flex min-h-[320px] items-center justify-center rounded-2xl border border-dashed border-[var(--border)] text-[13px] text-[var(--muted-foreground)]">
-                      {t("Select a notebook to inspect its saved records.")}
+                    <div className="mt-4 text-base font-medium text-[var(--foreground)]">
+                      Chưa có gói kiến thức nào
                     </div>
-                  )}
-                </div>
+                    <div className="mt-2 text-sm text-[var(--muted-foreground)]">
+                      Bắt đầu bằng wizard phía trên để tải bộ tài liệu đầu tiên cho lớp học.
+                    </div>
+                  </div>
+                )}
               </div>
             </section>
           </div>

--- a/web/app/(utility)/knowledge/page.tsx
+++ b/web/app/(utility)/knowledge/page.tsx
@@ -207,6 +207,12 @@ const makeInitialFileStatuses = (files: File[]): FileStatusInfo[] =>
     status: "uploaded",
   }));
 
+const makeDraftFileStatuses = (fileNames: string[]): FileStatusInfo[] =>
+  fileNames.map((name) => ({
+    name,
+    status: "uploaded",
+  }));
+
 export default function KnowledgePage() {
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
   const [progressMap, setProgressMap] = useState<Record<string, ProgressInfo>>({});
@@ -520,10 +526,12 @@ export default function KnowledgePage() {
     combinedKbs.find((kb) => kb.name === detailPackName) ??
     null;
 
-  const summaryFileStatuses =
+  const summaryFileStatuses: FileStatusInfo[] =
     selectedPack?.progress?.file_statuses?.length
       ? selectedPack.progress.file_statuses
-      : draftSummary?.fileNames.map((name) => ({ name, status: "uploaded" })) ?? [];
+      : draftSummary
+        ? makeDraftFileStatuses(draftSummary.fileNames)
+        : [];
 
   const indexedCount = summaryFileStatuses.filter((item) => item.status === "indexed").length;
   const processingCount = summaryFileStatuses.filter((item) =>

--- a/web/lib/knowledge-api.ts
+++ b/web/lib/knowledge-api.ts
@@ -21,12 +21,40 @@ export interface TeacherPackMetadata {
   content_types?: string[] | null;
 }
 
+export interface KnowledgeProgressSummary {
+  task_id?: string;
+  stage?: string;
+  message?: string;
+  current?: number;
+  total?: number;
+  percent?: number;
+  progress_percent?: number;
+  file_name?: string;
+  file_statuses?: Array<{
+    name: string;
+    status: string;
+    updated_at?: string;
+    error?: string;
+  }>;
+  error?: string;
+  timestamp?: string;
+}
+
+export interface KnowledgeBaseStatisticsSummary {
+  raw_documents?: number;
+  rag_provider?: string;
+  needs_reindex?: boolean;
+  status?: string;
+  progress?: KnowledgeProgressSummary;
+  [key: string]: unknown;
+}
+
 export interface KnowledgeBaseSummary {
   name: string;
   is_default?: boolean;
   status?: string;
-  progress?: Record<string, unknown>;
-  statistics?: Record<string, unknown>;
+  progress?: KnowledgeProgressSummary;
+  statistics?: KnowledgeBaseStatisticsSummary;
   metadata?: TeacherPackMetadata | null;
 }
 

--- a/web/tests/knowledge-page-wizard-shell.test.ts
+++ b/web/tests/knowledge-page-wizard-shell.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const KNOWLEDGE_PAGE_PATH = resolve(
+  process.cwd(),
+  "app/(utility)/knowledge/page.tsx",
+);
+
+function readKnowledgePageSource(): string {
+  return readFileSync(KNOWLEDGE_PAGE_PATH, "utf8");
+}
+
+test("knowledge page hides notebooks and provider selection from the main shell", () => {
+  const source = readKnowledgePageSource();
+
+  assert.doesNotMatch(source, /setTab\(<"knowledge" \| "notebooks">/);
+  assert.doesNotMatch(source, /listRagProviders/);
+  assert.doesNotMatch(source, /selectedProvider/);
+});
+
+test("knowledge page uses the wizard labels and difficulty choices", () => {
+  const source = readKnowledgePageSource();
+
+  assert.match(source, /Thông tin/);
+  assert.match(source, /Tài liệu/);
+  assert.match(source, /Hoàn tất/);
+  assert.match(source, /Mức độ khó/);
+  assert.match(source, /Cơ bản/);
+  assert.match(source, /Trung bình/);
+  assert.match(source, /Nâng cao/);
+});


### PR DESCRIPTION
## Summary
- redesign `/knowledge` into a Vietnamese-first wizard flow: `Thông tin -> Tài liệu -> Hoàn tất`
- remove visible notebook and provider/model controls from the knowledge screen, and replace the old grade field with `Mức độ khó`
- persist pack-level and per-file indexing status so the completion step can show real document progress

## Validation
- `pytest tests/api/test_knowledge_router.py tests/knowledge/test_progress_tracker.py -q`
- `cd web && node --test tests/knowledge-page-wizard-shell.test.ts tests/contest-vietnamese-coverage.test.ts`
- `git diff --check`
- `cd web && npm run lint -- --file 'app/(utility)/knowledge/page.tsx'` was blocked in this worktree because `eslint` is not available in PATH

## Notes
- the FE no longer sends `rag_provider` during normal pack creation
- the backend still uses the repo's single default KB pipeline rather than introducing a new provider id
