### PR TITLE
Rebalance shared sidebar shell

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,6 +34,21 @@ Rules:
 
 - Owner: Codex session
 - Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-sidebar-shell-rebalance`
+- Task: Rebalance the shared sidebar shell so chat history owns the middle space and the shell is wider
+- Status: implemented, pending PR
+- Branch: `fix/sidebar-shell-rebalance`
+- Task packet: `docs/superpowers/tasks/2026-04-30-sidebar-shell-rebalance.md`
+- Owned files: `web/components/sidebar/SidebarShell.tsx`, `web/components/SessionList.tsx`, `web/components/sidebar/nav-groups.ts`, `web/tests/sidebar-nav-groups.test.ts`, `web/tests/sidebar-shell-layout.test.ts`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `docs/superpowers/tasks/2026-04-30-sidebar-shell-rebalance.md`, `docs/superpowers/specs/2026-04-30-sidebar-shell-rebalance-design.md`, `docs/superpowers/plans/2026-04-30-sidebar-shell-rebalance.md`, `docs/superpowers/pr-notes/2026-04-30-sidebar-shell-rebalance.md`
+- PR: uncreated
+- Last update: 2026-04-30
+- Next action: stage the bounded shell/docs diff and open a draft PR if requested
+- Blocker: none
+
+### Assignment
+
+- Owner: Codex session
+- Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform`
 - Task: Add `Gói gia sư` selection and session binding for `/playground` chat using imported marketplace packs
 - Status: writing spec

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -433,3 +433,14 @@
 - Done: Blocks new sends when the bound tutor pack is no longer available while still allowing the user to read old messages.
 - Done: Shows the bound tutor pack in chat context and as a compact badge in session history.
 - Tests: `cd web && ./node_modules/.bin/eslint "app/(workspace)/playground/page.tsx" context/UnifiedChatContext.tsx components/SessionList.tsx lib/session-api.ts`; `cd web && npm run build`; `python3 -m py_compile deeptutor/api/routers/sessions.py deeptutor/services/session/turn_runtime.py`; `git diff --check`
+
+## UI_SIDEBAR_SHELL_REBALANCE
+
+- Branch: `fix/sidebar-shell-rebalance`
+- Task: `UI_SIDEBAR_SHELL_REBALANCE`
+- Done: Wrote the bounded design artifact `docs/superpowers/specs/2026-04-30-sidebar-shell-rebalance-design.md` and implementation plan `docs/superpowers/plans/2026-04-30-sidebar-shell-rebalance.md` before runtime edits.
+- Done: Rebalanced the expanded shared sidebar by widening it from `220px` to `264px`, removing the detached top-level `New Chat` row, and moving chat creation into the `Trò chuyện` section header.
+- Done: Promoted the session history into a dedicated middle `flex-1` panel so the list now owns the main vertical space instead of living under `/playground` with a `max-h-[112px]` cap.
+- Done: Left `SessionList.tsx` runtime behavior unchanged because the wider shell cleanly reuses the existing non-compact list rendering.
+- Tests: `cd web && node --test tests/sidebar-shell-layout.test.ts tests/sidebar-nav-groups.test.ts`; `git diff --check`
+- Notes: targeted lint could not run in this worktree because `web/node_modules/.bin/eslint` is unavailable.

--- a/docs/superpowers/plans/2026-04-30-sidebar-shell-rebalance.md
+++ b/docs/superpowers/plans/2026-04-30-sidebar-shell-rebalance.md
@@ -1,0 +1,280 @@
+# Sidebar Shell Rebalance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebalance the shared expanded sidebar so the route nav stays compact at the top, the chat section owns the new-chat action and most of the middle height, and the shell is about 20% wider.
+
+**Architecture:** Keep the existing `WorkspaceSidebar -> SidebarShell -> SessionList` contract intact where possible. Make the hierarchy change inside `SidebarShell`, use source-level FE tests to lock the new shell shape first, and only touch `SessionList` if the wider shell exposes weak row density or empty-state presentation.
+
+**Tech Stack:** Next.js App Router, React client components, existing sidebar/session components, Node `node:test` source-level FE regression tests
+
+---
+
+### Task 1: Lock The Sidebar Hierarchy Expectations In FE Tests
+
+**Files:**
+- Review: `web/components/sidebar/SidebarShell.tsx`
+- Review: `web/components/SessionList.tsx`
+- Modify: `web/tests/sidebar-nav-groups.test.ts`
+- Create: `web/tests/sidebar-shell-layout.test.ts`
+
+- [ ] **Step 1: Add the failing shell-shape test**
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SIDEBAR_SHELL_PATH = resolve(process.cwd(), "components/sidebar/SidebarShell.tsx");
+
+function readSidebarShell(): string {
+  return readFileSync(SIDEBAR_SHELL_PATH, "utf8");
+}
+
+test("expanded sidebar uses wider shell and chat-owned new-chat action", () => {
+  const source = readSidebarShell();
+
+  assert.match(source, /w-\\[264px\\]/);
+  assert.doesNotMatch(source, /New Chat"[\\s\\S]*expandedNavGroups/);
+  assert.match(source, /Trò chuyện|t\\("Chat"\)/);
+  assert.match(source, /Plus/);
+  assert.doesNotMatch(source, /max-h-\\[112px\\]/);
+});
+```
+
+- [ ] **Step 2: Run the FE shell test to verify it fails**
+
+Run: `cd web && node --test tests/sidebar-shell-layout.test.ts`
+Expected: FAIL because `SidebarShell.tsx` still uses `w-[220px]`, keeps the detached `New Chat` row, and still caps the compact session viewport.
+
+- [ ] **Step 3: Keep the existing nav-group regression green**
+
+Run: `cd web && node --test tests/sidebar-nav-groups.test.ts`
+Expected: PASS so the task starts from a known-good grouping baseline.
+
+- [ ] **Step 4: Commit the failing-test checkpoint**
+
+```bash
+git add web/tests/sidebar-shell-layout.test.ts web/tests/sidebar-nav-groups.test.ts
+git commit -m "test(sidebar): lock shell rebalance expectations [UI_SIDEBAR_SHELL_REBALANCE]"
+```
+
+### Task 2: Rebalance The Expanded Sidebar Layout Inside SidebarShell
+
+**Files:**
+- Modify: `web/components/sidebar/SidebarShell.tsx`
+
+- [ ] **Step 1: Increase the expanded shell width and reduce nav density**
+
+```tsx
+return (
+  <aside className="flex h-screen w-[264px] shrink-0 flex-col bg-[var(--secondary)] transition-all duration-200">
+```
+
+Also tighten the expanded nav item spacing:
+
+```tsx
+className={`flex items-center gap-2.5 rounded-lg px-3 py-1.5 text-[13.5px] transition-colors ${
+  active
+    ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
+    : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
+}`}
+```
+
+- [ ] **Step 2: Remove the detached top-level new-chat row**
+
+Delete the current expanded-mode block:
+
+```tsx
+<button
+  onClick={handleNewChat}
+  className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--background)]/60 hover:text-[var(--foreground)]"
+>
+  <Plus size={16} strokeWidth={2} />
+  <span>{t("New Chat")}</span>
+</button>
+```
+
+- [ ] **Step 3: Stop nesting the session list under the `/playground` nav item**
+
+Replace the current `hasSessionsBelow` path so `/playground` renders as a normal nav item only:
+
+```tsx
+const hasBots = item.href === "/agents";
+```
+
+and remove:
+
+```tsx
+{hasSessionsBelow && (
+  <div className={`${sessionViewportClassName} overflow-y-auto`}>
+    <SessionList ... compact />
+  </div>
+)}
+```
+
+- [ ] **Step 4: Add a dedicated chat section below the route groups**
+
+Insert a middle section after the primary nav:
+
+```tsx
+<div className="min-h-0 flex-1 px-2 pb-2 pt-3">
+  <div className="flex items-center justify-between px-3 pb-2">
+    <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]/80">
+      {t("Chat")}
+    </div>
+    <button
+      onClick={handleNewChat}
+      className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--background)]/60 hover:text-[var(--foreground)]"
+      aria-label={t("New Chat")}
+    >
+      <Plus size={15} strokeWidth={2} />
+    </button>
+  </div>
+  <div className="min-h-0 overflow-y-auto rounded-2xl bg-[var(--background)]/35 p-1">
+    <SessionList
+      sessions={sessions}
+      activeSessionId={activeSessionId}
+      loading={loadingSessions}
+      onSelect={onSelectSession!}
+      onRename={onRenameSession!}
+      onDelete={onDeleteSession!}
+    />
+  </div>
+</div>
+```
+
+- [ ] **Step 5: Keep the footer pinned after the chat section**
+
+Preserve the settings footer after the new `flex-1` chat section:
+
+```tsx
+<div className="border-t border-[var(--border)]/40 px-2 py-2">
+```
+
+- [ ] **Step 6: Run the shell FE tests**
+
+Run: `cd web && node --test tests/sidebar-shell-layout.test.ts tests/sidebar-nav-groups.test.ts`
+Expected: PASS once the width, detached-action removal, and chat-owned section are in place.
+
+- [ ] **Step 7: Commit the shell rebalance**
+
+```bash
+git add web/components/sidebar/SidebarShell.tsx web/tests/sidebar-shell-layout.test.ts web/tests/sidebar-nav-groups.test.ts
+git commit -m "feat(sidebar): rebalance expanded shell layout [UI_SIDEBAR_SHELL_REBALANCE]"
+```
+
+### Task 3: Refine SessionList Only If The Wider Shell Exposes Weak Rows
+
+**Files:**
+- Review: `web/components/SessionList.tsx`
+- Modify if needed: `web/components/SessionList.tsx`
+- Modify if needed: `web/tests/sidebar-shell-layout.test.ts`
+
+- [ ] **Step 1: Inspect whether the default SessionList rows already fit the new shell**
+
+Review these current branches:
+
+```tsx
+if (sessions.length === 0) {
+  if (compact) return null;
+  return (
+    <div className="px-3 py-4 text-center text-[11px] text-[var(--muted-foreground)]/70">
+      {t("No conversations yet")}
+    </div>
+  );
+}
+```
+
+and:
+
+```tsx
+if (compact) {
+  return (
+    <div className="ml-4 border-l border-[var(--border)]/30 py-2">
+```
+
+Expected: if the new dedicated chat section uses the non-compact path cleanly, `SessionList.tsx` may not need any runtime change.
+
+- [ ] **Step 2: If the empty state feels too weak, tighten only the non-compact empty state**
+
+Minimal allowed adjustment:
+
+```tsx
+return (
+  <div className="px-3 py-6 text-center text-[12px] text-[var(--muted-foreground)]/75">
+    <div>{t("No conversations yet")}</div>
+    <div className="mt-1 text-[11px]">{t("Click + to start a new chat")}</div>
+  </div>
+);
+```
+
+- [ ] **Step 3: If no SessionList runtime change is needed, record that by leaving the file untouched**
+
+Run: `git diff -- web/components/SessionList.tsx`
+Expected: no output when the shell-only implementation is sufficient.
+
+- [ ] **Step 4: Re-run the FE shell tests after any SessionList adjustment**
+
+Run: `cd web && node --test tests/sidebar-shell-layout.test.ts tests/sidebar-nav-groups.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit only if SessionList changed**
+
+```bash
+git add web/components/SessionList.tsx web/tests/sidebar-shell-layout.test.ts
+git commit -m "feat(sidebar): polish session list presentation [UI_SIDEBAR_SHELL_REBALANCE]"
+```
+
+### Task 4: Final Verification And Handoff Docs
+
+**Files:**
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-sidebar-shell-rebalance.md`
+- Update if needed: `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+
+- [ ] **Step 1: Write the PR note with the final shell hierarchy**
+
+```md
+# PR Note: Sidebar Shell Rebalance
+
+This PR rebalances the shared expanded sidebar so route navigation stays compact at the top, chat actions and chat history live in one section, and the shell is wider and less cramped.
+
+```mermaid
+flowchart TD
+  A["Sidebar header"] --> B["Primary route nav"]
+  B --> C["Chat section header (+)"]
+  C --> D["Scrollable session list"]
+  D --> E["Settings footer"]
+```
+```
+
+- [ ] **Step 2: Update the daily log with actual verification**
+
+Add an entry summarizing:
+
+```md
+- Done: widened the expanded sidebar to about 264px, moved `New Chat` into the chat section header, and let session history take the main middle height.
+- Tests: `cd web && node --test tests/sidebar-shell-layout.test.ts tests/sidebar-nav-groups.test.ts`
+```
+
+- [ ] **Step 3: Check whether the main system map needs an update**
+
+Run: inspect `ai_first/architecture/MAIN_SYSTEM_MAP.md`
+Expected: likely no change, because this is shell/layout refinement rather than a new subsystem boundary. If unchanged, state that in the PR note.
+
+- [ ] **Step 4: Run final verification**
+
+Run:
+- `cd web && node --test tests/sidebar-shell-layout.test.ts tests/sidebar-nav-groups.test.ts`
+- `git diff --check`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the final docs and handoff**
+
+```bash
+git add ai_first/daily/2026-04-30.md docs/superpowers/pr-notes/2026-04-30-sidebar-shell-rebalance.md
+git commit -m "docs(sidebar): capture shell rebalance handoff [UI_SIDEBAR_SHELL_REBALANCE]"
+```

--- a/docs/superpowers/pr-notes/2026-04-30-sidebar-shell-rebalance.md
+++ b/docs/superpowers/pr-notes/2026-04-30-sidebar-shell-rebalance.md
@@ -1,0 +1,31 @@
+# PR Note: Sidebar Shell Rebalance
+
+This PR rebalances the shared expanded sidebar so the route nav stays compact, the chat section owns the new-chat action, and session history gets the bulk of the available height.
+
+## What changed
+
+- widened the expanded sidebar shell from `220px` to `264px`
+- removed the detached expanded-mode `New Chat` row from the top of the sidebar
+- kept the primary route groups at the top, but tightened their vertical density
+- moved chat creation into the `Trò chuyện` section header with an inline `+` action
+- replaced the nested `/playground` compact session subtree with a dedicated middle history panel that scrolls independently
+- left `SessionList.tsx` runtime behavior unchanged because the existing non-compact list now fits the shell cleanly
+
+```mermaid
+flowchart TD
+  A["Sidebar header"] --> B["Primary route groups"]
+  B --> C["Chat section header (+)"]
+  C --> D["Scrollable session history"]
+  D --> E["Settings footer"]
+```
+
+## Architecture impact
+
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated.
+- The route map and runtime data contracts stay the same; this PR only changes shared sidebar hierarchy and presentation ownership between nav and chat history.
+
+## Verification
+
+- `cd web && node --test tests/sidebar-shell-layout.test.ts tests/sidebar-nav-groups.test.ts`
+- `git diff --check`
+- targeted lint was attempted but blocked because `web/node_modules/.bin/eslint` is not available in this worktree

--- a/docs/superpowers/specs/2026-04-30-sidebar-shell-rebalance-design.md
+++ b/docs/superpowers/specs/2026-04-30-sidebar-shell-rebalance-design.md
@@ -1,0 +1,169 @@
+# Sidebar Shell Rebalance
+
+- Date: 2026-04-30
+- Task ID: `UI_SIDEBAR_SHELL_REBALANCE`
+- Branch: `docs/sidebar-shell-rebalance`
+
+## Goal
+
+Improve the shared expanded sidebar so it feels structurally consistent and more usable for chat-heavy work: the conversation list should become the main middle content area, `Trò chuyện mới` should belong to the chat section instead of floating above the whole nav, and the expanded shell should be about 20% wider.
+
+## Current Behavior
+
+- The expanded sidebar width is `220px`, which is too narrow for Vietnamese labels such as `Bảng điều khiển giáo viên`.
+- `Trò chuyện mới` is rendered as a top-level action above all route groups, but the actual session list lives much lower inside the `Trò chuyện` item in the secondary tool section.
+- The session list viewport is artificially capped (`max-h-[112px]`), so the conversation history feels like a short afterthought instead of a primary working surface.
+- The visible hierarchy reads as:
+  - logo
+  - detached new-chat action
+  - route groups
+  - a small chat history pocket
+  - settings
+- This makes the sidebar feel cramped and internally inconsistent.
+
+## User-Approved Product Direction
+
+- Keep the route nav at the top.
+- Make the route nav more compact so it does not consume excessive height.
+- Move `Trò chuyện mới` into the `Trò chuyện` section header.
+- Make the conversation list the primary middle area of the sidebar.
+- Keep `Cài đặt` at the bottom.
+- Prefer changing `SidebarShell` directly and only adjust `SessionList` if the rows still feel too weak after the shell rebalance.
+
+## Codebase Survey
+
+### Entry points
+
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+  - loads sessions and passes them into the shell
+  - should remain mostly unchanged for this task if the shell contract stays stable
+- `web/components/sidebar/SidebarShell.tsx`
+  - owns expanded/collapsed layout
+  - currently places `New Chat` above route groups
+  - currently nests `SessionList` inside the `/playground` route item with a short viewport
+
+### Adjacent shared UI
+
+- `web/components/SessionList.tsx`
+  - may need row-density or empty-state adjustments if the wider shell exposes weak list presentation
+- `web/components/sidebar/nav-groups.ts`
+  - may need only minor copy/group verification, not a structural rewrite
+
+### Existing tests
+
+- `web/tests/sidebar-nav-groups.test.ts`
+  - currently validates route group behavior and should be extended only if nav grouping changes materially
+
+## Candidate Approaches
+
+### Approach A: Widen only
+
+- Increase sidebar width and raise the conversation-list viewport height.
+- Pros:
+  - very small diff
+  - low risk
+- Cons:
+  - does not solve the hierarchy problem
+  - keeps `Trò chuyện mới` detached from the place where conversations actually live
+  - still feels like a patched version of the old layout
+
+### Approach B: Rebalance the expanded shell hierarchy
+
+- Keep the same route shell, but change the structure to:
+  - header
+  - compact route nav
+  - dedicated `Trò chuyện` section with section header and inline `+`
+  - large scrollable session list
+  - bottom settings footer
+- Pros:
+  - matches the user’s reference and approved direction
+  - fixes both spacing and ownership of actions
+  - keeps the diff bounded to the shared shell
+- Cons:
+  - requires a more opinionated layout change than simple width tuning
+
+### Approach C: Chat-first sidebar
+
+- Promote sessions above most route nav and make the sidebar primarily a conversation browser.
+- Pros:
+  - very strong chat-first UX
+- Cons:
+  - shifts the whole information architecture too far for a product that still depends on top-level routes like Knowledge, Dashboard, Tutor, and Marketplace
+
+## Chosen Approach
+
+Approach B.
+
+It is the smallest change that actually fixes the current mismatch between action placement and content ownership, while preserving the product’s route-first navigation model.
+
+## Proposed Layout
+
+### 1. Header
+
+- Keep the `DeepTutor` logo/title on the left.
+- Keep the collapse toggle on the right.
+- Slightly relax horizontal spacing so the top row breathes better in the wider shell.
+
+### 2. Primary route nav
+
+- Keep the route groups at the top of the expanded sidebar.
+- Make items slightly denser so they consume less vertical space.
+- Increase shell width from `220px` to about `264px`.
+- Use that extra width to reduce awkward line wrapping, especially for Vietnamese labels.
+- Preserve active-state clarity, but avoid heavy “button slab” styling.
+
+### 3. Dedicated `Trò chuyện` section
+
+- Introduce a section header row:
+  - left: `Trò chuyện`
+  - right: icon-only `+` action for creating a new chat
+- Remove the old detached `New Chat` row above the route nav.
+- Remove the tiny capped session viewport attached to the route item.
+- Replace it with a dedicated chat-history area that uses the remaining vertical space (`flex-1`) and scrolls independently.
+- Empty state should live inside this section, not as dead space across the entire sidebar.
+
+### 4. Footer
+
+- Keep `Cài đặt` anchored at the bottom behind a light top border.
+- Do not let the footer compete with the session area.
+
+## Interaction Model
+
+- Clicking the `+` in the `Trò chuyện` section creates a new chat and routes to `/playground`, preserving the current action semantics.
+- Clicking a session still selects and loads that session through the existing `SidebarShell` callback contract.
+- Collapsed mode stays conceptually the same:
+  - top-level icon rail
+  - new-chat icon
+  - route icons
+  - footer icons
+- The main change is in expanded mode only.
+
+## Expected UI Outcome
+
+- The sidebar feels wider and less cramped.
+- `Bảng điều khiển giáo viên` is less likely to wrap awkwardly.
+- The relationship between `Trò chuyện mới` and the chat list becomes obvious.
+- The conversation history becomes the dominant middle surface instead of a short embedded box.
+- The shell feels closer to modern chat sidebars, while still respecting this repo’s multi-route product structure.
+
+## Files expected to change during implementation
+
+- `web/components/sidebar/SidebarShell.tsx`
+- `web/components/SessionList.tsx` only if shell changes reveal weak row spacing or empty-state presentation
+- `web/tests/sidebar-nav-groups.test.ts` only if grouping or related shell expectations need explicit regression coverage
+
+## Files reviewed but expected to remain unchanged
+
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+  - it should continue providing sessions and callbacks without needing a new contract
+- `web/components/sidebar/nav-groups.ts`
+  - unless final implementation needs a minor label/group cleanup
+
+## Validation expectations
+
+- expanded sidebar is visibly about 20% wider
+- nav items remain readable and better aligned
+- `Trò chuyện mới` is no longer detached above the entire nav
+- conversation list occupies the main middle area with real scroll room
+- `Cài đặt` stays pinned at the bottom
+- collapsed sidebar still works without layout regressions

--- a/docs/superpowers/tasks/2026-04-30-sidebar-shell-rebalance.md
+++ b/docs/superpowers/tasks/2026-04-30-sidebar-shell-rebalance.md
@@ -1,0 +1,60 @@
+# Task Packet: Sidebar Shell Rebalance
+
+- Task ID: `UI_SIDEBAR_SHELL_REBALANCE`
+- Date: 2026-04-30
+- Branch: `docs/sidebar-shell-rebalance`
+- Status: Writing spec
+
+## Objective
+
+Rebalance the shared expanded sidebar so the conversation list becomes the primary middle content area, the new-chat action sits inside the chat section, and the sidebar is about 20% wider.
+
+## User-Approved Scope
+
+- increase expanded sidebar width by roughly 20%
+- keep the main route nav at the top, but make it more compact
+- move `Trò chuyện mới` into the `Trò chuyện` section header
+- let the session list use most of the remaining sidebar height
+- keep `Cài đặt` anchored at the bottom
+- prefer editing `SidebarShell` directly and touch `SessionList` only if row density still needs refinement
+
+## Owned Files
+
+- `web/components/sidebar/SidebarShell.tsx`
+- `web/components/SessionList.tsx`
+- `web/components/sidebar/nav-groups.ts`
+- `web/tests/sidebar-nav-groups.test.ts`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-sidebar-shell-rebalance.md`
+- `docs/superpowers/specs/2026-04-30-sidebar-shell-rebalance-design.md`
+
+## Do-Not-Touch
+
+- the live `/playground` tutor-pack lane files outside shared sidebar scope
+- unrelated marketplace, knowledge-pack, and dashboard runtime lanes
+- global machine configuration
+
+## Design before implementation
+
+- Runtime behavior change: yes
+- Current behavior:
+  - `New Chat` is detached above the route nav
+  - the session list sits inside the `Trò chuyện` route item with a very short viewport
+  - the expanded sidebar is too narrow and causes awkward wrapping
+- Intended behavior change:
+  - shared expanded sidebar has clearer hierarchy and a larger, chat-owned session area
+- Candidate approach A:
+  - widen the sidebar and only raise the session viewport cap
+- Candidate approach B:
+  - rebalance the shell hierarchy inside `SidebarShell` so chat actions and chat history belong to the same section
+- Chosen approach and reason:
+  - approach B; it fixes both spacing and hierarchy instead of only making the old layout larger
+
+## Validation paths
+
+- expanded sidebar width feels materially wider
+- nav labels avoid awkward wrapping
+- `Trò chuyện mới` is owned by the chat section
+- session list uses the remaining middle height and scrolls independently
+- collapsed mode still behaves sensibly

--- a/web/components/sidebar/SidebarShell.tsx
+++ b/web/components/sidebar/SidebarShell.tsx
@@ -36,7 +36,6 @@ interface NavEntry {
 }
 
 const SECONDARY_NAV: NavEntry[] = [{ href: "/settings", label: "Settings", icon: Settings }];
-const DEFAULT_SESSION_VIEWPORT_CLASS_NAME = "max-h-[112px]";
 
 function getContestLabel(label: string): string {
   switch (label) {
@@ -81,7 +80,6 @@ interface SidebarShellProps {
   activeSessionId?: string | null;
   loadingSessions?: boolean;
   showSessions?: boolean;
-  sessionViewportClassName?: string;
   onNewChat?: () => void;
   onSelectSession?: (sessionId: string) => void | Promise<void>;
   onRenameSession?: (sessionId: string, title: string) => void | Promise<void>;
@@ -94,7 +92,6 @@ export function SidebarShell({
   activeSessionId = null,
   loadingSessions = false,
   showSessions = false,
-  sessionViewportClassName = DEFAULT_SESSION_VIEWPORT_CLASS_NAME,
   onNewChat,
   onSelectSession,
   onRenameSession,
@@ -107,6 +104,14 @@ export function SidebarShell({
   const [collapsed, setCollapsed] = useState(false);
   const collapsedNav = getCollapsedSidebarNav();
   const expandedNavGroups = getExpandedSidebarGroups();
+  const sessionControls =
+    showSessions && onSelectSession && onRenameSession && onDeleteSession
+      ? {
+          onSelectSession,
+          onRenameSession,
+          onDeleteSession,
+        }
+      : null;
 
   const handleNewChat = () => {
     if (onNewChat) {
@@ -189,7 +194,7 @@ export function SidebarShell({
 
   /* ---- Expanded state ---- */
   return (
-    <aside className="flex w-[220px] h-screen shrink-0 flex-col bg-[var(--secondary)] transition-all duration-200">
+    <aside className="flex h-screen w-[264px] shrink-0 flex-col bg-[var(--secondary)] transition-all duration-200">
       {/* Header: logo + collapse toggle */}
       <div className="flex h-12 items-center justify-between px-4">
         <Link href="/" className="flex items-center gap-2">
@@ -210,15 +215,6 @@ export function SidebarShell({
       {/* Primary nav */}
       <nav className="px-2 pt-1">
         <div className="space-y-px">
-          {/* New chat */}
-          <button
-            onClick={handleNewChat}
-            className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--background)]/60 hover:text-[var(--foreground)]"
-          >
-            <Plus size={16} strokeWidth={2} />
-            <span>{t("New Chat")}</span>
-          </button>
-
           {expandedNavGroups.map((group, index) => (
             <div key={group.id} className={index > 0 ? "pt-3" : ""}>
               <div className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]/80">
@@ -227,39 +223,20 @@ export function SidebarShell({
               {group.items.map((item) => {
                 const Icon = resolveNavIcon(item.icon);
                 const active = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
-                const hasSessionsBelow =
-                  item.href === "/playground" &&
-                  showSessions &&
-                  onSelectSession &&
-                  onRenameSession &&
-                  onDeleteSession;
                 const hasBots = item.href === "/agents";
                 return (
                   <div key={item.href}>
                     <Link
                       href={item.href}
-                      className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors ${
+                      className={`flex items-center gap-2.5 rounded-lg px-3 py-1.5 text-[13.5px] transition-colors ${
                         active
                           ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
                           : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"
                       }`}
-                      >
+                    >
                       <Icon size={16} strokeWidth={active ? 1.9 : 1.5} />
                       <span>{t(getContestLabel(item.label))}</span>
                     </Link>
-                    {hasSessionsBelow && (
-                      <div className={`${sessionViewportClassName} overflow-y-auto`}>
-                        <SessionList
-                          sessions={sessions}
-                          activeSessionId={activeSessionId}
-                          loading={loadingSessions}
-                          onSelect={onSelectSession}
-                          onRename={onRenameSession}
-                          onDelete={onDeleteSession}
-                          compact
-                        />
-                      </div>
-                    )}
                     {hasBots && <TutorBotRecent />}
                   </div>
                 );
@@ -269,8 +246,34 @@ export function SidebarShell({
         </div>
       </nav>
 
-      {/* Spacer */}
-      <div className="flex-1" />
+      {sessionControls ? (
+        <div className="min-h-0 flex-1 px-2 pb-2 pt-3">
+          <div className="flex items-center justify-between px-3 pb-2">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]/80">
+              {t("Chat")}
+            </div>
+            <button
+              onClick={handleNewChat}
+              className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--background)]/60 hover:text-[var(--foreground)]"
+              aria-label={t("New Chat")}
+            >
+              <Plus size={15} strokeWidth={2} />
+            </button>
+          </div>
+          <div className="min-h-0 overflow-y-auto rounded-2xl bg-[var(--background)]/35 p-1">
+            <SessionList
+              sessions={sessions}
+              activeSessionId={activeSessionId}
+              loading={loadingSessions}
+              onSelect={sessionControls.onSelectSession}
+              onRename={sessionControls.onRenameSession}
+              onDelete={sessionControls.onDeleteSession}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="flex-1" />
+      )}
 
       {/* Secondary nav + footer */}
       <div className="border-t border-[var(--border)]/40 px-2 py-2">
@@ -280,7 +283,7 @@ export function SidebarShell({
             <Link
               key={item.href}
               href={item.href}
-              className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13.5px] transition-colors ${
+              className={`flex items-center gap-2.5 rounded-lg px-3 py-1.5 text-[13.5px] transition-colors ${
                 active
                   ? "bg-[var(--background)]/70 font-medium text-[var(--foreground)]"
                   : "text-[var(--muted-foreground)] hover:bg-[var(--background)]/50 hover:text-[var(--foreground)]"

--- a/web/tests/sidebar-shell-layout.test.ts
+++ b/web/tests/sidebar-shell-layout.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const SIDEBAR_SHELL_PATH = resolve(process.cwd(), "components/sidebar/SidebarShell.tsx");
+
+function readSidebarShell(): string {
+  return readFileSync(SIDEBAR_SHELL_PATH, "utf8");
+}
+
+test("expanded sidebar uses a wider shell and a chat-owned new-chat action", () => {
+  const source = readSidebarShell();
+
+  assert.match(source, /w-\[264px\]/);
+  assert.doesNotMatch(source, /\/\*\s*Primary nav\s*\*\/[\s\S]*?<span>\{t\("New Chat"\)\}<\/span>/);
+  assert.match(source, /t\("Chat"\)|>Chat</);
+  assert.match(source, /Plus size=\{15\} strokeWidth=\{2\}/);
+  assert.doesNotMatch(source, /max-h-\[112px\]/);
+});


### PR DESCRIPTION
# PR Note: Sidebar Shell Rebalance

This PR rebalances the shared expanded sidebar so the route nav stays compact, the chat section owns the new-chat action, and session history gets the bulk of the available height.

## What changed

- widened the expanded sidebar shell from `220px` to `264px`
- removed the detached expanded-mode `New Chat` row from the top of the sidebar
- kept the primary route groups at the top, but tightened their vertical density
- moved chat creation into the `Trò chuyện` section header with an inline `+` action
- replaced the nested `/playground` compact session subtree with a dedicated middle history panel that scrolls independently
- left `SessionList.tsx` runtime behavior unchanged because the existing non-compact list now fits the shell cleanly

```mermaid
flowchart TD
  A["Sidebar header"] --> B["Primary route groups"]
  B --> C["Chat section header (+)"]
  C --> D["Scrollable session history"]
  D --> E["Settings footer"]
```

## Architecture impact

- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated.
- The route map and runtime data contracts stay the same; this PR only changes shared sidebar hierarchy and presentation ownership between nav and chat history.

## Verification

- `cd web && node --test tests/sidebar-shell-layout.test.ts tests/sidebar-nav-groups.test.ts`
- `git diff --check`
- targeted lint was attempted but blocked because `web/node_modules/.bin/eslint` is not available in this worktree
