### PR TITLE
[codex] Add business UI specs and task packets

### DIFF
--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -1,5 +1,23 @@
 # Daily Log: 2026-04-30
 
+## Business UI Spec Split
+
+- Branch: `docs/business-ui-specs`
+- Task: docs-only design split for business-facing UI improvements
+- Done: Created isolated worktree `.worktrees/docs-business-ui-specs` from `origin/main` because the repo root checkout is already assigned to the active `/playground` tutor-pack lane.
+- Done: Wrote three bounded design specs so the visual overhaul can proceed in separable lanes instead of one oversized UI branch:
+  - `docs/superpowers/specs/2026-04-30-business-shell-focus-design.md`
+  - `docs/superpowers/specs/2026-04-30-knowledge-pack-dashboard-shell-design.md`
+  - `docs/superpowers/specs/2026-04-30-teacher-dashboard-decision-flow-design.md`
+- Done: Wrote the matching task packets so each spec now has an execution contract with its own proposed branch, worktree, scope, and validation path:
+  - `docs/superpowers/tasks/2026-04-30-business-shell-focus.md`
+  - `docs/superpowers/tasks/2026-04-30-knowledge-pack-dashboard-shell.md`
+  - `docs/superpowers/tasks/2026-04-30-teacher-dashboard-decision-flow.md`
+- Done: Kept the scope docs-only and intentionally did not edit runtime files, active lane packets, or the dirty root-checkout lockfiles.
+- Tests: `git diff --check`
+- Blockers: none
+- Next: user can now choose whether to turn these three specs into three task packets, or collapse them into fewer execution lanes before implementation.
+
 ## Class Tutor Pack Flow Implementation
 
 - Branch: `fix/class-tutor-pack-flow`

--- a/docs/superpowers/specs/2026-04-30-business-shell-focus-design.md
+++ b/docs/superpowers/specs/2026-04-30-business-shell-focus-design.md
@@ -1,0 +1,148 @@
+# Business Shell Focus Design
+
+- Date: 2026-04-30
+- Task ID: `UI_BUSINESS_SHELL_FOCUS`
+- Branch: `docs/business-ui-specs`
+
+## Goal
+
+Reframe the shared business-facing shell so pages like `Gói kiến thức` and `Bảng điều khiển giáo viên` feel like focused web-app work surfaces instead of mixed chat-plus-dashboard canvases.
+
+## Current Behavior
+
+- Business pages still inherit a shell where chat history competes with the main task area.
+- The left-side shell is trying to serve two jobs at once:
+  - product navigation
+  - conversation browsing
+- On dashboard-style routes, this makes the page feel noisier than necessary and weakens the visual priority of the main content.
+- The product currently lacks a clean distinction between:
+  - chat-first routes such as `/playground`
+  - business/task routes such as `/knowledge`, `/dashboard`, and `/agents`
+
+## Intended Behavior
+
+- Chat history should remain dominant only on chat-first workspaces.
+- Business/task routes should keep the product nav, but should not let conversation history compete with the primary page surface.
+- Shared visual primitives across business routes should become more consistent:
+  - card shells
+  - section spacing
+  - heading rhythm
+  - badges/status pills
+  - filter bars
+
+## User-Approved Direction
+
+- Keep the app-shell model with a product sidebar.
+- Do not let chat history occupy high-value visual space on business pages.
+- Use a calmer dashboard/web-app visual language:
+  - neutral background
+  - compact headings
+  - clear card containers
+  - one primary action per major block
+
+## Candidate Approaches
+
+### Approach A: Hide chat history per page with route-local overrides
+
+- Add page-specific wrappers or props that selectively suppress history on `knowledge` and `dashboard`.
+- Pros:
+  - smallest code diff
+  - low risk for chat routes
+- Cons:
+  - spreads shell rules across multiple pages
+  - makes future business routes repeat the same override logic
+
+### Approach B: Introduce an explicit shell distinction between chat routes and business routes
+
+- Keep one shared navigation system, but add a first-class shell mode:
+  - `chat workspace`
+  - `business workspace`
+- Pros:
+  - correct architecture boundary
+  - makes future pages easier to classify
+  - keeps history available where it matters and out of the way elsewhere
+- Cons:
+  - requires a deliberate shell contract change
+
+### Approach C: Remove history from the sidebar entirely
+
+- Keep only route navigation in the sidebar, and move chat history somewhere else product-wide.
+- Pros:
+  - simplest mental model
+- Cons:
+  - weakens the chat experience on `/playground`
+  - too broad for the current problem
+
+## Chosen Approach
+
+Approach B.
+
+The product already has both chat-first and business-first routes. The clean fix is to formalize that distinction in the shell instead of patching each page individually.
+
+## Proposed Design
+
+### 1. Shell Modes
+
+- Add a shared shell distinction:
+  - `chat workspace`
+  - `business workspace`
+- `chat workspace` keeps:
+  - route nav
+  - large chat-history area
+  - new-chat action
+- `business workspace` keeps:
+  - route nav
+  - compact supporting actions only
+  - no dominant chat-history block
+
+### 2. Business Shell Layout
+
+- The left sidebar remains visible for product navigation.
+- The main content column becomes visually dominant.
+- History should not appear as a large middle rail inside the sidebar on business pages.
+- If conversation access is still needed, expose it as:
+  - a small icon/button
+  - or a secondary drawer/panel
+  - but not as the primary shell middle area
+
+### 3. Shared Visual Primitives
+
+- Define a business-page visual baseline:
+  - page header with short helper text
+  - section cards with moderate radius and neutral borders
+  - compact section headings
+  - status pills for state
+  - compact filter toolbar patterns
+- Treat this as the design substrate for both `Gói kiến thức` and `Bảng điều khiển giáo viên`.
+
+### 4. Route Ownership
+
+- `playground` remains the chat-first route.
+- `knowledge`, `dashboard`, and teacher-facing setup routes should opt into the business shell mode.
+- This spec does not redesign those pages by itself; it only defines the shell and shared visual constraints they should inherit.
+
+## Files Expected To Change During Implementation
+
+- `web/components/sidebar/SidebarShell.tsx`
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+- any route-level shell selection point that decides how the sidebar/history layout is composed
+- shared shell tests if they already cover history visibility and layout mode behavior
+
+## Files Reviewed But Expected To Remain Mostly Unchanged
+
+- page-level `knowledge` logic
+- page-level `dashboard` logic
+- backend contracts
+- session/chat runtime flows
+
+## Validation Expectations
+
+- business routes no longer display chat history as the dominant sidebar middle area
+- `/playground` keeps the current chat-first shell behavior
+- route navigation remains consistent across modes
+- the shell clearly supports downstream dashboard-style pages without introducing route-specific hacks
+
+## Notes For Follow-On Specs
+
+- `2026-04-30-knowledge-pack-dashboard-shell-design.md` should assume this business shell exists.
+- `2026-04-30-teacher-dashboard-decision-flow-design.md` should also assume this business shell exists.

--- a/docs/superpowers/specs/2026-04-30-knowledge-pack-dashboard-shell-design.md
+++ b/docs/superpowers/specs/2026-04-30-knowledge-pack-dashboard-shell-design.md
@@ -1,0 +1,177 @@
+# Knowledge Pack Dashboard Shell Design
+
+- Date: 2026-04-30
+- Task ID: `UI_KNOWLEDGE_PACK_DASHBOARD_SHELL`
+- Branch: `docs/business-ui-specs`
+
+## Goal
+
+Redesign the `Gói kiến thức` screen into a focused two-column business workflow where creating a pack, tracking ingest status, and managing existing packs feel like one coherent dashboard instead of one long stacked page.
+
+## Current Behavior
+
+- The page mixes too many layers in one vertical flow:
+  - page intro
+  - loop/context copy
+  - wizard
+  - ingest state
+  - existing knowledge packs
+- The wizard structure is conceptually right, but visually weak:
+  - steps read like text more than process UI
+  - the form fields feel densely stacked
+  - the CTA bar does not strongly anchor the step action
+- Ingest status is important to the flow but currently lacks a strong companion panel or KPI-style status treatment.
+- Existing-pack management appears too close to the create flow, so it competes with the primary task.
+
+## Intended Behavior
+
+- Desktop layout should read as:
+  - left: create/edit wizard
+  - right: ingest status for the active pack
+  - bottom: existing-pack management
+- The current stepper should become visually stronger and easier to scan.
+- `Mức độ khó` should become a clear segmented choice.
+- Existing packs should move into a more compact management surface such as a table or consistent card grid.
+
+## Relationship To Earlier Spec
+
+- This spec supersedes the earlier wizard-only framing by adding a clearer dashboard-shell treatment on top of the already approved three-step Knowledge Pack flow.
+- The core wizard direction stays the same:
+  - `Thông tin`
+  - `Tài liệu`
+  - `Hoàn tất`
+
+## Candidate Approaches
+
+### Approach A: Keep the existing wizard and only polish spacing/copy
+
+- Pros:
+  - low implementation risk
+  - preserves current structure
+- Cons:
+  - still leaves the page too linear
+  - does not fix the weak relationship between form and ingest status
+
+### Approach B: Two-column create flow plus bottom management zone
+
+- Left column owns the active wizard.
+- Right column owns ingest status and file-processing feedback.
+- Existing packs move below as a separate management section.
+- Pros:
+  - strongest alignment with the user’s requested mental model
+  - keeps the main task obvious
+  - makes ingest feel like immediate system feedback instead of an afterthought
+- Cons:
+  - requires a more opinionated page layout refactor
+
+### Approach C: Split create and manage into separate routes
+
+- Pros:
+  - clean information architecture
+- Cons:
+  - broader routing change than needed
+  - unnecessary before validating the stronger two-column layout
+
+## Chosen Approach
+
+Approach B.
+
+This is the smallest redesign that changes the user’s scanning experience in the right way without widening into route-level IA work.
+
+## Proposed Layout
+
+### 1. Header
+
+- H1: `Gói kiến thức`
+- one-sentence helper text only
+- optional secondary CTA on the right:
+  - `Nhập từ file`
+  - or `Tạo nhanh`
+- keep the top area compact so the wizard starts earlier on the page
+
+### 2. Main Two-Column Zone
+
+#### Left: Wizard
+
+- show the three-step flow as connected step cards:
+  - `1. Thông tin`
+  - `2. Tài liệu`
+  - `3. Hoàn tất`
+- current step uses a stronger accent state
+- completed steps show a clear success/check treatment
+
+#### Form Structure
+
+- row 1:
+  - `Tên gói`
+  - `Chủ đề`
+- row 2:
+  - `Chương trình học`
+  - `Mức độ khó`
+- `Mức độ khó` uses a segmented control:
+  - `Cơ bản`
+  - `Trung bình`
+  - `Nâng cao`
+- `Mục tiêu học tập` becomes a labeled textarea with helper text under the field, not placeholder-heavy pseudo content
+- the footer action bar should feel anchored and important:
+  - `Lưu nháp`
+  - primary `Tiếp tục sang Tài liệu`
+
+#### Right: Ingest Status Panel
+
+- use a dedicated status card
+- support three primary states:
+  - no documents yet
+  - processing/indexing
+  - completed
+- panel content should include:
+  - progress bar
+  - number of files
+  - latest update time
+  - most recent error if present
+- if no active pack exists yet, show a proper empty state with icon and short guidance
+
+### 3. Existing Packs Section
+
+- place existing-pack management below the create/ingest zone
+- use either:
+  - a table on desktop
+  - or compact consistent cards if the table becomes too dense
+- preferred table columns:
+  - `Tên gói`
+  - `Chủ đề`
+  - `Chương trình`
+  - `Tài liệu`
+  - `Trạng thái`
+  - `Cập nhật`
+  - `Hành động`
+
+### 4. Status and Metadata Treatment
+
+- `Mặc định` becomes a small badge
+- ingest/index state becomes a normalized status pill
+- remove inconsistent raw display values that make difficulty or other metadata look unnormalized
+- if a data field is semantically different from `Mức độ khó`, do not display it in the same visual slot
+
+## Files Expected To Change During Implementation
+
+- `web/app/(utility)/knowledge/page.tsx`
+- any extracted Knowledge-page UI subcomponents if the page is split for clarity
+- `web/locales/vi/app.json`
+- `web/locales/en/app.json`
+- focused knowledge-page tests covering wizard shell and Vietnamese-first labels
+
+## Files Reviewed But Expected To Remain Mostly Unchanged
+
+- backend ingestion runtime
+- notebook backend internals if the page no longer exposes them
+- marketplace routes
+- teacher dashboard routes
+
+## Validation Expectations
+
+- the create flow is visually dominant over the pack-management list
+- ingest status reads as a companion panel, not buried text below the form
+- the stepper feels like progress UI, not plain labels
+- difficulty selection is clearly clickable and mutually exclusive
+- existing knowledge packs are easier to scan and manage as a separate lower layer

--- a/docs/superpowers/specs/2026-04-30-teacher-dashboard-decision-flow-design.md
+++ b/docs/superpowers/specs/2026-04-30-teacher-dashboard-decision-flow-design.md
@@ -1,0 +1,189 @@
+# Teacher Dashboard Decision Flow Design
+
+- Date: 2026-04-30
+- Task ID: `UI_TEACHER_DASHBOARD_DECISION_FLOW`
+- Branch: `docs/business-ui-specs`
+
+## Goal
+
+Restructure the `Bảng điều khiển giáo viên` screen into a decision-first dashboard where urgent student interventions come first, supporting topics and metrics come second, and technical/debug details are removed from the default teacher view.
+
+## Current Behavior
+
+- The page has the right raw ingredients, but too many of them compete in the same reading layer:
+  - hero summary
+  - loop copy
+  - teacher insights
+  - KPI summaries
+  - filters
+  - activity/history
+- Student-insight cards are especially overloaded:
+  - observed evidence
+  - inferred diagnosis
+  - raw variables
+  - rationale
+  - multiple actions
+  - debug-style strings
+- Several user-facing strings still read as technical or unfinished English.
+- IDs and raw classifier/debug outputs leak into the primary teacher-facing view.
+
+## Intended Behavior
+
+- The page should answer this order of questions:
+  1. điều gì cần xem ngay;
+  2. lớp đang vướng ở chủ đề nào;
+  3. lớp đang làm tốt ở đâu;
+  4. gần đây đã diễn ra những gì.
+- High-priority intervention should dominate the page.
+- Metrics and history should still exist, but in calmer supporting layers.
+- Technical details should be hidden behind optional disclosure, not shown by default.
+
+## Relationship To Earlier Spec
+
+- This spec extends the earlier teacher-dashboard refresh direction with a stronger dashboard layout and stricter display rules for non-technical end users.
+- The earlier narrative cleanup remains valid, but this spec makes the page structure more explicitly decision-first.
+
+## Candidate Approaches
+
+### Approach A: Keep the existing layout and only simplify copy
+
+- Pros:
+  - minimal implementation cost
+- Cons:
+  - leaves scanning difficulty unresolved
+  - keeps overloaded insight cards
+
+### Approach B: Four-zone decision dashboard
+
+- top KPI row
+- left priority intervention column
+- right supporting topic/action column
+- lower recent-activity zone
+- Pros:
+  - matches teacher decision-making
+  - gives every layer a clear job
+  - easiest path to removing default technical clutter
+- Cons:
+  - requires a meaningful page-layout refactor
+
+### Approach C: Split the dashboard into multiple tabs
+
+- Pros:
+  - reduces single-page density
+- Cons:
+  - adds navigation friction
+  - weakens the “what do I do now?” dashboard purpose
+
+## Chosen Approach
+
+Approach B.
+
+The dashboard should help a teacher decide quickly, not browse through multiple tabs or parse one long narrative surface.
+
+## Proposed Layout
+
+### 1. Top KPI Row
+
+- four compact KPI cards:
+  - `Học sinh cần hỗ trợ`
+  - `Nhóm cần can thiệp`
+  - `Điểm trung bình gần đây`
+  - `Phiên học đang mở`
+- each card should emphasize:
+  - the number
+  - a short label
+  - optional small delta/trend if available
+
+### 2. Main Intervention Layer
+
+#### Left Column: `Cần xem ngay`
+
+- this becomes the dominant section
+- each student card should answer only:
+  - who needs attention
+  - what topic they are struggling with
+  - how urgent it is
+  - what the next teacher move should be
+
+#### Student Card Structure
+
+- row 1:
+  - student display name
+  - priority badge
+  - optional state badge
+- row 2:
+  - `Đang vướng: <chủ đề>`
+- row 3:
+  - two short evidence chips such as:
+    - `1 câu cần xem lại`
+    - `Hỗ trợ hiện tại: có hướng dẫn`
+- row 4:
+  - `Gợi ý tiếp theo: <can thiệp ngắn gọn>`
+- row 5:
+  - primary action:
+    - `Xem hồ sơ học sinh`
+  - secondary action:
+    - `Đánh dấu đã xem`
+
+### 3. Right Supporting Column
+
+- stack smaller cards:
+  - `Chủ đề cần hỗ trợ`
+  - `Chủ đề lớp đang làm tốt`
+  - `Gợi ý nhóm`
+- each item should be short and count-based
+- use badges to show how many students are affected
+
+### 4. Lower Follow-Up Layer
+
+- compact trend panel for recent score movement if available
+- filter toolbar in one clear row
+- recent activity list/table with denser rows and less preview text
+
+## Strict Display Rules
+
+The default teacher-facing view must not show:
+
+- raw student IDs such as `UNIFIED_...`
+- debug variables such as:
+  - `miss_count=1`
+  - `support_level=guided`
+  - `contradiction_ratio=0.0`
+- unfinished English technical copy such as:
+  - `Primary support for...`
+  - `careless_error pattern`
+
+These may be moved into an optional collapsed section such as `Chi tiết hệ thống` if the product still needs operator access.
+
+## Presenter / Mapping Direction
+
+- Map raw diagnosis terms into teacher-friendly Vietnamese summaries.
+- Map raw confidence/debug states into bounded status pills.
+- Prefer short phrases such as:
+  - `Hệ thống nghi ngờ lỗi bất cẩn`
+  - `Nên cho làm lại câu dễ hơn`
+  - `Cần giáo viên xem trước khi tiếp tục`
+
+## Files Expected To Change During Implementation
+
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/components/dashboard/TeacherInsightPanel.tsx`
+- `web/components/dashboard/StudentInsightCard.tsx`
+- `web/components/dashboard/dashboard-presenters.ts`
+- `web/locales/vi/app.json`
+- `web/locales/en/app.json`
+- focused dashboard copy/presenter tests
+
+## Files Reviewed But Expected To Remain Mostly Unchanged
+
+- backend dashboard APIs
+- recommendation-generation services
+- activity/session storage
+- knowledge-pack management screens
+
+## Validation Expectations
+
+- the first screenful clearly shows urgent teacher action before deeper analytics
+- student cards are scannable in under a few seconds each
+- raw/debug/English technical strings are removed from the default UI
+- supporting topics and recent activity remain accessible but visually secondary

--- a/docs/superpowers/tasks/2026-04-30-business-shell-focus.md
+++ b/docs/superpowers/tasks/2026-04-30-business-shell-focus.md
@@ -1,0 +1,123 @@
+# Task Packet: Business Shell Focus
+
+- Task ID: `UI_BUSINESS_SHELL_FOCUS`
+- Commit tag: `UI-BIZ-SHELL`
+- Date: 2026-04-30
+- Branch: `fix/business-shell-focus`
+- Worktree: `.worktrees/fix-business-shell-focus`
+- Status: Proposed
+
+## Objective
+
+Create a business-facing shell mode that keeps product navigation but removes chat history as the dominant sidebar middle area on non-chat routes such as `Gói kiến thức`, `Bảng điều khiển giáo viên`, and teacher-facing setup screens.
+
+## User-Approved Scope
+
+- keep the shared product sidebar
+- preserve the chat-first shell on `/playground`
+- make business/task pages visually focused and less chat-centric
+- establish shared business-route shell primitives that downstream pages can reuse
+
+## Owned Files
+
+- `web/components/sidebar/SidebarShell.tsx`
+- `web/components/sidebar/WorkspaceSidebar.tsx`
+- any route-level shell selection point that decides chat mode vs business mode
+- `web/tests/sidebar-shell-layout.test.ts`
+- `web/tests/sidebar-nav-groups.test.ts`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-business-shell-focus.md`
+- `docs/superpowers/specs/2026-04-30-business-shell-focus-design.md`
+- `docs/superpowers/plans/2026-04-30-business-shell-focus.md`
+- `docs/superpowers/pr-notes/2026-04-30-business-shell-focus.md`
+
+## Do-Not-Touch
+
+- `web/app/(utility)/knowledge/page.tsx` except for shell wiring if the chosen implementation requires a route-level mode flag
+- `web/app/(workspace)/dashboard/page.tsx` except for shell wiring if required
+- backend session/chat runtime
+- unrelated `/playground` message or composer behavior
+- lockfiles unless dependency changes are required
+
+## Design before implementation
+
+- Runtime behavior change: yes
+- Approved spec:
+  - `docs/superpowers/specs/2026-04-30-business-shell-focus-design.md`
+- Current behavior:
+  - business routes inherit a sidebar where chat history competes with the main task area
+- Intended behavior change:
+  - chat history remains dominant only on chat-first routes; business routes use a calmer, nav-first shell mode
+- Candidate approach A:
+  - route-local suppression of history
+- Candidate approach B:
+  - explicit shell distinction between chat workspace and business workspace
+- Chosen approach and reason:
+  - approach B; it creates the correct reusable boundary instead of page-by-page overrides
+
+## Required code reading
+
+- Entry points/handlers to inspect:
+  - `web/components/sidebar/WorkspaceSidebar.tsx`
+  - `web/components/sidebar/SidebarShell.tsx`
+- Primary logic/service/use-case modules to inspect:
+  - any current shell-mode or sidebar-layout selection logic
+- Shared contracts/schemas/types to inspect:
+  - shell props passed into `SidebarShell`
+  - session-list integration points
+- Adjacent or reused flows to inspect:
+  - `/playground` shell behavior
+  - any route already varying shell density or layout
+- Existing tests to inspect:
+  - `web/tests/sidebar-shell-layout.test.ts`
+  - `web/tests/sidebar-nav-groups.test.ts`
+
+## Impact surface and stop conditions
+
+- Expected affected areas:
+  - shared sidebar layout
+  - history visibility rules
+  - shell-mode selection for business routes
+- Files/modules likely to change:
+  - `SidebarShell`
+  - `WorkspaceSidebar`
+  - focused sidebar tests
+- Files/modules that must be reviewed even if they remain unchanged:
+  - business routes using the shared shell
+  - `/playground` route shell behavior
+- Minimum validation paths before the task can stop:
+  - `/playground` still shows the chat-first shell
+  - business routes no longer show a dominant history rail
+  - route navigation remains usable and consistent
+- What would count as a shallow fix for this task:
+  - hiding one visual block in CSS without creating an explicit shell distinction
+
+## Acceptance criteria
+
+- non-chat business routes do not dedicate the sidebar middle area to chat history
+- `/playground` still retains the chat-first sidebar behavior
+- product navigation remains intact across both shell modes
+- future business routes can opt into the calmer shell without ad hoc page hacks
+
+## Required tests
+
+- focused sidebar-shell regression tests
+- targeted eslint on shell files
+- `cd web && npm run build`
+
+## Manual verification
+
+- confirm `/playground` still behaves as chat workspace
+- confirm business routes feel focused and no longer split attention with history
+- confirm sidebar collapse/expand still works
+
+## Parallel-work notes
+
+- This task should start in its own dedicated worktree from `origin/main`.
+- Add the lane to `ai_first/ACTIVE_ASSIGNMENTS.md` before runtime edits begin.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` likely does not need an update unless shell-mode differences become part of the documented primary product structure.

--- a/docs/superpowers/tasks/2026-04-30-knowledge-pack-dashboard-shell.md
+++ b/docs/superpowers/tasks/2026-04-30-knowledge-pack-dashboard-shell.md
@@ -1,0 +1,127 @@
+# Task Packet: Knowledge Pack Dashboard Shell
+
+- Task ID: `UI_KNOWLEDGE_PACK_DASHBOARD_SHELL`
+- Commit tag: `UI-KNOWLEDGE-SHELL`
+- Date: 2026-04-30
+- Branch: `fix/knowledge-pack-dashboard-shell`
+- Worktree: `.worktrees/fix-knowledge-pack-dashboard-shell`
+- Status: Proposed
+
+## Objective
+
+Refactor the `Gói kiến thức` page into a two-column business workflow where the wizard lives on the left, ingest status lives on the right, and existing-pack management sits below as a separate layer.
+
+## User-Approved Scope
+
+- keep the current route
+- preserve the three-step wizard concept
+- strengthen the stepper and form layout
+- make ingest status a first-class companion panel
+- move existing-pack management into a separate lower section
+- normalize status/badge treatment and reduce dense text
+
+## Owned Files
+
+- `web/app/(utility)/knowledge/page.tsx`
+- extracted Knowledge-page UI subcomponents/helpers if created during refactor
+- `web/locales/vi/app.json`
+- `web/locales/en/app.json`
+- `web/tests/contest-vietnamese-coverage.test.ts`
+- any focused knowledge-page shell test added for the new layout
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-knowledge-pack-dashboard-shell.md`
+- `docs/superpowers/specs/2026-04-30-knowledge-pack-dashboard-shell-design.md`
+- `docs/superpowers/plans/2026-04-30-knowledge-pack-dashboard-shell.md`
+- `docs/superpowers/pr-notes/2026-04-30-knowledge-pack-dashboard-shell.md`
+
+## Do-Not-Touch
+
+- unrelated `/playground` and tutor runtime lanes
+- teacher dashboard runtime files
+- backend ingestion logic unless the UI cannot render required status data without a bounded contract adjustment
+- lockfiles unless dependency changes are required
+
+## Design before implementation
+
+- Runtime behavior change: yes
+- Approved spec:
+  - `docs/superpowers/specs/2026-04-30-knowledge-pack-dashboard-shell-design.md`
+- Current behavior:
+  - wizard, ingest state, and pack list are mixed in one long vertical flow
+- Intended behavior change:
+  - two-column create flow with separate bottom management section
+- Candidate approach A:
+  - spacing/copy cleanup only
+- Candidate approach B:
+  - left wizard, right ingest panel, lower management section
+- Chosen approach and reason:
+  - approach B; it fixes scanning order and task clarity without a route split
+
+## Required code reading
+
+- Entry points/handlers to inspect:
+  - `web/app/(utility)/knowledge/page.tsx`
+- Primary logic/service/use-case modules to inspect:
+  - any extracted FE upload/index state helpers already used by the page
+- Shared contracts/schemas/types to inspect:
+  - knowledge-pack metadata fields
+  - pack progress/status payloads
+- Adjacent or reused flows to inspect:
+  - current wizard step states
+  - current pack-card/table management presentation
+- Existing tests to inspect:
+  - `web/tests/contest-vietnamese-coverage.test.ts`
+  - any existing knowledge-page shell/source tests
+
+## Impact surface and stop conditions
+
+- Expected affected areas:
+  - page layout
+  - stepper treatment
+  - difficulty control
+  - ingest status panel
+  - existing-pack management view
+- Files/modules likely to change:
+  - knowledge page
+  - extracted FE subcomponents/helpers
+  - locale files
+- Files/modules that must be reviewed even if they remain unchanged:
+  - backend ingestion progress contracts
+  - notebook/runtime seams already hidden from visible FE
+- Minimum validation paths before the task can stop:
+  - stepper reads as real progress UI
+  - `Mức độ khó` reads as a clickable segmented control
+  - ingest status sits beside the wizard, not buried below it
+  - existing-pack list is visually separated from the create flow
+- What would count as a shallow fix for this task:
+  - copy-only cleanup while keeping the same long stacked page structure
+
+## Acceptance criteria
+
+- the create flow is visually dominant over the management list
+- the page reads as `create/edit now` first, `manage existing` second
+- the status panel gives immediate ingest feedback
+- the existing-pack list is easier to scan and action
+
+## Required tests
+
+- focused FE tests for wizard shell labels and layout assumptions where practical
+- targeted eslint on touched FE files
+- `cd web && npm run build`
+
+## Manual verification
+
+- open the page on desktop and confirm the left-right hierarchy is obvious
+- confirm ingest states feel like a live companion surface
+- confirm the lower management section no longer interrupts the create flow
+
+## Parallel-work notes
+
+- This task should begin only after the business-shell lane is either merged or explicitly declared non-blocking.
+- Use a separate worktree from `origin/main` and record the lane in `ai_first/ACTIVE_ASSIGNMENTS.md`.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` likely does not need an update unless the screen’s role in the documented product flow changes materially.

--- a/docs/superpowers/tasks/2026-04-30-teacher-dashboard-decision-flow.md
+++ b/docs/superpowers/tasks/2026-04-30-teacher-dashboard-decision-flow.md
@@ -1,0 +1,132 @@
+# Task Packet: Teacher Dashboard Decision Flow
+
+- Task ID: `UI_TEACHER_DASHBOARD_DECISION_FLOW`
+- Commit tag: `UI-TEACHER-DASH`
+- Date: 2026-04-30
+- Branch: `fix/teacher-dashboard-decision-flow`
+- Worktree: `.worktrees/fix-teacher-dashboard-decision-flow`
+- Status: Proposed
+
+## Objective
+
+Refactor the `Bảng điều khiển giáo viên` screen into a decision-first dashboard with a strong intervention layer, compact KPI row, supporting topic cards, and a calmer lower activity/history section.
+
+## User-Approved Scope
+
+- top KPI summary row
+- left intervention column for students needing attention now
+- right supporting column for topics and group recommendations
+- lower trend/filter/activity layer
+- remove raw/debug/unfinished English technical strings from the default teacher-facing UI
+
+## Owned Files
+
+- `web/app/(workspace)/dashboard/page.tsx`
+- `web/components/dashboard/TeacherInsightPanel.tsx`
+- `web/components/dashboard/StudentInsightCard.tsx`
+- `web/components/dashboard/dashboard-presenters.ts`
+- `web/locales/vi/app.json`
+- `web/locales/en/app.json`
+- `web/tests/teacher-dashboard-copy.test.ts`
+- any focused dashboard shell/decision-flow tests added during implementation
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `docs/superpowers/tasks/2026-04-30-teacher-dashboard-decision-flow.md`
+- `docs/superpowers/specs/2026-04-30-teacher-dashboard-decision-flow-design.md`
+- `docs/superpowers/plans/2026-04-30-teacher-dashboard-decision-flow.md`
+- `docs/superpowers/pr-notes/2026-04-30-teacher-dashboard-decision-flow.md`
+
+## Do-Not-Touch
+
+- backend dashboard/recommendation services unless a bounded presenter-contract fix is absolutely required
+- knowledge-pack page runtime files
+- tutor chat routes
+- lockfiles unless dependency changes are required
+
+## Design before implementation
+
+- Runtime behavior change: yes
+- Approved spec:
+  - `docs/superpowers/specs/2026-04-30-teacher-dashboard-decision-flow-design.md`
+- Current behavior:
+  - the dashboard mixes urgent intervention, metrics, filters, history, and debug-style strings in the same reading layer
+- Intended behavior change:
+  - intervention-first teacher dashboard with strict display rules for non-technical users
+- Candidate approach A:
+  - copy simplification only
+- Candidate approach B:
+  - four-zone decision dashboard with presenter-based teacher-friendly mapping
+- Chosen approach and reason:
+  - approach B; it changes the scan order and hides technical clutter without requiring new routes
+
+## Required code reading
+
+- Entry points/handlers to inspect:
+  - `web/app/(workspace)/dashboard/page.tsx`
+- Primary logic/service/use-case modules to inspect:
+  - `web/components/dashboard/TeacherInsightPanel.tsx`
+  - `web/components/dashboard/StudentInsightCard.tsx`
+  - any existing dashboard presenter/helper layer
+- Shared contracts/schemas/types to inspect:
+  - dashboard API response fields that currently feed names, topics, confidence, and recommendation text
+- Adjacent or reused flows to inspect:
+  - recent activity/history presentation
+  - any current KPI metric surfaces
+- Existing tests to inspect:
+  - `web/tests/teacher-dashboard-copy.test.ts`
+  - `web/tests/contest-terminology.test.ts` if new Vietnamese terminology needs protection
+
+## Impact surface and stop conditions
+
+- Expected affected areas:
+  - KPI row
+  - intervention card layout
+  - topic/group summary column
+  - history/filter presentation
+  - presenter mapping for teacher-friendly language
+- Files/modules likely to change:
+  - dashboard page
+  - teacher insight panel
+  - student card
+  - dashboard presenters
+  - locale and copy tests
+- Files/modules that must be reviewed even if they remain unchanged:
+  - backend dashboard API contracts
+  - group recommendation surfaces
+  - any existing detail/disclosure path for system/debug content
+- Minimum validation paths before the task can stop:
+  - first screenful clearly prioritizes intervention
+  - student cards are scannable and action-oriented
+  - raw/debug/unfinished English strings are gone from default UI
+  - history and filters are still accessible but visually secondary
+- What would count as a shallow fix for this task:
+  - translating strings without restructuring the information hierarchy or hiding debug/raw content
+
+## Acceptance criteria
+
+- teachers can see urgent decisions first
+- student cards emphasize next action instead of technical detail
+- topic and group summaries support the main intervention layer without overwhelming it
+- debug/raw variables are not shown by default
+
+## Required tests
+
+- focused dashboard presenter/copy tests
+- targeted eslint on touched dashboard files
+- `cd web && npm run build`
+
+## Manual verification
+
+- open the dashboard and confirm the first scan surface is `what do I need to do now?`
+- confirm card actions feel primary and grouped
+- confirm system detail is hidden or demoted behind optional disclosure
+
+## Parallel-work notes
+
+- This task should begin only after the business-shell lane is either merged or explicitly declared non-blocking.
+- Use a dedicated worktree from `origin/main` and record the lane in `ai_first/ACTIVE_ASSIGNMENTS.md`.
+
+## PR architecture note
+
+- Must include Mermaid diagram.
+- `ai_first/architecture/MAIN_SYSTEM_MAP.md` likely does not need an update unless the dashboard’s role in the documented teacher workflow changes materially.


### PR DESCRIPTION
## Summary
- add three bounded business-UI design specs for shell focus, knowledge-pack dashboard shell, and teacher-dashboard decision flow
- add three matching task packets with proposed branches, worktrees, scope, validation, and stop conditions
- update the daily log for this docs-only lane

## Why
The UI work is too broad to safely implement in one mixed lane. These docs split the effort into three reviewable runtime lanes so the shell, knowledge screen, and teacher dashboard can move forward independently.

## Validation
- `git diff --check`
