### PR TITLE
feat(contest-demo): expand realistic local seed dataset [DEMO-SEED]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -34,6 +34,21 @@ Rules:
 
 - Owner: Codex session
 - Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-demo-realistic-seed-data`
+- Task: Expand the local contest demo seed so every core teacher-first screen has realistic, diverse, demo-safe data for video capture
+- Status: implemented, pending PR
+- Branch: `fix/demo-realistic-seed-data`
+- Task packet: `docs/superpowers/tasks/2026-04-30-demo-realistic-seed-data.md`
+- Owned files: `scripts/contest/reset_demo_data.py`, `tests/scripts/test_reset_demo_data.py`, `docs/contest/DEMO_DATA_RESET.md`, `docs/contest/SMOKE_RUNBOOK.md`, `docs/superpowers/tasks/2026-04-30-demo-realistic-seed-data.md`, `docs/superpowers/specs/2026-04-30-demo-realistic-seed-data-design.md`, `docs/superpowers/pr-notes/2026-04-30-demo-realistic-seed-data.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-04-30.md`, `ai_first/AI_OPERATING_PROMPT.md` only if repo-level operating guidance changes
+- PR: uncreated
+- Last update: 2026-04-30
+- Next action: run final verification, commit the lane, open a draft PR, then merge once CI is green
+- Blocker: none
+
+### Assignment
+
+- Owner: Codex session
+- Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-marketplace-dashboard-fetch-recovery`
 - Task: Recover marketplace and teacher-dashboard fetch paths, then harden the related error-state layout for the contest UI
 - Status: implemented, pending PR

--- a/ai_first/daily/2026-04-30.md
+++ b/ai_first/daily/2026-04-30.md
@@ -576,3 +576,14 @@
 - Done: Added focused regression tests `web/tests/api-base-url.test.ts` and `web/tests/agents-boolean-field-layout.test.ts`.
 - Tests: `cd web && node --test tests/api-base-url.test.ts`; `cd web && node --test tests/agents-boolean-field-layout.test.ts`; `git diff --check`
 - Notes: targeted eslint still cannot run in this worktree because `web/eslint.config.mjs` cannot resolve `eslint-config-next`.
+
+## DEMO_SEED
+
+- Branch: `fix/demo-realistic-seed-data`
+- Task: `DEMO-SEED-2026-04-30`
+- Done: Wrote the bounded design artifact `docs/superpowers/specs/2026-04-30-demo-realistic-seed-data-design.md` and implementation plan `docs/superpowers/plans/2026-04-30-demo-realistic-seed-data.md` for the richer demo-safe seed lane.
+- Done: Expanded `scripts/contest/reset_demo_data.py` from a two-session stub into a realistic local dataset builder that now seeds 7 shareable marketplace packs, 2 imported private workspace packs, 12 classroom sessions, 16 observations, 4 student-state rollups, and non-empty teacher evidence tables.
+- Done: Seeded evidence rows by first deriving the real recommendation and small-group ids from the existing diagnosis builders, then attaching acknowledgements, feedback, overrides, actions, and intervention assignments to those ids so dashboard cards stay consistent with runtime logic.
+- Done: Updated `docs/contest/DEMO_DATA_RESET.md` and `docs/contest/SMOKE_RUNBOOK.md` so the contest runbooks now describe the fuller marketplace/import/review/replay/dashboard dataset available for smoke and video capture.
+- Done: Added the PR architecture note `docs/superpowers/pr-notes/2026-04-30-demo-realistic-seed-data.md` with Mermaid and stated that `ai_first/architecture/MAIN_SYSTEM_MAP.md` did not change because this is a local demo helper lane.
+- Tests: `pytest tests/scripts/test_reset_demo_data.py -v`; `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`; repeated the same reset command a second time to confirm idempotent output; manual SQLite count check confirmed `sessions=12`, `messages=40`, `turns=12`, `observations=16`, `student_states=4`, `teacher_actions=3`, `recommendation_acks=3`, `recommendation_feedback=3`, `teacher_overrides=1`, `diagnosis_feedback=2`, and `intervention_assignments=3`.

--- a/docs/contest/DEMO_DATA_RESET.md
+++ b/docs/contest/DEMO_DATA_RESET.md
@@ -10,16 +10,18 @@ This runbook is backed by a local demo-safe reset utility. It writes only local 
 
 | State | Required value | Why it exists |
 | --- | --- | --- |
-| Knowledge Pack identifier | `contest-demo-quadratics` | Shared context for Knowledge Pack, assessment, tutor, and dashboard evidence. |
+| Anchor Knowledge Pack identifier | `contest-demo-quadratics` | Shared context for the flagship contest algebra story. |
+| Shareable marketplace packs | At least `6` public/team packs with varied metadata | Makes marketplace search, sort, preview, and import look real during video capture. |
+| Imported workspace packs | At least `2` private `__imported` packs | Shows that a teacher has already brought packs into the local workspace. |
 | Subject | `Mathematics` | Keeps the assessment and tutor story consistent. |
 | Grade | `Grade 9` | Gives the demo a realistic classroom level. |
 | Curriculum | `Vietnam secondary algebra` | Makes the contest story local and teacher-oriented. |
 | Learning objective | Solve quadratic equations and explain common mistakes | Connects generated assessment, feedback, and tutoring. |
 | Owner | `Contest Demo Teacher` | Shows teacher-owned pack metadata without private data. |
-| Sharing status | `demo` or equivalent non-private status | Makes clear that this is safe public demo data. |
-| Assessment session | `contest-assessment-demo` | Lets smoke checks confirm assessment activity exists. |
-| Tutor session | `contest-tutor-demo` | Lets smoke checks confirm student tutoring activity exists. |
-| Dashboard activity | Assessment and tutor records referencing the demo Knowledge Pack | Proves the teacher can review recent learning activity. |
+| Sharing status | Public/team for marketplace packs, private for imported packs | Separates browseable packs from teacher-owned workspace copies. |
+| Assessment sessions | `contest-assessment-demo` plus additional classroom sessions | Lets review and dashboard pages show believable trends instead of one stub. |
+| Tutor sessions | `contest-tutor-demo` plus additional follow-up sessions | Gives replay pages multiple realistic teacher/student conversations. |
+| Dashboard activity | Observations, student states, acknowledgements, feedback, overrides, actions, and intervention assignments | Proves the teacher can review and act on evidence across the full loop. |
 
 Do not use real student names, private class data, API keys, or provider credentials in demo data.
 
@@ -44,8 +46,10 @@ Run this from the repository root:
 The command:
 
 - validates that `--api-base` is local;
-- creates or updates Knowledge Pack `contest-demo-quadratics`;
-- creates or replaces sessions `contest-assessment-demo` and `contest-tutor-demo`;
+- creates or updates a richer set of shareable and imported demo-safe Knowledge Packs;
+- creates or replaces the anchor sessions `contest-assessment-demo` and `contest-tutor-demo`;
+- seeds additional assessment and tutor sessions for the same classroom story;
+- seeds dashboard evidence tables so recommendation, acknowledgement, feedback, override, and intervention cards are non-empty;
 - prints the ids and local paths it touched;
 - can be run repeatedly without duplicating demo sessions.
 
@@ -79,9 +83,9 @@ Use this only for local demo data that can be safely recreated.
 
 1. Back up any local data you may need before changing `data/`.
 2. Remove or replace only demo-specific records for:
-   - Knowledge Pack `contest-demo-quadratics`;
-   - session `contest-assessment-demo`;
-   - session `contest-tutor-demo`.
+   - demo-safe Knowledge Packs created by the reset utility;
+   - all `contest-...` sessions created by the reset utility;
+   - demo student observations and teacher-evidence rows created by the reset utility.
 3. Recreate the inventory in this runbook through the UI or local API.
 4. Re-run the smoke runbook.
 5. If smoke fails, record the failure as `Blocked` in the validation report instead of marking evidence current.
@@ -95,7 +99,7 @@ The reset script must:
 - create or update only demo-safe records;
 - be idempotent;
 - avoid provider credentials and private data;
-- print the Knowledge Pack id and session ids it created;
+- print the anchor Knowledge Pack id and the session ids it created;
 - refuse to run against production or unknown environments;
 - leave screenshots and optional video as manual refresh steps.
 
@@ -108,10 +112,11 @@ Current location:
 
 | Check | Expected result | Evidence file |
 | --- | --- | --- |
-| Knowledge Pack exists | `contest-demo-quadratics` appears with demo-safe metadata | `VALIDATION_REPORT.md` |
-| Assessment session exists | `contest-assessment-demo` can be fetched locally | `VALIDATION_REPORT.md` |
-| Tutor session exists | `contest-tutor-demo` can be fetched locally | `VALIDATION_REPORT.md` |
-| Dashboard sees activity | Dashboard overview and recent endpoints show demo context | `VALIDATION_REPORT.md` |
+| Marketplace breadth exists | At least 6 public/team packs and at least 2 imported private packs exist locally | `VALIDATION_REPORT.md` |
+| Anchor Knowledge Pack exists | `contest-demo-quadratics` appears with demo-safe metadata | `VALIDATION_REPORT.md` |
+| Assessment sessions exist | `contest-assessment-demo` and additional classroom assessments can be fetched locally | `VALIDATION_REPORT.md` |
+| Tutor sessions exist | `contest-tutor-demo` and additional replay sessions can be fetched locally | `VALIDATION_REPORT.md` |
+| Dashboard sees full evidence | Overview, recent activity, and teacher-insight cards show demo context with non-empty intervention traces | `VALIDATION_REPORT.md` |
 | Screenshots remain meaningful | Existing screenshot status is `Current`, or updated to `Stale`/`Blocked` | `EVIDENCE_CHECKLIST.md` |
 
 ## Mermaid Flow
@@ -119,16 +124,21 @@ Current location:
 ```mermaid
 flowchart TD
   Reset["Demo data reset"]
-  Pack["Knowledge Pack: contest-demo-quadratics"]
-  Assessment["Assessment session"]
-  Tutor["Tutor session"]
-  Dashboard["Dashboard activity"]
+  Marketplace["Shareable marketplace packs"]
+  Imported["Imported workspace packs"]
+  Pack["Anchor pack: contest-demo-quadratics"]
+  Assessment["Multiple assessment sessions"]
+  Tutor["Multiple tutor sessions"]
+  Dashboard["Dashboard evidence + intervention traces"]
   Smoke["SMOKE_RUNBOOK.md"]
   Evidence["VALIDATION_REPORT.md"]
 
+  Reset --> Marketplace
+  Reset --> Imported
   Reset --> Pack
   Pack --> Assessment
   Pack --> Tutor
+  Marketplace --> Imported
   Assessment --> Dashboard
   Tutor --> Dashboard
   Dashboard --> Smoke

--- a/docs/contest/SMOKE_RUNBOOK.md
+++ b/docs/contest/SMOKE_RUNBOOK.md
@@ -21,6 +21,13 @@ The helper currently shells out to `python3` for the reset check, so the repo `.
 
 Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTION_QUEUE.md` and `ai_first/daily/YYYY-MM-DD.md`.
 
+The reset utility now primes a fuller teacher-first dataset before smoke or video capture:
+
+- multiple shareable marketplace packs;
+- imported private workspace packs;
+- multiple assessment and tutor sessions;
+- dashboard evidence and intervention traces.
+
 ## Stage 1: Backend
 
 - Command: use the existing backend startup path for local validation.
@@ -36,7 +43,7 @@ Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTIO
 ## Stage 3: Knowledge Pack
 
 - Action: confirm Knowledge Pack metadata is visible and matches the expected demo data shape.
-- Success: metadata is present after load or reload.
+- Success: metadata is present after load or reload, and the demo workspace can show at least one imported pack.
 - Stop condition: Knowledge Pack metadata is missing or broken.
 
 ## Stage 4: Assessment
@@ -54,7 +61,7 @@ Stop the lane on the first hard failure. Record the result in `ai_first/EXECUTIO
 ## Stage 6: Dashboard
 
 - Action: open the Dashboard after the assessment and tutor steps.
-- Success: recent activity reflects assessment and tutor usage with Knowledge Pack context where available.
+- Success: recent activity reflects assessment and tutor usage with Knowledge Pack context where available, and teacher insight cards are not empty.
 - Stop condition: dashboard activity is empty, broken, or missing the expected context.
 
 ## Result handling

--- a/docs/superpowers/plans/2026-04-30-demo-realistic-seed-data.md
+++ b/docs/superpowers/plans/2026-04-30-demo-realistic-seed-data.md
@@ -1,0 +1,173 @@
+# Realistic Demo Seed Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the local demo reset utility so one command seeds realistic, diverse, demo-safe data across marketplace, imported packs, assessment review, tutor replay, and dashboard evidence.
+
+**Architecture:** Keep the existing `scripts.contest.reset_demo_data` entry point and extend it with bounded helpers that seed only local demo-safe knowledge-pack metadata plus SQLite-backed session/evidence rows. Use script-level TDD first, then implement the minimum helper structure needed to satisfy the richer dataset and idempotency guarantees.
+
+**Tech Stack:** Python, SQLite, pytest, local JSON metadata under `data/knowledge_bases/`, existing evidence helper modules
+
+---
+
+### Task 1: Lock the richer reset contract with failing tests
+
+**Files:**
+- Modify: `tests/scripts/test_reset_demo_data.py`
+- Reference: `scripts/contest/reset_demo_data.py`
+
+- [ ] **Step 1: Write the failing test expectations for the richer dataset**
+
+Add assertions for:
+- multiple public/team marketplace packs in `kb_config.json`
+- at least one imported workspace pack ending with `__imported`
+- multiple assessment/tutor sessions
+- non-empty `observations` and `student_states`
+- non-empty teacher evidence tables
+
+- [ ] **Step 2: Run the script tests to verify RED**
+
+Run: `rtk pytest tests/scripts/test_reset_demo_data.py -v`
+Expected: FAIL because the current reset script only creates one pack, two sessions, and no richer evidence rows.
+
+- [ ] **Step 3: Refine the test to avoid false positives**
+
+Keep the expectations bounded to exact demo-safe ids and minimum counts so the test proves realistic breadth without over-coupling to incidental implementation details.
+
+- [ ] **Step 4: Re-run the script tests**
+
+Run: `rtk pytest tests/scripts/test_reset_demo_data.py -v`
+Expected: FAIL for the same missing richer-seed reasons, but with the final intended assertions.
+
+### Task 2: Implement richer knowledge-pack and session seeding
+
+**Files:**
+- Modify: `scripts/contest/reset_demo_data.py`
+- Reference: `deeptutor/services/session/sqlite_store.py`
+- Reference: `deeptutor/api/routers/marketplace.py`
+- Reference: `deeptutor/services/session/assessment_review.py`
+
+- [ ] **Step 1: Add bounded demo dataset constants and cleanup helpers**
+
+Create explicit demo namespaces and helper lists for:
+- shareable marketplace packs
+- imported workspace packs
+- assessment sessions
+- tutor sessions
+- student ids and cohort metadata
+
+Also add cleanup helpers that delete only demo-owned records from the SQLite tables and knowledge-base config entries.
+
+- [ ] **Step 2: Seed richer marketplace and workspace pack metadata**
+
+Extend the script so it writes:
+- 6 to 10 public/team demo packs with varied metadata and marketplace review summaries
+- 2 to 3 imported/private workspace packs linked back to shareable sources
+- raw document placeholders for preview/document counts where needed
+
+- [ ] **Step 3: Seed assessment and tutor sessions using the current session contract**
+
+Seed:
+- 8 to 12 assessment sessions with `[Quiz Performance]` messages and linked knowledge bases
+- 3 to 5 tutor sessions with natural-looking user/assistant transcript messages
+- session preferences including `student_id`, `cohort`, `knowledge_bases`, `capability`, and `demo`
+
+- [ ] **Step 4: Run script tests after the first implementation pass**
+
+Run: `rtk pytest tests/scripts/test_reset_demo_data.py -v`
+Expected: some failures may remain around evidence-table coverage or idempotency details, but the counts for packs/sessions should move toward the target.
+
+### Task 3: Seed dashboard evidence and close idempotency gaps
+
+**Files:**
+- Modify: `scripts/contest/reset_demo_data.py`
+- Reference: `deeptutor/services/evidence/teacher_actions.py`
+- Reference: `deeptutor/services/evidence/recommendation_acks.py`
+- Reference: `deeptutor/services/evidence/recommendation_feedback.py`
+- Reference: `deeptutor/services/evidence/teacher_overrides.py`
+- Reference: `deeptutor/services/evidence/diagnosis_feedback.py`
+- Reference: `deeptutor/services/evidence/intervention_assignments.py`
+
+- [ ] **Step 1: Seed observations and student-state rollups for the classroom story**
+
+Populate observation rows with varied timestamps, topics, correctness, hint counts, retries, and dominant errors. Then write student-state rollups so dashboard reasoning surfaces have realistic support and misconception signals.
+
+- [ ] **Step 2: Seed teacher evidence tables with believable workflow traces**
+
+Create:
+- recommendation acknowledgements
+- recommendation feedback
+- teacher overrides
+- teacher actions
+- intervention assignments
+- diagnosis feedback
+
+Cover both student-level and at least one small-group storyline.
+
+- [ ] **Step 3: Run the script tests to verify GREEN**
+
+Run: `rtk pytest tests/scripts/test_reset_demo_data.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Run the reset command twice against the worktree repo root**
+
+Run: `rtk .venv/bin/python -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
+Run again: `rtk .venv/bin/python -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
+Expected: both runs succeed and report stable demo ids/paths without duplicate growth.
+
+### Task 4: Update contest docs and record the lane
+
+**Files:**
+- Modify: `docs/contest/DEMO_DATA_RESET.md`
+- Modify: `docs/contest/SMOKE_RUNBOOK.md`
+- Modify: `ai_first/daily/2026-04-30.md`
+- Create: `docs/superpowers/pr-notes/2026-04-30-demo-realistic-seed-data.md`
+
+- [ ] **Step 1: Update the reset runbook**
+
+Document the richer seeded dataset shape, including that the reset now prepares marketplace, multiple assessment/tutor sessions, and dashboard evidence for video capture.
+
+- [ ] **Step 2: Update the smoke runbook only where the richer dataset matters**
+
+Clarify that the reset primes a fuller teacher-first dataset before smoke and video capture, without changing the smoke sequence itself.
+
+- [ ] **Step 3: Add the PR architecture note with Mermaid**
+
+Create a short note describing the local-only data flow from reset script to knowledge-base metadata and SQLite evidence tables. State that `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not changed because this is a local demo helper lane.
+
+- [ ] **Step 4: Update the daily log**
+
+Record the new richer reset utility scope, tests run, and any residual environment limitations.
+
+### Task 5: Verify, commit, open PR, and merge if eligible
+
+**Files:**
+- Modify: tracked files from Tasks 1-4 only
+
+- [ ] **Step 1: Run the required verification commands**
+
+Run:
+- `rtk pytest tests/scripts/test_reset_demo_data.py -v`
+- `rtk rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" scripts tests docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first`
+- `rtk python3 -m compileall scripts`
+- `rtk git diff --check`
+
+Expected: all commands succeed.
+
+- [ ] **Step 2: Review the diff and commit with the required tag**
+
+Commit format:
+`feat(contest-demo): expand realistic local seed dataset [DEMO-SEED]`
+
+- [ ] **Step 3: Push the lane branch and open a draft PR**
+
+Push `fix/demo-realistic-seed-data`, create a draft PR, and include the PR note path plus validation summary in the description.
+
+- [ ] **Step 4: Move PR to Ready and merge only if eligible**
+
+Only merge if:
+- local verification is complete
+- PR is no longer draft
+- required CI is green
+- no blocking review exists
+

--- a/docs/superpowers/pr-notes/2026-04-30-demo-realistic-seed-data.md
+++ b/docs/superpowers/pr-notes/2026-04-30-demo-realistic-seed-data.md
@@ -1,0 +1,56 @@
+# PR Architecture Note: Realistic Demo Seed Data
+
+## Summary
+
+Expands the local contest demo reset utility so one command now rebuilds a realistic, diverse, demo-safe dataset across marketplace metadata, imported workspace packs, classroom assessment history, tutor replay sessions, and dashboard intervention evidence.
+
+## Scope
+
+- local-only demo reset utility
+- knowledge-pack metadata and preview files
+- SQLite-backed session seeds
+- SQLite-backed teacher evidence seeds
+- contest reset and smoke runbook updates
+
+## Mermaid Diagram
+
+```mermaid
+flowchart LR
+  Reset["reset_demo_data.py"]
+  KB["data/knowledge_bases/*"]
+  Config["kb_config.json"]
+  Sessions["chat_history.db sessions/messages/turns"]
+  Observations["observations + student_states"]
+  Evidence["teacher evidence tables"]
+  Screens["Marketplace / Assessment / Tutor / Dashboard"]
+
+  Reset --> KB
+  Reset --> Config
+  Reset --> Sessions
+  Reset --> Observations
+  Reset --> Evidence
+  KB --> Screens
+  Config --> Screens
+  Sessions --> Screens
+  Observations --> Screens
+  Evidence --> Screens
+```
+
+## Main System Map Update
+
+`ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated. This lane extends a local-only demo helper and its seed coverage, but it does not change runtime architecture, route ownership, or production data flow.
+
+## Validation
+
+```bash
+rtk pytest tests/scripts/test_reset_demo_data.py -v
+rtk .venv/bin/python -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001
+rtk rg -n "demo data|reset|seed|smoke|Knowledge Pack|contest|Mermaid" scripts tests docs/contest docs/superpowers/tasks docs/superpowers/pr-notes ai_first
+rtk python3 -m compileall scripts
+rtk git diff --check
+```
+
+## Notes
+
+- The utility deletes and recreates only demo-owned rows and files in its bounded namespace.
+- No generated `data/` outputs are committed.

--- a/docs/superpowers/specs/2026-04-30-demo-realistic-seed-data-design.md
+++ b/docs/superpowers/specs/2026-04-30-demo-realistic-seed-data-design.md
@@ -1,0 +1,209 @@
+# Realistic Demo Seed Data Design
+
+Date: 2026-04-30
+Task packet: `docs/superpowers/tasks/2026-04-30-demo-realistic-seed-data.md`
+Branch: `fix/demo-realistic-seed-data`
+
+## Objective
+
+Upgrade the existing local demo reset flow so one command can populate believable, varied, demo-safe data across the teacher-first contest journey without requiring live services or manual DB edits.
+
+## Scope
+
+In scope:
+
+- expand the local contest reset utility
+- write richer knowledge-pack metadata under `data/knowledge_bases/`
+- seed SQLite session and evidence records under `data/user/chat_history.db`
+- document the final reset and verification flow
+
+Out of scope:
+
+- frontend code changes
+- API/router changes
+- dependency changes
+- committing generated `data/` outputs
+
+## Current behavior
+
+The current reset utility creates one knowledge pack and two sessions:
+
+- one assessment demo session
+- one tutor demo session
+
+That is enough for a smoke baseline but not enough to support a polished product video. Marketplace listing, dashboard cards, grouped recommendations, intervention history, and replay variety remain too thin or empty.
+
+## Intended behavior
+
+The reset utility should create a cohesive classroom storyline:
+
+- one teacher owns a classroom with multiple students
+- several shareable knowledge packs exist with realistic metadata diversity
+- a subset of packs is imported into the local workspace
+- students have multiple assessment attempts with mixed performance
+- tutor sessions reflect follow-up support after assessment findings
+- dashboard evidence surfaces show both student-level and group-level intervention decisions
+
+## Candidate approaches
+
+### Approach 1: Extend the existing reset utility
+
+Use the current `scripts/contest/reset_demo_data.py` entry point and factor it into bounded helpers for:
+
+- marketplace/shareable pack metadata
+- imported/local knowledge packs
+- seeded assessment sessions
+- seeded tutor sessions
+- seeded observations and student states
+- seeded teacher evidence actions and feedback
+
+Pros:
+
+- keeps one known-safe command
+- matches the existing contest runbook
+- minimizes operator confusion
+
+Cons:
+
+- script complexity increases and needs structure
+
+### Approach 2: Add a parallel video-only seed command
+
+Keep the old reset script untouched and add a new command dedicated to rich demo data.
+
+Pros:
+
+- avoids changing the current script behavior
+
+Cons:
+
+- duplicates safety and storage logic
+- creates two competing demo reset paths
+- higher maintenance drift risk
+
+## Chosen approach
+
+Choose Approach 1. The richer dataset is still the same demo reset concern, so it belongs in the existing utility rather than a separate parallel script.
+
+## Data model and content design
+
+### Marketplace and knowledge packs
+
+Seed 6 to 10 demo-safe knowledge packs with varied metadata fields the marketplace already reads:
+
+- name and short description
+- subject, grade, curriculum
+- learning objectives
+- owner and sharing status
+- updated timestamps
+- review and rating summary fields when supported by metadata
+- popularity/import-count style fields when supported by metadata
+
+The set should include one flagship algebra pack plus adjacent packs so search and sorting feel real:
+
+- quadratic equations
+- factoring foundations
+- linear systems review
+- geometry proof starters
+- statistics and charts
+- STEM microscope observation writing
+
+### Assessment sessions
+
+Seed 8 to 12 assessment sessions across multiple students in one classroom cohort:
+
+- varying scores
+- multiple topics
+- repeated misconceptions for some students
+- improving trend for some students
+- fresh low-score attempts for recommendation triggering
+
+Each session should include:
+
+- a teacher-readable title
+- preferences with capability and knowledge-pack linkage
+- user and assistant messages
+- turn record and timestamps
+- assessment payloads/events required by the current review and dashboard readers
+
+### Tutor replay sessions
+
+Seed 3 to 5 tutor sessions linked to the same classroom story:
+
+- one remediation-focused session
+- one confidence-building session
+- one follow-up after intervention
+- optional one advanced student extension session
+
+These should contain longer, natural transcripts so replay pages look believable instead of stubbed.
+
+### Dashboard evidence and intervention traces
+
+Seed the evidence tables the dashboard already aggregates:
+
+- `observations`
+- `student_states`
+- teacher actions
+- recommendation acknowledgements
+- recommendation feedback
+- teacher overrides
+- diagnosis feedback
+- intervention assignments
+
+The data should intentionally create:
+
+- at least one student with repeated factoring mistakes
+- at least one student with sign-error misconceptions
+- at least one small group sharing the same weak topic
+- at least one recommendation that has been acknowledged but not acted on
+- at least one intervention assignment in progress
+- at least one closed-loop history chain for the video
+
+## Implementation structure
+
+Refactor the reset utility into bounded helpers:
+
+- `_seed_marketplace_packs`
+- `_seed_workspace_knowledge_packs`
+- `_seed_assessment_sessions`
+- `_seed_tutor_sessions`
+- `_seed_observations_and_student_states`
+- `_seed_teacher_evidence`
+- `_clear_existing_demo_records`
+
+The exact helper names can vary, but the structure should separate metadata seeding from session/evidence seeding.
+
+## Safety and idempotency
+
+The command must:
+
+- keep the existing local API base safety gate
+- only touch known demo ids or clearly demo-tagged records
+- delete and recreate only demo-safe rows owned by this script
+- avoid touching unrelated user data
+- produce the same final dataset shape on repeated runs
+
+## Validation
+
+Minimum validation after implementation:
+
+- script test suite passes
+- one local run of the reset command succeeds
+- a second run leaves counts stable
+- direct DB inspection confirms the seeded tables and ids exist
+- main contest-path reads are non-empty for marketplace, dashboard, assessment review, and tutor replay
+
+## Risks and controls
+
+- Risk: over-seeding fields the UI does not read.
+  Control: align seeded metadata with existing router/test expectations.
+
+- Risk: polluting unrelated local sessions.
+  Control: reserve a `contest-` or other explicit demo id namespace and clean only within that namespace.
+
+- Risk: making the dataset look synthetic.
+  Control: vary timestamps, student outcomes, teacher notes, and intervention status.
+
+## Approval checkpoint
+
+After this spec is approved, implementation can proceed in the dedicated worktree and branch with changes limited to the task packet scope.

--- a/docs/superpowers/tasks/2026-04-30-demo-realistic-seed-data.md
+++ b/docs/superpowers/tasks/2026-04-30-demo-realistic-seed-data.md
@@ -1,0 +1,109 @@
+# Task Packet: Realistic Demo Seed Data Expansion
+
+Owner: Codex session
+Branch: `fix/demo-realistic-seed-data`
+Task ID: `DEMO-SEED-2026-04-30`
+Commit tag: `DEMO-SEED`
+
+## Goal
+
+Expand the local demo data reset utility so one explicit command can rebuild a realistic, diverse, demo-safe dataset that fills the teacher-first contest journey end to end: marketplace, imported knowledge packs, assessment review, tutor replay, dashboard evidence, and related intervention traces.
+
+## User-visible outcome
+
+After running the local reset command, the repo should present non-empty, believable data across the main demo screens without requiring manual DB edits or live LLM/API calls.
+
+## Owned files/modules
+
+- `scripts/contest/reset_demo_data.py`
+- `tests/scripts/test_reset_demo_data.py`
+- `docs/contest/DEMO_DATA_RESET.md`
+- `docs/contest/SMOKE_RUNBOOK.md`
+- `docs/superpowers/tasks/2026-04-30-demo-realistic-seed-data.md`
+- `docs/superpowers/specs/2026-04-30-demo-realistic-seed-data-design.md`
+- `docs/superpowers/pr-notes/2026-04-30-demo-realistic-seed-data.md`
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-04-30.md`
+- `ai_first/AI_OPERATING_PROMPT.md` only if repo-level operating guidance changes
+
+## Do-not-touch files/modules
+
+- `web/`
+- `deeptutor/api/`
+- `deeptutor/services/` except using existing runtime/storage contracts as-is
+- `.env*`
+- committed `data/` outputs or any private local data
+- lockfiles and dependency manifests
+
+## Design before implementation
+
+### Current behavior
+
+The existing reset utility seeds one demo knowledge pack and two minimal sessions. It is safe and idempotent, but the resulting dataset is too sparse for a realistic full-product video across marketplace, dashboard, review, and tutor replay surfaces.
+
+### Intended behavior change
+
+The reset utility should build a richer local-only dataset using the current file and SQLite persistence layers. The command must remain idempotent and safe, but now create enough metadata, sessions, observations, student states, and teacher-action traces to make the main contest path look realistic and varied.
+
+### Candidate approaches
+
+1. Extend the existing reset utility.
+   - Pros: reuses the established safety gate, command entry point, and demo workflow docs; keeps one reset story.
+   - Cons: the script becomes denser and needs clearer internal structure.
+
+2. Add a second video-only seed script.
+   - Pros: isolates the richer dataset from the original minimal reset flow.
+   - Cons: duplicates logic, splits the demo workflow, and increases drift risk.
+
+Chosen approach: extend the existing reset utility with bounded helper functions for each seeded area. This keeps the operator workflow simple and aligned with the current contest runbook.
+
+### Concrete files or modules expected to change
+
+- `scripts/contest/reset_demo_data.py`
+- `tests/scripts/test_reset_demo_data.py`
+- `docs/contest/DEMO_DATA_RESET.md`
+- `docs/contest/SMOKE_RUNBOOK.md`
+- lane docs in `docs/superpowers/` plus `ai_first/ACTIVE_ASSIGNMENTS.md` and `ai_first/daily/2026-04-30.md`
+
+### Tests to add or update
+
+- Extend script-level tests for idempotency and safety.
+- Add assertions that the seeded DB contains the expected counts and key ids for marketplace/demo sessions/evidence traces.
+- Add a focused verification run that the script can be executed repeatedly without duplicate rows.
+
+## Codebase survey
+
+- Entry point: `scripts/contest/reset_demo_data.py`
+- Persistence contract: `deeptutor/services/session/sqlite_store.py`
+- Dashboard/evidence readers: `deeptutor/api/routers/dashboard.py`
+- Existing lane contract baseline: `docs/superpowers/tasks/2026-04-19-scripted-demo-data-reset.md`
+
+## Expected impact surface
+
+Files likely to change:
+
+- `scripts/contest/reset_demo_data.py`
+- `tests/scripts/test_reset_demo_data.py`
+- `docs/contest/DEMO_DATA_RESET.md`
+- `docs/contest/SMOKE_RUNBOOK.md`
+
+Files reviewed but expected to remain unchanged:
+
+- `deeptutor/services/session/sqlite_store.py`
+- `deeptutor/api/routers/dashboard.py`
+- `web/` screens and API clients
+
+Validation paths that must pass before completion:
+
+- local reset command succeeds against a local API base
+- repeated reset command keeps the same dataset shape without duplication
+- seeded DB contains believable activity for marketplace, dashboard, assessment review, and tutor replay
+
+## Acceptance criteria
+
+- One explicit local command rebuilds or refreshes the realistic demo dataset.
+- Marketplace has diverse shareable pack metadata suitable for search, sort, preview, and import.
+- Dashboard has non-empty evidence, diagnoses, recommendations, acknowledgements, feedback, override, action, and intervention traces.
+- Assessment review and tutor replay each have multiple believable sessions rather than a single shallow stub.
+- The script remains local-only, demo-safe, and idempotent.
+

--- a/scripts/contest/reset_demo_data.py
+++ b/scripts/contest/reset_demo_data.py
@@ -1,30 +1,917 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
+import shutil
 import sqlite3
-import time
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
+from deeptutor.services.evidence.diagnosis import build_student_diagnosis
+from deeptutor.services.evidence.diagnosis_feedback import create_diagnosis_feedback
+from deeptutor.services.evidence.intervention_assignments import create_intervention_assignment
+from deeptutor.services.evidence.recommendation_acks import create_recommendation_ack
+from deeptutor.services.evidence.recommendation_feedback import create_recommendation_feedback
+from deeptutor.services.evidence.teacher_actions import create_teacher_action
+from deeptutor.services.evidence.teacher_insights import build_teacher_insights_payload
+from deeptutor.services.evidence.teacher_overrides import create_teacher_override
 from deeptutor.services.session.sqlite_store import SQLiteSessionStore
 
 
 DEMO_KB_ID = "contest-demo-quadratics"
 ASSESSMENT_SESSION_ID = "contest-assessment-demo"
 TUTOR_SESSION_ID = "contest-tutor-demo"
+DEMO_MARKER = "[contest-demo]"
+DEMO_COHORT = "Class 9A1"
+DEMO_OWNER = "Contest Demo Teacher"
+SECONDS_PER_DAY = 24 * 60 * 60
 
-DEMO_METADATA = {
-    "subject": "Mathematics",
-    "grade": "Grade 9",
-    "curriculum": "Vietnam secondary algebra",
-    "learning_objectives": [
-        "Solve quadratic equations",
-        "Explain common mistakes",
-    ],
-    "owner": "Contest Demo Teacher",
-    "sharing_status": "demo",
-}
+DEMO_STUDENTS = [
+    {"id": "Ngoc An", "focus_topic": "quadratic factoring"},
+    {"id": "Minh Chau", "focus_topic": "quadratic factoring"},
+    {"id": "Bao Han", "focus_topic": "discriminant selection"},
+    {"id": "Quoc Dat", "focus_topic": "graph interpretation"},
+]
+
+DEMO_SHAREABLE_PACKS = [
+    {
+        "name": DEMO_KB_ID,
+        "description": "Contest-ready pack for Grade 9 quadratic equations and common factoring errors.",
+        "subject": "Mathematics",
+        "grade": "Grade 9",
+        "curriculum": "Vietnam secondary algebra",
+        "learning_objectives": [
+            "Solve quadratic equations",
+            "Explain common factoring mistakes",
+            "Check roots against the original equation",
+        ],
+        "owner": DEMO_OWNER,
+        "sharing_status": "public",
+        "tags": ["algebra", "quadratics", "contest-demo"],
+        "difficulty": "intermediate",
+        "language": "Vietnamese",
+        "estimated_hours": 6.0,
+        "prerequisites": ["Linear equations", "Integer arithmetic"],
+        "content_types": ["notes", "worked_examples", "practice_sets"],
+        "documents": [
+            "lesson-overview.md",
+            "factoring-patterns.md",
+            "common-mistakes.md",
+            "guided-practice.md",
+        ],
+        "marketplace_reviews": [
+            {
+                "reviewer": "Teacher Lan",
+                "rating": 5,
+                "comment": "Students used the mistake notes right away during revision week.",
+                "created_at": "2026-04-18T08:30:00",
+            },
+            {
+                "reviewer": "Teacher Minh",
+                "rating": 4,
+                "comment": "Clear sequence for remediation after a short quiz.",
+                "created_at": "2026-04-17T14:10:00",
+            },
+        ],
+        "created_at": "2026-04-10T08:00:00",
+        "updated_at": "2026-04-29T09:15:00",
+    },
+    {
+        "name": "contest-demo-factoring-foundations",
+        "description": "Warm-up pack for factor pairs, sign checks, and binomial pattern fluency.",
+        "subject": "Mathematics",
+        "grade": "Grade 8",
+        "curriculum": "Vietnam secondary algebra",
+        "learning_objectives": [
+            "Recognize factor pairs",
+            "Track positive and negative signs while factoring",
+        ],
+        "owner": "Teacher Thu",
+        "sharing_status": "public",
+        "tags": ["factoring", "foundations"],
+        "difficulty": "beginner",
+        "language": "Vietnamese",
+        "estimated_hours": 4.0,
+        "prerequisites": ["Multiplication facts"],
+        "content_types": ["notes", "exit_tickets"],
+        "documents": [
+            "factor-pairs.md",
+            "sign-check-drill.md",
+            "exit-ticket.md",
+        ],
+        "marketplace_reviews": [
+            {
+                "reviewer": "Teacher Hanh",
+                "rating": 5,
+                "comment": "Strong prep before moving to quadratics.",
+                "created_at": "2026-04-20T09:00:00",
+            }
+        ],
+        "created_at": "2026-04-08T09:30:00",
+        "updated_at": "2026-04-27T11:00:00",
+    },
+    {
+        "name": "contest-demo-linear-systems-bridge",
+        "description": "Bridge pack linking substitution habits to later quadratic structure work.",
+        "subject": "Mathematics",
+        "grade": "Grade 9",
+        "curriculum": "Vietnam secondary algebra",
+        "learning_objectives": [
+            "Solve linear systems by substitution",
+            "Explain why variable isolation matters",
+        ],
+        "owner": "Teacher Bao",
+        "sharing_status": "team",
+        "tags": ["systems", "algebra-bridge"],
+        "difficulty": "intermediate",
+        "language": "Vietnamese",
+        "estimated_hours": 5.0,
+        "prerequisites": ["Linear equations"],
+        "content_types": ["notes", "practice_sets"],
+        "documents": [
+            "substitution-review.md",
+            "bridge-examples.md",
+            "guided-exercises.md",
+        ],
+        "marketplace_reviews": [
+            {
+                "reviewer": "Teacher Phuc",
+                "rating": 4,
+                "comment": "Useful bridge unit for mixed-ability groups.",
+                "created_at": "2026-04-16T07:45:00",
+            }
+        ],
+        "created_at": "2026-04-07T10:00:00",
+        "updated_at": "2026-04-25T15:00:00",
+    },
+    {
+        "name": "contest-demo-geometry-proof-starters",
+        "description": "Short proof starters for building justification language in lower-secondary geometry.",
+        "subject": "Mathematics",
+        "grade": "Grade 8",
+        "curriculum": "Vietnam geometry foundations",
+        "learning_objectives": [
+            "State known and unknown information clearly",
+            "Use congruence clues in short written proofs",
+        ],
+        "owner": "Teacher Nhi",
+        "sharing_status": "public",
+        "tags": ["geometry", "proof-writing"],
+        "difficulty": "intermediate",
+        "language": "Vietnamese",
+        "estimated_hours": 3.5,
+        "prerequisites": ["Basic angle relationships"],
+        "content_types": ["worked_examples", "discussion_prompts"],
+        "documents": [
+            "proof-language.md",
+            "triangle-congruence.md",
+            "discussion-prompts.md",
+        ],
+        "marketplace_reviews": [],
+        "created_at": "2026-04-05T13:30:00",
+        "updated_at": "2026-04-21T08:40:00",
+    },
+    {
+        "name": "contest-demo-statistics-charts",
+        "description": "Chart-reading pack with class survey data and common interpretation traps.",
+        "subject": "Mathematics",
+        "grade": "Grade 7",
+        "curriculum": "Vietnam applied statistics",
+        "learning_objectives": [
+            "Read bar and line charts accurately",
+            "Summarize a class dataset in one sentence",
+        ],
+        "owner": "Teacher Giang",
+        "sharing_status": "public",
+        "tags": ["statistics", "charts"],
+        "difficulty": "beginner",
+        "language": "Vietnamese",
+        "estimated_hours": 2.5,
+        "prerequisites": ["Whole-number comparison"],
+        "content_types": ["slides", "practice_sets"],
+        "documents": [
+            "class-survey.md",
+            "bar-charts.md",
+            "line-charts.md",
+        ],
+        "marketplace_reviews": [
+            {
+                "reviewer": "Teacher Vy",
+                "rating": 4,
+                "comment": "Good for quick dashboard screenshots with varied metadata.",
+                "created_at": "2026-04-14T12:00:00",
+            }
+        ],
+        "created_at": "2026-04-04T08:00:00",
+        "updated_at": "2026-04-19T09:25:00",
+    },
+    {
+        "name": "contest-demo-microscope-observation-writing",
+        "description": "STEM pack for recording microscope observations with precise evidence language.",
+        "subject": "Science",
+        "grade": "Grade 7",
+        "curriculum": "Integrated STEM",
+        "learning_objectives": [
+            "Describe what is observed before drawing conclusions",
+            "Use evidence-based sentence starters",
+        ],
+        "owner": "Teacher Quynh",
+        "sharing_status": "team",
+        "tags": ["science", "stem", "observation-writing"],
+        "difficulty": "beginner",
+        "language": "Vietnamese",
+        "estimated_hours": 3.0,
+        "prerequisites": ["Basic lab routines"],
+        "content_types": ["lab-sheet", "rubrics"],
+        "documents": [
+            "microscope-routine.md",
+            "observation-sentences.md",
+            "lab-checklist.md",
+        ],
+        "marketplace_reviews": [
+            {
+                "reviewer": "Teacher Dung",
+                "rating": 5,
+                "comment": "Nice cross-subject example for the marketplace page.",
+                "created_at": "2026-04-13T16:20:00",
+            }
+        ],
+        "created_at": "2026-04-03T10:20:00",
+        "updated_at": "2026-04-18T14:55:00",
+    },
+    {
+        "name": "contest-demo-graph-reading-extensions",
+        "description": "Extension pack for connecting graph features to verbal reasoning.",
+        "subject": "Mathematics",
+        "grade": "Grade 9",
+        "curriculum": "Vietnam algebra applications",
+        "learning_objectives": [
+            "Interpret turning points and intercepts",
+            "Explain graph behavior in words",
+        ],
+        "owner": "Teacher Linh",
+        "sharing_status": "public",
+        "tags": ["graphs", "reasoning"],
+        "difficulty": "advanced",
+        "language": "Vietnamese",
+        "estimated_hours": 4.5,
+        "prerequisites": ["Coordinate plane", "Linear graphs"],
+        "content_types": ["worked_examples", "practice_sets"],
+        "documents": [
+            "graph-features.md",
+            "reasoning-prompts.md",
+            "challenge-questions.md",
+        ],
+        "marketplace_reviews": [
+            {
+                "reviewer": "Teacher Khoa",
+                "rating": 4,
+                "comment": "Strong extension material for confident students.",
+                "created_at": "2026-04-15T17:00:00",
+            }
+        ],
+        "created_at": "2026-04-06T07:50:00",
+        "updated_at": "2026-04-26T10:35:00",
+    },
+]
+
+DEMO_IMPORTED_PACKS = [
+    {
+        "source_name": DEMO_KB_ID,
+        "name": f"{DEMO_KB_ID}__imported",
+        "description": "Imported into the contest demo workspace for the active classroom flow.",
+        "created_at": "2026-04-29T09:20:00",
+        "updated_at": "2026-04-29T09:20:00",
+    },
+    {
+        "source_name": "contest-demo-statistics-charts",
+        "name": "contest-demo-statistics-charts__imported",
+        "description": "Imported reference pack used to show multiple teacher-owned packs in the workspace.",
+        "created_at": "2026-04-28T15:40:00",
+        "updated_at": "2026-04-28T15:40:00",
+    },
+]
+
+DEMO_ASSESSMENTS = [
+    {
+        "session_id": ASSESSMENT_SESSION_ID,
+        "student_id": "Ngoc An",
+        "title": "Ngoc An - Quadratic Checkpoint 1",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-17T08:10:00",
+        "request": "Generate a short quadratic factoring check for Ngoc An in class 9A1.",
+        "quiz_intro": "Generated a short class checkpoint focused on factoring and checking roots.",
+        "review": [
+            {
+                "question_id": "q1",
+                "question": "Factor x^2 - 5x + 6",
+                "answer": "(x+2)(x+3)",
+                "correct_answer": "(x-2)(x-3)",
+                "is_correct": False,
+                "duration_seconds": 53,
+            },
+            {
+                "question_id": "q2",
+                "question": "Solve x^2 - 5x + 6 = 0",
+                "answer": "x = -2, -3",
+                "correct_answer": "x = 2, 3",
+                "is_correct": False,
+                "duration_seconds": 61,
+            },
+            {
+                "question_id": "q3",
+                "question": "Check whether x = 3 is a root of x^2 - 5x + 6",
+                "answer": "Yes",
+                "correct_answer": "Yes",
+                "is_correct": True,
+                "duration_seconds": 22,
+            },
+            {
+                "question_id": "q4",
+                "question": "State one sign check to confirm the factors",
+                "answer": "Multiply to 6 and add to -5",
+                "correct_answer": "Multiply to 6 and add to -5",
+                "is_correct": True,
+                "duration_seconds": 31,
+            },
+        ],
+    },
+    {
+        "session_id": "contest-assessment-ngoc-an-followup",
+        "student_id": "Ngoc An",
+        "title": "Ngoc An - Quadratic Checkpoint 2",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-24T08:05:00",
+        "request": "Generate a follow-up factoring check after a reteach mini lesson.",
+        "quiz_intro": "Generated a follow-up checkpoint with the same topic and lighter scaffolding.",
+        "review": [
+            {
+                "question_id": "q1",
+                "question": "Factor x^2 - 7x + 12",
+                "answer": "(x-3)(x-4)",
+                "correct_answer": "(x-3)(x-4)",
+                "is_correct": True,
+                "duration_seconds": 35,
+            },
+            {
+                "question_id": "q2",
+                "question": "Solve x^2 - 7x + 12 = 0",
+                "answer": "x = 3, 4",
+                "correct_answer": "x = 3, 4",
+                "is_correct": True,
+                "duration_seconds": 29,
+            },
+            {
+                "question_id": "q3",
+                "question": "Factor x^2 - x - 12",
+                "answer": "(x-4)(x+3)",
+                "correct_answer": "(x-4)(x+3)",
+                "is_correct": True,
+                "duration_seconds": 44,
+            },
+            {
+                "question_id": "q4",
+                "question": "Explain how the middle term helps choose the signs",
+                "answer": "The factors add to -1 so one sign must be negative.",
+                "correct_answer": "The factors add to -1 so one sign must be negative.",
+                "is_correct": True,
+                "duration_seconds": 41,
+            },
+        ],
+    },
+    {
+        "session_id": "contest-assessment-minh-chau-1",
+        "student_id": "Minh Chau",
+        "title": "Minh Chau - Quadratic Checkpoint 1",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-17T08:25:00",
+        "request": "Generate a quadratic factoring check for Minh Chau.",
+        "quiz_intro": "Generated a class checkpoint focused on factor selection and sign tracking.",
+        "review": [
+            {
+                "question_id": "q1",
+                "question": "Factor x^2 - 6x + 8",
+                "answer": "(x+2)(x+4)",
+                "correct_answer": "(x-2)(x-4)",
+                "is_correct": False,
+                "duration_seconds": 49,
+            },
+            {
+                "question_id": "q2",
+                "question": "Solve x^2 - 6x + 8 = 0",
+                "answer": "x = -2, -4",
+                "correct_answer": "x = 2, 4",
+                "is_correct": False,
+                "duration_seconds": 57,
+            },
+            {
+                "question_id": "q3",
+                "question": "Check whether x = 4 is a root of x^2 - 6x + 8",
+                "answer": "Yes",
+                "correct_answer": "Yes",
+                "is_correct": True,
+                "duration_seconds": 24,
+            },
+        ],
+    },
+    {
+        "session_id": "contest-assessment-minh-chau-2",
+        "student_id": "Minh Chau",
+        "title": "Minh Chau - Quadratic Checkpoint 2",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-25T08:15:00",
+        "request": "Generate a second factoring check after guided practice.",
+        "quiz_intro": "Generated a follow-up checkpoint with one application question included.",
+        "review": [
+            {
+                "question_id": "q1",
+                "question": "Factor x^2 - 9x + 20",
+                "answer": "(x-4)(x-5)",
+                "correct_answer": "(x-4)(x-5)",
+                "is_correct": True,
+                "duration_seconds": 33,
+            },
+            {
+                "question_id": "q2",
+                "question": "Factor x^2 - 2x - 15",
+                "answer": "(x-5)(x+3)",
+                "correct_answer": "(x-5)(x+3)",
+                "is_correct": True,
+                "duration_seconds": 39,
+            },
+            {
+                "question_id": "q3",
+                "question": "Solve x^2 - 2x - 15 = 0",
+                "answer": "x = 5, -3",
+                "correct_answer": "x = 5, -3",
+                "is_correct": True,
+                "duration_seconds": 30,
+            },
+            {
+                "question_id": "q4",
+                "question": "Describe one fast way to reject the wrong sign pair",
+                "answer": "Check the sum before multiplying out the full expression.",
+                "correct_answer": "Check the sum before multiplying out the full expression.",
+                "is_correct": True,
+                "duration_seconds": 34,
+            },
+        ],
+    },
+    {
+        "session_id": "contest-assessment-bao-han-1",
+        "student_id": "Bao Han",
+        "title": "Bao Han - Discriminant Checkpoint 1",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-18T09:05:00",
+        "request": "Generate a short discriminant quiz for Bao Han.",
+        "quiz_intro": "Generated a checkpoint on choosing the discriminant before solving.",
+        "review": [
+            {
+                "question_id": "q1",
+                "question": "What is the discriminant of x^2 - 4x + 7 = 0",
+                "answer": "9",
+                "correct_answer": "-12",
+                "is_correct": False,
+                "duration_seconds": 46,
+            },
+            {
+                "question_id": "q2",
+                "question": "How many real roots does x^2 - 4x + 7 = 0 have",
+                "answer": "2",
+                "correct_answer": "0",
+                "is_correct": False,
+                "duration_seconds": 38,
+            },
+            {
+                "question_id": "q3",
+                "question": "What does a negative discriminant tell you",
+                "answer": "No real roots",
+                "correct_answer": "No real roots",
+                "is_correct": True,
+                "duration_seconds": 19,
+            },
+        ],
+    },
+    {
+        "session_id": "contest-assessment-bao-han-2",
+        "student_id": "Bao Han",
+        "title": "Bao Han - Discriminant Checkpoint 2",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-26T09:10:00",
+        "request": "Generate a second discriminant checkpoint with a quick transfer question.",
+        "quiz_intro": "Generated a follow-up discriminant check after notebook review.",
+        "review": [
+            {
+                "question_id": "q1",
+                "question": "What is the discriminant of x^2 + 2x - 3 = 0",
+                "answer": "16",
+                "correct_answer": "16",
+                "is_correct": True,
+                "duration_seconds": 28,
+            },
+            {
+                "question_id": "q2",
+                "question": "How many real roots does x^2 + 2x - 3 = 0 have",
+                "answer": "2",
+                "correct_answer": "2",
+                "is_correct": True,
+                "duration_seconds": 22,
+            },
+            {
+                "question_id": "q3",
+                "question": "What is the discriminant of x^2 + 6x + 10 = 0",
+                "answer": "4",
+                "correct_answer": "-4",
+                "is_correct": False,
+                "duration_seconds": 35,
+            },
+        ],
+    },
+    {
+        "session_id": "contest-assessment-quoc-dat-1",
+        "student_id": "Quoc Dat",
+        "title": "Quoc Dat - Graph Interpretation 1",
+        "knowledge_bases": ["contest-demo-graph-reading-extensions"],
+        "created_at": "2026-04-19T10:00:00",
+        "request": "Generate a graph interpretation check for Quoc Dat.",
+        "quiz_intro": "Generated a graph-reading extension check with one verbal reasoning item.",
+        "review": [
+            {
+                "question_id": "q1",
+                "question": "What does the x-intercept represent on a quadratic graph",
+                "answer": "A root",
+                "correct_answer": "A root",
+                "is_correct": True,
+                "duration_seconds": 18,
+            },
+            {
+                "question_id": "q2",
+                "question": "What does the turning point tell you about the graph",
+                "answer": "It shows the maximum or minimum value",
+                "correct_answer": "It shows the maximum or minimum value",
+                "is_correct": True,
+                "duration_seconds": 24,
+            },
+            {
+                "question_id": "q3",
+                "question": "Describe how the graph changes after the vertex",
+                "answer": "It rises again after the minimum",
+                "correct_answer": "It rises again after the minimum",
+                "is_correct": True,
+                "duration_seconds": 29,
+            },
+        ],
+    },
+    {
+        "session_id": "contest-assessment-quoc-dat-2",
+        "student_id": "Quoc Dat",
+        "title": "Quoc Dat - Graph Interpretation 2",
+        "knowledge_bases": ["contest-demo-graph-reading-extensions"],
+        "created_at": "2026-04-27T10:05:00",
+        "request": "Generate a follow-up graph reasoning check for Quoc Dat.",
+        "quiz_intro": "Generated a follow-up extension with one transfer item.",
+        "review": [
+            {
+                "question_id": "q1",
+                "question": "A graph opens upward and crosses the x-axis twice. What does that imply",
+                "answer": "It has two real roots",
+                "correct_answer": "It has two real roots",
+                "is_correct": True,
+                "duration_seconds": 21,
+            },
+            {
+                "question_id": "q2",
+                "question": "What does the y-intercept show on y = x^2 - 4x + 3",
+                "answer": "The value when x = 0",
+                "correct_answer": "The value when x = 0",
+                "is_correct": True,
+                "duration_seconds": 19,
+            },
+            {
+                "question_id": "q3",
+                "question": "Explain one way graph shape supports your answer about roots",
+                "answer": "Where it crosses the axis shows the roots",
+                "correct_answer": "Where it crosses the axis shows the roots",
+                "is_correct": True,
+                "duration_seconds": 26,
+            },
+        ],
+    },
+]
+
+DEMO_TUTORS = [
+    {
+        "session_id": TUTOR_SESSION_ID,
+        "student_id": "Ngoc An",
+        "title": "Ngoc An - Tutor Replay",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-17T14:15:00",
+        "messages": [
+            ("user", "I still mix up the signs when I factor x^2 - 5x + 6."),
+            (
+                "assistant",
+                "Start with factor pairs of 6: (1, 6) and (2, 3). Now ask which pair adds to -5. Both numbers must be negative.",
+            ),
+            ("user", "So I should test the sum before I write the brackets?"),
+            (
+                "assistant",
+                "Yes. Quick check first: the product gives 6 and the sum gives -5, so (x-2)(x-3) is the match. Then verify by expanding once.",
+            ),
+        ],
+    },
+    {
+        "session_id": "contest-tutor-minh-chau-followup",
+        "student_id": "Minh Chau",
+        "title": "Minh Chau - Tutor Follow-up",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-18T15:05:00",
+        "messages": [
+            ("user", "I know the factor pair, but I rush and flip the signs."),
+            (
+                "assistant",
+                "Use a two-step routine: choose the factor pair, then say the target sum out loud before writing the brackets.",
+            ),
+            ("user", "Can you give me one similar example?"),
+            (
+                "assistant",
+                "Try x^2 - 6x + 8. The pair is 2 and 4, and because the sum must be -6, both signs are negative.",
+            ),
+        ],
+    },
+    {
+        "session_id": "contest-tutor-bao-han-discriminant",
+        "student_id": "Bao Han",
+        "title": "Bao Han - Tutor Replay",
+        "knowledge_bases": [f"{DEMO_KB_ID}__imported"],
+        "created_at": "2026-04-20T13:30:00",
+        "messages": [
+            ("user", "I forget when the discriminant means there are no real roots."),
+            (
+                "assistant",
+                "Compute b squared minus 4ac first. If the result is negative, the graph does not cross the x-axis, so there are no real roots.",
+            ),
+            ("user", "So I should decide the number of roots before solving?"),
+            (
+                "assistant",
+                "Exactly. That keeps the logic clean and avoids choosing an impossible answer set.",
+            ),
+        ],
+    },
+    {
+        "session_id": "contest-tutor-quoc-dat-extension",
+        "student_id": "Quoc Dat",
+        "title": "Quoc Dat - Extension Replay",
+        "knowledge_bases": ["contest-demo-graph-reading-extensions"],
+        "created_at": "2026-04-28T11:10:00",
+        "messages": [
+            ("user", "I can name the vertex, but I want to explain what it means better."),
+            (
+                "assistant",
+                "Describe it as the point where the graph changes direction and where the output reaches its maximum or minimum value.",
+            ),
+            ("user", "How do I connect that to roots?"),
+            (
+                "assistant",
+                "Use both features together: the vertex shows the turning point, and the x-intercepts show where the output becomes zero.",
+            ),
+        ],
+    },
+]
+
+DEMO_OBSERVATIONS = [
+    {
+        "observation_id": "contest-demo-obs-ngoc-an-a1",
+        "session_id": ASSESSMENT_SESSION_ID,
+        "student_id": "Ngoc An",
+        "source": "assessment",
+        "topic": "quadratic factoring",
+        "question_id": "q1",
+        "is_correct": False,
+        "latency_seconds": 53,
+        "hint_count": 1,
+        "retry_count": 2,
+        "dominant_error": "procedure_breakdown",
+        "created_at": "2026-04-17T08:14:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-ngoc-an-a2",
+        "session_id": ASSESSMENT_SESSION_ID,
+        "student_id": "Ngoc An",
+        "source": "assessment",
+        "topic": "quadratic factoring",
+        "question_id": "q2",
+        "is_correct": False,
+        "latency_seconds": 61,
+        "hint_count": 1,
+        "retry_count": 2,
+        "dominant_error": "procedure_breakdown",
+        "created_at": "2026-04-17T08:16:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-ngoc-an-t1",
+        "session_id": TUTOR_SESSION_ID,
+        "student_id": "Ngoc An",
+        "source": "tutoring",
+        "topic": "quadratic factoring",
+        "question_id": "followup-1",
+        "is_correct": True,
+        "latency_seconds": 37,
+        "hint_count": 1,
+        "retry_count": 1,
+        "dominant_error": "procedure_breakdown",
+        "created_at": "2026-04-17T14:20:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-ngoc-an-a3",
+        "session_id": "contest-assessment-ngoc-an-followup",
+        "student_id": "Ngoc An",
+        "source": "assessment",
+        "topic": "quadratic factoring",
+        "question_id": "q3",
+        "is_correct": True,
+        "latency_seconds": 44,
+        "hint_count": 0,
+        "retry_count": 1,
+        "dominant_error": "procedure_breakdown",
+        "created_at": "2026-04-24T08:18:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-minh-chau-a1",
+        "session_id": "contest-assessment-minh-chau-1",
+        "student_id": "Minh Chau",
+        "source": "assessment",
+        "topic": "quadratic factoring",
+        "question_id": "q1",
+        "is_correct": False,
+        "latency_seconds": 49,
+        "hint_count": 1,
+        "retry_count": 2,
+        "dominant_error": "procedure_breakdown",
+        "created_at": "2026-04-17T08:28:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-minh-chau-a2",
+        "session_id": "contest-assessment-minh-chau-1",
+        "student_id": "Minh Chau",
+        "source": "assessment",
+        "topic": "quadratic factoring",
+        "question_id": "q2",
+        "is_correct": False,
+        "latency_seconds": 57,
+        "hint_count": 1,
+        "retry_count": 2,
+        "dominant_error": "procedure_breakdown",
+        "created_at": "2026-04-17T08:31:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-minh-chau-t1",
+        "session_id": "contest-tutor-minh-chau-followup",
+        "student_id": "Minh Chau",
+        "source": "tutoring",
+        "topic": "quadratic factoring",
+        "question_id": "followup-1",
+        "is_correct": True,
+        "latency_seconds": 34,
+        "hint_count": 1,
+        "retry_count": 1,
+        "dominant_error": "procedure_breakdown",
+        "created_at": "2026-04-18T15:12:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-minh-chau-a3",
+        "session_id": "contest-assessment-minh-chau-2",
+        "student_id": "Minh Chau",
+        "source": "assessment",
+        "topic": "quadratic factoring",
+        "question_id": "q4",
+        "is_correct": True,
+        "latency_seconds": 34,
+        "hint_count": 0,
+        "retry_count": 0,
+        "dominant_error": "procedure_breakdown",
+        "created_at": "2026-04-25T08:18:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-bao-han-a1",
+        "session_id": "contest-assessment-bao-han-1",
+        "student_id": "Bao Han",
+        "source": "assessment",
+        "topic": "discriminant selection",
+        "question_id": "q1",
+        "is_correct": False,
+        "latency_seconds": 46,
+        "hint_count": 1,
+        "retry_count": 1,
+        "dominant_error": "concept_gap",
+        "created_at": "2026-04-18T09:08:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-bao-han-a2",
+        "session_id": "contest-assessment-bao-han-1",
+        "student_id": "Bao Han",
+        "source": "assessment",
+        "topic": "discriminant selection",
+        "question_id": "q2",
+        "is_correct": False,
+        "latency_seconds": 38,
+        "hint_count": 1,
+        "retry_count": 1,
+        "dominant_error": "concept_gap",
+        "created_at": "2026-04-18T09:10:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-bao-han-t1",
+        "session_id": "contest-tutor-bao-han-discriminant",
+        "student_id": "Bao Han",
+        "source": "tutoring",
+        "topic": "discriminant selection",
+        "question_id": "followup-1",
+        "is_correct": True,
+        "latency_seconds": 27,
+        "hint_count": 1,
+        "retry_count": 0,
+        "dominant_error": "concept_gap",
+        "created_at": "2026-04-20T13:34:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-bao-han-a3",
+        "session_id": "contest-assessment-bao-han-2",
+        "student_id": "Bao Han",
+        "source": "assessment",
+        "topic": "discriminant selection",
+        "question_id": "q3",
+        "is_correct": False,
+        "latency_seconds": 35,
+        "hint_count": 0,
+        "retry_count": 1,
+        "dominant_error": "concept_gap",
+        "created_at": "2026-04-26T09:16:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-quoc-dat-a1",
+        "session_id": "contest-assessment-quoc-dat-1",
+        "student_id": "Quoc Dat",
+        "source": "assessment",
+        "topic": "graph interpretation",
+        "question_id": "q1",
+        "is_correct": True,
+        "latency_seconds": 18,
+        "hint_count": 0,
+        "retry_count": 0,
+        "dominant_error": "",
+        "created_at": "2026-04-19T10:04:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-quoc-dat-a2",
+        "session_id": "contest-assessment-quoc-dat-1",
+        "student_id": "Quoc Dat",
+        "source": "assessment",
+        "topic": "graph interpretation",
+        "question_id": "q2",
+        "is_correct": True,
+        "latency_seconds": 24,
+        "hint_count": 0,
+        "retry_count": 0,
+        "dominant_error": "",
+        "created_at": "2026-04-19T10:06:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-quoc-dat-t1",
+        "session_id": "contest-tutor-quoc-dat-extension",
+        "student_id": "Quoc Dat",
+        "source": "tutoring",
+        "topic": "graph interpretation",
+        "question_id": "followup-1",
+        "is_correct": True,
+        "latency_seconds": 22,
+        "hint_count": 0,
+        "retry_count": 0,
+        "dominant_error": "",
+        "created_at": "2026-04-28T11:14:00",
+    },
+    {
+        "observation_id": "contest-demo-obs-quoc-dat-a3",
+        "session_id": "contest-assessment-quoc-dat-2",
+        "student_id": "Quoc Dat",
+        "source": "assessment",
+        "topic": "graph interpretation",
+        "question_id": "q3",
+        "is_correct": True,
+        "latency_seconds": 26,
+        "hint_count": 0,
+        "retry_count": 0,
+        "dominant_error": "",
+        "created_at": "2026-04-27T10:08:00",
+    },
+]
+
+DEMO_SHAREABLE_PACK_NAMES = [pack["name"] for pack in DEMO_SHAREABLE_PACKS]
+DEMO_IMPORTED_PACK_NAMES = [pack["name"] for pack in DEMO_IMPORTED_PACKS]
+DEMO_KB_NAMES = DEMO_SHAREABLE_PACK_NAMES + DEMO_IMPORTED_PACK_NAMES
+DEMO_SESSION_IDS = [row["session_id"] for row in DEMO_ASSESSMENTS] + [row["session_id"] for row in DEMO_TUTORS]
+DEMO_STUDENT_IDS = [row["id"] for row in DEMO_STUDENTS]
 
 
 def _validate_local_api_base(api_base: str) -> None:
@@ -38,137 +925,551 @@ def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
-def _seed_knowledge_pack(project_root: Path) -> Path:
+def _read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8") or "{}")
+    except json.JSONDecodeError:
+        return {}
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _iso_to_timestamp(value: str) -> float:
+    return datetime.fromisoformat(value).replace(tzinfo=timezone.utc).timestamp()
+
+
+def _clear_demo_knowledge_packs(project_root: Path) -> dict:
     kb_root = project_root / "data" / "knowledge_bases"
-    kb_dir = kb_root / DEMO_KB_ID
-    (kb_dir / "llamaindex_storage").mkdir(parents=True, exist_ok=True)
-    (kb_dir / "raw").mkdir(parents=True, exist_ok=True)
-
-    metadata = {
-        "name": DEMO_KB_ID,
-        "description": "Contest demo Knowledge Pack for quadratic equations.",
-        "rag_provider": "llamaindex",
-        "status": "ready",
-        **DEMO_METADATA,
-    }
-    _write_json(kb_dir / "metadata.json", metadata)
-
     config_path = kb_root / "kb_config.json"
-    if config_path.exists():
-        try:
-            config = json.loads(config_path.read_text(encoding="utf-8") or "{}")
-        except json.JSONDecodeError:
-            config = {}
-    else:
-        config = {}
+    config = _read_json(config_path)
     config.setdefault("knowledge_bases", {})
-    config["knowledge_bases"][DEMO_KB_ID] = {
-        "path": DEMO_KB_ID,
-        "description": metadata["description"],
+    for name in DEMO_KB_NAMES:
+        config["knowledge_bases"].pop(name, None)
+        pack_dir = kb_root / name
+        if pack_dir.exists():
+            shutil.rmtree(pack_dir)
+    _write_json(config_path, config)
+    return config
+
+
+def _pack_metadata(pack: dict, *, sharing_status: str | None = None, imported_from: str | None = None) -> dict:
+    metadata = {
+        "name": pack["name"],
+        "description": pack["description"],
         "rag_provider": "llamaindex",
         "status": "ready",
-        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
-        **DEMO_METADATA,
+        "subject": pack["subject"],
+        "grade": pack["grade"],
+        "curriculum": pack["curriculum"],
+        "learning_objectives": list(pack["learning_objectives"]),
+        "owner": pack["owner"],
+        "sharing_status": sharing_status or pack["sharing_status"],
+        "tags": list(pack.get("tags", [])),
+        "difficulty": pack.get("difficulty"),
+        "language": pack.get("language"),
+        "estimated_hours": pack.get("estimated_hours"),
+        "prerequisites": list(pack.get("prerequisites", [])),
+        "content_types": list(pack.get("content_types", [])),
     }
-    _write_json(config_path, config)
-    return kb_dir
+    if imported_from:
+        metadata["imported_from"] = imported_from
+    return metadata
 
 
-def _insert_session(
-    conn: sqlite3.Connection,
-    *,
-    session_id: str,
-    title: str,
-    capability: str,
-    user_message: str,
-    assistant_message: str,
-) -> None:
-    now = time.time()
-    preferences = {
-        "capability": capability,
-        "tools": ["rag"],
-        "knowledge_bases": [DEMO_KB_ID],
-        "language": "en",
-        "demo": True,
+def _write_pack_files(kb_root: Path, pack: dict, *, metadata: dict) -> Path:
+    pack_dir = kb_root / pack["name"]
+    (pack_dir / "llamaindex_storage").mkdir(parents=True, exist_ok=True)
+    (pack_dir / "rag_storage").mkdir(parents=True, exist_ok=True)
+    raw_dir = pack_dir / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    for doc_name in pack.get("documents", []):
+        (raw_dir / doc_name).write_text(
+            f"# {pack['name']}\n\n{doc_name}\n\nDemo-safe placeholder content for local preview.\n",
+            encoding="utf-8",
+        )
+    _write_json(pack_dir / "metadata.json", metadata)
+    return pack_dir
+
+
+def _config_entry(pack: dict, *, metadata: dict, path_name: str, description: str, imported_from: str | None = None) -> dict:
+    entry = {
+        "path": path_name,
+        "description": description,
+        "rag_provider": "llamaindex",
+        "status": "ready",
+        "created_at": pack["created_at"],
+        "updated_at": pack["updated_at"],
+        "subject": metadata["subject"],
+        "grade": metadata["grade"],
+        "curriculum": metadata["curriculum"],
+        "learning_objectives": metadata["learning_objectives"],
+        "owner": metadata["owner"],
+        "sharing_status": metadata["sharing_status"],
+        "tags": metadata["tags"],
+        "difficulty": metadata["difficulty"],
+        "language": metadata["language"],
+        "estimated_hours": metadata["estimated_hours"],
+        "prerequisites": metadata["prerequisites"],
+        "content_types": metadata["content_types"],
+        "marketplace_reviews": list(pack.get("marketplace_reviews", [])),
     }
-    turn_id = f"turn-{session_id}"
-
-    conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
-    conn.execute(
-        """
-        INSERT INTO sessions (
-            id, title, created_at, updated_at, compressed_summary, summary_up_to_msg_id, preferences_json
-        ) VALUES (?, ?, ?, ?, '', 0, ?)
-        """,
-        (session_id, title, now, now, json.dumps(preferences, ensure_ascii=False)),
-    )
-    conn.execute(
-        """
-        INSERT INTO messages (
-            session_id, role, content, capability, events_json, attachments_json, created_at
-        ) VALUES (?, 'user', ?, ?, '[]', '[]', ?)
-        """,
-        (session_id, user_message, capability, now),
-    )
-    conn.execute(
-        """
-        INSERT INTO messages (
-            session_id, role, content, capability, events_json, attachments_json, created_at
-        ) VALUES (?, 'assistant', ?, ?, '[]', '[]', ?)
-        """,
-        (session_id, assistant_message, capability, now + 1),
-    )
-    conn.execute(
-        """
-        INSERT INTO turns (id, session_id, capability, status, error, created_at, updated_at, finished_at)
-        VALUES (?, ?, ?, 'completed', '', ?, ?, ?)
-        """,
-        (turn_id, session_id, capability, now, now + 1, now + 1),
-    )
+    if imported_from:
+        entry["imported_from"] = imported_from
+        entry["import_date"] = pack["updated_at"]
+    return entry
 
 
-def _seed_sessions(project_root: Path) -> Path:
-    db_path = project_root / "data" / "user" / "chat_history.db"
+def _seed_knowledge_packs(project_root: Path) -> dict[str, object]:
+    kb_root = project_root / "data" / "knowledge_bases"
+    kb_root.mkdir(parents=True, exist_ok=True)
+    config = _clear_demo_knowledge_packs(project_root)
+
+    for pack in DEMO_SHAREABLE_PACKS:
+        metadata = _pack_metadata(pack)
+        _write_pack_files(kb_root, pack, metadata=metadata)
+        config["knowledge_bases"][pack["name"]] = _config_entry(
+            pack,
+            metadata=metadata,
+            path_name=pack["name"],
+            description=pack["description"],
+        )
+
+    shareable_by_name = {pack["name"]: pack for pack in DEMO_SHAREABLE_PACKS}
+    for imported in DEMO_IMPORTED_PACKS:
+        source_pack = shareable_by_name[imported["source_name"]]
+        pack_payload = dict(source_pack)
+        pack_payload["name"] = imported["name"]
+        pack_payload["description"] = imported["description"]
+        pack_payload["sharing_status"] = "private"
+        pack_payload["created_at"] = imported["created_at"]
+        pack_payload["updated_at"] = imported["updated_at"]
+        metadata = _pack_metadata(
+            pack_payload,
+            sharing_status="private",
+            imported_from=imported["source_name"],
+        )
+        _write_pack_files(kb_root, pack_payload, metadata=metadata)
+        config["knowledge_bases"][imported["name"]] = _config_entry(
+            pack_payload,
+            metadata=metadata,
+            path_name=imported["name"],
+            description=imported["description"],
+            imported_from=imported["source_name"],
+        )
+
+    _write_json(kb_root / "kb_config.json", config)
+    return {
+        "anchor_path": kb_root / DEMO_KB_ID,
+        "shareable": DEMO_SHAREABLE_PACK_NAMES,
+        "imported": DEMO_IMPORTED_PACK_NAMES,
+    }
+
+
+def _clear_demo_db_records(db_path: Path) -> None:
     SQLiteSessionStore(db_path)
     with sqlite3.connect(db_path) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
-        _insert_session(
-            conn,
-            session_id=ASSESSMENT_SESSION_ID,
-            title="Contest Demo Assessment",
-            capability="deep_question",
-            user_message="Generate Grade 9 quadratic equation questions from contest-demo-quadratics.",
-            assistant_message=(
-                "Generated demo-safe questions with answers, explanations, and common mistakes "
-                "for solving quadratic equations."
-            ),
+        conn.executemany("DELETE FROM sessions WHERE id = ?", [(session_id,) for session_id in DEMO_SESSION_IDS])
+        conn.executemany("DELETE FROM observations WHERE student_id = ?", [(student_id,) for student_id in DEMO_STUDENT_IDS])
+        conn.executemany("DELETE FROM student_states WHERE student_id = ?", [(student_id,) for student_id in DEMO_STUDENT_IDS])
+
+        for table_name, column_name in (
+            ("teacher_actions", "teacher_instruction"),
+            ("recommendation_acks", "teacher_note"),
+            ("recommendation_feedback", "teacher_note"),
+            ("teacher_overrides", "teacher_note"),
+            ("diagnosis_feedback", "teacher_note"),
+        ):
+            if _table_exists(conn, table_name):
+                conn.execute(f"DELETE FROM {table_name} WHERE {column_name} LIKE ?", (f"%{DEMO_MARKER}%",))
+        if _table_exists(conn, "intervention_assignments"):
+            conn.execute(
+                "DELETE FROM intervention_assignments WHERE teacher_note LIKE ? OR practice_note LIKE ?",
+                (f"%{DEMO_MARKER}%", f"%{DEMO_MARKER}%"),
+            )
+        conn.commit()
+
+
+def _format_quiz_review(review_rows: list[dict]) -> str:
+    lines = ["[Quiz Performance]"]
+    for index, row in enumerate(review_rows, start=1):
+        status = "Correct" if row["is_correct"] else "Incorrect"
+        correct_suffix = f", correct: {row['correct_answer']}" if not row["is_correct"] else ""
+        duration_suffix = (
+            f", time: {int(row['duration_seconds'])}s"
+            if row.get("duration_seconds") is not None
+            else ""
         )
-        _insert_session(
-            conn,
-            session_id=TUTOR_SESSION_ID,
-            title="Contest Demo Tutor",
-            capability="chat",
-            user_message="Help a student understand a common quadratic equation mistake.",
-            assistant_message=(
-                "The Tutor Agent explains how to check factoring steps and compare both roots "
-                "against the original equation."
-            ),
+        lines.append(
+            f"{index}. [{row['question_id']}] Q: {row['question']} -> Answered: {row['answer']} "
+            f"({status}{correct_suffix}{duration_suffix})"
+        )
+    total = len(review_rows)
+    correct = sum(1 for row in review_rows if row["is_correct"])
+    percent = round((correct / total) * 100) if total else 0
+    lines.append(f"Score: {correct}/{total} ({percent}%)")
+    return "\n".join(lines)
+
+
+async def _seed_assessment_sessions(store: SQLiteSessionStore) -> None:
+    for row in DEMO_ASSESSMENTS:
+        await store.create_session(title=row["title"], session_id=row["session_id"])
+        await store.update_session_preferences(
+            row["session_id"],
+            {
+                "capability": "deep_question",
+                "tools": ["rag"],
+                "knowledge_bases": list(row["knowledge_bases"]),
+                "language": "en",
+                "student_id": row["student_id"],
+                "cohort": DEMO_COHORT,
+                "demo": True,
+            },
+        )
+        turn = await store.create_turn(row["session_id"], capability="deep_question")
+        await store.add_message(row["session_id"], "user", row["request"], capability="deep_question")
+        await store.add_message(row["session_id"], "assistant", row["quiz_intro"], capability="deep_question")
+        await store.add_message(
+            row["session_id"],
+            "user",
+            _format_quiz_review(row["review"]),
+            capability="deep_question",
+        )
+        await store.update_turn_status(turn["id"], "completed")
+
+
+async def _seed_tutor_sessions(store: SQLiteSessionStore) -> None:
+    for row in DEMO_TUTORS:
+        await store.create_session(title=row["title"], session_id=row["session_id"])
+        await store.update_session_preferences(
+            row["session_id"],
+            {
+                "capability": "chat",
+                "tools": ["rag"],
+                "knowledge_bases": list(row["knowledge_bases"]),
+                "language": "en",
+                "student_id": row["student_id"],
+                "cohort": DEMO_COHORT,
+                "demo": True,
+            },
+        )
+        turn = await store.create_turn(row["session_id"], capability="chat")
+        for role, content in row["messages"]:
+            await store.add_message(row["session_id"], role, content, capability="chat")
+        await store.update_turn_status(turn["id"], "completed")
+
+
+def _set_session_timestamp(db_path: Path, session_id: str, timestamp_value: float) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE sessions SET created_at = ?, updated_at = ? WHERE id = ?",
+            (timestamp_value, timestamp_value, session_id),
+        )
+        conn.execute(
+            "UPDATE turns SET created_at = ?, updated_at = ?, finished_at = ? WHERE session_id = ?",
+            (timestamp_value, timestamp_value, timestamp_value, session_id),
+        )
+        message_rows = conn.execute(
+            "SELECT id FROM messages WHERE session_id = ? ORDER BY id ASC",
+            (session_id,),
+        ).fetchall()
+        for offset, message_row in enumerate(message_rows):
+            conn.execute(
+                "UPDATE messages SET created_at = ? WHERE id = ?",
+                (timestamp_value + offset * 60, message_row[0]),
+            )
+        conn.commit()
+
+
+async def _seed_observations_and_states(store: SQLiteSessionStore) -> dict[str, list[dict]]:
+    observation_rows = []
+    for row in DEMO_OBSERVATIONS:
+        payload = dict(row)
+        payload["created_at"] = _iso_to_timestamp(row["created_at"])
+        observation_rows.append(payload)
+    await store.save_observations(observation_rows)
+
+    observations_by_student: dict[str, list[dict]] = {}
+    for student_id in DEMO_STUDENT_IDS:
+        observations = await store.list_observations(student_id)
+        observations_by_student[student_id] = observations
+        state = await store.build_student_state_rollup(student_id)
+        if state is not None:
+            await store.upsert_student_state(student_id, state)
+    return observations_by_student
+
+
+def _set_student_state_timestamp(db_path: Path, student_id: str, timestamp_value: float) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE student_states SET updated_at = ? WHERE student_id = ?",
+            (timestamp_value, student_id),
         )
         conn.commit()
-    return db_path
+
+
+def _seed_demo_evidence(store: SQLiteSessionStore, *, student_payloads: list[dict], observations_by_student: dict[str, list[dict]]) -> None:
+    insights = build_teacher_insights_payload(
+        student_payloads=student_payloads,
+        observations_by_student=observations_by_student,
+    )
+    student_rows = {
+        row["student_id"]: row
+        for row in insights["students"]
+    }
+    group_row = next(
+        (
+            row
+            for row in insights["small_groups"]
+            if sorted(row["student_ids"]) == ["Minh Chau", "Ngoc An"]
+        ),
+        None,
+    )
+    if group_row is None:
+        raise RuntimeError("Expected a quadratic factoring small-group storyline for demo data")
+
+    ngoc_action = create_teacher_action(
+        store,
+        target_type="student",
+        target_id="Ngoc An",
+        source_recommendation_id=student_rows["Ngoc An"]["recommended_actions"][0]["action_id"],
+        action_type="scaffolded_practice",
+        topic="quadratic factoring",
+        teacher_instruction=f"{DEMO_MARKER} Run a 10-minute sign-check routine with two guided examples before independent practice.",
+        priority="high",
+    )
+    create_recommendation_ack(
+        store,
+        source_recommendation_id=student_rows["Ngoc An"]["recommended_actions"][0]["action_id"],
+        target_type="student",
+        target_id="Ngoc An",
+        status="accepted",
+        teacher_note=f"{DEMO_MARKER} Use this in tomorrow's warm-up block.",
+    )
+    create_recommendation_feedback(
+        store,
+        source_recommendation_id=student_rows["Ngoc An"]["recommended_actions"][0]["action_id"],
+        target_type="student",
+        target_id="Ngoc An",
+        feedback_label="practical",
+        teacher_note=f"{DEMO_MARKER} The recommendation matches the student's actual error pattern.",
+    )
+    create_diagnosis_feedback(
+        store,
+        student_id="Ngoc An",
+        source_topic=student_rows["Ngoc An"]["inferred"][0]["topic"],
+        source_diagnosis_type=student_rows["Ngoc An"]["inferred"][0]["diagnosis_type"],
+        feedback_label="helpful",
+        teacher_note=f"{DEMO_MARKER} This lines up with the student's written work.",
+    )
+    create_intervention_assignment(
+        store,
+        teacher_action_id=ngoc_action["id"],
+        assignment_type="practice_set",
+        title="Quadratic factoring sign-check set",
+        teacher_note=f"{DEMO_MARKER} Assign four short factor-and-check problems after reteach.",
+        practice_note=f"{DEMO_MARKER} Start with sum/product checks before expanding.",
+    )
+
+    bao_action = create_teacher_action(
+        store,
+        target_type="student",
+        target_id="Bao Han",
+        source_recommendation_id=student_rows["Bao Han"]["recommended_actions"][0]["action_id"],
+        action_type="review_prerequisite",
+        topic="discriminant selection",
+        teacher_instruction=f"{DEMO_MARKER} Review b squared minus 4ac with one worked comparison between positive and negative discriminants.",
+        priority="medium",
+    )
+    create_recommendation_ack(
+        store,
+        source_recommendation_id=student_rows["Bao Han"]["recommended_actions"][0]["action_id"],
+        target_type="student",
+        target_id="Bao Han",
+        status="deferred",
+        teacher_note=f"{DEMO_MARKER} Hold until the class finishes the current factoring cycle.",
+    )
+    create_recommendation_feedback(
+        store,
+        source_recommendation_id=student_rows["Bao Han"]["recommended_actions"][0]["action_id"],
+        target_type="student",
+        target_id="Bao Han",
+        feedback_label="relevant",
+        teacher_note=f"{DEMO_MARKER} Good fit after notebook review.",
+    )
+    create_teacher_override(
+        store,
+        source_recommendation_id=student_rows["Bao Han"]["recommended_actions"][0]["action_id"],
+        target_type="student",
+        target_id="Bao Han",
+        override_reason="needs_more_context",
+        teacher_selected_move="review_prerequisite",
+        teacher_note=f"{DEMO_MARKER} Teacher wants one prerequisite recap before another quiz.",
+    )
+    create_diagnosis_feedback(
+        store,
+        student_id="Bao Han",
+        source_topic=student_rows["Bao Han"]["inferred"][0]["topic"],
+        source_diagnosis_type=student_rows["Bao Han"]["inferred"][0]["diagnosis_type"],
+        feedback_label="incomplete",
+        teacher_note=f"{DEMO_MARKER} Useful, but still needs one more observation from class discussion.",
+    )
+    create_intervention_assignment(
+        store,
+        teacher_action_id=bao_action["id"],
+        assignment_type="prerequisite_review",
+        title="Discriminant recap notes",
+        teacher_note=f"{DEMO_MARKER} Review the discriminant flow before the next independent attempt.",
+        practice_note=f"{DEMO_MARKER} Mark each expression as positive, zero, or negative before solving.",
+    )
+
+    group_action = create_teacher_action(
+        store,
+        target_type="small_group",
+        target_id=group_row["target_id"],
+        source_recommendation_id=f"group:{group_row['topic']}:{group_row['diagnosis_type']}",
+        action_type="small_group_remediation",
+        topic=group_row["topic"],
+        teacher_instruction=f"{DEMO_MARKER} Pull Ngoc An and Minh Chau for one 12-minute mini group on sign checks and root verification.",
+        priority="high",
+    )
+    create_recommendation_ack(
+        store,
+        source_recommendation_id=f"group:{group_row['topic']}:{group_row['diagnosis_type']}",
+        target_type="small_group",
+        target_id=group_row["target_id"],
+        status="accepted",
+        teacher_note=f"{DEMO_MARKER} This pair can be regrouped during the workshop block.",
+    )
+    create_recommendation_feedback(
+        store,
+        source_recommendation_id=f"group:{group_row['topic']}:{group_row['diagnosis_type']}",
+        target_type="small_group",
+        target_id=group_row["target_id"],
+        feedback_label="relevant",
+        teacher_note=f"{DEMO_MARKER} Shared misconception is obvious in both assessments.",
+    )
+    create_intervention_assignment(
+        store,
+        teacher_action_id=group_action["id"],
+        assignment_type="small_group_activity",
+        title="Quadratic factoring mini-group",
+        teacher_note=f"{DEMO_MARKER} Run one worked example together, then release to paired practice.",
+        practice_note=f"{DEMO_MARKER} Students say the target sum before writing factor brackets.",
+    )
+
+
+def _set_evidence_timestamps(db_path: Path) -> None:
+    table_updates = {
+        "teacher_actions": [
+            ("teacher_instruction LIKE '%Ngoc An%'", "2026-04-24T15:10:00"),
+            ("teacher_instruction LIKE '%Bao Han%'", "2026-04-26T14:25:00"),
+            ("teacher_instruction LIKE '%Minh Chau%'", "2026-04-25T10:30:00"),
+        ],
+        "recommendation_acks": [
+            ("teacher_note LIKE '%warm-up block%'", "2026-04-24T15:00:00"),
+            ("teacher_note LIKE '%current factoring cycle%'", "2026-04-26T14:20:00"),
+            ("teacher_note LIKE '%workshop block%'", "2026-04-25T10:20:00"),
+        ],
+        "recommendation_feedback": [
+            ("teacher_note LIKE '%actual error pattern%'", "2026-04-24T15:05:00"),
+            ("teacher_note LIKE '%notebook review%'", "2026-04-26T14:22:00"),
+            ("teacher_note LIKE '%Shared misconception%'", "2026-04-25T10:22:00"),
+        ],
+        "teacher_overrides": [
+            ("teacher_note LIKE '%prerequisite recap%'", "2026-04-26T14:24:00"),
+        ],
+        "diagnosis_feedback": [
+            ("teacher_note LIKE '%written work%'", "2026-04-24T15:08:00"),
+            ("teacher_note LIKE '%class discussion%'", "2026-04-26T14:26:00"),
+        ],
+        "intervention_assignments": [
+            ("title = 'Quadratic factoring sign-check set'", "2026-04-24T15:12:00"),
+            ("title = 'Discriminant recap notes'", "2026-04-26T14:28:00"),
+            ("title = 'Quadratic factoring mini-group'", "2026-04-25T10:32:00"),
+        ],
+    }
+    with sqlite3.connect(db_path) as conn:
+        for table_name, rules in table_updates.items():
+            if not _table_exists(conn, table_name):
+                continue
+            for where_clause, iso_value in rules:
+                ts_value = _iso_to_timestamp(iso_value)
+                conn.execute(
+                    f"UPDATE {table_name} SET created_at = ?, updated_at = ? WHERE {where_clause}",
+                    (ts_value, ts_value),
+                )
+        conn.commit()
+
+
+async def _seed_db(project_root: Path) -> dict[str, object]:
+    db_path = project_root / "data" / "user" / "chat_history.db"
+    _clear_demo_db_records(db_path)
+    store = SQLiteSessionStore(db_path)
+
+    await _seed_assessment_sessions(store)
+    await _seed_tutor_sessions(store)
+
+    for row in DEMO_ASSESSMENTS:
+        _set_session_timestamp(db_path, row["session_id"], _iso_to_timestamp(row["created_at"]))
+    for row in DEMO_TUTORS:
+        _set_session_timestamp(db_path, row["session_id"], _iso_to_timestamp(row["created_at"]))
+
+    observations_by_student = await _seed_observations_and_states(store)
+    for student_id, observations in observations_by_student.items():
+        latest_ts = max(float(item["created_at"]) for item in observations)
+        _set_student_state_timestamp(db_path, student_id, latest_ts)
+
+    student_payloads = []
+    for student_id in DEMO_STUDENT_IDS:
+        observations = observations_by_student[student_id]
+        student_state = await store.get_student_state(student_id)
+        student_payloads.append(
+            build_student_diagnosis(
+                student_id=student_id,
+                observations=observations,
+                student_state=student_state,
+            )
+        )
+
+    _seed_demo_evidence(
+        store,
+        student_payloads=student_payloads,
+        observations_by_student=observations_by_student,
+    )
+    _set_evidence_timestamps(db_path)
+
+    return {
+        "db_path": db_path,
+        "session_ids": DEMO_SESSION_IDS,
+        "student_ids": DEMO_STUDENT_IDS,
+    }
 
 
 def reset_demo_data(project_root: str | Path = ".", *, api_base: str = "http://localhost:8001") -> dict:
     _validate_local_api_base(api_base)
     root = Path(project_root).expanduser().resolve()
-    kb_dir = _seed_knowledge_pack(root)
-    db_path = _seed_sessions(root)
+    kb_state = _seed_knowledge_packs(root)
+    db_state = asyncio.run(_seed_db(root))
     return {
         "knowledge_pack": DEMO_KB_ID,
-        "sessions": [ASSESSMENT_SESSION_ID, TUTOR_SESSION_ID],
+        "knowledge_packs": {
+            "shareable": list(kb_state["shareable"]),
+            "imported": list(kb_state["imported"]),
+        },
+        "sessions": list(db_state["session_ids"]),
+        "students": list(db_state["student_ids"]),
         "paths": {
-            "knowledge_pack": str(kb_dir),
-            "session_db": str(db_path),
+            "knowledge_pack": str(kb_state["anchor_path"]),
+            "session_db": str(db_state["db_path"]),
         },
         "api_base": api_base,
     }

--- a/tests/scripts/test_reset_demo_data.py
+++ b/tests/scripts/test_reset_demo_data.py
@@ -23,24 +23,46 @@ def _count_rows(db_path: Path, table: str) -> int:
         return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
 
 
+def _kb_entries(config: dict) -> dict:
+    return config.get("knowledge_bases", {})
+
+
 def test_reset_demo_data_creates_expected_kb_and_sessions(tmp_path: Path) -> None:
     result = reset_demo_data(tmp_path, api_base="http://localhost:8001")
 
     kb_root = tmp_path / "data" / "knowledge_bases"
     config = _read_json(kb_root / "kb_config.json")
-    kb_entry = config["knowledge_bases"][DEMO_KB_ID]
+    entries = _kb_entries(config)
+    kb_entry = entries[DEMO_KB_ID]
     metadata = _read_json(kb_root / DEMO_KB_ID / "metadata.json")
     db_path = tmp_path / "data" / "user" / "chat_history.db"
+    shareable = [
+        row for row in entries.values() if row.get("sharing_status") in {"public", "team"}
+    ]
+    imported = [
+        name for name, row in entries.items() if name.endswith("__imported") and row.get("sharing_status") == "private"
+    ]
 
     assert result["knowledge_pack"] == DEMO_KB_ID
-    assert result["sessions"] == [ASSESSMENT_SESSION_ID, TUTOR_SESSION_ID]
+    assert ASSESSMENT_SESSION_ID in result["sessions"]
+    assert TUTOR_SESSION_ID in result["sessions"]
     assert kb_entry["subject"] == "Mathematics"
     assert kb_entry["grade"] == "Grade 9"
     assert metadata["owner"] == "Contest Demo Teacher"
     assert (kb_root / DEMO_KB_ID / "llamaindex_storage").is_dir()
-    assert _count_rows(db_path, "sessions") == 2
-    assert _count_rows(db_path, "messages") == 4
-    assert _count_rows(db_path, "turns") == 2
+    assert len(shareable) >= 6
+    assert len(imported) >= 2
+    assert _count_rows(db_path, "sessions") >= 10
+    assert _count_rows(db_path, "messages") >= 30
+    assert _count_rows(db_path, "turns") >= 10
+    assert _count_rows(db_path, "observations") >= 12
+    assert _count_rows(db_path, "student_states") >= 4
+    assert _count_rows(db_path, "teacher_actions") >= 2
+    assert _count_rows(db_path, "recommendation_acks") >= 2
+    assert _count_rows(db_path, "recommendation_feedback") >= 2
+    assert _count_rows(db_path, "teacher_overrides") >= 1
+    assert _count_rows(db_path, "diagnosis_feedback") >= 2
+    assert _count_rows(db_path, "intervention_assignments") >= 2
 
 
 def test_reset_demo_data_is_idempotent(tmp_path: Path) -> None:
@@ -49,12 +71,18 @@ def test_reset_demo_data_is_idempotent(tmp_path: Path) -> None:
 
     db_path = tmp_path / "data" / "user" / "chat_history.db"
     config = _read_json(tmp_path / "data" / "knowledge_bases" / "kb_config.json")
+    entries = _kb_entries(config)
 
     assert first["sessions"] == second["sessions"]
-    assert list(config["knowledge_bases"]) == [DEMO_KB_ID]
-    assert _count_rows(db_path, "sessions") == 2
-    assert _count_rows(db_path, "messages") == 4
-    assert _count_rows(db_path, "turns") == 2
+    assert first["knowledge_pack"] == second["knowledge_pack"] == DEMO_KB_ID
+    assert len(entries) >= 8
+    assert _count_rows(db_path, "sessions") >= 10
+    assert _count_rows(db_path, "messages") >= 30
+    assert _count_rows(db_path, "turns") >= 10
+    assert _count_rows(db_path, "observations") >= 12
+    assert _count_rows(db_path, "student_states") >= 4
+    assert _count_rows(db_path, "teacher_actions") >= 2
+    assert _count_rows(db_path, "intervention_assignments") >= 2
 
 
 def test_reset_demo_data_rejects_non_local_api_base(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- expand the local contest reset utility from a two-session stub into a richer demo-safe classroom dataset
- seed shareable marketplace packs, imported workspace packs, multi-session assessment/tutor history, and dashboard evidence traces
- update the reset/smoke runbooks and add the required architecture note

## Validation
- `pytest tests/scripts/test_reset_demo_data.py -v`
- `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.venv/bin/python -m scripts.contest.reset_demo_data --project-root . --api-base http://localhost:8001`
- repeated the same reset command to confirm idempotent output
- `python3 -m compileall scripts`
- `git diff --check`

## Architecture Note
- `docs/superpowers/pr-notes/2026-04-30-demo-realistic-seed-data.md`
- `ai_first/architecture/MAIN_SYSTEM_MAP.md` was not updated because this lane only extends a local demo helper and its seed coverage.