### PR TITLE
fix(build): harden web compile boundaries [L1-BUILD]

### DIFF
--- a/ai_first/ACTIVE_ASSIGNMENTS.md
+++ b/ai_first/ACTIVE_ASSIGNMENTS.md
@@ -30,6 +30,21 @@ Rules:
 
 ## Active
 
+### Assignment
+
+- Owner: Codex session
+- Machine: local desktop
+- Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-build-hygiene-productization`
+- Task: Fix `L1` build hygiene blockers so the web app builds cleanly on a clean machine and test/dev config no longer leaks into the production compile path
+- Status: implemented, validation passing
+- Branch: `fix/build-hygiene-productization`
+- Task packet: `docs/superpowers/tasks/2026-05-06-l1-build-hygiene-productization.md`
+- Owned files: `web/tsconfig.json`, `web/vitest.config.ts`, `web/package.json`, `web/package-lock.json` only if required, `web/next.config.*`, `web/next-env.d.ts` only if required, `web/tests/build-config-hygiene.test.ts`, `docs/superpowers/tasks/2026-05-06-l1-build-hygiene-productization.md`, `docs/superpowers/specs/2026-05-06-l1-build-hygiene-productization-design.md`, `docs/superpowers/pr-notes/2026-05-06-l1-build-hygiene-productization.md`, `ai_first/ACTIVE_ASSIGNMENTS.md`, `ai_first/daily/2026-05-06.md`
+- PR: uncreated
+- Last update: 2026-05-06
+- Next action: self-review the bounded config/docs diff, then stage and open a draft PR if requested
+- Blocker: none
+
 - Owner: Codex session
 - Machine: local desktop
 - Worktree: `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-auth-multi-user-foundation`

--- a/ai_first/daily/2026-05-06.md
+++ b/ai_first/daily/2026-05-06.md
@@ -1,5 +1,21 @@
 # 2026-05-06
 
+## L1 build hygiene productization lane
+
+- Opened isolated worktree `/Users/nguyenhuuloc/Documents/Multiagent-learning-platform/.worktrees/fix-build-hygiene-productization` on branch `fix/build-hygiene-productization`.
+- Recorded active ownership for `L1_BUILD_HYGIENE` covering `web/tsconfig.json`, `web/vitest.config.ts`, `web/package.json`, and adjacent build-config surfaces.
+- Wrote the bounded design artifact `docs/superpowers/specs/2026-05-06-l1-build-hygiene-productization-design.md` before runtime edits.
+- Confirmed the initial build attempt in the fresh worktree fails even earlier with `next: command not found`, meaning the lane must first install `web` dependencies before reproducing the TypeScript compile-path blocker on a clean machine.
+- Installed `web` dependencies inside the isolated worktree, then confirmed the lane-specific baseline: focused Vitest still passed while the app `tsconfig` continued to include `tests/**`, `vitest.config.ts`, and `playwright.config.ts` in the production compile boundary.
+- Added `web/tests/build-config-hygiene.test.ts` as a regression guard, proving the current config was still missing test-only excludes and an explicit `turbopack.root`.
+- Fixed `web/tsconfig.json` to exclude `tests/**`, `vitest.config.ts`, and `playwright.config.ts` from the app compile path without changing runtime source coverage.
+- Fixed `web/next.config.js` to pin `turbopack.root = __dirname`, removing the parent-home workspace-root warning from `next build`.
+- Added the lane task packet plus PR note to this runtime branch so the implementation worktree carries its own execution contract and review artifact.
+- Verification passed with:
+  - `cd web && node node_modules/vitest/vitest.mjs run tests/build-config-hygiene.test.ts tests/api-base-url.test.ts`
+  - `cd web && npm run build`
+  - `git diff --check`
+
 ## Frontend auth cookie hardening lane
 
 - Root-caused the reported post-login Knowledge upload `401`: backend protected routers now trust only the `deeptutor_session` cookie, while multiple legacy teacher-first frontend fetches still omit `credentials: "include"`.

--- a/docs/superpowers/pr-notes/2026-05-06-l1-build-hygiene-productization.md
+++ b/docs/superpowers/pr-notes/2026-05-06-l1-build-hygiene-productization.md
@@ -1,0 +1,24 @@
+# PR Note: L1 Build Hygiene Productization
+
+## Summary
+
+- exclude Vitest, Playwright, and `tests/**` from the app TypeScript compile path
+- add a regression test that locks the compile-boundary contract
+- pin `turbopack.root` to the web workspace so `next build` stops inferring the parent home directory as the workspace root
+
+## Validation
+
+- `cd web && node node_modules/vitest/vitest.mjs run tests/build-config-hygiene.test.ts tests/api-base-url.test.ts`
+- `cd web && npm run build`
+- `git diff --check`
+
+## Build Hygiene Flow
+
+```mermaid
+flowchart LR
+    A["Next.js production build"] --> B["web/tsconfig.json compile path"]
+    B --> C["App runtime files only"]
+    D["Vitest + Playwright config"] --> E["Excluded from app compile path"]
+    A --> F["web/next.config.js"]
+    F --> G["turbopack.root = __dirname"]
+```

--- a/docs/superpowers/specs/2026-05-06-l1-build-hygiene-productization-design.md
+++ b/docs/superpowers/specs/2026-05-06-l1-build-hygiene-productization-design.md
@@ -1,0 +1,83 @@
+# L1 Build Hygiene Productization Design
+
+- Date: 2026-05-06
+- Lane: `L1_BUILD_HYGIENE`
+- Status: approved for implementation inside this lane
+
+## Current Behavior
+
+- `web/tsconfig.json` includes all `**/*.ts` and `**/*.tsx` under `web/`
+- `web/vitest.config.ts` therefore participates in the app TypeScript compile path
+- on a machine with `web` dependencies installed, `next build` reaches TypeScript and fails trying to resolve `vitest/config`
+- in a fresh isolated worktree, `web` dependencies are absent until installed, so the first failure can present as `next: command not found`
+
+## Intended Behavior Change
+
+- production build should compile only app/runtime-relevant files
+- Vitest-only config should not be part of the Next app compile path
+- the lane should preserve existing frontend test behavior while making `cd web && npm run build` pass on a clean machine after dependencies are installed
+
+## Candidate Approaches
+
+### Approach A: Exclude test config from app tsconfig
+
+- narrow `web/tsconfig.json` include/exclude so `vitest.config.ts` and other test-only config files do not enter the Next compile path
+- keep Vitest config file name and location unchanged
+
+Pros:
+
+- minimal and explicit
+- low risk to existing test commands
+- preserves current dev ergonomics
+
+Cons:
+
+- requires careful include/exclude hygiene so no runtime files are accidentally excluded
+
+### Approach B: Move or rename Vitest config into a separate config namespace
+
+- move `vitest.config.ts` to a location or name outside the default Next app compile path
+- adjust scripts if needed
+
+Pros:
+
+- strong separation between app and test config
+
+Cons:
+
+- larger mechanical change
+- more likely to affect test tooling, docs, and future lanes unnecessarily
+
+## Chosen Approach
+
+Chosen: `Approach A`
+
+Reason:
+
+- this lane should fix the blocker with the smallest useful surface area
+- the problem is compile-path leakage, not the existence of Vitest itself
+- adjusting `tsconfig` boundaries is sufficient unless investigation reveals a second root cause
+
+## Expected Files To Change
+
+- `web/tsconfig.json`
+- `web/package.json` only if build/test commands need bounded clarification
+- `web/vitest.config.ts` only if a minimal companion tweak is necessary
+- `ai_first/ACTIVE_ASSIGNMENTS.md`
+- `ai_first/daily/2026-05-06.md`
+
+## Files Reviewed But Expected To Remain Unchanged
+
+- `web/app/**`
+- backend services and routers
+- product route shells
+- auth/session/classroom domain modules
+
+## Validation Plan
+
+- install dependencies in the isolated `web` worktree
+- reproduce failing `cd web && npm run build`
+- apply the smallest compile-path fix
+- rerun `cd web && npm run build`
+- run a focused frontend test command to ensure Vitest config still works
+- run `git diff --check`

--- a/docs/superpowers/tasks/2026-05-06-l1-build-hygiene-productization.md
+++ b/docs/superpowers/tasks/2026-05-06-l1-build-hygiene-productization.md
@@ -1,0 +1,49 @@
+# Task Packet: L1 Build Hygiene Productization
+
+- Task ID: `L1_BUILD_HYGIENE`
+- Commit tag: `L1-BUILD`
+- Branch: `fix/build-hygiene-productization`
+- Worktree: `.worktrees/fix-build-hygiene-productization`
+- Depends on: none
+
+## Goal
+
+Make the web app build clean on a clean machine and remove test/dev configuration bleed-through from the production compile path.
+
+## Why This Lane Exists
+
+Current `main` is blocked by build hygiene issues, including `vitest.config.ts` being included in the app compile path. This must be fixed before the wider beta-productization train can proceed safely.
+
+## Owned Files
+
+- `web/tsconfig.json`
+- `web/vitest.config.ts`
+- `web/package.json`
+- `web/package-lock.json` only if dependency changes are truly required
+- `web/next.config.*`
+- `web/next-env.d.ts` only if required by the build fix
+- `docs/superpowers/pr-notes/2026-05-06-l1-build-hygiene-productization.md`
+- `ai_first/daily/2026-05-06.md`
+
+## Do Not Touch
+
+- product route structure
+- backend routers/services
+- auth/runtime logic
+- classroom/assignment domain files
+
+## Required Outcomes
+
+- `cd web && npm run build` passes on this lane
+- production compile path excludes Vitest-only config/types
+- dependency boundaries between runtime and dev/test tooling are explicit
+- any root/workspace lockfile ambiguity that affects Next build is either fixed or intentionally documented
+
+## Validation
+
+- `cd web && npm run build`
+- `git diff --check`
+
+## PR Scope
+
+This PR must stay strictly about build/release hygiene. No product feature work.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -15,6 +15,7 @@ const nextConfig = {
 
   // Turbopack configuration (used when running `npm run dev:turbo`)
   turbopack: {
+    root: __dirname,
     resolveAlias: {
       // Fix for mermaid's cytoscape dependency - use CJS version
       cytoscape: "cytoscape/dist/cytoscape.cjs.js",

--- a/web/tests/build-config-hygiene.test.ts
+++ b/web/tests/build-config-hygiene.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const tsconfig = JSON.parse(
+  readFileSync(path.resolve(__dirname, "../tsconfig.json"), "utf-8"),
+) as {
+  exclude?: string[];
+};
+
+const nextConfigSource = readFileSync(
+  path.resolve(__dirname, "../next.config.js"),
+  "utf-8",
+);
+
+describe("frontend build hygiene config", () => {
+  it("keeps test-only inputs out of the app TypeScript compile path", () => {
+    expect(tsconfig.exclude).toEqual(
+      expect.arrayContaining([
+        "tests",
+        "tests/**",
+        "vitest.config.ts",
+        "playwright.config.ts",
+      ]),
+    );
+  });
+
+  it("pins turbopack root to the web workspace", () => {
+    expect(nextConfigSource).toContain("root: __dirname");
+  });
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -24,5 +24,11 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "tests",
+    "tests/**",
+    "vitest.config.ts",
+    "playwright.config.ts"
+  ]
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "tests/auth-signup-page.test.tsx",
       "tests/auth-teacher-surface-gate.test.tsx",
       "tests/auth-verify-page.test.tsx",
+      "tests/build-config-hygiene.test.ts",
       "tests/class-tutor-pack-presenters.test.ts",
       "tests/introduce-content.test.ts",
       "tests/introduce-gallery.test.tsx",


### PR DESCRIPTION
# PR Note: L1 Build Hygiene Productization

## Summary

- exclude Vitest, Playwright, and `tests/**` from the app TypeScript compile path
- add a regression test that locks the compile-boundary contract
- pin `turbopack.root` to the web workspace so `next build` stops inferring the parent home directory as the workspace root

## Validation

- `cd web && node node_modules/vitest/vitest.mjs run tests/build-config-hygiene.test.ts tests/api-base-url.test.ts`
- `cd web && npm run build`
- `git diff --check`

## Build Hygiene Flow

```mermaid
flowchart LR
    A["Next.js production build"] --> B["web/tsconfig.json compile path"]
    B --> C["App runtime files only"]
    D["Vitest + Playwright config"] --> E["Excluded from app compile path"]
    A --> F["web/next.config.js"]
    F --> G["turbopack.root = __dirname"]
```
